### PR TITLE
Release name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ make.arch
 make.config
 __pycache__
 .idea
+RELEASE

--- a/makefile
+++ b/makefile
@@ -32,6 +32,9 @@ endif
 ################################################################################
 # Build targets
 ################################################################################
+
+# You can disable automatic release determination by setting the release
+# explicitely in the RELEASE file in the source root directory.
 .PHONY: update_release
 update_release:
 	mkdir -p $(BUILDDIR)
@@ -148,7 +151,8 @@ check_dptools_py3:
 distclean:
 	rm -rf $(BUILDDIR)
 
-
+# Create a source distribution from current git check-out
+# Note: check-out must contain all submodules
 ARCHIVE_NAME := dftbplus
 .PHONY: sourcedist
 sourcedist:

--- a/makefile
+++ b/makefile
@@ -32,6 +32,11 @@ endif
 ################################################################################
 # Build targets
 ################################################################################
+.PHONY: update_release
+update_release:
+	mkdir -p $(BUILDDIR)
+	[ -r $(ROOT)/RELEASE ] && cp -a $(ROOT)/RELEASE $(BUILDDIR)/RELEASE \
+        || $(ROOT)/utils/build/update_release $(BUILDDIR)/RELEASE
 
 .PHONY: dftb+ modes waveplot
 dftb+ modes waveplot:
@@ -39,7 +44,7 @@ dftb+ modes waveplot:
 	$(MAKE) -C $(BUILDDIR)/prog/$@ -f $(ROOT)/prog/$@/make.build \
 	    ROOT=$(ROOT) BUILDROOT=$(BUILDDIR)
 
-dftb+: external_xmlf90
+dftb+: update_release external_xmlf90
 ifeq ($(strip $(WITH_SOCKETS)),1)
 dftb+: external_fsockets
 endif
@@ -142,3 +147,12 @@ check_dptools_py3:
 .PHONY: distclean
 distclean:
 	rm -rf $(BUILDDIR)
+
+
+ARCHIVE_NAME := dftbplus
+.PHONY: sourcedist
+sourcedist:
+	rm -rf $(BUILDDIR)/_sourcedist
+	mkdir -p $(BUILDDIR)/_sourcedist
+	$(ROOT)/utils/build/make_archive.sh $(ARCHIVE_NAME) \
+            $(BUILDDIR)/_sourcedist

--- a/prog/dftb+/lib_io/formatout.F90
+++ b/prog/dftb+/lib_io/formatout.F90
@@ -327,7 +327,7 @@ contains
     integer, parameter :: headerWidth = 80
 
     write(stdOut, '(2A,/,A)') vbar, repeat(hbar, headerWidth - 1), vbar
-    write(stdOut, '(4A)') vbar, '  DFTB+ (Release ', release, ')'
+    write(stdOut, '(3A)') vbar, '  DFTB+  Release ', release
     write(stdOut, '(A)') vbar
     write(stdOut, '(2A,I0,A)') vbar, '  Copyright (C) ', year, '  DFTB+ developers group'
     write(stdOut, '(A,/,2A,/,A)') vbar, vbar, repeat(hbar, headerWidth - 1), vbar

--- a/prog/dftb+/lib_io/formatout.F90
+++ b/prog/dftb+/lib_io/formatout.F90
@@ -327,7 +327,7 @@ contains
     integer, parameter :: headerWidth = 80
 
     write(stdOut, '(2A,/,A)') vbar, repeat(hbar, headerWidth - 1), vbar
-    write(stdOut, '(3A)') vbar, '  DFTB+  Release ', release
+    write(stdOut, '(3A)') vbar, '  DFTB+ ', trim(release)
     write(stdOut, '(A)') vbar
     write(stdOut, '(2A,I0,A)') vbar, '  Copyright (C) ', year, '  DFTB+ developers group'
     write(stdOut, '(A,/,2A,/,A)') vbar, vbar, repeat(hbar, headerWidth - 1), vbar

--- a/prog/dftb+/make.common
+++ b/prog/dftb+/make.common
@@ -7,7 +7,7 @@
 
 .SUFFIXES:
 .SUFFIXES: .f .f90 .F90 .o
-.PRECIOUS: %.f90
+#.PRECIOUS: %.f90
 
 FXXCLEAN = *.mod
 
@@ -19,6 +19,9 @@ FYPPINC = -I
 include $(ROOT)/make.config
 
 FYPPOPT += -DDEBUG=$(DEBUG)
+
+RELEASE := $(shell cat $(BUILDROOT)/RELEASE)
+FYPPOPT += -DRELEASE="'$(RELEASE)'"
 
 vpath % $(SRCDIRS)
 

--- a/prog/dftb+/prg_dftb/dftbplus.F90
+++ b/prog/dftb+/prg_dftb/dftbplus.F90
@@ -17,14 +17,14 @@ program dftbplus
   use initprogram, only : initProgramVariables
   implicit none
 
