### PR TITLE
Ext charge adt

### DIFF
--- a/prog/dftb+/lib_dftb/externalcharges.F90
+++ b/prog/dftb+/lib_dftb/externalcharges.F90
@@ -61,12 +61,12 @@ module ExternalCharges
 
   contains
     private
-    
+
     procedure :: updateCoordsCluster
     procedure :: updateCoordsPeriodic
     procedure :: addForceDcCluster
     procedure :: addForceDcPeriodic
-    
+
     !> Updates the stored coordinates for point charges
     generic, public :: updateCoords => updateCoordsCluster, updateCoordsPeriodic
 

--- a/prog/dftb+/lib_dftb/externalcharges.F90
+++ b/prog/dftb+/lib_dftb/externalcharges.F90
@@ -20,6 +20,7 @@ module ExternalCharges
   private
 
   public :: TExtCharge, init_ExtChrg
+  public :: addShiftPerAtom_ExtChrg, updateCoords_ExtChrg, addForceDCSCC_ExtChrg
 
   !> Add the potential from the point charges
   interface addShiftPerAtom_ExtChrg
@@ -42,7 +43,7 @@ module ExternalCharges
 
   !> Private module variables
   type TExtCharge
-    
+
     !> Number of point charges
     integer :: nChrg
 
@@ -75,15 +76,12 @@ module ExternalCharges
 
     !> Real lattice points for Ewald-sum.
     real(dp), allocatable :: rCellVec(:,:)
-    
+
   contains
 
-    procedure :: updateCoords_ExtChrg
     procedure :: updateLatVecs_ExtChrg
-    procedure :: addShiftPerAtom_ExtChrg
     procedure :: addEnergyPerAtom_ExtChrg
-    procedure :: addForceDCSCC_ExtChrg
-    
+
   end type TExtCharge
 
 contains
@@ -96,7 +94,7 @@ contains
 
     !> External charge object
     type(TExtCharge), intent(out) :: this
-    
+
     !> (4, nAtom) array with coordinates and charges
     real(dp), intent(in) :: coordsAndCharges(:,:)
 
@@ -168,7 +166,7 @@ contains
 
     !> External charges structure
     class(TExtCharge), intent(inout) :: this
-    
+
     !> New lattice vectors
     real(dp), intent(in) :: latVecs(:,:)
 
@@ -193,8 +191,8 @@ contains
   subroutine updateCoords_ExtChrg_cluster(this, atomCoords)
 
     !> External charges structure
-    class(TExtCharge), intent(inout) :: this
-    
+    type(TExtCharge), intent(inout) :: this
+
     !> Coordinates of the atoms (not the point charges!)
     real(dp), intent(in) :: atomCoords(:,:)
 
@@ -219,8 +217,8 @@ contains
   subroutine updateCoords_ExtChrg_periodic(this, atomCoords, gLat, alpha, volume)
 
     !> External charges structure
-    class(TExtCharge), intent(inout) :: this
-    
+    type(TExtCharge), intent(inout) :: this
+
     !> Coordinates of the atoms (not the point charges!)
     real(dp), intent(in) :: atomCoords(:,:)
 
@@ -251,8 +249,8 @@ contains
   subroutine addShift1(this, shift)
 
     !> External charges structure
-    class(TExtCharge), intent(in) :: this
-    
+    type(TExtCharge), intent(in) :: this
+
     !> Shift vector to add the contribution to.
     real(dp), intent(inout) :: shift(:)
 
@@ -268,8 +266,8 @@ contains
   subroutine addShift2(this, shift)
 
     !> External charges structure
-    class(TExtCharge), intent(in) :: this
-    
+    type(TExtCharge), intent(in) :: this
+
     !> Shift vector to add the contribution to.
     real(dp), intent(inout) :: shift(:,:)
 
@@ -286,7 +284,7 @@ contains
 
     !> External charges structure
     class(TExtCharge), intent(in) :: this
-    
+
     !> Charge of the atoms
     real(dp), intent(in) :: atomCharges(:)
 
@@ -307,8 +305,8 @@ contains
   subroutine addForceDCSCC_ExtChrg_cluster(this, atomForces, chrgForces, atomCoords, atomCharges)
 
     !> External charges structure
-    class(TExtCharge), intent(in) :: this
-    
+    type(TExtCharge), intent(in) :: this
+
     !> Force vectors on the atoms
     real(dp), intent(inout) :: atomForces(:,:)
 
