### PR TITLE
Implement clean abort

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -2564,7 +2564,7 @@ This block collects some global options for the run.
 \item[\is{TimingVerbosity}] Level of information regarding CPU and wall clock
   timings of sections of the code, higher values becoming more verbose. Setting
   this parameter to 0 or below supresses any information being printed
-  (default).
+  (default). Setting it to -1 includes all measured timings.
 
 \item[\is{ShowFoldedCoords}] Print coordinates folded back into the
   central cell, so if an atom moves outside the central cell it will

--- a/prog/dftb+/lib_common/environment.F90
+++ b/prog/dftb+/lib_common/environment.F90
@@ -41,7 +41,7 @@ module environment
     !> Global timers
     type(TTimerArray), public :: globalTimer
 
-    !> Registry for files, which may be open and must be closed when environment is aborted
+    !> Registry of files, which may be open and must be closed when environment is aborted
     type(TFileRegistry), public :: fileFinalizer
 
   #:if WITH_MPI
@@ -63,7 +63,7 @@ module environment
   #:if WITH_SCALAPACK
     procedure :: initBlacs => TEnvironment_initBlacs
   #:endif
-    
+
   end type TEnvironment
 
   type(TTimerItem), parameter :: globalTimerItems(14) = [&
@@ -105,6 +105,7 @@ module environment
 
 contains
 
+  !> Returns an initialized instance.
   subroutine TEnvironment_init(this)
 
     !> Instance
@@ -128,7 +129,7 @@ contains
   end subroutine TEnvironment_destruct
     
   
-  !> Gracefully aborts finalizing the current environment first
+  !> Gracefully cleans up and aborts
   subroutine TEnvironment_abort(this)
 
     !> Instance

--- a/prog/dftb+/lib_common/environment.F90
+++ b/prog/dftb+/lib_common/environment.F90
@@ -9,7 +9,9 @@
 
 !> Contains computer environment settings
 module environment
+  use globalenv, only : abort, stdOut
   use timerarray
+  use fileregistry
 #:if WITH_MPI
   use mpienv
 #:endif
@@ -25,6 +27,7 @@ module environment
 
   !> Contains environment settings.
   type :: TEnvironment
+    private
 
     !> Whether this process is the master?
     logical, public :: tGlobalMaster = .true.
@@ -36,7 +39,10 @@ module environment
     integer, public :: myGroup = 0
 
     !> Global timers
-    type(TTimerArray) :: globalTimer
+    type(TTimerArray), public :: globalTimer
+
+    !> Registry for files, which may be open and must be closed when environment is aborted
+    type(TFileRegistry), public :: fileFinalizer
 
   #:if WITH_MPI
     !> Global mpi settings
@@ -48,13 +54,16 @@ module environment
   #:endif
 
   contains
+    procedure :: destruct => TEnvironment_destruct
+    procedure :: abort => TEnvironment_abort
+    procedure :: initGlobalTimer => TEnvironment_initGlobalTimer
   #:if WITH_MPI
-    procedure :: initMpi
+    procedure :: initMpi => TEnvironment_initMpi
   #:endif
   #:if WITH_SCALAPACK
-    procedure :: initBlacs
+    procedure :: initBlacs => TEnvironment_initBlacs
   #:endif
-
+    
   end type TEnvironment
 
   type(TTimerItem), parameter :: globalTimerItems(14) = [&
@@ -96,21 +105,67 @@ module environment
 
 contains
 
-  !> Returns an initialized instance.
   subroutine TEnvironment_init(this)
 
     !> Instance
     type(TEnvironment), intent(out) :: this
 
-    call TTimerArray_init(this%globalTimer, globalTimerItems)
+    call TFileRegistry_init(this%fileFinalizer)
 
   end subroutine TEnvironment_init
+
+
+  !> Finalizes the environment.
+  subroutine TEnvironment_destruct(this)
+
+    !> Instance
+    class(TEnvironment), intent(inout) :: this
+
+    call this%globalTimer%writeTimings()
+    call this%fileFinalizer%closeAll()
+    flush(stdOut)
+
+  end subroutine TEnvironment_destruct
+    
+  
+  !> Gracefully aborts finalizing the current environment first
+  subroutine TEnvironment_abort(this)
+
+    !> Instance
+    class(TEnvironment), intent(out) :: this
+
+    call this%destruct()
+    call abort()
+
+  end subroutine TEnvironment_abort
+
+
+  !> Initlaizes the global timer of the environment.
+  subroutine TEnvironment_initGlobalTimer(this, timingLevel, header, unit)
+
+    !> Instance
+    class(TEnvironment), intent(inout) :: this
+
+    !> Timing level up to which timings should be printed (-1 for all)
+    integer, intent(in) :: timingLevel
+
+    !> Header of the timing table
+    character(*), intent(in) :: header
+
+    !> File unit into which the table should be written
+    integer, intent(in) :: unit
+
+    call TTimerArray_init(this%globalTimer, globalTimerItems, maxLevel=timingLevel, header=header,&
+        & unit=unit)
+
+  end subroutine TEnvironment_initGlobalTimer
+
 
 
 #:if WITH_MPI
 
   !> Initializes MPI environment.
-  subroutine initMpi(this, nGroup)
+  subroutine TEnvironment_initMpi(this, nGroup)
 
     !> Instance
     class(TEnvironment), intent(inout) :: this
@@ -124,7 +179,7 @@ contains
     this%nGroup = this%mpi%nGroup
     this%myGroup = this%mpi%myGroup
 
-  end subroutine initMpi
+  end subroutine TEnvironment_initMpi
 
 #:endif
 
@@ -132,7 +187,7 @@ contains
 #:if WITH_SCALAPACK
 
   !> Initializes BLACS environment
-  subroutine initBlacs(this, rowBlock, colBlock, nOrb, nAtom)
+  subroutine TEnvironment_initBlacs(this, rowBlock, colBlock, nOrb, nAtom)
 
     !> Instance
     class(TEnvironment), intent(inout) :: this
@@ -151,7 +206,7 @@ contains
 
     call TBlacsEnv_init(this%blacs, this%mpi, rowBlock, colBlock, nOrb, nAtom)
 
-  end subroutine initBlacs
+  end subroutine TEnvironment_initBlacs
 
 #:endif
 

--- a/prog/dftb+/lib_common/fileregistry.F90
+++ b/prog/dftb+/lib_common/fileregistry.F90
@@ -1,0 +1,80 @@
+!> Contains a file registry which keeps track of eventually open files and closes them.
+module fileregistry
+  implicit none
+  private
+
+  public :: TFileRegistry_init, TFileRegistry
+
+
+  !> Implements a file registry
+  type :: TFileRegistry
+    private
+    integer, allocatable :: registeredFiles(:)
+    integer :: nRegistered = -1
+  contains
+    procedure :: register => TFileRegistry_register
+    procedure :: closeAll => TFileRegistry_closeAll
+  end type TFileRegistry
+
+
+  !> Default registry size (nr. of files to be stored before reallocation)
+  integer, parameter :: defaultSize = 20
+
+contains
+
+
+  !> Initializes the file registry.
+  subroutine TFileRegistry_init(this)
+
+    !> Initialized instance on exit.
+    type(TFileRegistry), intent(out) :: this
+
+    allocate(this%registeredFiles(defaultSize))
+    this%nRegistered = 0
+
+  end subroutine TFileRegistry_init
+
+
+  !> Registers a file into the registry.
+  subroutine TFileRegistry_register(this, unit)
+
+    !> Instance
+    class(TFileRegistry), intent(inout) :: this
+
+    !> File unit to register
+    integer, intent(in) :: unit
+
+    integer, allocatable :: buffer(:)
+
+    if (this%nRegistered == size(this%registeredFiles)) then
+      allocate(buffer(2 * size(this%registeredFiles)))
+      buffer(1:this%nRegistered) = this%registeredFiles
+      call move_alloc(buffer, this%registeredFiles)
+    end if
+    this%nRegistered = this%nRegistered + 1
+    this%registeredFiles(this%nRegistered) = unit
+
+  end subroutine TFileRegistry_register
+
+
+  !> Checks the status of all registered files and closes those which are still opened.
+  subroutine TFileRegistry_closeAll(this)
+
+    !> Instance
+    class(TFileRegistry), intent(in) :: this
+
+    integer :: unit, ii
+    logical :: tOpen
+
+    do ii = 1, size(this%registeredFiles)
+      unit = this%registeredFiles(ii)
+      inquire(unit=unit, opened=tOpen)
+      if (tOpen) then
+        close(unit)
+      end if
+    end do
+
+  end subroutine TFileRegistry_closeAll
+  
+
+end module fileregistry

--- a/prog/dftb+/lib_common/make.deps
+++ b/prog/dftb+/lib_common/make.deps
@@ -20,29 +20,34 @@ _mod_constants = $(constants.o)
 
 #:if WITH_MPI
 #:if WITH_SCALAPACK
-environment.o: common.fypp _mod_timerarray _mod_mpienv _mod_blacsenv
-environment.o = environment.o $(common.fypp) $(_mod_timerarray) $(_mod_mpienv) $(_mod_blacsenv)
+environment.o: _mod_fileregistry common.fypp _mod_globalenv _mod_timerarray _mod_mpienv _mod_blacsenv
+environment.o = environment.o $(_mod_fileregistry) $(common.fypp) $(_mod_globalenv) $(_mod_timerarray) $(_mod_mpienv) $(_mod_blacsenv)
 _mod_environment: environment.o
 _mod_environment = $(environment.o)
 #:else
-environment.o: common.fypp _mod_timerarray _mod_mpienv
-environment.o = environment.o $(common.fypp) $(_mod_timerarray) $(_mod_mpienv)
+environment.o: _mod_fileregistry common.fypp _mod_globalenv _mod_timerarray _mod_mpienv
+environment.o = environment.o $(_mod_fileregistry) $(common.fypp) $(_mod_globalenv) $(_mod_timerarray) $(_mod_mpienv)
 _mod_environment: environment.o
 _mod_environment = $(environment.o)
 #:endif
 #:else
 #:if WITH_SCALAPACK
-environment.o: common.fypp _mod_timerarray _mod_blacsenv
-environment.o = environment.o $(common.fypp) $(_mod_timerarray) $(_mod_blacsenv)
+environment.o: _mod_fileregistry common.fypp _mod_globalenv _mod_timerarray _mod_blacsenv
+environment.o = environment.o $(_mod_fileregistry) $(common.fypp) $(_mod_globalenv) $(_mod_timerarray) $(_mod_blacsenv)
 _mod_environment: environment.o
 _mod_environment = $(environment.o)
 #:else
-environment.o: common.fypp _mod_timerarray
-environment.o = environment.o $(common.fypp) $(_mod_timerarray)
+environment.o: _mod_fileregistry common.fypp _mod_globalenv _mod_timerarray
+environment.o = environment.o $(_mod_fileregistry) $(common.fypp) $(_mod_globalenv) $(_mod_timerarray)
 _mod_environment: environment.o
 _mod_environment = $(environment.o)
 #:endif
 #:endif
+
+fileregistry.o:
+fileregistry.o = fileregistry.o
+_mod_fileregistry: fileregistry.o
+_mod_fileregistry = $(fileregistry.o)
 
 #:if WITH_MPI
 globalenv.o: common.fypp _mod_mpifx

--- a/prog/dftb+/lib_common/timerarray.F90
+++ b/prog/dftb+/lib_common/timerarray.F90
@@ -54,7 +54,7 @@ contains
     !> Names of the sub-timers to use
     type(TTimerItem), intent(in) :: timerItems(:)
 
-    !> Last level to be included (default: all levels are included)
+    !> Last timer level to be included in printing (default: all)
     integer, intent(in), optional :: maxLevel
 
     !> Optional header message for the timings

--- a/prog/dftb+/prg_dftb/dftbplus.F90
+++ b/prog/dftb+/prg_dftb/dftbplus.F90
@@ -27,9 +27,11 @@ program dftbplus
   call printDftbHeader(releaseName, releaseYear)
   allocate(input)
   call parseHsdInput(input)
+  call TEnvironment_init(env)
   call initProgramVariables(input, env)
   deallocate(input)
   call runDftbPlus(env)
+  call env%destruct()
   call destructGlobalEnv()
 
 end program dftbplus

--- a/prog/dftb+/prg_dftb/main.F90
+++ b/prog/dftb+/prg_dftb/main.F90
@@ -436,10 +436,9 @@ contains
       end if
 
       if (tSccCalc .and. .not. tXlbomd .and. .not. tConverged) then
-        if (tConvrgForces) then
-          call error("SCC is NOT converged, maximal SCC iterations exceeded")
-        else
-          call warning("SCC is NOT converged, maximal SCC iterations exceeded")
+        call warning("SCC is NOT converged, maximal SCC iterations exceeded")
+        if (.not. tConvrgForces) then
+          call env%abort()
         end if
       end if
 
@@ -641,7 +640,6 @@ contains
     call env%globalTimer%startTimer(globalTimers%postGeoOpt)
 
     call destructProgramVariables()
-    call env%globalTimer%writeTimings(msg="DFTB+ running times", maxLevel=timingLevel)
 
   end subroutine runDftbPlus
 

--- a/prog/dftb+/prg_dftb/parser.F90
+++ b/prog/dftb+/prg_dftb/parser.F90
@@ -2606,7 +2606,7 @@ contains
     end if
     call getChildValue(node, "ShowFoldedCoords", ctrl%tShowFoldedCoord, .false.)
   #:if DEBUG > 0
-    call getChildValue(node, "TimingVerbosity", ctrl%timingLevel, 3)
+    call getChildValue(node, "TimingVerbosity", ctrl%timingLevel, -1)
   #:else
     call getChildValue(node, "TimingVerbosity", ctrl%timingLevel, 0)
   #:endif


### PR DESCRIPTION
Environment can be be aborted in a clean way closing open files and
writing collected timing information.

Note: the error on failing scc-convergence has been converted into a warning (I think it is more appropriate), but code stops immediately stops after that.