-  character(len=*), parameter :: RELEASE_VERSION = '17.1'
-  integer, parameter :: RELEASE_YEAR = 2017
+  character(len=*), parameter :: releaseName = '${RELEASE}$'
+  integer, parameter :: releaseYear = 2017
 
   type(TEnvironment) :: env
   type(inputData), allocatable :: input
 
   call initGlobalEnv()
-  call printDftbHeader(RELEASE_VERSION, RELEASE_YEAR)
+  call printDftbHeader(releaseName, releaseYear)
   allocate(input)
   call parseHsdInput(input)
   call initProgramVariables(input, env)

--- a/prog/dftb+/prg_dftb/make.extdeps
+++ b/prog/dftb+/prg_dftb/make.extdeps
@@ -1,0 +1,1 @@
+dftbplus.o: $(BUILDROOT)/RELEASE

--- a/utils/build/make_archive.sh
+++ b/utils/build/make_archive.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#------------------------------------------------------------------------------#
+#  DFTB+: general package for performing fast atomistic simulations            #
+#  Copyright (C) 2017  DFTB+ developers group                                  #
+#                                                                              #
+#  See the LICENSE file for terms of usage and distribution.                   #
+#------------------------------------------------------------------------------#
+
+#
+# Creates a source archive from the current git-checkout.
+#
+# Usage:
+#
+#  make_archive.sh ARCHIVE_NAME TEMPDIR
+#
+#  where ARCHIVE_NAME specifies the name of the archive (without extension)
+#  and TEMPDIR a temporary directory where packing/unpacking can be done. The script
+#  must be invoked from the root of the git repository.
+#
+
+archive=$1
+if [ -z "$archive" ]; then
+  echo "Missing first argument (archive name)" >&2
+  exit 1
+fi
+
+tmpdir=$2
+if [ -z "$tmpdir" ]; then
+  echo "Missing second argument (temporary directory)" >&2
+  exit 1
+fi
+
+if [ ! -d "$tmpdir" ]; then
+  echo "Could not create temporary directory $tmpdir"
+  exit
+fi
+
+echo "Temporary directory: $tmpdir"
+echo "Archiving repository with prefix: $archive/"
+git archive --format=tar --prefix $archive/ HEAD | tar -C $tmpdir -x -f -
+if [ -e .gitmodules ]; then
+  paths=$(grep 'path =' .gitmodules | sed -s 's/path = //g')
+  for path in $paths; do
+    echo "Archiving sub-module with prefix: $archive/$path/"
+    cd $path
+    git archive --format=tar --prefix $archive/$path/ HEAD | tar -C $tmpdir -x -f -
+    cd -
+  done
+fi
+./utils/build/update_release $tmpdir/$archive/RELEASE
+
+echo "Creating archive ${archive}.tar.xz"
+tar -C $tmpdir -c -J -f $PWD/${archive}.tar.xz $archive/

