### PR TITLE
Enable hybrid parallelisation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "external/mpifx/origin"]
 	path = external/mpifx/origin
-	url = https://github.com/dftbplus/mpifx.git
-	branch = master
+	url = https://github.com/aradi/mpifx.git
+	branch = initThread
 [submodule "external/scalapackfx/origin"]
 	path = external/scalapackfx/origin
 	url = https://github.com/dftbplus/scalapackfx.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "external/mpifx/origin"]
 	path = external/mpifx/origin
-	url = https://github.com/aradi/mpifx.git
-	branch = initThread
+	url = https://github.com/dftbplus/mpifx.git
+	branch = master
 [submodule "external/scalapackfx/origin"]
 	path = external/scalapackfx/origin
 	url = https://github.com/dftbplus/scalapackfx.git

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -98,8 +98,8 @@ Compile
   ``BUILDDIR``), but the default location is inside the root of the source tree.
 
 
-Test
-====
+Testing DFTB+
+=============
 
 * After successful compilation, execute the tests with ::
 
@@ -108,7 +108,7 @@ Test
   You may also run the tests in parallel (option ``-j``) in order to speed this
   up.  If you use parallel testing, ensure that the number of OpenMP threads is
   reduced accordingly. As an example, assuming 4 cores in your workstation you
-  could issue::
+  could use::
 
     make -j2 test TEST_OMP_THREADS=2
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -97,21 +97,30 @@ Compile
   build directory location within the `make.config` file (variable
   ``BUILDDIR``), but the default location is inside the root of the source tree.
 
+
+Test
+====
+
 * After successful compilation, execute the tests with ::
 
     make test
 
   You may also run the tests in parallel (option ``-j``) in order to speed this
   up.  If you use parallel testing, ensure that the number of OpenMP threads is
-  set to be 1 via the ``OMP_NUM_THREADS`` environment variable before starting
-  the tests, e.g.::
+  reduced accordingly. As an example, assuming 4 cores in your workstation you
+  could issue::
 
-    export OMP_NUM_THREADS=1
+    make -j2 test TEST_OMP_THREADS=2
 
-  if using the bash shell. If you want to test the MPI-binary with more than one
-  processes, you can set the TESTPROC variable accordingly e.g::
+  If you want to test the MPI-binary with more than one MPI-processes, you can
+  set the TEST_MPI_PROCS variable accordingly e.g::
 
-    make test TESTPROC=2
+    make test TEST_MPI_PROCS=2
+
+  Testing with hybrid (MPI/OpenMP) parallelisation can be specified by setting
+  both, the ``TEST_MPI_PROCS`` and ``TEST_OMP_THREADS`` variables, e.g::
+
+    make test TEST_MPI_PROCS=2 TEST_OMP_THREADS=2
 
 * The compiled executables can be copied into an installation directory by ::
 

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -3016,15 +3016,16 @@ the code. They only take effect, if the code was compiled with MPI-support.
 \item[\is{UseOmpThreads}] Enables the usage of OpenMP-threads (hybrid
   MPI/OpenMP-parallelisation). In order to prevent you from accidently running
   more processes and threads than appropriate for your hardware, this feature is
-  turned off by default. Consequently the MPI-parallelised binary stops if the
-  maximal number of OpenMP-threads is greater than one when DFTB+ is
-  started. (You can usually set the number of maximally allowed OpenMP-threads
-  by setting the \is{OMP\_NUM\_THREADS} environment variable in your shell.)
+  turned off by default. Consequently in this case the MPI-parallelised binary
+  will stop if the maximal number of OpenMP-threads is greater than one when
+  DFTB+ is started. (You can usually set the number of maximally allowed
+  OpenMP-threads by setting the \is{OMP\_NUM\_THREADS} environment variable in
+  your shell.)
 
   You can enable this option if you wish to run DFTB+ with hybrid
-  parallelisation. You would then typically start less MPI-processes than
-  physical cores on each node and set the number of threads accordingly.  This
-  is currently an experimental feature in DFTB+ and is recommended for
+  parallelisation. You would then typically start fewer MPI-processes than
+  physical cores on each node and also set the number of threads accordingly.
+  This is currently an experimental feature in DFTB+ and is recommended for
   experienced users only.
 
 \item[\is{Blacs}] Contain BLACS specific settings. Currently only supports

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -3002,6 +3002,7 @@ the code. They only take effect, if the code was compiled with MPI-support.
 
 \begin{ptable}
   \kw{Groups} & i & 1 & & \\
+  \kw{UseOmpThreads} & l & .false. & & \\
   \kw{Blacs} & p & \cb & & \\
 \end{ptable}
 \begin{description}
@@ -3011,6 +3012,20 @@ the code. They only take effect, if the code was compiled with MPI-support.
   same time. The number of process groups must be a divisor of the total number
   of MPI-processes. Default: 1 (all processes work at the same k-point and spin
   at a given time).
+
+\item[\is{UseOmpThreads}] Enables the usage of OpenMP-threads (hybrid
+  MPI/OpenMP-parallelisation). In order to prevent you from accidently running
+  more processes and threads than appropriate for your hardware, this feature is
+  turned off by default. Consequently the MPI-parallelised binary stops if the
+  maximal number of OpenMP-threads is greater than one when DFTB+ is
+  started. (You can usually set the number of maximally allowed OpenMP-threads
+  by setting the \is{OMP\_NUM\_THREADS} environment variable in your shell.)
+
+  You can enable this option if you wish to run DFTB+ with hybrid
+  parallelisation. You would then typically start less MPI-processes than
+  physical cores on each node and set the number of threads accordingly.  This
+  is currently an experimental feature in DFTB+ and is recommended for
+  experienced users only.
 
 \item[\is{Blacs}] Contain BLACS specific settings. Currently only supports
   \is{BlockSize}, which specifies the row and column block size for the

--- a/external/fsockets/fsockets.f90
+++ b/external/fsockets/fsockets.f90
@@ -39,7 +39,7 @@ module f90sockets
   implicit none
   private
 
-  public :: connect_inet_socket, connect_unix_socket, readbuffer, writebuffer, shutdown_socket
+  public :: connect_inet_socket, connect_unix_socket, readbuffer, writebuffer, close_socket
 
 
   interface writebuffer
@@ -84,10 +84,10 @@ module f90sockets
       integer(c_int), value, intent(in) :: len
     end subroutine readbuffer_socket_c
 
-    subroutine shutdown_socket_c(sockfd) bind(C, name='shutdown_socket')
+    subroutine close_socket_c(sockfd) bind(C, name='close_socket')
       import :: c_int
       integer(c_int), value, intent(in) :: sockfd
-    end subroutine shutdown_socket_c
+    end subroutine close_socket_c
 
   end interface
 
@@ -115,12 +115,12 @@ contains
 
 
   ! Close the socket
-  subroutine shutdown_socket(sockfd)
+  subroutine close_socket(sockfd)
     integer(c_int), intent(in) :: sockfd
 
-    call shutdown_socket_c(sockfd)
+    call close_socket_c(sockfd)
 
-  end subroutine shutdown_socket
+  end subroutine close_socket
 
 
   ! write a float (real)

--- a/external/fsockets/sockets.c
+++ b/external/fsockets/sockets.c
@@ -189,10 +189,9 @@ Args:
 }
 
 
-void shutdown_socket(int sockfd)
-/* Shuts down the socket.
+void close_socket(int sockfd)
+/* Closes the socket.
 */
 {
-  shutdown(sockfd, 2);
   close(sockfd);
 }

--- a/make.config
+++ b/make.config
@@ -37,8 +37,11 @@ WITH_DFTD3 := 0
 # 2 -- level 1 checks plus extra runtime compiler checks
 DEBUG := 0
 
-# Nr. of MPI processes used for testing (not aware of OpenMP shared memory threads)
-TESTPROC := 1
+# Nr. of MPI processes used for testing
+TEST_MPI_PROCS := 1
+
+# Nr. of OpenMP shared memory threads used for testing
+TEST_OMP_THREADS := 1
 
 ################################################################################
 # Architecture dependent settings

--- a/prog/dftb+/lib_common/globalenv.F90
+++ b/prog/dftb+/lib_common/globalenv.F90
@@ -55,7 +55,7 @@ contains
   subroutine initGlobalEnv()
 
   #:if WITH_MPI
-    call mpifx_init()
+    call mpifx_init_thread(requiredThreading=MPI_THREAD_FUNNELED)
     call globalMpiComm%init()
     if (globalMpiComm%master) then
       stdOut = stdOut0

--- a/prog/dftb+/lib_io/ipisocket.F90
+++ b/prog/dftb+/lib_io/ipisocket.F90
@@ -365,7 +365,7 @@ contains
     !> Instance
     class(IpiSocketComm), intent(inout) :: this
 
-    call shutdown_socket(this%socket)
+    call close_socket(this%socket)
     this%tInit = .false.
 
   end subroutine shutdown

