### PR TITLE
Removed separate exposure of derivative_nonSCC in forces

### DIFF
--- a/prog/dftb+/lib_dftb/forces.F90
+++ b/prog/dftb+/lib_dftb/forces.F90
@@ -19,7 +19,7 @@ module forces
 
   private
 
-  public :: derivative_nonSCC, derivative_shift
+  public :: derivative_shift
 
 
   !> forces with shift vectors present

--- a/prog/dftb+/prg_dftb/dftbplus.F90
+++ b/prog/dftb+/prg_dftb/dftbplus.F90
@@ -1793,7 +1793,7 @@ program dftbplus
               & neighborList%iNeighbor, nNeighbor, img2CentCell, iPair, orb,&
               & potential%intBlock, potential%iorbitalBlock)
         else
-          call derivative_nonscc(derivs, nonSccDeriv, rhoPrim(:,1), ERhoPrim,&
+          call derivative_shift(derivs, nonSccDeriv, rhoPrim(:,1), ERhoPrim,&
               & skHamCont, skOverCont, coord, species, neighborList%iNeighbor,&
               & nNeighbor, img2CentCell, iPair, orb)
         end if


### PR DESCRIPTION
Responding to comment on mailing list about dual exposure of derivative_nonSCC as public and through public interface derivative_shift in forces.F90.