### PR TITLE
Removed dead variables, added implicit none

### DIFF
--- a/prog/dftb+/lib_common/globalenv.F90
+++ b/prog/dftb+/lib_common/globalenv.F90
@@ -104,7 +104,10 @@ contains
     !> Error code to emit (default: 1)
     integer, intent(in), optional :: errorCode
 
-    integer :: error, errorCode0
+    integer :: errorCode0
+  #:if WITH_MPI
+    integer :: error
+  #:endif
 
     if (.not. present(errorCode)) then
       errorCode0 = 1

--- a/prog/dftb+/lib_common/timerarray.F90
+++ b/prog/dftb+/lib_common/timerarray.F90
@@ -152,7 +152,6 @@ contains
     real(dp) :: totalCpu, totalWall, cpuTime, wallTime, allCpu, allWall
     integer :: iTimer, level, maxLevel
     character :: operation
-    character(100) :: formatStr
     character(:), allocatable :: prefix
 
     if (this%maxLevel < 0) then

--- a/prog/dftb+/lib_dftb/coulomb.F90
+++ b/prog/dftb+/lib_dftb/coulomb.F90
@@ -477,7 +477,6 @@ contains
 
     !> Neighbor summation with local scope for predictable OMP <= 4.0 behaviour
     subroutine addNeighborContribs(iAt1, pNeighList, coords, alpha, invRMat)
-      implicit none
       integer, intent(in) :: iAt1
       type(TDynNeighList), pointer, intent(in) :: pNeighList
       real(dp), intent(in) :: coords(:,:)
@@ -865,7 +864,6 @@ contains
 
     !> Neighbor summation with local scope for predictable OMP <= 4.0 behaviour
     subroutine addNeighborContribs(iAtom1, pNeighList, coords, deltaQAtom, alpha, deriv)
-      implicit none
       integer, intent(in) :: iAtom1
       type(TDynNeighList), pointer, intent(in) :: pNeighList
       real(dp), intent(in) :: coords(:,:)
@@ -1760,9 +1758,8 @@ contains
 
   contains
 
-    !> Neighbor summation with local scope fo predictable OMP <= 4.0 behaviour
+    !> Neighbor summation with local scope for predictable OMP <= 4.0 behaviour
     subroutine addNeighborContribs(iAtom1, pNeighList, coords, alpha, dQAtom, stress)
-      implicit none
       integer, intent(in) :: iAtom1
       type(TDynNeighList), pointer, intent(in) :: pNeighList
       real(dp), intent(in) :: coords(:,:)

--- a/prog/dftb+/lib_dftb/coulomb.F90
+++ b/prog/dftb+/lib_dftb/coulomb.F90
@@ -477,6 +477,7 @@ contains
 
     !> Neighbor summation with local scope for predictable OMP <= 4.0 behaviour
     subroutine addNeighborContribs(iAt1, pNeighList, coords, alpha, invRMat)
+      implicit none
       integer, intent(in) :: iAt1
       type(TDynNeighList), pointer, intent(in) :: pNeighList
       real(dp), intent(in) :: coords(:,:)
@@ -864,6 +865,7 @@ contains
 
     !> Neighbor summation with local scope for predictable OMP <= 4.0 behaviour
     subroutine addNeighborContribs(iAtom1, pNeighList, coords, deltaQAtom, alpha, deriv)
+      implicit none
       integer, intent(in) :: iAtom1
       type(TDynNeighList), pointer, intent(in) :: pNeighList
       real(dp), intent(in) :: coords(:,:)
@@ -1758,10 +1760,11 @@ contains
 
   contains
 
-    !> Neighbor summation with local scope for predictable OMP <= 4.0 behaviour
-    subroutine addNeighborContribs(iAtom1, neighList, coords, alpha, dQAtom, stress)
+    !> Neighbor summation with local scope fo predictable OMP <= 4.0 behaviour
+    subroutine addNeighborContribs(iAtom1, pNeighList, coords, alpha, dQAtom, stress)
+      implicit none
       integer, intent(in) :: iAtom1
-      type(TDynNeighList), pointer, intent(in) :: neighList
+      type(TDynNeighList), pointer, intent(in) :: pNeighList
       real(dp), intent(in) :: coords(:,:)
       real(dp), intent(in) :: dQAtom(:)
       real(dp), intent(in) :: alpha

--- a/prog/dftb+/lib_dftb/externalcharges.F90
+++ b/prog/dftb+/lib_dftb/externalcharges.F90
@@ -116,8 +116,6 @@ contains
     !> Cutoff for the ewald summation
     real(dp), intent(in), optional :: blurWidths(:)
 
-    real(dp), allocatable :: dummy(:,:)
-
     this%nChrg = size(coordsAndCharges, dim=2)
 
     @:ASSERT(size(coordsAndCharges, dim=1) == 4)
@@ -160,7 +158,7 @@ contains
 
 
   !> Updates the module, if the lattice vectors had been changed
-  subroutine updateLatVecs(this, latVecs, recVecs, ewaldCutoff)
+  subroutine updateLatVecs(this, latVecs, recVecs)
 
     !> External charges structure
     class(TExtCharge), intent(inout) :: this
@@ -170,11 +168,6 @@ contains
 
     !> New reciprocal lattice vectors.
     real(dp), intent(in) :: recVecs(:,:)
-
-    !> Cutoff for the Ewald function.
-    real(dp), intent(in) :: ewaldCutoff
-
-    real(dp), allocatable :: dummy(:,:)
 
     @:ASSERT(this%tInitialized .and. this%tPeriodic)
 

--- a/prog/dftb+/lib_dftb/scc.F90
+++ b/prog/dftb+/lib_dftb/scc.F90
@@ -545,7 +545,7 @@ contains
 
     call this%ewaldNeighList%updateLatVecs(latVec, recVec / (2.0_dp * pi))
     if (this%tExtChrg) then
-      call this%extCharge%updateLatVecs(latVec, recVec, maxREwald)
+      call this%extCharge%updateLatVecs(latVec, recVec)
     end if
 
   end subroutine updateLatVecs


### PR DESCRIPTION
For several contained routines in coulomb.F90, they inherit
variable types from their container, so added implicit none.

Removed some unused variables that are not required for serial or
MPI code.