--- a/prog/dftb+/make.build
+++ b/prog/dftb+/make.build
@@ -57,7 +57,7 @@ AUTOTEST_CMD := $(AUTOTEST_SCRIPT) -r $(TESTDIR) -w $(AUTOTEST_WORKDIR) \
 CREATE_PRETESTFILE := $(if $(filter test,$(MAKECMDGOALS)),\
 	$(shell $(ROOT)/utils/test/testlist_to_fypp < $(TESTFILE) > $(PROCESSED_TESTFILE).fypp),)
 CREATE_TESTFILE := $(if $(filter test,$(MAKECMDGOALS)),\
-	$(shell $(FYPP) $(FYPPOPT) $(inc-opts) -DNPROC=$(TESTPROC) $(PROCESSED_TESTFILE).fypp > $(PROCESSED_TESTFILE)),)
+	$(shell $(FYPP) $(FYPPOPT) $(inc-opts) -DMPI_PROCS=$(TEST_MPI_PROCS) -DOMP_THREADS=$(TEST_OMP_THREADS) $(PROCESSED_TESTFILE).fypp > $(PROCESSED_TESTFILE)),)
 TESTS := $(if $(filter test,$(MAKECMDGOALS)),\
 	$(shell $(AUTOTEST_CMD) -f $(PROCESSED_TESTFILE) -l),)
 

--- a/prog/dftb+/prg_dftb/inputdata.F90
+++ b/prog/dftb+/prg_dftb/inputdata.F90
@@ -52,6 +52,9 @@ module inputdata_module
     !> Blacs options
     type(TBlacsOpts) :: blacsOpts
 
+    !> Whether hybrid parallelisation is enable
+    logical :: tOmpThreads
+
   end type TParallelOpts
 
 

--- a/prog/dftb+/prg_dftb/parser.F90
+++ b/prog/dftb+/prg_dftb/parser.F90
@@ -3385,6 +3385,7 @@ contains
       end if
       allocate(parallelOpts)
       call getChildValue(node, "Groups", parallelOpts%nGroup, 1)
+      call getChildValue(node, "UseOmpThreads", parallelOpts%tOmpThreads, .not. withMpi)
       call readBlacs(node, parallelOpts%blacsOpts)
     end if
 

--- a/sys/make.x86_64-linux-gnu
+++ b/sys/make.x86_64-linux-gnu
@@ -13,22 +13,21 @@ FXX = mpif90
 CC = gcc
 
 # Compiler options
-FXXOPT = -O2 -funroll-all-loops
+FXXOPT = -O2 -funroll-all-loops -fopenmp
 CCOPT = -O2 -funroll-all-loops -fall-intrinsics
 
 # Linker
 LN = $(FXX)
-LNOPT =
+LNOPT = -fopenmp
 
 # How to link specific libraries
 
 # ScaLAPACK
 SCALAPACKDIR = /usr/lib
-LIB_SCALAPACK = -L$(SCALAPACKDIR) -lscalapack -L$(ATLASDIR)
+LIB_SCALAPACK = -L$(SCALAPACKDIR) -lscalapack
 
 # LAPACK/BLAS
-ATLASDIR = /usr/lib
-LIB_LAPACK = -L$(ATLASDIR) -llapack -lf77blas -lcblas -latlas
+LIB_LAPACK = -llapack -lblas
 
 # Any other libraries to be linked
 OTHERLIBS =
@@ -38,7 +37,7 @@ M4 = m4
 M4OPT = 
 
 # Command to run the test binary
-TESTRUNNER = mpirun -n $(TESTPROC)
+TESTRUNNER = env OMP_NUM_THREADS=$(TEST_OMP_THREADS) mpiexec -n $(TEST_MPI_PROCS)
 
 else
 ############################################################################
@@ -60,15 +59,14 @@ LNOPT = -fopenmp
 # How to link specific libraries
 
 # LAPACK/BLAS
-# Consider using a threaded LAPACK/BLAS implementation for full performance
-ATLASDIR = /usr/lib
-LIB_LAPACK = -L$(ATLASDIR) -llapack -lf77blas -lcblas -latlas
+# Make sure you use threaded LAPACK/BLAS (e.g. openBLAS) for full performance!
+LIB_LAPACK = -llapack -lblas
 
 # Any other libraries to be linked
-OTHERLIBS = -lgomp -lpthread
+OTHERLIBS =
 
 # Command to run a binary
-TESTRUNNER =
+TESTRUNNER = env OMP_NUM_THREADS=$(TEST_OMP_THREADS)
 
 endif
 
@@ -90,12 +88,12 @@ LIBOPT =
 # Override options for different DEBUG modes
 ifeq ($(strip $(DEBUG)),1)
     OTHERLIBS = 
-    FXXOPT = -g -Wall -std=f2008 -pedantic
+    FXXOPT = -fopenmp -g -Wall -std=f2008 -pedantic
     CCOPT = -g -Wall -pedantic -fall-intrinsics
 endif
 
 ifeq ($(strip $(DEBUG)),2)
     OTHERLIBS = 
-    FXXOPT = -g -Wall -std=f2008 -pedantic -fbounds-check
+    FXXOPT = -fopenmp -g -Wall -std=f2008 -pedantic -fbounds-check
     CCOPT = -g -Wall -pedantic -fall-intrinsics -fbounds-check
 endif

--- a/sys/make.x86_64-linux-intel
+++ b/sys/make.x86_64-linux-intel
@@ -13,7 +13,7 @@ FXX = mpif90
 CC = icc
 
 # Compiler options
-FXXOPT = -O2 -ip -standard-semantics -heap-arrays 10
+FXXOPT = -O2 -qopenmp -ip -standard-semantics -heap-arrays 10
 CCOPT = -O2 -ip
 
 # Linker
@@ -28,7 +28,7 @@ MKL_LIBDIR = $(MKLROOT)/lib/intel64
 LIB_SCALAPACK = -L$(MKL_LIBDIR) -lmkl_scalapack_lp64 -lmkl_blacs_intelmpi_lp64
 
 # LAPACK/BLAS
-LIB_LAPACK = -L$(MKL_LIBDIR) -lmkl_intel_lp64 -lmkl_sequential -lmkl_core
+LIB_LAPACK = -L$(MKL_LIBDIR) -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core
 
 # Any other libraries to be linked
 OTHERLIBS = -liomp5
@@ -38,7 +38,7 @@ M4 = m4
 M4OPT = 
 
 # Command to run the test binary
-TESTRUNNER = mpirun -n $(TESTPROC)
+TESTRUNNER = env OMP_NUM_THREADS=$(TEST_OMP_THREADS) mpiexec -n $(TEST_MPI_PROCS)
 
 else
 ############################################################################
@@ -55,20 +55,19 @@ CCOPT = -O2 -ip
 
 # Linker
 LN = $(FXX)
-LNOPT = -static
+LNOPT =
 
 # How to link specific libraries
 
 # LAPACK/BLAS
 MKL_LIBDIR = $(MKLROOT)/lib/intel64
-LIB_LAPACK   = -L$(MKL_LIBDIR) -Wl,--start-group -lmkl_intel_lp64 \
-  -lmkl_intel_thread -lmkl_core -Wl,--end-group
+LIB_LAPACK   = -L$(MKL_LIBDIR) -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core
 
 # Any other libraries to be linked
-OTHERLIBS = -liomp5 -pthread
+OTHERLIBS = -liomp5
 
 # Command to run a binary
-TESTRUNNER =
+TESTRUNNER = env OMP_NUM_THREADS=$(TEST_OMP_THREADS)
 
 endif
 
@@ -89,10 +88,10 @@ LIBOPT =
 
 # Override options for different DEBUG modes
 ifeq ($(strip $(DEBUG)),1)
-    FXXOPT = -g -warn all -stand f08 -standard-semantics -diag-error-limit 1 -traceback
+    FXXOPT = -qopenmp -g -warn all -stand f08 -standard-semantics -diag-error-limit 1 -traceback
     CCOPT = -g -warn all
 endif
 ifeq ($(strip $(DEBUG)),2)
-    FXXOPT = -g -warn all -stand f08 -standard-semantics -check -diag-error-limit 1 -traceback
+    FXXOPT = -qopenmp -g -warn all -stand f08 -standard-semantics -check -diag-error-limit 1 -traceback
     CCOPT = -g -warn all -check
 endif

--- a/sys/make.x86_64-linux-nag
+++ b/sys/make.x86_64-linux-nag
@@ -94,10 +94,10 @@ LIBOPT =
 
 # Override options for different DEBUG modes
 ifeq ($(strip $(DEBUG)),1)
-    FXXOPT = -openmp -ieee=full -f2008 -g -gline -mismatch
+    FXXOPT = -ieee=full -f2008 -g -gline -mismatch
     CCOPT = -g -Wall -pedantic -fall-intrinsics
 endif
 ifeq ($(strip $(DEBUG)),2)
-    FXXOPT = -openmp -ieee=full -f2008 -g -gline -C=all  -nan -mtrace=all -mismatch
+    FXXOPT = -ieee=full -f2008 -g -gline -C=all -nan -mtrace=all -mismatch
     CCOPT = -g -Wall -pedantic -fall-intrinsics -fbounds-check
 endif

--- a/sys/make.x86_64-linux-nag
+++ b/sys/make.x86_64-linux-nag
@@ -13,12 +13,12 @@ FXX = mpif90
 CC = gcc
 
 # Compiler options