--- a/utils/build/update_release
+++ b/utils/build/update_release
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+#------------------------------------------------------------------------------#
+#  DFTB+: general package for performing fast atomistic simulations            #
+#  Copyright (C) 2017  DFTB+ developers group                                  #
+#                                                                              #
+#  See the LICENSE file for terms of usage and distribution.                   #
+#------------------------------------------------------------------------------#
+
+"""Determines the release from the git tags and updates a given release file
+with that information.
+
+Usage:
+
+    get_release RELEASE_FILE
+
+where RELEASE_FILE is the file, in which the release information should be
+updated. If RELEASE_FILE is not present, it will be created. If it is present
+and contains already the right release information, it will be left unchanged.
+"""
+
+from __future__ import print_function
+import re
+import subprocess as sub
+import sys
+import os.path
+
+# Pattern to match revision tag names
+REVISION_PATTERN = re.compile(
+    r'(?P<year>\d\d)\.(?P<major>\d+)(?:\.(?P<minor>\d+))?$')
+
+# Name of git command
+GITCMD = 'git'
+
+
+def main():
+    "Main script"
+
+    scriptDir = os.path.dirname(sys.argv[0])
+    rootDir = os.path.realpath(os.path.join(scriptDir, '../..'))
+    release_file = sys.argv[1]
+
+    current_tag = get_current_tag(rootDir)
+    if current_tag:
+        update_release(release_file, get_release_name(current_tag))
+        sys.exit(0)
+
+    last_tag = get_last_tag(rootDir)
+    current_commit = get_current_commit(rootDir)
+    if last_tag is not None and current_commit is not None:
+        update_release(release_file, get_release_name(last_tag, current_commit))
+    else:
+        sys.stderr.write('Warning: Release could not be determined\n')
+        update_release(release_file, update_release('(Unknown)'))
+
+
+def get_current_tag(rootDir):
+    """Returns release tag belonging to current commit.
+
+    Args:
+        rootDir: Root directory of the git repository
+
+    Returns:
+        Current release tag as (year, major, minor) integer tuple or None if
+        no release tag belongs to current commit or if the git command failed.
+    """
+    cmd = [GITCMD, '-C', rootDir, 'tag', '--contains']
+    try:
+        proc = sub.Popen(cmd, stdout=sub.PIPE, stderr=sub.PIPE)
+    except OSError:
+        return None
+    rawtags = proc.stdout.read().split()
+    tags = convert_tags(rawtags)
+    if tags:
+        tags.sort()
+        return tags[-1]
+    else:
+        return None
+
+
+def get_last_tag(rootDir):
+    """Returns latest release tag available in the repository.
+
+    Args:
+        rootDir: Root directory of the git repository
+
+    Returns:
+        Latest release tag as (year, major, minor) integer tuple or None if
+        no release tag could be found or if the git command failed.
+    """
+    cmd = [GITCMD, '-C', rootDir, 'tag', '--merged']
+    try:
+        proc = sub.Popen(cmd, stdout=sub.PIPE, stderr=sub.PIPE)
+    except OSError:
+        return None
+    rawtags = proc.stdout.read().split()
+    tags = convert_tags(rawtags)
+    if tags:
+        tags.sort()
+        return tags[-1]
+    else:
+        return None
+
+
+def get_current_commit(rootDir):
+    """Returns current commit id.
+
+    Args:
+        rootDir: Root directory of the git repository
+
+    Returns:
+        Current commit id or None if the git command failed.
+    """
+    cmd = [GITCMD, '-C', rootDir, 'rev-parse', '--short', 'HEAD']
+    try:
+        proc = sub.Popen(cmd, stdout=sub.PIPE, stderr=sub.PIPE)
+    except OSError:
+        return None
+    commit = proc.stdout.read().strip()
+    return decode(commit)
+
+
+def get_release_name(tag, commit=None):
+    """Returns the name of the release.
+
+    Args:
+        tag: Release tag as found in the repository. If commit argument is also
+            supplied, it is assumed that the tag is the latest release tag, and
+            represents an earlier state of the code.
+        commit: Optional commit tag.
+
+    Returns:
+        String representation of the release name.
+    """
+    if tag[2]:
+        release = '%d.%d.%d' % tag
+    else:
+        release = '%d.%d' % tag[0:2]
+    if commit is not None:
+        release += '* commit %s' % commit
+    return release
+
+
+def convert_tags(rawtags):
+    """Converts list of raw tag names to tag-tuples.
+
+    Args:
+        rawtags: List of raw tag names from the git repository
+
+    Returns:
+        List of (year, majory, minor) integer tuples.
+    """
+    tags = []
+    for rawtag in rawtags:
+        match = REVISION_PATTERN.match(decode(rawtag))
+        if match:
+            year, major, minor = match.groups()
+            if minor is None:
+                minor = 0
+            tags.append((int(year), int(major), int(minor)))
+    return tags
+
+
+def update_release(release_file, release_name):
+    """Updates the release file with release name, if it changed.
+
+    Args:
+        release_file: File where to write the release name. If the file already
+            exists and contains the same release name, it is left unchanged.
+        release_name: Name of the current release.
+    """
+    old_release_name = ''
+    if os.path.exists(release_file):
+        with open(release_file, 'r') as fp:
+            old_release_name = fp.read().strip()
+    if old_release_name != release_name:
+        with open(release_file, 'w') as fp:
+            fp.write(release_name)
+
+
+# Convert bytes to string when using Python 3
+if sys.version_info[0] >= 3:
+    def decode(str):
+        return str.decode()
+else:
+    def decode(str):
+        return str
+
+
+if __name__ == '__main__':
+    main()

--- a/utils/build/update_release
+++ b/utils/build/update_release
@@ -136,7 +136,7 @@ def get_release_name(tag, commit=None):
     else:
         release = '%d.%d' % tag[0:2]
     if commit is not None:
-        release += '* commit %s' % commit
+        release += '* [commit %s]' % commit
     return release
 
 

--- a/utils/build/update_release
+++ b/utils/build/update_release
@@ -135,9 +135,12 @@ def get_release_name(tag, commit=None):
         release = '%d.%d.%d' % tag
     else:
         release = '%d.%d' % tag[0:2]
-    if commit is not None:
-        release += '* [commit %s]' % commit
-    return release
+    if commit is None:
+        relname = 'release ' + release
+    else:
+        relname = ('development version (base: %s, commit: %s)'
+                   % (release, commit))
+    return relname
 
 
 def convert_tags(rawtags):

--- a/utils/srcmanip/set_source_headers
+++ b/utils/srcmanip/set_source_headers
@@ -38,6 +38,8 @@ FILE_TYPES = [
     ('test/prog/dftb+/bin/*', 'shell'),
     ('tools/misc/*', 'python'),
     ('utils/*', 'python'),
+    ('utils/build/*.sh', 'shell'),
+    ('utils/build/*', 'python'),
     ('utils/build/cr_makedep/*', 'python'),
     ('utils/build/fpp/*', 'shell'),
 ]


### PR DESCRIPTION
Automatic git tag based release name determination during build (but can be disabled if needed).

Note: in order to reliably determine last release, the tagged release must be reachable from the current development version, therefore the release branch has been merged into this branch. This does not introduce any code changes, only includes the corresponding merge commit.