### PR TITLE
Write spin index in band.out for non-collinear spin

### DIFF
--- a/prog/dftb+/prg_dftb/dftbplus.F90
+++ b/prog/dftb+/prg_dftb/dftbplus.F90
@@ -988,7 +988,7 @@ program dftbplus
         if (tWriteBandDat) then
           open(unit=fdBand, file=bandOut, action="write")
           do nk=1,nKPoint
-            write(fdBand,*)'KPT ',nk, ' KWEIGHT ', kweight(nk)
+            write(fdBand, *) 'KPT ',nk,' SPIN ', 1, ' KWEIGHT ', kweight(nK)
             do iEgy=1,sqrHamSize
               write(fdBand, formatEnergy) Hartree__eV*eigen(iEgy,nk,1),&
                   & filling(iEgy,nk,1)


### PR DESCRIPTION
Makes band.out digestable for dp_bands also for non-collinear spin.