### PR TITLE
Locally export thread number in tests

### DIFF
--- a/prog/dftb+/make.build
+++ b/prog/dftb+/make.build
@@ -64,6 +64,9 @@ TESTS := $(if $(filter test,$(MAKECMDGOALS)),\
 
 .PHONY: $(TESTS) test
 
+# set threads as dictated in make.config
+$(TESTS): export OMP_NUM_THREADS = $(TEST_OMP_THREADS)
+
 # Prepare and run individual tests, possibly in parallel.
 $(TESTS):
 	@$(AUTOTEST_CMD) -P "$(TESTRUNNER)" -p ./dftb+ -Q "$(POSTRUN)" -s P,R \


### PR DESCRIPTION
Partial fix for threaded BLAS using additional threads.

Tests with openBLAS suggest it can still spawn additional threads, except in the case TEST_OMP_THREADS=1, where it does use only one thread.