### PR TITLE
Fixed abort without clean up issue

### DIFF
--- a/prog/dftb+/lib_common/environment.F90
+++ b/prog/dftb+/lib_common/environment.F90
@@ -133,7 +133,7 @@ contains
   subroutine TEnvironment_abort(this)
 
     !> Instance
-    class(TEnvironment), intent(out) :: this
+    class(TEnvironment), intent(inout) :: this
 
     call this%destruct()
     call abort()


### PR DESCRIPTION
Tested in serial and parallel, seems to now write timings and files on abort OK.