### PR TITLE
Changed port number to avoid conflicts in tests

### DIFF
--- a/test/prog/dftb+/sockets/diamond_exit/dftb_in.hsd
+++ b/test/prog/dftb+/sockets/diamond_exit/dftb_in.hsd
@@ -4,7 +4,7 @@ Geometry = GenFormat {
 
 Driver = Socket {
     Host = '127.0.0.1' # local host
-    Port = 21012
+    Port = 21013
     Verbosity = 0 # max verbose
     Protocol = i-PI {} # i-PI interface
     MaxSteps = -1 # Terminate this instance according to the external driver

--- a/test/prog/dftb+/sockets/diamond_exit/prerun.py
+++ b/test/prog/dftb+/sockets/diamond_exit/prerun.py
@@ -11,7 +11,7 @@ NR_STEPS = 1
 
 def connect():
     serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    serversocket.bind(('localhost', 21012))
+    serversocket.bind(('localhost', 21013))
     serversocket.listen(1)
     connection, address = serversocket.accept()
     return connection


### PR DESCRIPTION
Both sockets/diamond and sockets/diamond_exit were using the same port
number, so could not be run simultaneously.