-FXXOPT = -O2 -ieee=full -mismatch
+FXXOPT = -O2 -ieee=full -mismatch -openmp
 CCOPT = -O2 -funroll-all-loops -fall-intrinsics
 
 # Linker
 LN = $(FXX)
-LNOPT =
+LNOPT = -openmp
 
 # How to link specific libraries
 
@@ -27,8 +27,7 @@ SCALAPACKDIR = /usr/lib
 LIB_SCALAPACK = -L$(SCALAPACKDIR) -lscalapack
 
 # LAPACK/BLAS
-ATLASDIR = /usr/lib
-LIB_LAPACK =  -L$(ATLASDIR) -llapack -lf77blas -lcblas -latlas
+LIB_LAPACK = -llapack -lblas
 
 # Any other libraries to be linked
 OTHERLIBS =
@@ -38,7 +37,7 @@ M4 = m4
 M4OPT = 
 
 # Command to run the test binary
-TESTRUNNER = mpirun -n $(TESTPROC)
+TESTRUNNER = env OMP_NUM_THREADS=$(TEST_OMP_THREADS) mpiexec -n $(TEST_MPI_PROCS)
 
 else
 ############################################################################
@@ -67,15 +66,14 @@ endif
 # How to link specific libraries
 
 # LAPACK/BLAS
-# Consider using a threaded LAPACK/BLAS implementation for full performance
-ATLASDIR = /usr/lib
-LIB_LAPACK = -L$(ATLASDIR) -llapack -lf77blas -lcblas -latlas
+# Make sure you use threaded LAPACK/BLAS (e.g. openBLAS) for full performance
+LIB_LAPACK = -llapack -lblas
 
 # Any other libraries to be linked
 OTHERLIBS =
 
 # Command to run a binary
-TESTRUNNER =
+TESTRUNNER = env OMP_NUM_THREADS=$(TEST_OMP_THREADS)
 
 endif
 
@@ -96,12 +94,10 @@ LIBOPT =
 
 # Override options for different DEBUG modes
 ifeq ($(strip $(DEBUG)),1)
-    FXXOPT = -ieee=full -f2008 -g -gline -mismatch
-    LNOPT =
+    FXXOPT = -openmp -ieee=full -f2008 -g -gline -mismatch
     CCOPT = -g -Wall -pedantic -fall-intrinsics
 endif
 ifeq ($(strip $(DEBUG)),2)
-    FXXOPT = -ieee=full -f2008 -g -gline -C=all  -nan -mtrace=all -mismatch
-    LNOPT =
+    FXXOPT = -openmp -ieee=full -f2008 -g -gline -C=all  -nan -mtrace=all -mismatch
     CCOPT = -g -Wall -pedantic -fall-intrinsics -fbounds-check
 endif

--- a/sys/make.x86_64-linux-pgi
+++ b/sys/make.x86_64-linux-pgi
@@ -11,11 +11,11 @@ ifeq ($(strip $(WITH_MPI)),1)
 ############################################################################
 
 # Compilers
-FXX = mpifort
+FXX = mpif90
 CC = pgcc
 
 # Compiler options
-FXXOPT = -O2 -Mallocatable=03
+FXXOPT = -O2 -Mallocatable=03 -mp
 CCOPT = -O2
 
 # Linker
@@ -28,7 +28,6 @@ LNOPT =
 LIB_SCALAPACK = -L$(PGI_LIBDIR)/scalapack/scalapack-2.0.2/openmpi-2.1.2/lib -lscalapack
 
 # LAPACK/BLAS
-ATLASDIR = /usr/lib
 LIB_LAPACK = -L$(PGI_LIBDIR) -llapack -lblas
 
 # Any other libraries to be linked
@@ -39,7 +38,7 @@ M4 = m4
 M4OPT =
 
 # Command to run the test binary
-TESTRUNNER = mpirun -n $(TESTPROC)
+TESTRUNNER = env OMP_NUM_THREADS=$(TEST_OMP_THREADS) mpiexec -n $(TEST_MPI_PROCS)
 
 else
 ############################################################################
@@ -61,14 +60,13 @@ LNOPT =
 # How to link specific libraries
 
 # LAPACK/BLAS
-# Consider using a threaded LAPACK/BLAS implementation for full performance
 LIB_LAPACK = -L$(PGI_LIBDIR) -llapack -lblas
 
 # Any other libraries to be linked
 OTHERLIBS =
 
 # Command to run a binary
-TESTRUNNER =
+TESTRUNNER = env OMP_NUM_THREADS=$(TEST_OMP_THREADS)
 
 endif
 
@@ -89,8 +87,8 @@ LIBOPT =
 
 # Override options for different DEBUG modes
 ifeq ($(strip $(DEBUG)),1)
-    FXXOPT = -g -traceback -Mallocatable=03
+    FXXOPT = -mp -g -traceback -Mallocatable=03
 endif
 ifeq ($(strip $(DEBUG)),2)
-    FXXOPT = -g -C -Mchkptr -traceback -Mallocatable=03
+    FXXOPT = -mp -g -C -Mchkptr -traceback -Mallocatable=03
 endif

