### PR TITLE
Corrected specification of PipekMezey input in manual

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -2745,7 +2745,10 @@ For systems with non-gamma-point $k$-points, no further options are available.
 \begin{verbatim}
 Analysis = {
   Localise = {
-    PipekMezey = Yes        # Default options otherwise
+    PipekMezey = {
+       Tollerance = 1.0E-4
+       MaxIterations = 100
+    }  # These are the default options, which are also set if the bracket is left empty.
   }
 }
 \end{verbatim}


### PR DESCRIPTION
The specification of the PipekMezey input was incorrect in the manual

    PipekMezey = Yes
leads to an error
 
    -> Node contains superfluous free text: 'Yes'

The correct format is:

    PipekMezey = {
    }

for defaults or

    PipekMezey = {
        Tollerance = 1.0E-4
        MaxIterations = 100
    }

This is changed in the Pull Request.  The spelling error in Tollerance is on purpose, because it's also written like this in the dftb+ executable.