### PR TITLE
Use graceful exit when scc does not converge

### DIFF
--- a/prog/dftb+/lib_common/environment.F90
+++ b/prog/dftb+/lib_common/environment.F90
@@ -9,7 +9,7 @@
 
 !> Contains computer environment settings
 module environment
-  use globalenv, only : abort, stdOut
+  use globalenv, only : shutdown, stdOut
   use timerarray
   use fileregistry
 #:if WITH_MPI
@@ -41,7 +41,7 @@ module environment
     !> Global timers
     type(TTimerArray), public :: globalTimer
 
-    !> Registry of files, which may be open and must be closed when environment is aborted
+    !> Registry of files, which may be open and must be closed when environment is shut down
     type(TFileRegistry), public :: fileFinalizer
 
   #:if WITH_MPI
@@ -55,7 +55,7 @@ module environment
 
   contains
     procedure :: destruct => TEnvironment_destruct
-    procedure :: abort => TEnvironment_abort
+    procedure :: shutdown => TEnvironment_shutdown
     procedure :: initGlobalTimer => TEnvironment_initGlobalTimer
   #:if WITH_MPI
     procedure :: initMpi => TEnvironment_initMpi
@@ -129,16 +129,19 @@ contains
   end subroutine TEnvironment_destruct
     
   
-  !> Gracefully cleans up and aborts
-  subroutine TEnvironment_abort(this)
+  !> Gracefully cleans up and shuts down.
+  !>
+  !> Note: This routine must be collectively called by all processes.
+  !>
+  subroutine TEnvironment_shutdown(this)
 
     !> Instance
     class(TEnvironment), intent(inout) :: this
 
     call this%destruct()
-    call abort()
+    call shutdown()
 
-  end subroutine TEnvironment_abort
+  end subroutine TEnvironment_shutdown
 
 
   !> Initlaizes the global timer of the environment.

--- a/prog/dftb+/lib_common/globalenv.F90
+++ b/prog/dftb+/lib_common/globalenv.F90
@@ -23,7 +23,7 @@ module globalenv
   private
 
   public :: initGlobalEnv, destructGlobalEnv
-  public :: abort, synchronizeAll
+  public :: abort, shutdown, synchronizeAll
   public :: stdOut, tIoProc
   public :: withScalapack, withMpi
 
@@ -81,7 +81,24 @@ contains
   end subroutine destructGlobalEnv
 
 
-  !> Aborts program execution.
+  !> Gracefully shuts down environment and stops execution.
+  !>
+  !> Note: this routine must be called collectively by all processes.
+  !>
+  subroutine shutdown()
+
+    call synchronizeAll()
+    call destructGlobalEnv()
+    stop
+
+  end subroutine shutdown
+
+
+  !> Aborts program execution immediately.
+  !>
+  !> Note: if this routine is called by any the processes, execution immediately stops
+  !> without waiting for any other processes.
+  !>
   subroutine abort(errorCode)
 
     !> Error code to emit (default: 1)

--- a/prog/dftb+/prg_dftb/main.F90
+++ b/prog/dftb+/prg_dftb/main.F90
@@ -438,7 +438,7 @@ contains
       if (tSccCalc .and. .not. tXlbomd .and. .not. tConverged) then
         call warning("SCC is NOT converged, maximal SCC iterations exceeded")
         if (tUseConvergedForces) then
-          call env%abort()
+          call env%shutdown()
         end if
       end if
 


### PR DESCRIPTION
Prevents MPI to complain about aborted process despite a clean shutdown.