@@ -343,8 +341,8 @@ contains
       & gVec, alpha, vol)
 
     !> External charges structure
-    class(TExtCharge), intent(in) :: this
-    
+    type(TExtCharge), intent(in) :: this
+
     !> Force vectors on the atoms
     real(dp), intent(inout) :: atomForces(:,:)
 

--- a/prog/dftb+/lib_dftb/scc.F90
+++ b/prog/dftb+/lib_dftb/scc.F90
@@ -315,11 +315,11 @@ contains
     ! Initialise external charges
     if (this%tExtChrg) then
       if (this%tPeriodic) then
-        call init_ExtChrg(this%extCharge, inp%extCharges, this%nAtom, inp%latVecs, inp%recVecs,&
+        call TExtCharge_init(this%extCharge, inp%extCharges, this%nAtom, inp%latVecs, inp%recVecs,&
             & this%maxREwald)
       else
         @:ASSERT(allocated(inp%blurWidths))
-        call init_ExtChrg(this%extCharge, inp%extCharges, this%nAtom, blurWidths=inp%blurWidths)
+        call TExtCharge_init(this%extCharge, inp%extCharges, this%nAtom, blurWidths=inp%blurWidths)
       end if
     end if
 
@@ -415,9 +415,9 @@ contains
 
     if (this%tExtChrg) then
       if (this%tPeriodic) then
-        call updateCoords_ExtChrg(this%extCharge, coord, this%gLatPoint, this%alpha, this%volume)
+        call this%extCharge%updateCoords(coord, this%gLatPoint, this%alpha, this%volume)
       else
-        call updateCoords_ExtChrg(this%extCharge, coord)
+        call this%extCharge%updateCoords(coord)
       end if
     end if
 
@@ -457,7 +457,7 @@ contains
     this%cutoff = max(this%cutoff, this%maxREwald)
 
     if (this%tExtChrg) then
-      call this%extCharge%updateLatVecs_extChrg(latVec, recVec, this%maxREwald)
+      call this%extCharge%updateLatVecs(latVec, recVec, this%maxREwald)
     end if
 
   end subroutine updateLatVecs
@@ -552,7 +552,7 @@ contains
     eScc(:) = 0.5_dp * (this%shiftPerAtom * this%deltaQAtom &
         & + sum(this%shiftPerL * this%deltaQPerLShell, dim=1))
     if (this%tExtChrg) then
-      call this%extCharge%addEnergyPerAtom_ExtChrg(this%deltaQAtom, eScc)
+      call this%extCharge%addEnergyPerAtom(this%deltaQAtom, eScc)
     end if
     if (this%tChrgConstr) then
       call addEnergyPerAtom(this%chrgConstr, eScc, this%deltaQAtom)
@@ -660,13 +660,13 @@ contains
       call addInvRPrime(force, this%nAtom, coord, this%nNeighEwald, iNeighbor, &
           & img2CentCell, this%gLatPoint, this%alpha, this%volume, this%deltaQAtom)
       if (this%tExtChrg) then
-        call addForceDcScc_ExtChrg(this%extCharge, force, chrgForce, coord, this%deltaQAtom,&
-            & this%gLatPoint, this%alpha, this%volume)
+        call this%extCharge%addForceDc(force, chrgForce, coord, this%deltaQAtom, this%gLatPoint,&
+            & this%alpha, this%volume)
       end if
     else
       call addInvRPrime(force, this%nAtom, coord, this%deltaQAtom)
       if (this%tExtChrg) then
-        call addForceDcScc_ExtChrg(this%extCharge, force, chrgForce, coord, this%deltaQAtom)
+        call this%extCharge%addForceDc(force, chrgForce, coord, this%deltaQAtom)
       end if
     end if
 
@@ -738,7 +738,7 @@ contains
 
     shift = this%shiftPerAtom
     if (this%tExtChrg) then
-      call addShiftPerAtom_ExtChrg(this%extCharge, shift)
+      call this%extCharge%addShiftPerAtom(shift)
     end if
     if (this%tChrgConstr) then
       call addShiftPerAtom(this%chrgConstr, shift)


### PR DESCRIPTION
Temporary fix to allow multiple TScc objects with external charges. The externalcharges module would require further re-working to make all routines available as methods of the type (due to the differences in their interfaces).