### PR TITLE
Revert back to behaviour in 17.1 release

### DIFF
--- a/prog/dftb+/prg_dftb/main.F90
+++ b/prog/dftb+/prg_dftb/main.F90
@@ -437,7 +437,7 @@ contains
 
       if (tSccCalc .and. .not. tXlbomd .and. .not. tConverged) then
         call warning("SCC is NOT converged, maximal SCC iterations exceeded")
-        if (.not. tConvrgForces) then
+        if (tConvrgForces) then
           call env%abort()
         end if
       end if


### PR DESCRIPTION
When tConvrgForces = T the code should terminate if not converged at
the end of the SCC loop attempt.