### PR TITLE
Change default HSD writing choice for modes

### DIFF
--- a/doc/dftb+/manual/modes.tex
+++ b/doc/dftb+/manual/modes.tex
@@ -26,7 +26,7 @@ Additionally optional definitions may be present:
 \begin{ptableh}  
   \kw{DisplayModes} & p & & - & \pref{sec:modes.DisplayModes} \\
   \kw{Atoms} & i+|m &  & 1:-1 & \\
-  \kw{WriteHSDInput} & l & & Yes & \\
+  \kw{WriteHSDInput} & l & & No & \\
   \kw{WriteXMLInput} & l & & No & \\
 \end{ptableh}
 

--- a/prog/modes/initmodes.F90
+++ b/prog/modes/initmodes.F90
@@ -264,7 +264,7 @@ contains
       call destruct(realBuffer)
     end if
 
-    call getChildValue(root, "WriteHSDInput", tWriteHSD, .true.)
+    call getChildValue(root, "WriteHSDInput", tWriteHSD, .false.)
     call getChildValue(root, "WriteXMLInput", tWriteXML, .false.)
 
     !! Issue warning about unprocessed nodes


### PR DESCRIPTION
Switch off HSD output by default in modes, avoiding the default settings running into the large hessian matrix write out issue #13 