### PR TITLE
Results tag2

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -2565,9 +2565,10 @@ This block collects some global options for the run.
   is needed among others by the \verb|waveplot| utility for
   visualising molecular orbitals.)
 
-\item[\is{WriteResultsTag}] Turns the creation of the
-  \verb|results.tag| file on and off. (That file is used by several
-  utilities processing the results of \dftbp.)
+\item[\is{WriteResultsTag}] Turns the creation of the \verb|results.tag| file on
+  and off. (That file is used by several utilities processing the results of
+  \dftbp.) For a description of the file format see
+  p.~\pref{sec:dftbp.results}.
 
 \item[\is{WriteDetailedOut}] Controls the creation of the file
   \verb|detailed.out|. Since this contains the detailed information
@@ -3058,6 +3059,38 @@ This chapter contains the description of some of the output files of
 \dftbp{} where the output format is not self documenting. Unless
 indicated otherwise, numbers in the output files are given in atomic
 units (with Hartree as the energy unit).
+
+\section{results.tag}
+\label{sec:dftbp.results}
+\index{results.tag}
+
+This contains machine readable results labeled with the type and size of the
+data blocks. The results are given in atomic units and are formatted as:
+\begin{verbatim}
+label               :type:shape:
+\end{verbatim}
+
+The variable type is real, complex, integer or logical. The shape information is
+\newline :ndim: size$_1$,size$_2$,$\ldots$,size$_{ndim}$:\newline where ndim is
+the number of dimensions, organised with the Fortran convention and of size
+size$_1 \times$size$_2 \times$size$_2 \times \ldots$.
+
+In the special case of scalar variables the shape is :0:.
+
+A typical example of mixed scalar and both one and two dimensional results would
+be similar to:
+\begin{verbatim}
+mermin_energy       :real:0:
+ -0.672967201447815E+000
+total_energy        :real:0:
+ -0.672879398682698E+000
+forces              :real:2:3,3
+ -0.243590222274811E+000 -0.199780753617099E-001 -0.000000000000000E+000
+  0.465478448963764E+000 -0.228550455811745E+000 -0.000000000000000E+000
+ -0.221888226688953E+000  0.248528531173455E+000 -0.000000000000000E+000
+gross_atomic_charges:real:1:3
+  0.171448741143825E+000 -0.254714832621691E+000  0.832660914778645E-001
+\end{verbatim}
 
 \section{hamsqrN.dat, oversqr.dat}
 \label{sec:dftbp.hamsqr}

--- a/prog/dftb+/lib_io/taggedoutput.F90
+++ b/prog/dftb+/lib_io/taggedoutput.F90
@@ -68,6 +68,9 @@ module taggedoutput
   !> Gibbs free energy for finite pressure periodic systems
   character(*), parameter, public :: tag_Gibbsfree = 'gibbs_energy'
 
+  !> Gross atomic charges
+  character(*), parameter, public :: tag_qOutAtGross  = 'gross_atomic_charges'
+
   !> numerically calculated second derivatives matrix
   character(*), parameter, public :: tag_HessianNum = 'hessian_numerical'
 

--- a/prog/dftb+/prg_dftb/main.F90
+++ b/prog/dftb+/prg_dftb/main.F90
@@ -630,13 +630,13 @@ contains
         cellVol = abs(determinant33(latVec))
         energy%EGibbs = energy%EMermin + extPressure * cellVol
       end if
-      call writeAutotestTag(fdAutotest, autotestTag, tPeriodic, cellVol, tMulliken, qOutput, q0,&
+      call writeAutotestTag(fdAutotest, autotestTag, tPeriodic, cellVol, tMulliken, qOutput,&
           & derivs, chrgForces, excitedDerivs, tStress, totalStress, pDynMatrix,&
           & energy%EMermin, extPressure, energy%EGibbs, coord0, tLocalise, localisation, esp)
     end if
     if (tWriteResultsTag) then
       call writeResultsTag(fdResultsTag, resultsTag, energy, derivs, chrgForces, tStress,&
-          & totalStress, pDynMatrix, tPeriodic, cellVol)
+          & totalStress, pDynMatrix, tPeriodic, cellVol, tMulliken, qOutput, q0)
     end if
     if (tWriteDetailedXML) then
       call writeDetailedXml(runId, speciesName, species0, pCoord0Out, tPeriodic, latVec, tRealHS,&

--- a/prog/dftb+/prg_dftb/main.F90
+++ b/prog/dftb+/prg_dftb/main.F90
@@ -630,7 +630,7 @@ contains
         cellVol = abs(determinant33(latVec))
         energy%EGibbs = energy%EMermin + extPressure * cellVol
       end if
-      call writeAutotestTag(fdAutotest, autotestTag, tPeriodic, cellVol, tMulliken, qOutput,&
+      call writeAutotestTag(fdAutotest, autotestTag, tPeriodic, cellVol, tMulliken, qOutput, q0,&
           & derivs, chrgForces, excitedDerivs, tStress, totalStress, pDynMatrix,&
           & energy%EMermin, extPressure, energy%EGibbs, coord0, tLocalise, localisation, esp)
     end if

--- a/prog/dftb+/prg_dftb/mainio.F90
+++ b/prog/dftb+/prg_dftb/mainio.F90
@@ -1905,7 +1905,7 @@ contains
 
   !> Write tagged output of data from the code at the end of the DFTB+ run, data being then used for
   !> regression testing
-  subroutine writeAutotestTag(fd, fileName, tPeriodic, cellVol, tMulliken, qOutput, derivs,&
+  subroutine writeAutotestTag(fd, fileName, tPeriodic, cellVol, tMulliken, qOutput, q0, derivs,&
       & chrgForces, excitedDerivs, tStress, totalStress, pDynMatrix, freeEnergy, pressure,&
       & gibbsFree, endCoords, tLocalise, localisation, esp)
 
@@ -1926,6 +1926,9 @@ contains
 
     !> Output Mulliken charges
     real(dp), intent(in) :: qOutput(:,:,:)
+
+    !> Reference atomic charges
+    real(dp), intent(in) :: q0(:,:,:)
 
     !> Atomic derivatives (allocation status used as a flag)
     real(dp), allocatable, intent(in) :: derivs(:,:)
@@ -1977,6 +1980,7 @@ contains
       qOutputUpDown = qOutput
       call qm2ud(qOutputUpDown)
       call writeTagged(fd, tag_qOutput, qOutputUpDown(:,:,1))
+      call writeTagged(fd, tag_qOutAtGross, sum(q0(:,:,1) - qOutputUpDown(:,:,1), dim=1))
     end if
     if (allocated(derivs)) then
       call writeTagged(fd, tag_forceTot, -derivs)


### PR DESCRIPTION
Returns atomic charges to results.tag and adds some documentation on this file to the manual.

However, to match the main code change of labeling, both internally and in other output files, the charges now have the tag "gross_atomic_charges".