### PR TITLE
Size for any optional default set in getChVal_*R1 routines

### DIFF
--- a/prog/dftb+/lib_io/hsdutils.F90
+++ b/prog/dftb+/lib_io/hsdutils.F90
@@ -277,6 +277,9 @@ contains
       call setAttribute(child2, attrProcessed, "")
     elseif (present(default)) then
       variableValue = default
+      if (present(nItem)) then
+        nItem = size(default)
+      end if
       if (present(modifier)) then
         modifier = ""
       end if
@@ -482,6 +485,9 @@ contains
       call setAttribute(child2, attrProcessed, "")
     elseif (present(default)) then
       variableValue = default
+      if (present(nItem)) then
+        nItem = size(default)
+      end if
       if (present(modifier)) then
         modifier = ""
       end if
@@ -682,6 +688,9 @@ contains
       call setAttribute(child2, attrProcessed, "")
     elseif (present(default)) then
       variableValue = default
+      if (present(nItem)) then
+        nItem = size(default)
+      end if
       if (present(modifier)) then
         modifier = ""
       end if


### PR DESCRIPTION
The nItem was not being set if a default was supplied in these
cases. This causes the 2D defaults to fail (as the size is tested).