--- a/test/prog/dftb+/analysis/10-0Ctube_ESP/dftb_in.hsd
+++ b/test/prog/dftb+/analysis/10-0Ctube_ESP/dftb_in.hsd
@@ -99,3 +99,10 @@ Options = {
 ParserOptions = {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/analysis/C2H4_localise/dftb_in.hsd
+++ b/test/prog/dftb+/analysis/C2H4_localise/dftb_in.hsd
@@ -40,3 +40,10 @@ ParserOptions = {
   ParserVersion = 4
 }
 
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/analysis/C60_ESP/dftb_in.hsd
+++ b/test/prog/dftb+/analysis/C60_ESP/dftb_in.hsd
@@ -96,3 +96,10 @@ Analysis = {
 ParserOptions = {
   ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/analysis/Ga4As4_ESP/dftb_in.hsd
+++ b/test/prog/dftb+/analysis/Ga4As4_ESP/dftb_in.hsd
@@ -51,3 +51,10 @@ Options = {
 ParserOptions = {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/analysis/H2O_ESP/dftb_in.hsd
+++ b/test/prog/dftb+/analysis/H2O_ESP/dftb_in.hsd
@@ -59,3 +59,10 @@ Options = {
 ParserOptions = {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/analysis/H2O_mdESP/dftb_in.hsd
+++ b/test/prog/dftb+/analysis/H2O_mdESP/dftb_in.hsd
@@ -57,5 +57,9 @@ Parallel = {
   Blacs = BlockSize {
     4 # very small for test purposes
   }
+
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
 }
 

--- a/test/prog/dftb+/analysis/graphene_localise/dftb_in.hsd
+++ b/test/prog/dftb+/analysis/graphene_localise/dftb_in.hsd
@@ -49,3 +49,10 @@ Analysis = {
 ParserOptions = {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/derivatives/C6H6_scc/dftb_in.hsd
+++ b/test/prog/dftb+/derivatives/C6H6_scc/dftb_in.hsd
@@ -45,3 +45,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/derivatives/Si_2_Delta/dftb_in.hsd
+++ b/test/prog/dftb+/derivatives/Si_2_Delta/dftb_in.hsd
@@ -47,3 +47,10 @@ Analysis = {
 ParserOptions = {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/derivatives/Si_2_Richardson/dftb_in.hsd
+++ b/test/prog/dftb+/derivatives/Si_2_Richardson/dftb_in.hsd
@@ -45,3 +45,10 @@ Analysis = {
 ParserOptions = {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/dftb+u/CH3/dftb_in.hsd
+++ b/test/prog/dftb+/dftb+u/CH3/dftb_in.hsd
@@ -56,3 +56,10 @@ ParserOptions = {
   ParserVersion = 3
 }
 
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/dftb+u/Fe4/dftb_in.hsd
+++ b/test/prog/dftb+/dftb+u/Fe4/dftb_in.hsd
@@ -51,3 +51,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/dftb+u/Fe4_read/dftb_in.hsd
+++ b/test/prog/dftb+/dftb+u/Fe4_read/dftb_in.hsd
@@ -55,3 +55,10 @@ Analysis = {
 ParserOptions = {
   ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/dftb+u/GaAs_2/dftb_in.hsd
+++ b/test/prog/dftb+/dftb+u/GaAs_2/dftb_in.hsd
@@ -73,3 +73,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/dispersion/2H2O/dftb_in.hsd
+++ b/test/prog/dftb+/dispersion/2H2O/dftb_in.hsd
@@ -59,3 +59,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/dispersion/2H2O_uff/dftb_in.hsd
+++ b/test/prog/dftb+/dispersion/2H2O_uff/dftb_in.hsd
@@ -56,3 +56,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/dispersion/DNA-damped/dftb_in.hsd
+++ b/test/prog/dftb+/dispersion/DNA-damped/dftb_in.hsd
@@ -163,3 +163,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/dispersion/DNA/dftb_in.hsd
+++ b/test/prog/dftb+/dispersion/DNA/dftb_in.hsd
@@ -158,3 +158,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/dispersion/DNA_dftd3_bj/dftb_in.hsd
+++ b/test/prog/dftb+/dispersion/DNA_dftd3_bj/dftb_in.hsd
@@ -47,3 +47,10 @@ Options {
 ParserOptions {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/dispersion/DNA_dftd3_zero/dftb_in.hsd
+++ b/test/prog/dftb+/dispersion/DNA_dftd3_zero/dftb_in.hsd
@@ -44,3 +44,10 @@ Options {
 ParserOptions {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/dispersion/DNA_uff/dftb_in.hsd
+++ b/test/prog/dftb+/dispersion/DNA_uff/dftb_in.hsd
@@ -100,3 +100,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/Cchain_lattice/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/Cchain_lattice/dftb_in.hsd
@@ -41,3 +41,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/Cchain_lattice_lbfgs/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/Cchain_lattice_lbfgs/dftb_in.hsd
@@ -41,3 +41,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/GaAs_8_latconst/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/GaAs_8_latconst/dftb_in.hsd
@@ -45,3 +45,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/GaAs_8_latconst_lbfgs/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/GaAs_8_latconst_lbfgs/dftb_in.hsd
@@ -45,3 +45,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/H2O-constr/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/H2O-constr/dftb_in.hsd
@@ -48,3 +48,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/H2O-nonscc/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/H2O-nonscc/dftb_in.hsd
@@ -38,3 +38,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/H2O/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/H2O/dftb_in.hsd
@@ -46,3 +46,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/H2O_lbfgs/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/H2O_lbfgs/dftb_in.hsd
@@ -47,3 +47,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/Si_2_latconst/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/Si_2_latconst/dftb_in.hsd
@@ -39,3 +39,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/Si_2_lattice/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/Si_2_lattice/dftb_in.hsd
@@ -38,3 +38,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/Si_2_lattice_lbfgs/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/Si_2_lattice_lbfgs/dftb_in.hsd
@@ -38,3 +38,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/Si_6/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/Si_6/dftb_in.hsd
@@ -45,3 +45,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/Vsi+O-nonscc/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/Vsi+O-nonscc/dftb_in.hsd
@@ -78,3 +78,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/Vsi+O/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/Vsi+O/dftb_in.hsd
@@ -84,3 +84,10 @@ ParserOptions = {
   ParserVersion = 4
 }
 
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/Vsi+O_lbfgs/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/Vsi+O_lbfgs/dftb_in.hsd
@@ -84,3 +84,10 @@ ParserOptions = {
   ParserVersion = 4
 }
 
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/diamond_isotropic/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/diamond_isotropic/dftb_in.hsd
@@ -45,3 +45,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/geoopt/diamond_presure/dftb_in.hsd
+++ b/test/prog/dftb+/geoopt/diamond_presure/dftb_in.hsd
@@ -45,3 +45,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/legacy/Si2_oldSKinterp/dftb_in.hsd
+++ b/test/prog/dftb+/legacy/Si2_oldSKinterp/dftb_in.hsd
@@ -43,3 +43,10 @@ Options = {
 ParserOptions = {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/legacy/Si2_polyRep/dftb_in.hsd
+++ b/test/prog/dftb+/legacy/Si2_polyRep/dftb_in.hsd
@@ -45,3 +45,10 @@ Options = {
 ParserOptions = {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/legacy/SiC_polyRep/dftb_in.hsd
+++ b/test/prog/dftb+/legacy/SiC_polyRep/dftb_in.hsd
@@ -48,3 +48,10 @@ Options = {
 ParserOptions = {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/DNA/dftb_in.hsd
+++ b/test/prog/dftb+/md/DNA/dftb_in.hsd
@@ -131,3 +131,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/DNA_Berendsen2/dftb_in.hsd
+++ b/test/prog/dftb+/md/DNA_Berendsen2/dftb_in.hsd
@@ -131,3 +131,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/H2O-extfield/dftb_in.hsd
+++ b/test/prog/dftb+/md/H2O-extfield/dftb_in.hsd
@@ -48,3 +48,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/H3/dftb_in.hsd
+++ b/test/prog/dftb+/md/H3/dftb_in.hsd
@@ -44,3 +44,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/H3_isotopes/dftb_in.hsd
+++ b/test/prog/dftb+/md/H3_isotopes/dftb_in.hsd
@@ -49,3 +49,10 @@ ParserOptions = {
     ParserVersion = 5
 }
 
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/SiC64-xlbomdfast-T0/dftb_in.hsd
+++ b/test/prog/dftb+/md/SiC64-xlbomdfast-T0/dftb_in.hsd
@@ -179,3 +179,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/SiC64-xlbomdfast/dftb_in.hsd
+++ b/test/prog/dftb+/md/SiC64-xlbomdfast/dftb_in.hsd
@@ -182,3 +182,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/SiH-surface/dftb_in.hsd
+++ b/test/prog/dftb+/md/SiH-surface/dftb_in.hsd
@@ -92,3 +92,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/Si_8-tempprofile/dftb_in.hsd
+++ b/test/prog/dftb+/md/Si_8-tempprofile/dftb_in.hsd
@@ -58,3 +58,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/Si_8-thermostat/dftb_in.hsd
+++ b/test/prog/dftb+/md/Si_8-thermostat/dftb_in.hsd
@@ -56,3 +56,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/Si_8-thermostat2/dftb_in.hsd
+++ b/test/prog/dftb+/md/Si_8-thermostat2/dftb_in.hsd
@@ -57,3 +57,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/Si_8/dftb_in.hsd
+++ b/test/prog/dftb+/md/Si_8/dftb_in.hsd
@@ -56,3 +56,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/Si_8_NHC/dftb_in.hsd
+++ b/test/prog/dftb+/md/Si_8_NHC/dftb_in.hsd
@@ -51,3 +51,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/Si_8_NHC_restart/dftb_in.hsd
+++ b/test/prog/dftb+/md/Si_8_NHC_restart/dftb_in.hsd
@@ -66,3 +66,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/Si_8_restart/dftb_in.hsd
+++ b/test/prog/dftb+/md/Si_8_restart/dftb_in.hsd
@@ -61,3 +61,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/ice_Ic/dftb_in.hsd
+++ b/test/prog/dftb+/md/ice_Ic/dftb_in.hsd
@@ -98,3 +98,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/ptcda-xlbomd-ldep/dftb_in.hsd
+++ b/test/prog/dftb+/md/ptcda-xlbomd-ldep/dftb_in.hsd
@@ -95,3 +95,10 @@ ParserOptions {
   ParserVersion = 5
 }
 
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/ptcda-xlbomd/dftb_in.hsd
+++ b/test/prog/dftb+/md/ptcda-xlbomd/dftb_in.hsd
@@ -94,3 +94,10 @@ ParserOptions {
   ParserVersion = 5
 }
 
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/ptcda-xlbomdfast-ldep/dftb_in.hsd
+++ b/test/prog/dftb+/md/ptcda-xlbomdfast-ldep/dftb_in.hsd
@@ -96,3 +96,10 @@ ParserOptions {
   ParserVersion = 5
 }
 
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/md/ptcda-xlbomdfast/dftb_in.hsd
+++ b/test/prog/dftb+/md/ptcda-xlbomdfast/dftb_in.hsd
@@ -93,3 +93,10 @@ ParserOptions {
   ParserVersion = 5
 }
 
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/non-scc/10-0Ctube/dftb_in.hsd
+++ b/test/prog/dftb+/non-scc/10-0Ctube/dftb_in.hsd
@@ -72,3 +72,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/non-scc/10-0Ctube_Efield/dftb_in.hsd
+++ b/test/prog/dftb+/non-scc/10-0Ctube_Efield/dftb_in.hsd
@@ -86,3 +86,10 @@ Analysis = {
   MullikenAnalysis = Yes
   CalculateForces = Yes
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/non-scc/10-10Ctube/dftb_in.hsd
+++ b/test/prog/dftb+/non-scc/10-10Ctube/dftb_in.hsd
@@ -73,3 +73,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/non-scc/CH4/dftb_in.hsd
+++ b/test/prog/dftb+/non-scc/CH4/dftb_in.hsd
@@ -47,3 +47,10 @@ Analysis = {
     }  
   }  
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/non-scc/GaAs_2/dftb_in.hsd
+++ b/test/prog/dftb+/non-scc/GaAs_2/dftb_in.hsd
@@ -70,3 +70,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/non-scc/HBDI-cationic/dftb_in.hsd
+++ b/test/prog/dftb+/non-scc/HBDI-cationic/dftb_in.hsd
@@ -60,3 +60,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/non-scc/HBDI-neutral/dftb_in.hsd
+++ b/test/prog/dftb+/non-scc/HBDI-neutral/dftb_in.hsd
@@ -60,3 +60,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/non-scc/Si41C23N35/dftb_in.hsd
+++ b/test/prog/dftb+/non-scc/Si41C23N35/dftb_in.hsd
@@ -263,3 +263,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/non-scc/Si_2/dftb_in.hsd
+++ b/test/prog/dftb+/non-scc/Si_2/dftb_in.hsd
@@ -39,3 +39,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/non-scc/Si_216/dftb_in.hsd
+++ b/test/prog/dftb+/non-scc/Si_216/dftb_in.hsd
@@ -255,3 +255,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/non-scc/Si_2_independentk/dftb_in.hsd
+++ b/test/prog/dftb+/non-scc/Si_2_independentk/dftb_in.hsd
@@ -45,3 +45,10 @@ ParserOptions = {
     ParserVersion = 5
 }
 
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/non-scc/Si_384/dftb_in.hsd
+++ b/test/prog/dftb+/non-scc/Si_384/dftb_in.hsd
@@ -418,3 +418,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/non-scc/decapentaene/dftb_in.hsd
+++ b/test/prog/dftb+/non-scc/decapentaene/dftb_in.hsd
@@ -51,3 +51,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/10-0Ctube-extfield/dftb_in.hsd
+++ b/test/prog/dftb+/scc/10-0Ctube-extfield/dftb_in.hsd
@@ -82,3 +82,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/2H2O-3rdorder/dftb_in.hsd
+++ b/test/prog/dftb+/scc/2H2O-3rdorder/dftb_in.hsd
@@ -40,3 +40,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/2H2O-3rdorder_read/dftb_in.hsd
+++ b/test/prog/dftb+/scc/2H2O-3rdorder_read/dftb_in.hsd
@@ -45,3 +45,10 @@ Analysis = {
 ParserOptions = {
   ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/C2H6_3rdfull-damp/dftb_in.hsd
+++ b/test/prog/dftb+/scc/C2H6_3rdfull-damp/dftb_in.hsd
@@ -40,3 +40,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/C2H6_3rdfull/dftb_in.hsd
+++ b/test/prog/dftb+/scc/C2H6_3rdfull/dftb_in.hsd
@@ -40,3 +40,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/C4H8_3rdfull-damp/dftb_in.hsd
+++ b/test/prog/dftb+/scc/C4H8_3rdfull-damp/dftb_in.hsd
@@ -45,3 +45,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/C4H8_3rdfull/dftb_in.hsd
+++ b/test/prog/dftb+/scc/C4H8_3rdfull/dftb_in.hsd
@@ -44,3 +44,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/C60/dftb_in.hsd
+++ b/test/prog/dftb+/scc/C60/dftb_in.hsd
@@ -90,3 +90,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/C60_Fermi/dftb_in.hsd
+++ b/test/prog/dftb+/scc/C60_Fermi/dftb_in.hsd
@@ -90,3 +90,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/GaAs_2/dftb_in.hsd
+++ b/test/prog/dftb+/scc/GaAs_2/dftb_in.hsd
@@ -42,3 +42,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/GaAs_2_customU/dftb_in.hsd
+++ b/test/prog/dftb+/scc/GaAs_2_customU/dftb_in.hsd
@@ -49,3 +49,10 @@ Analysis {
 ParserOptions {
   ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/H-chain/dftb_in.hsd
+++ b/test/prog/dftb+/scc/H-chain/dftb_in.hsd
@@ -31,3 +31,10 @@ Options {
 ParserOptions {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/H2O+CH3COOH-3rdorder/dftb_in.hsd
+++ b/test/prog/dftb+/scc/H2O+CH3COOH-3rdorder/dftb_in.hsd
@@ -46,3 +46,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/H2O-extchrg-blur/dftb_in.hsd
+++ b/test/prog/dftb+/scc/H2O-extchrg-blur/dftb_in.hsd
@@ -50,3 +50,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/H2O-extchrg-direct/dftb_in.hsd
+++ b/test/prog/dftb+/scc/H2O-extchrg-direct/dftb_in.hsd
@@ -50,3 +50,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/H2O-extchrg-periodic/dftb_in.hsd
+++ b/test/prog/dftb+/scc/H2O-extchrg-periodic/dftb_in.hsd
@@ -49,3 +49,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/H2O-extchrg/dftb_in.hsd
+++ b/test/prog/dftb+/scc/H2O-extchrg/dftb_in.hsd
@@ -41,3 +41,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/H2O-extfield/dftb_in.hsd
+++ b/test/prog/dftb+/scc/H2O-extfield/dftb_in.hsd
@@ -39,3 +39,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/H2O2-3rdfull-ldep/dftb_in.hsd
+++ b/test/prog/dftb+/scc/H2O2-3rdfull-ldep/dftb_in.hsd
@@ -37,3 +37,10 @@ Analysis {
 ParserOptions {
   ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/H2O2_3rdfull-damp/dftb_in.hsd
+++ b/test/prog/dftb+/scc/H2O2_3rdfull-damp/dftb_in.hsd
@@ -36,3 +36,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/H2O2_3rdfull/dftb_in.hsd
+++ b/test/prog/dftb+/scc/H2O2_3rdfull/dftb_in.hsd
@@ -36,3 +36,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/H3/dftb_in.hsd
+++ b/test/prog/dftb+/scc/H3/dftb_in.hsd
@@ -36,3 +36,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/SiC64+V_chgconstr/dftb_in.hsd
+++ b/test/prog/dftb+/scc/SiC64+V_chgconstr/dftb_in.hsd
@@ -115,3 +115,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/SiC64+V_dynforce/dftb_in.hsd
+++ b/test/prog/dftb+/scc/SiC64+V_dynforce/dftb_in.hsd
@@ -113,4 +113,8 @@ ParserOptions {
 
 Parallel {
   Groups = 2
+
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
 }

--- a/test/prog/dftb+/scc/SiC64+V_dynforce_groups/dftb_in.hsd
+++ b/test/prog/dftb+/scc/SiC64+V_dynforce_groups/dftb_in.hsd
@@ -113,5 +113,9 @@ ParserOptions {
 
 Parallel {
   Groups = 4
+
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
 }
 

--- a/test/prog/dftb+/scc/SiC_32-extchrg-blur/dftb_in.hsd
+++ b/test/prog/dftb+/scc/SiC_32-extchrg-blur/dftb_in.hsd
@@ -119,3 +119,10 @@ Analysis = {
 ParserOptions = {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/scc/SiC_64/dftb_in.hsd
+++ b/test/prog/dftb+/scc/SiC_64/dftb_in.hsd
@@ -107,3 +107,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/sockets/H2O/dftb_in.hsd
+++ b/test/prog/dftb+/sockets/H2O/dftb_in.hsd
@@ -38,3 +38,10 @@ Options {
 ParserOptions {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/sockets/H2O_cluster/dftb_in.hsd
+++ b/test/prog/dftb+/sockets/H2O_cluster/dftb_in.hsd
@@ -32,3 +32,10 @@ Options {
 ParserOptions {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/sockets/diamond/dftb_in.hsd
+++ b/test/prog/dftb+/sockets/diamond/dftb_in.hsd
@@ -33,3 +33,10 @@ Options = {
 ParserOptions = {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/sockets/diamond/prerun.py
+++ b/test/prog/dftb+/sockets/diamond/prerun.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 import struct
 import socket
+import time
 import numpy as np
 import numpy.linalg as la
 from sockettools import frac2cart, readgen, receive_all, a0
@@ -62,6 +63,7 @@ def main():
         unpacked_data = struct.unpack('i', buf)
         print(unpacked_data)
 
+    time.sleep(2)
     connection.shutdown(socket.SHUT_RDWR)
     connection.close()
 

--- a/test/prog/dftb+/sockets/diamond/prerun.sh
+++ b/test/prog/dftb+/sockets/diamond/prerun.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Start a python server to drive the DFTB+ instance
+sleep 2
 ./prerun.py &
 echo "$!" > subprocess.pid
 sleep 2

--- a/test/prog/dftb+/sockets/diamond_exit/dftb_in.hsd
+++ b/test/prog/dftb+/sockets/diamond_exit/dftb_in.hsd
@@ -33,3 +33,10 @@ Options = {
 ParserOptions = {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/sockets/diamond_exit/prerun.py
+++ b/test/prog/dftb+/sockets/diamond_exit/prerun.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 import struct
 import socket
+import time
 import numpy as np
 import numpy.linalg as la
 from sockettools import frac2cart, readgen, receive_all, a0
@@ -66,6 +67,7 @@ def main():
     print("Requesting clean shutdown of DFTB+")
     connection.sendall('EXIT        ')
 
+    time.sleep(2)
     connection.shutdown(socket.SHUT_RDWR)
     connection.close()
 

--- a/test/prog/dftb+/sockets/diamond_exit/prerun.sh
+++ b/test/prog/dftb+/sockets/diamond_exit/prerun.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Start a python server to drive the DFTB+ instance
+sleep 2
 ./prerun.py &
 echo "$!" > subprocess.pid
 sleep 2

--- a/test/prog/dftb+/spin/Fe4/dftb_in.hsd
+++ b/test/prog/dftb+/spin/Fe4/dftb_in.hsd
@@ -46,4 +46,8 @@ ParserOptions {
 
 Parallel {
   Groups = 2
+
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
 }

--- a/test/prog/dftb+/spin/Fe4_Fermi/dftb_in.hsd
+++ b/test/prog/dftb+/spin/Fe4_Fermi/dftb_in.hsd
@@ -48,3 +48,10 @@ Analysis = {
 ParserOptions = {
     ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spin/Fe4_commonFermi/dftb_in.hsd
+++ b/test/prog/dftb+/spin/Fe4_commonFermi/dftb_in.hsd
@@ -50,3 +50,10 @@ Analysis {
 ParserOptions {
   ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spin/Fe4_noncolinear/dftb_in.hsd
+++ b/test/prog/dftb+/spin/Fe4_noncolinear/dftb_in.hsd
@@ -60,3 +60,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spin/GaAs-spin-ext/dftb_in.hsd
+++ b/test/prog/dftb+/spin/GaAs-spin-ext/dftb_in.hsd
@@ -91,3 +91,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spin/GaAs_2/dftb_in.hsd
+++ b/test/prog/dftb+/spin/GaAs_2/dftb_in.hsd
@@ -91,3 +91,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spin/H2/dftb_in.hsd
+++ b/test/prog/dftb+/spin/H2/dftb_in.hsd
@@ -50,3 +50,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spin/H2O-periodic/dftb_in.hsd
+++ b/test/prog/dftb+/spin/H2O-periodic/dftb_in.hsd
@@ -62,3 +62,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spin/H2O/dftb_in.hsd
+++ b/test/prog/dftb+/spin/H2O/dftb_in.hsd
@@ -55,3 +55,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spin/OH_commonFermi/dftb_in.hsd
+++ b/test/prog/dftb+/spin/OH_commonFermi/dftb_in.hsd
@@ -62,3 +62,10 @@ Options {
 ParserOptions {
   ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spinorbit/As4S4/dftb_in.hsd
+++ b/test/prog/dftb+/spinorbit/As4S4/dftb_in.hsd
@@ -56,3 +56,10 @@ Analysis = {
     MullikenAnalysis = Yes
     AtomResolvedEnergies = Yes    
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spinorbit/EuN/dftb_in.hsd
+++ b/test/prog/dftb+/spinorbit/EuN/dftb_in.hsd
@@ -76,3 +76,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spinorbit/EuN_customU/dftb_in.hsd
+++ b/test/prog/dftb+/spinorbit/EuN_customU/dftb_in.hsd
@@ -81,3 +81,10 @@ Options {
 ParserOptions {
   ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spinorbit/Fe2/dftb_in.hsd
+++ b/test/prog/dftb+/spinorbit/Fe2/dftb_in.hsd
@@ -51,3 +51,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spinorbit/Fe2_dual/dftb_in.hsd
+++ b/test/prog/dftb+/spinorbit/Fe2_dual/dftb_in.hsd
@@ -47,3 +47,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spinorbit/GaAs_2/dftb_in.hsd
+++ b/test/prog/dftb+/spinorbit/GaAs_2/dftb_in.hsd
@@ -44,3 +44,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 3
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spinorbit/Si2_dual/dftb_in.hsd
+++ b/test/prog/dftb+/spinorbit/Si2_dual/dftb_in.hsd
@@ -40,3 +40,10 @@ ParserOptions = {
   ParserVersion = 4
 }
 
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/spinorbit/Si_2/dftb_in.hsd
+++ b/test/prog/dftb+/spinorbit/Si_2/dftb_in.hsd
@@ -39,3 +39,10 @@ Options = {
 ParserOptions = {
   ParserVersion = 4
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/tests
+++ b/test/prog/dftb+/tests
@@ -1,162 +1,162 @@
 #! This file will be preprocessed using the same preprocessor options as used
-#! for the compilation and additionally setting NPROC equal to the make variable
-#! $(TESTPROC)
+#! for the compilation and additionally setting MPI_PROCS equal to the make variable
+#! $(TEST_MPI_PROCS) and OMP_THREADS to $(TEST_OMP_THREADS).
 
 #:include 'common.fypp'
 
-derivatives/Si_2_Delta                 #? NPROC <= 1
-legacy/Si2_oldSKinterp                 #? NPROC <= 1
-legacy/Si2_polyRep                     #? NPROC <= 1
-non-scc/Si_2                           #? NPROC <= 1
-non-scc/Si_2_independentk              #? NPROC <= 1
-scc/H2O2_3rdfull-damp                  #? NPROC <= 1
-scc/H3                                 #? NPROC <= 1
-spin/H2                                #? NPROC <= 1
+derivatives/Si_2_Delta                 #? MPI_PROCS <= 1
+legacy/Si2_oldSKinterp                 #? MPI_PROCS <= 1
+legacy/Si2_polyRep                     #? MPI_PROCS <= 1
+non-scc/Si_2                           #? MPI_PROCS <= 1
+non-scc/Si_2_independentk              #? MPI_PROCS <= 1
+scc/H2O2_3rdfull-damp                  #? MPI_PROCS <= 1
+scc/H3                                 #? MPI_PROCS <= 1
+spin/H2                                #? MPI_PROCS <= 1
 
 #! MPI implementation not available
 analysis/C2H4_localise                 #? not WITH_MPI
 analysis/graphene_localise             #? not WITH_MPI
 
-dftb+u/CH3                             #? NPROC <= 1
-dispersion/2H2O                        #? NPROC <= 1
-dispersion/2H2O_uff                    #? NPROC <= 1
-geoopt/H2O-nonscc                      #? NPROC <= 1
-non-scc/CH4                            #? NPROC <= 1
-non-scc/decapentaene                   #? NPROC <= 2
-scc/2H2O-3rdorder                      #? NPROC <= 1
-scc/2H2O-3rdorder_read                 #? NPROC <= 1
-scc/C2H6_3rdfull                       #? NPROC <= 1
-scc/C2H6_3rdfull-damp                  #? NPROC <= 1
-scc/H2O2_3rdfull                       #? NPROC <= 1
-scc/H2O2-3rdfull-ldep                  #? NPROC <= 1
-scc/H2O-extchrg                        #? NPROC <= 1
-scc/H2O-extchrg-blur                   #? NPROC <= 1
-scc/H2O-extchrg-direct                 #? NPROC <= 1
-scc/H2O-extchrg-periodic               #? NPROC <= 1
-scc/H2O-extfield                       #? NPROC <= 1
-spin/H2O-periodic                      #? NPROC <= 1
-spin/OH_commonFermi                    #? NPROC <= 1
-derivatives/Si_2_Richardson            #? NPROC <= 1
-geoopt/H2O-constr                      #? NPROC <= 1
-legacy/SiC_polyRep                     #? NPROC <= 1
-scc/C4H8_3rdfull                       #? NPROC <= 1
-scc/C4H8_3rdfull-damp                  #? NPROC <= 1
-spin/Fe4                               #? NPROC == 2
-spin/Fe4_commonFermi                   #? NPROC <= 2
+dftb+u/CH3                             #? MPI_PROCS <= 1
+dispersion/2H2O                        #? MPI_PROCS <= 1
+dispersion/2H2O_uff                    #? MPI_PROCS <= 1
+geoopt/H2O-nonscc                      #? MPI_PROCS <= 1
+non-scc/CH4                            #? MPI_PROCS <= 1
+non-scc/decapentaene                   #? MPI_PROCS <= 2
+scc/2H2O-3rdorder                      #? MPI_PROCS <= 1
+scc/2H2O-3rdorder_read                 #? MPI_PROCS <= 1
+scc/C2H6_3rdfull                       #? MPI_PROCS <= 1
+scc/C2H6_3rdfull-damp                  #? MPI_PROCS <= 1
+scc/H2O2_3rdfull                       #? MPI_PROCS <= 1
+scc/H2O2-3rdfull-ldep                  #? MPI_PROCS <= 1
+scc/H2O-extchrg                        #? MPI_PROCS <= 1
+scc/H2O-extchrg-blur                   #? MPI_PROCS <= 1
+scc/H2O-extchrg-direct                 #? MPI_PROCS <= 1
+scc/H2O-extchrg-periodic               #? MPI_PROCS <= 1
+scc/H2O-extfield                       #? MPI_PROCS <= 1
+spin/H2O-periodic                      #? MPI_PROCS <= 1
+spin/OH_commonFermi                    #? MPI_PROCS <= 1
+derivatives/Si_2_Richardson            #? MPI_PROCS <= 1
+geoopt/H2O-constr                      #? MPI_PROCS <= 1
+legacy/SiC_polyRep                     #? MPI_PROCS <= 1
+scc/C4H8_3rdfull                       #? MPI_PROCS <= 1
+scc/C4H8_3rdfull-damp                  #? MPI_PROCS <= 1
+spin/Fe4                               #? MPI_PROCS == 2
+spin/Fe4_commonFermi                   #? MPI_PROCS <= 2
 
-timedep/2CH3-Temp                      #? WITH_ARPACK and NPROC <= 1
-timedep/2CH3-Triplet-Temp              #? WITH_ARPACK and NPROC <= 1
-timedep/NO                             #? WITH_ARPACK and NPROC <= 1
-timedep/propadiene_OscWindow           #? WITH_ARPACK and NPROC <= 1
+timedep/2CH3-Temp                      #? WITH_ARPACK and MPI_PROCS <= 1
+timedep/2CH3-Triplet-Temp              #? WITH_ARPACK and MPI_PROCS <= 1
+timedep/NO                             #? WITH_ARPACK and MPI_PROCS <= 1
+timedep/propadiene_OscWindow           #? WITH_ARPACK and MPI_PROCS <= 1
 
-analysis/H2O_ESP                       #? NPROC <= 1
-analysis/H2O_mdESP                     #? NPROC <= 2
-geoopt/H2O_lbfgs                       #? NPROC <= 1
-geoopt/H2O                             #? NPROC <= 1
-md/Si_8_NHC_restart                    #? NPROC <= 1
-non-scc/GaAs_2                         #? NPROC <= 1
-scc/GaAs_2                             #? NPROC <= 1
-scc/GaAs_2_customU                     #? NPROC <= 1
-spinorbit/Fe2_dual                     #? NPROC <= 2
-spinorbit/Si_2                         #? NPROC <= 1
+analysis/H2O_ESP                       #? MPI_PROCS <= 1
+analysis/H2O_mdESP                     #? MPI_PROCS <= 2
+geoopt/H2O_lbfgs                       #? MPI_PROCS <= 1
+geoopt/H2O                             #? MPI_PROCS <= 1
+md/Si_8_NHC_restart                    #? MPI_PROCS <= 1
+non-scc/GaAs_2                         #? MPI_PROCS <= 1
+scc/GaAs_2                             #? MPI_PROCS <= 1
+scc/GaAs_2_customU                     #? MPI_PROCS <= 1
+spinorbit/Fe2_dual                     #? MPI_PROCS <= 2
+spinorbit/Si_2                         #? MPI_PROCS <= 1
 
-timedep/C4H6-S1-Force                  #? WITH_ARPACK and NPROC <= 1
-timedep/C4H6-Singlet                   #? WITH_ARPACK and NPROC <= 1
-timedep/C4H6-Singlet_wfn               #? WITH_ARPACK and NPROC <= 1
-timedep/C4H6-T1-Force                  #? WITH_ARPACK and NPROC <= 1
-timedep/C4H6-Triplet                   #? WITH_ARPACK and NPROC <= 1
+timedep/C4H6-S1-Force                  #? WITH_ARPACK and MPI_PROCS <= 1
+timedep/C4H6-Singlet                   #? WITH_ARPACK and MPI_PROCS <= 1
+timedep/C4H6-Singlet_wfn               #? WITH_ARPACK and MPI_PROCS <= 1
+timedep/C4H6-T1-Force                  #? WITH_ARPACK and MPI_PROCS <= 1
+timedep/C4H6-Triplet                   #? WITH_ARPACK and MPI_PROCS <= 1
 
-dftb+u/Fe4                             #? NPROC <= 2
-dftb+u/Fe4_read                        #? NPROC <= 2
-geoopt/Cchain_lattice_lbfgs            #? NPROC <= 1
-geoopt/Cchain_lattice                  #? NPROC <= 1
-scc/H2O+CH3COOH-3rdorder               #? NPROC <= 1
-spinorbit/Fe2                          #? NPROC <= 4
-non-scc/10-0Ctube_Efield               #? NPROC <= 4
-non-scc/10-10Ctube                     #? NPROC <= 4
-analysis/10-0Ctube_ESP                 #? NPROC <= 4
-md/H2O-extfield                        #? NPROC <= 1
-non-scc/10-0Ctube                      #? NPROC <= 4
-spin/Fe4_noncolinear                   #? NPROC <= 4
-non-scc/HBDI-neutral                   #? NPROC <= 4
-non-scc/HBDI-cationic                  #? NPROC <= 4
-scc/C60                                #? NPROC <= 4
-analysis/C60_ESP                       #? NPROC <= 4
-spin/H2O                               #? NPROC <= 1
+dftb+u/Fe4                             #? MPI_PROCS <= 2
+dftb+u/Fe4_read                        #? MPI_PROCS <= 2
+geoopt/Cchain_lattice_lbfgs            #? MPI_PROCS <= 1
+geoopt/Cchain_lattice                  #? MPI_PROCS <= 1
+scc/H2O+CH3COOH-3rdorder               #? MPI_PROCS <= 1
+spinorbit/Fe2                          #? MPI_PROCS <= 4
+non-scc/10-0Ctube_Efield               #? MPI_PROCS <= 4
+non-scc/10-10Ctube                     #? MPI_PROCS <= 4
+analysis/10-0Ctube_ESP                 #? MPI_PROCS <= 4
+md/H2O-extfield                        #? MPI_PROCS <= 1
+non-scc/10-0Ctube                      #? MPI_PROCS <= 4
+spin/Fe4_noncolinear                   #? MPI_PROCS <= 4
+non-scc/HBDI-neutral                   #? MPI_PROCS <= 4
+non-scc/HBDI-cationic                  #? MPI_PROCS <= 4
+scc/C60                                #? MPI_PROCS <= 4
+analysis/C60_ESP                       #? MPI_PROCS <= 4
+spin/H2O                               #? MPI_PROCS <= 1
 
-timedep/cyclopentadienyl               #? WITH_ARPACK and NPROC <= 1
-timedep/C6H6-Sym                       #? WITH_ARPACK and NPROC <= 1
-timedep/C6H6-Sym_Arnoldi               #? WITH_ARPACK and NPROC <= 1
-timedep/OCH2-S1-Opt                    #? WITH_ARPACK and NPROC <= 1
+timedep/cyclopentadienyl               #? WITH_ARPACK and MPI_PROCS <= 1
+timedep/C6H6-Sym                       #? WITH_ARPACK and MPI_PROCS <= 1
+timedep/C6H6-Sym_Arnoldi               #? WITH_ARPACK and MPI_PROCS <= 1
+timedep/OCH2-S1-Opt                    #? WITH_ARPACK and MPI_PROCS <= 1
 
-md/Si_8_restart                        #? NPROC <= 1
-spin/GaAs_2                            #? NPROC <= 1
-spin/GaAs-spin-ext                     #? NPROC <= 1
-spinorbit/As4S4                        #? NPROC <= 8
+md/Si_8_restart                        #? MPI_PROCS <= 1
+spin/GaAs_2                            #? MPI_PROCS <= 1
+spin/GaAs-spin-ext                     #? MPI_PROCS <= 1
+spinorbit/As4S4                        #? MPI_PROCS <= 8
 
-dispersion/DNA-damped                  #? NPROC <= 4
-md/ice_Ic                              #? NPROC <= 4
-derivatives/C6H6_scc                   #? NPROC <= 1
-dftb+u/GaAs_2                          #? NPROC <= 1
-geoopt/diamond_presure                 #? NPROC <= 1
-scc/C60_Fermi                          #? NPROC <= 4
-scc/10-0Ctube-extfield                 #? NPROC <= 4
-scc/SiC_64                             #? NPROC <= 4
-scc/SiC_32-extchrg-blur                #? NPROC <= 2
-md/H3                                  #? NPROC <= 1
+dispersion/DNA-damped                  #? MPI_PROCS <= 4
+md/ice_Ic                              #? MPI_PROCS <= 4
+derivatives/C6H6_scc                   #? MPI_PROCS <= 1
+dftb+u/GaAs_2                          #? MPI_PROCS <= 1
+geoopt/diamond_presure                 #? MPI_PROCS <= 1
+scc/C60_Fermi                          #? MPI_PROCS <= 4
+scc/10-0Ctube-extfield                 #? MPI_PROCS <= 4
+scc/SiC_64                             #? MPI_PROCS <= 4
+scc/SiC_32-extchrg-blur                #? MPI_PROCS <= 2
+md/H3                                  #? MPI_PROCS <= 1
 
-dispersion/DNA_dftd3_zero              #? WITH_DFTD3 and NPROC <= 4
+dispersion/DNA_dftd3_zero              #? WITH_DFTD3 and MPI_PROCS <= 4
 
-sockets/diamond                        #? WITH_SOCKETS and NPROC <= 1
-sockets/diamond_exit                   #? WITH_SOCKETS and NPROC <= 1
-sockets/H2O                            #? WITH_SOCKETS and NPROC <= 4
-sockets/H2O_cluster                    #? WITH_SOCKETS and NPROC <= 1
+sockets/diamond                        #? WITH_SOCKETS and MPI_PROCS <= 1
+sockets/diamond_exit                   #? WITH_SOCKETS and MPI_PROCS <= 1
+sockets/H2O                            #? WITH_SOCKETS and MPI_PROCS <= 4
+sockets/H2O_cluster                    #? WITH_SOCKETS and MPI_PROCS <= 1
 
-spinorbit/GaAs_2                       #? NPROC <= 1
+spinorbit/GaAs_2                       #? MPI_PROCS <= 1
 
-geoopt/Si_2_latconst                   #? NPROC <= 1
-md/SiH-surface                         #? NPROC <= 4
-geoopt/Si_2_lattice_lbfgs              #? NPROC <= 1
-geoopt/Si_2_lattice                    #? NPROC <= 1
-md/Si_8_NHC                            #? NPROC <= 1
+geoopt/Si_2_latconst                   #? MPI_PROCS <= 1
+md/SiH-surface                         #? MPI_PROCS <= 4
+geoopt/Si_2_lattice_lbfgs              #? MPI_PROCS <= 1
+geoopt/Si_2_lattice                    #? MPI_PROCS <= 1
+md/Si_8_NHC                            #? MPI_PROCS <= 1
 
-timedep/C66O10N4H44_Ewindow            #? WITH_ARPACK and NPROC <= 1
+timedep/C66O10N4H44_Ewindow            #? WITH_ARPACK and MPI_PROCS <= 1
 
-spin/Fe4_Fermi                         #? NPROC <= 2
-non-scc/Si41C23N35                     #? NPROC <= 4
-geoopt/diamond_isotropic               #? NPROC <= 1
-spinorbit/EuN                          #? NPROC <= 2
-geoopt/Si_6                            #? NPROC <= 1
-md/ptcda-xlbomdfast                    #? NPROC <= 4
-spinorbit/EuN_customU                  #? NPROC <= 2
-dispersion/DNA                         #? NPROC <= 4
-spinorbit/Si2_dual                     #? NPROC <= 1
-md/Si_8                                #? NPROC <= 1
-md/Si_8-thermostat2                    #? NPROC <= 1
-geoopt/GaAs_8_latconst_lbfgs           #? NPROC <= 2
-geoopt/GaAs_8_latconst                 #? NPROC <= 2
-analysis/Ga4As4_ESP                    #? NPROC <= 2
-md/Si_8-thermostat                     #? NPROC <= 1
-md/ptcda-xlbomdfast-ldep               #? NPROC <= 4
-md/Si_8-tempprofile                    #? NPROC <= 1
+spin/Fe4_Fermi                         #? MPI_PROCS <= 2
+non-scc/Si41C23N35                     #? MPI_PROCS <= 4
+geoopt/diamond_isotropic               #? MPI_PROCS <= 1
+spinorbit/EuN                          #? MPI_PROCS <= 2
+geoopt/Si_6                            #? MPI_PROCS <= 1
+md/ptcda-xlbomdfast                    #? MPI_PROCS <= 4
+spinorbit/EuN_customU                  #? MPI_PROCS <= 2
+dispersion/DNA                         #? MPI_PROCS <= 4
+spinorbit/Si2_dual                     #? MPI_PROCS <= 1
+md/Si_8                                #? MPI_PROCS <= 1
+md/Si_8-thermostat2                    #? MPI_PROCS <= 1
+geoopt/GaAs_8_latconst_lbfgs           #? MPI_PROCS <= 2
+geoopt/GaAs_8_latconst                 #? MPI_PROCS <= 2
+analysis/Ga4As4_ESP                    #? MPI_PROCS <= 2
+md/Si_8-thermostat                     #? MPI_PROCS <= 1
+md/ptcda-xlbomdfast-ldep               #? MPI_PROCS <= 4
+md/Si_8-tempprofile                    #? MPI_PROCS <= 1
 
-dispersion/DNA_dftd3_bj                #? WITH_DFTD3 and NPROC <= 4
+dispersion/DNA_dftd3_bj                #? WITH_DFTD3 and MPI_PROCS <= 4
 
-geoopt/Vsi+O-nonscc                    #? NPROC <= 4
-non-scc/Si_384                         #? NPROC <= 4
-md/DNA                                 #? NPROC <= 4
-md/DNA_Berendsen2                      #? NPROC <= 4
-md/ptcda-xlbomd                        #? NPROC <= 4
-md/SiC64-xlbomdfast-T0                 #? NPROC <= 4
-md/SiC64-xlbomdfast                    #? NPROC <= 4
+geoopt/Vsi+O-nonscc                    #? MPI_PROCS <= 4
+non-scc/Si_384                         #? MPI_PROCS <= 4
+md/DNA                                 #? MPI_PROCS <= 4
+md/DNA_Berendsen2                      #? MPI_PROCS <= 4
+md/ptcda-xlbomd                        #? MPI_PROCS <= 4
+md/SiC64-xlbomdfast-T0                 #? MPI_PROCS <= 4
+md/SiC64-xlbomdfast                    #? MPI_PROCS <= 4
 
-timedep/C66O10N4H44_OscWindow          #? WITH_ARPACK and NPROC <= 1
-timedep/C60_OscWindow                  #? WITH_ARPACK and NPROC <= 1
-timedep/C60_EandOsc                    #? WITH_ARPACK and NPROC <= 1
+timedep/C66O10N4H44_OscWindow          #? WITH_ARPACK and MPI_PROCS <= 1
+timedep/C60_OscWindow                  #? WITH_ARPACK and MPI_PROCS <= 1
+timedep/C60_EandOsc                    #? WITH_ARPACK and MPI_PROCS <= 1
 
-non-scc/Si_216                         #? NPROC <= 4
-md/ptcda-xlbomd-ldep                   #? NPROC <= 4
-geoopt/Vsi+O_lbfgs                     #? NPROC <= 4
-geoopt/Vsi+O                           #? NPROC <= 4
-scc/SiC64+V_dynforce_groups            #? NPROC <= 8 and NPROC % 4 == 0 
-scc/SiC64+V_dynforce                   #? NPROC <= 4 and NPROC % 2 == 0
+non-scc/Si_216                         #? MPI_PROCS <= 4
+md/ptcda-xlbomd-ldep                   #? MPI_PROCS <= 4
+geoopt/Vsi+O_lbfgs                     #? MPI_PROCS <= 4
+geoopt/Vsi+O                           #? MPI_PROCS <= 4
+scc/SiC64+V_dynforce_groups            #? MPI_PROCS <= 8 and MPI_PROCS % 4 == 0 
+scc/SiC64+V_dynforce                   #? MPI_PROCS <= 4 and MPI_PROCS % 2 == 0

--- a/test/prog/dftb+/timedep/2CH3-Temp/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/2CH3-Temp/dftb_in.hsd
@@ -36,3 +36,10 @@ ExcitedState {
 ParserOptions {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/2CH3-Triplet-Temp/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/2CH3-Triplet-Temp/dftb_in.hsd
@@ -40,3 +40,10 @@ ExcitedState {
 ParserOptions {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/C4H6-S1-Force/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/C4H6-S1-Force/dftb_in.hsd
@@ -38,3 +38,10 @@ Options {
 ParserOptions {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/C4H6-Singlet/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/C4H6-Singlet/dftb_in.hsd
@@ -33,3 +33,10 @@ Options {
 ParserOptions {
     ParserVersion = 5
 }            
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/C4H6-Singlet_wfn/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/C4H6-Singlet_wfn/dftb_in.hsd
@@ -35,3 +35,10 @@ Options {
 ParserOptions {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/C4H6-T1-Force/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/C4H6-T1-Force/dftb_in.hsd
@@ -42,3 +42,10 @@ Options {
 ParserOptions {
     ParserVersion = 5
 }            
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/C4H6-Triplet/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/C4H6-Triplet/dftb_in.hsd
@@ -37,3 +37,10 @@ ExcitedState {
         Symmetry = Triplet
     }
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/C60_EandOsc/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/C60_EandOsc/dftb_in.hsd
@@ -95,3 +95,10 @@ Options = {
 ParserOptions = {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/C60_OscWindow/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/C60_OscWindow/dftb_in.hsd
@@ -93,3 +93,10 @@ Options = {
 ParserOptions = {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/C66O10N4H44_Ewindow/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/C66O10N4H44_Ewindow/dftb_in.hsd
@@ -76,3 +76,10 @@ Options = {
 ParserOptions = {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/C66O10N4H44_OscWindow/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/C66O10N4H44_OscWindow/dftb_in.hsd
@@ -77,3 +77,10 @@ ParserOptions = {
     ParserVersion = 5
 }
 
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/C6H6-Sym/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/C6H6-Sym/dftb_in.hsd
@@ -33,3 +33,10 @@ Options {
 ParserOptions {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/C6H6-Sym_Arnoldi/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/C6H6-Sym_Arnoldi/dftb_in.hsd
@@ -34,3 +34,10 @@ Options {
 ParserOptions {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/NO/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/NO/dftb_in.hsd
@@ -58,3 +58,10 @@ Options {
 ParserOptions {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/OCH2-S1-Opt/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/OCH2-S1-Opt/dftb_in.hsd
@@ -37,3 +37,10 @@ ExcitedState {
 ParserOptions {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/cyclopentadienyl/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/cyclopentadienyl/dftb_in.hsd
@@ -53,3 +53,10 @@ Options {
 ParserOptions {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+

--- a/test/prog/dftb+/timedep/propadiene_OscWindow/dftb_in.hsd
+++ b/test/prog/dftb+/timedep/propadiene_OscWindow/dftb_in.hsd
@@ -43,3 +43,10 @@ ExcitedState {
 ParserOptions {
     ParserVersion = 5
 }
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}
+


### PR DESCRIPTION
* Makefiles modified to enable hybrid (MPI/OpenMP) parallelisation by default.
* Keyword UseOmpThreads added, so that users must request hybrid parallelisation explicitely.
* Socket handling fixed to avoid long timeouts blocking the port.