### PR TITLE
Fix hanging on error with parallel WriteHS options

### DIFF
--- a/prog/dftb+/prg_dftb/initprogram.F90
+++ b/prog/dftb+/prg_dftb/initprogram.F90
@@ -2072,8 +2072,8 @@ contains
     tWriteResultsTag = env%tGlobalMaster .and. input%ctrl%tWriteResultsTag
     tWriteDetailedOut = env%tGlobalMaster .and. input%ctrl%tWriteDetailedOut
     tWriteBandDat = env%tGlobalMaster .and. input%ctrl%tWriteBandDat
-    tWriteHS = env%tGlobalMaster .and. input%ctrl%tWriteHS
-    tWriteRealHS = env%tGlobalMaster .and. input%ctrl%tWriteRealHS
+    tWriteHS = input%ctrl%tWriteHS
+    tWriteRealHS = input%ctrl%tWriteRealHS
 
     ! Check if stopfiles already exist and quit if yes
     inquire(file=fStopSCC, exist=tExist)


### PR DESCRIPTION
The `error()` call was only reached in the master process, making some process hanging after error message was printed.