### PR TITLE
Regularise make templates

### DIFF
--- a/make.config
+++ b/make.config
@@ -18,13 +18,14 @@ WITH_MPI := 0
 # Whether the socket library (external control) should be linked.
 WITH_SOCKETS := 1
 
+# Whether the ARPACK library (needed by TD-DFTB) should be linked with DFTB+
+# Only affects serial build (MPI-version is built without ARPACK/TD-DFTB).
+WITH_ARPACK := 1
+
 # Whether the DFTD3 library (dispersion) should be linked.
 # NOTE: Due to license incompatibility, distribution of a DFTB+ binary built
 # with this component is not permitted. Use it only for your personal research.
 WITH_DFTD3 := 0
-
-# Whether the ARPACK library (needed by TD-DFTB) should be linked with DFTB+
-WITH_ARPACK := 1
 
 ################################################################################
 # General building/testing options

--- a/sys/make.x86_64-linux-gnu
+++ b/sys/make.x86_64-linux-gnu
@@ -60,7 +60,7 @@ LNOPT = -fopenmp
 # How to link specific libraries
 
 # LAPACK/BLAS
-# Consider to use a threaded LAPACK/BLAS implementation for full performance
+# Consider using a threaded LAPACK/BLAS implementation for full performance
 ATLASDIR = /usr/lib
 LIB_LAPACK = -L$(ATLASDIR) -llapack -lf77blas -lcblas -latlas
 

--- a/sys/make.x86_64-linux-gnu
+++ b/sys/make.x86_64-linux-gnu
@@ -60,6 +60,7 @@ LNOPT = -fopenmp
 # How to link specific libraries
 
 # LAPACK/BLAS
+# Consider to use a threaded LAPACK/BLAS implementation for full performance
 ATLASDIR = /usr/lib
 LIB_LAPACK = -L$(ATLASDIR) -llapack -lf77blas -lcblas -latlas
 

--- a/sys/make.x86_64-linux-intel
+++ b/sys/make.x86_64-linux-intel
@@ -13,7 +13,7 @@ FXX = mpif90
 CC = icc
 
 # Compiler options
-FXXOPT = -O2 -ip -standard-semantics -heap-arrays 10 #-qopenmp 
+FXXOPT = -O2 -ip -standard-semantics -heap-arrays 10
 CCOPT = -O2 -ip
 
 # Linker
@@ -27,7 +27,7 @@ MKL_LIBDIR = $(MKLROOT)/lib/intel64
 LIB_SCALAPACK = -L$(MKL_LIBDIR) -lmkl_scalapack_lp64 -lmkl_blacs_openmpi_lp64
 
 # LAPACK/BLAS
-LIB_LAPACK = -L$(MKL_LIBDIR) -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core
+LIB_LAPACK = -L$(MKL_LIBDIR) -lmkl_intel_lp64 -lmkl_sequential -lmkl_core
 
 # Any other libraries to be linked
 OTHERLIBS = -liomp5
@@ -60,11 +60,8 @@ LNOPT = -static
 
 # LAPACK/BLAS
 MKL_LIBDIR = $(MKLROOT)/lib/intel64
-LIB_LAPACK   = -L$(MKL_LIBDIR) -Wl,--start-group \
-  -lmkl_intel_lp64 \
-  -lmkl_intel_thread \
-  -lmkl_core \
-  -Wl,--end-group
+LIB_LAPACK   = -L$(MKL_LIBDIR) -Wl,--start-group -lmkl_intel_lp64 \
+  -lmkl_intel_thread -lmkl_core -Wl,--end-group
 
 # Any other libraries to be linked
 OTHERLIBS = -liomp5 -pthread

--- a/sys/make.x86_64-linux-nag
+++ b/sys/make.x86_64-linux-nag
@@ -67,7 +67,7 @@ endif
 # How to link specific libraries
 
 # LAPACK/BLAS
-# Consider to use a threaded LAPACK/BLAS implementation for full performance
+# Consider using a threaded LAPACK/BLAS implementation for full performance
 ATLASDIR = /usr/lib
 LIB_LAPACK = -L$(ATLASDIR) -llapack -lf77blas -lcblas -latlas
 

--- a/sys/make.x86_64-linux-nag
+++ b/sys/make.x86_64-linux-nag
@@ -18,7 +18,7 @@ CCOPT = -O2 -funroll-all-loops -fall-intrinsics
 
 # Linker
 LN = $(FXX)
-LNOPT = -openmp
+LNOPT =
 
 # How to link specific libraries
 
@@ -67,6 +67,7 @@ endif
 # How to link specific libraries
 
 # LAPACK/BLAS
+# Consider to use a threaded LAPACK/BLAS implementation for full performance
 ATLASDIR = /usr/lib
 LIB_LAPACK = -L$(ATLASDIR) -llapack -lf77blas -lcblas -latlas
 

--- a/sys/make.x86_64-linux-pgi
+++ b/sys/make.x86_64-linux-pgi
@@ -61,7 +61,7 @@ LNOPT =
 # How to link specific libraries
 
 # LAPACK/BLAS
-# Consider to use a threaded LAPACK/BLAS implementation for full performance
+# Consider using a threaded LAPACK/BLAS implementation for full performance
 LIB_LAPACK = -L$(PGI_LIBDIR) -llapack -lblas
 
 # Any other libraries to be linked

--- a/sys/make.x86_64-linux-pgi
+++ b/sys/make.x86_64-linux-pgi
@@ -15,7 +15,7 @@ FXX = mpifort
 CC = pgcc
 
 # Compiler options
-FXXOPT = -O1 -Mallocatable=03
+FXXOPT = -O2 -Mallocatable=03
 CCOPT = -O2
 
 # Linker
@@ -51,7 +51,7 @@ FXX = pgfortran
 CC = pgcc
 
 # Compile options
-FXXOPT = -O1 -Mallocatable=03
+FXXOPT = -O2 -Mallocatable=03 -mp
 CCOPT = -O2
 
 # Linker
@@ -61,8 +61,8 @@ LNOPT =
 # How to link specific libraries
 
 # LAPACK/BLAS
-ATLASDIR = /usr/lib
-LIB_LAPACK = -L$(ATLASDIR) -llapack -lf77blas -lcblas -latlas
+# Consider to use a threaded LAPACK/BLAS implementation for full performance
+LIB_LAPACK = -L$(PGI_LIBDIR) -llapack -lblas
 
 # Any other libraries to be linked
 OTHERLIBS =


### PR DESCRIPTION
Serial compilation uses openMP-options and links or suggests threaded
LAPACK/BLAS, mpi compilation has no openMP-options and links
non-threaded LAPACK/BLAS.