### PR TITLE
Modes translation

### DIFF
--- a/doc/dftb+/manual/modes.tex
+++ b/doc/dftb+/manual/modes.tex
@@ -28,6 +28,8 @@ Additionally optional definitions may be present:
   \kw{Atoms} & i+|m &  & 1:-1 & \\
   \kw{WriteHSDInput} & l & & No & \\
   \kw{WriteXMLInput} & l & & No & \\
+  \kw{RemoveTranslation} & l & & No & \\
+  \kw{RemoveRotation} & l & & No & \\
 \end{ptableh}
 
 \begin{description}
@@ -48,6 +50,11 @@ Additionally optional definitions may be present:
   out in HSD format. (You shouldn't turn it off without good reason.)
 \item[\is{WriteXMLInput}] Specifies, if the processed input should be written
   out in XML format.
+\item[\is{RemoveTranslation}] Explicitly set the 3 translational modes of the
+  system to be at 0 frequency.
+\item[\is{RemoveRotation}] Explicitly set the rotation modes of the system to be
+  at 0 frequency. Note, for periodic systems, this is usually incorrect (if used
+  for a molecule full inside the central cell, it may be harmless).
 \end{description}
 
 

--- a/prog/modes/initmodes.F90
+++ b/prog/modes/initmodes.F90
@@ -32,7 +32,7 @@ module InitModes
 
 
   !> program version
-  character(len=*), parameter :: version =  "0.01"
+  character(len=*), parameter :: version =  "0.02"
 
   !> root node name of the input tree
   character(len=*), parameter :: rootTag = "modes"
@@ -86,6 +86,9 @@ module InitModes
   !> use xmakemol dialect xyz
   logical, public :: tXmakeMol
 
+  !> Remove translation modes
+  logical, public :: tRemoveTranslate
+
   !> modes to produce xyz file for
   integer, allocatable, public :: modesToPlot(:)
 
@@ -103,6 +106,9 @@ module InitModes
 
   !> list of atoms in dynamical matrix
   integer, allocatable, public :: iMovedAtoms(:)
+
+  !> Number of derivatives
+  integer, public :: nDerivs
 
   !! Locally created variables
 
@@ -125,7 +131,6 @@ contains
     type(listCharLc), allocatable :: skFiles(:)
     character(lc) :: prefix, suffix, separator, elem1, strTmp, filename
     logical :: tLower, tExist
-    integer :: nDerivs
     logical :: tWriteXML, tWriteHSD ! XML or HSD output?
 
     !! Write header
@@ -152,6 +157,8 @@ contains
 
     call getChild(root, "Geometry", tmp)
     call readGeometry(tmp, geo)
+
+    call getChildValue(root, "RemoveTranslation", tRemoveTranslate, .false.)
 
     call getChildValue(root, "Atoms", buffer2, "1:-1", child=child, multiple=.true.)
     call convAtomRangeToInt(char(buffer2), geo%speciesNames, geo%species, &

--- a/prog/modes/initmodes.F90
+++ b/prog/modes/initmodes.F90
@@ -89,6 +89,9 @@ module InitModes
   !> Remove translation modes
   logical, public :: tRemoveTranslate
 
+  !> Remove rotation modes
+  logical, public :: tRemoveRotate
+
   !> modes to produce xyz file for
   integer, allocatable, public :: modesToPlot(:)
 
@@ -159,6 +162,7 @@ contains
     call readGeometry(tmp, geo)
 
     call getChildValue(root, "RemoveTranslation", tRemoveTranslate, .false.)
+    call getChildValue(root, "RemoveRotation", tRemoveRotate, .false.)
 
     call getChildValue(root, "Atoms", buffer2, "1:-1", child=child, multiple=.true.)
     call convAtomRangeToInt(char(buffer2), geo%speciesNames, geo%species, &

--- a/prog/modes/make.deps
+++ b/prog/modes/make.deps
@@ -3,6 +3,11 @@ initmodes.o = initmodes.o $(_mod_hsdparser) $(common.fypp) $(_mod_fileid) $(_mod
 _mod_initmodes: initmodes.o
 _mod_initmodes = $(initmodes.o)
 
-modes.o: common.fypp _mod_constants _mod_blasroutines _mod_simplealgebra _mod_assert _mod_taggedoutput _mod_initmodes _mod_eigensolver _mod_accuracy _mod_io _mod_typegeometry
-modes.o = modes.o $(common.fypp) $(_mod_constants) $(_mod_blasroutines) $(_mod_simplealgebra) $(_mod_assert) $(_mod_taggedoutput) $(_mod_initmodes) $(_mod_eigensolver) $(_mod_accuracy) $(_mod_io) $(_mod_typegeometry)
+modes.o: _mod_projectoutnullmodes common.fypp _mod_constants _mod_message _mod_assert _mod_taggedoutput _mod_initmodes _mod_eigensolver _mod_accuracy _mod_io _mod_typegeometry
+modes.o = modes.o $(_mod_projectoutnullmodes) $(common.fypp) $(_mod_constants) $(_mod_message) $(_mod_assert) $(_mod_taggedoutput) $(_mod_initmodes) $(_mod_eigensolver) $(_mod_accuracy) $(_mod_io) $(_mod_typegeometry)
+
+project.o: common.fypp _mod_message _mod_blasroutines _mod_simplealgebra _mod_eigensolver _mod_accuracy _mod_typegeometry
+project.o = project.o $(common.fypp) $(_mod_message) $(_mod_blasroutines) $(_mod_simplealgebra) $(_mod_eigensolver) $(_mod_accuracy) $(_mod_typegeometry)
+_mod_projectoutnullmodes: project.o
+_mod_projectoutnullmodes = $(project.o)
 

--- a/prog/modes/make.deps
+++ b/prog/modes/make.deps
@@ -3,6 +3,6 @@ initmodes.o = initmodes.o $(_mod_hsdparser) $(common.fypp) $(_mod_fileid) $(_mod
 _mod_initmodes: initmodes.o
 _mod_initmodes = $(initmodes.o)
 
-modes.o: common.fypp _mod_constants _mod_assert _mod_taggedoutput _mod_initmodes _mod_eigensolver _mod_accuracy _mod_io _mod_typegeometry
-modes.o = modes.o $(common.fypp) $(_mod_constants) $(_mod_assert) $(_mod_taggedoutput) $(_mod_initmodes) $(_mod_eigensolver) $(_mod_accuracy) $(_mod_io) $(_mod_typegeometry)
+modes.o: common.fypp _mod_constants _mod_blasroutines _mod_assert _mod_taggedoutput _mod_initmodes _mod_eigensolver _mod_accuracy _mod_io _mod_typegeometry
+modes.o = modes.o $(common.fypp) $(_mod_constants) $(_mod_blasroutines) $(_mod_assert) $(_mod_taggedoutput) $(_mod_initmodes) $(_mod_eigensolver) $(_mod_accuracy) $(_mod_io) $(_mod_typegeometry)
 

--- a/prog/modes/make.deps
+++ b/prog/modes/make.deps
@@ -3,6 +3,6 @@ initmodes.o = initmodes.o $(_mod_hsdparser) $(common.fypp) $(_mod_fileid) $(_mod
 _mod_initmodes: initmodes.o
 _mod_initmodes = $(initmodes.o)
 
-modes.o: common.fypp _mod_constants _mod_blasroutines _mod_assert _mod_taggedoutput _mod_initmodes _mod_eigensolver _mod_accuracy _mod_io _mod_typegeometry
-modes.o = modes.o $(common.fypp) $(_mod_constants) $(_mod_blasroutines) $(_mod_assert) $(_mod_taggedoutput) $(_mod_initmodes) $(_mod_eigensolver) $(_mod_accuracy) $(_mod_io) $(_mod_typegeometry)
+modes.o: common.fypp _mod_constants _mod_blasroutines _mod_simplealgebra _mod_assert _mod_taggedoutput _mod_initmodes _mod_eigensolver _mod_accuracy _mod_io _mod_typegeometry
+modes.o = modes.o $(common.fypp) $(_mod_constants) $(_mod_blasroutines) $(_mod_simplealgebra) $(_mod_assert) $(_mod_taggedoutput) $(_mod_initmodes) $(_mod_eigensolver) $(_mod_accuracy) $(_mod_io) $(_mod_typegeometry)
 

--- a/prog/modes/modes.F90
+++ b/prog/modes/modes.F90
@@ -16,10 +16,9 @@ program modes
   use constants, only : Hartree__cm, Bohr__AA, pi
   use TypeGeometry
   use eigensolver, only : heev
-  use blasroutines, only : herk
-  use simplealgebra, only : cross3
   use TaggedOutput
   use Message
+  use projectOutNullModes
   implicit none
 
   integer :: ii, jj, kk, ll, iMode, iAt, iAtMoved, nAtom
@@ -28,10 +27,6 @@ program modes
   real(dp), allocatable :: displ(:,:,:)
 
   character(lc) :: lcTmp, lcTmp2
-
-  real(dp), allocatable :: vectorsToNull(:,:), projector(:,:)
-  real(dp) :: centreOfMass(3), rTmp(3), vTmp(3)
-  integer :: nToNull
 
   ! Allocate resources
   call initProgramVariables()
@@ -55,84 +50,8 @@ program modes
     end do
   end do
 
-  nToNull = 0
-  if (tRemoveTranslate) then
-    nToNull = nToNull + 3
-  end if
-  if (tRemoveRotate) then
-    nToNull = nToNull + 3
-  end if
-
-  if (tRemoveTranslate .or. tRemoveRotate) then
-    allocate(vectorsToNull(nDerivs, nToNull))
-    allocate(projector(nDerivs, nDerivs))
-    projector(:,:) = 0.0_dp
-    vectorsToNull(:,:) = 0.0_dp
-
-    ! symmetrize dynamical matrix
-    do jj = 1, nDerivs
-      dynMatrix(jj, jj + 1 :) = dynMatrix(jj + 1 :, jj)
-    end do
-
-    do jj = 1, nDerivs
-      projector(jj, jj) = 1.0_dp
-    end do
-
-    if (tRemoveTranslate) then
-      do iAt = 1, nMovedAtom
-        vectorsToNull((iAt - 1) * 3 + 1, 1) = 1.0_dp
-        vectorsToNull((iAt - 1) * 3 + 2, 2) = 1.0_dp
-        vectorsToNull((iAt - 1) * 3 + 3, 3) = 1.0_dp
-      end do
-    end if
-
-    if (tRemoveRotate) then
-      ! rotation directions
-      if (geo%tPeriodic) then
-        call warning("Rotational modes were requested to be removed for a periodic geometry -&
-            & results probably unphysical!")
-      end if
-      centreOfMass(:) = 0.0_dp
-      do iAt = 1, nMovedAtom
-        centreOfMass(:) = centreOfMass + geo%coords(:,iAt) * atomicMasses(iAt)
-      end do
-      centreOfMass(:) = centreOfMass / sum(atomicMasses(:nMovedAtom))
-      do ii = 1, 3
-        vTmp(:) = 0.0_dp
-        vTmp(ii) = 1.0_dp
-        do iAt = 1, nMovedAtom
-          call cross3(rTmp, vTmp, geo%coords(:,iAt) - centreOfMass)
-          vectorsToNull((iAt - 1) * 3 + 1 : iAt * 3, nToNull - ii + 1) = rTmp
-        end do
-      end do
-    end if
-
-    ! Change from displacements to weighted displacements basis of the Hessian
-    do iAt = 1, nMovedAtom
-      vectorsToNull((iAt - 1) * 3 + 1 : iAt * 3, :) =&
-          & vectorsToNull((iAt - 1) * 3 + 1 : iAt * 3, :) * sqrt(atomicMasses(iAt))
-    end do
-
-    ! normalise non-null vectors
-    do ii = 1, nToNull
-      if (sum(vectorsToNull(:,ii)**2) > epsilon(1.0_dp)) then
-        vectorsToNull(:,ii) = vectorsToNull(:,ii) / sqrt(sum(vectorsToNull(:,ii)**2))
-      end if
-    end do
-
-    call herk(projector, vectorsToNull, alpha=-1.0_dp, beta=1.0_dp)
-
-    ! copy to other triangle
-    do jj = 1, nDerivs
-      projector(jj,jj+1:) = projector(jj+1:,jj)
-    end do
-
-    ! project out removed degrees of freedom
-    dynMatrix = matmul(projector, matmul(dynMatrix, projector))
-
-    deallocate(vectorsToNull)
-    deallocate(projector)
-  end if
+  ! remove translations or rotations if neccessary
+  call project(dynMatrix, tRemoveTranslate, tRemoveRotate, nDerivs, nMovedAtom, geo, atomicMasses)
 
   ! solve the eigenproblem
   if (tPlotModes) then

--- a/prog/modes/project.F90
+++ b/prog/modes/project.F90
@@ -1,0 +1,188 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2018  DFTB+ developers group                                                      !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+#:include 'common.fypp'
+
+!> Removal of translation or rotation related modes
+module projectOutNullModes
+  use accuracy, only : dp
+  use message
+  use TypeGeometry
+  use blasroutines, only : herk
+  use simplealgebra, only : cross3
+  use eigensolver, only : heev
+  implicit none
+
+  private
+  public :: project
+
+contains
+
+  !> Projection out of the space of the dynamical matrix
+  subroutine project(dynMatrix, tRemoveTranslate, tRemoveRotate, nDerivs, nMovedAtom, geo,&
+      & atomicMasses)
+
+    !> Dynamical matrix
+    real(dp), intent(inout) :: dynMatrix(:,:)
+
+    !> Whether translation is removed
+    logical, intent(in) :: tRemoveTranslate
+
+    !> Whether rotation is removed
+    logical, intent(in) :: tRemoveRotate
+
+    !> Number of derivatives (dimension of dynMatrix)
+    integer, intent(in) :: nDerivs
+
+    !> Number of moving atoms
+    integer, intent(in) :: nMovedAtom
+
+    !> Geometry information on the system
+    type(TGeometry), intent(in) :: geo
+
+    !> Masses of the atoms in the system
+    real(dp), intent(in) :: atomicMasses(:)
+
+    real(dp), allocatable :: vectorsToNull(:,:), projector(:,:)
+    real(dp) :: centreOfMass(3), rTmp(3), vTmp(3), I(3,3), moments(3)
+    integer :: nToNull, ii, jj, iAt
+
+    nToNull = 0
+    if (tRemoveTranslate) then
+      nToNull = nToNull + 3
+    end if
+    if (tRemoveRotate) then
+      nToNull = nToNull + 3
+    end if
+
+    if (nToNull == 0) then
+      return
+    end if
+
+    allocate(vectorsToNull(nDerivs, nToNull))
+    allocate(projector(nDerivs, nDerivs))
+    projector(:,:) = 0.0_dp
+    vectorsToNull(:,:) = 0.0_dp
+
+    ! symmetrize dynamical matrix
+    do jj = 1, nDerivs
+      dynMatrix(jj, jj + 1 :) = dynMatrix(jj + 1 :, jj)
+    end do
+
+    do jj = 1, nDerivs
+      projector(jj, jj) = 1.0_dp
+    end do
+
+    if (tRemoveTranslate) then
+      do iAt = 1, nMovedAtom
+        do ii = 1, 3
+          vectorsToNull((iAt - 1) * 3 + ii, ii) = 1.0_dp
+        end do
+      end do
+    end if
+
+    if (tRemoveRotate) then
+      if (geo%tPeriodic) then
+        call warning("Rotational modes were requested to be removed for a periodic geometry -&
+            & results probably unphysical!")
+      end if
+      centreOfMass(:) = 0.0_dp
+      do iAt = 1, nMovedAtom
+        centreOfMass(:) = centreOfMass + geo%coords(:,iAt) * atomicMasses(iAt)
+      end do
+      centreOfMass(:) = centreOfMass / sum(atomicMasses(:nMovedAtom))
+
+      call principleAxes(I, moments, geo%coords, atomicMasses, centreOfMass, nMovedAtom)
+
+      ! axis to project with respect to
+      do ii = 1, 3
+        if (moments(ii) < epsilon(0.0_dp)) then
+          ! zero moment of inertia - linear molecule, and this direction is along its axis
+          cycle
+        end if
+        vTmp(:) = I(:,ii)
+        do iAt = 1, nMovedAtom
+          call cross3(rTmp, vTmp, geo%coords(:,iAt) - centreOfMass)
+          vectorsToNull((iAt - 1) * 3 + 1 : iAt * 3, nToNull - ii + 1) = rTmp
+        end do
+      end do
+    end if
+
+    ! Change from displacements to weighted displacements basis of the Hessian
+    do iAt = 1, nMovedAtom
+      vectorsToNull((iAt - 1) * 3 + 1 : iAt * 3, :) =&
+          & vectorsToNull((iAt - 1) * 3 + 1 : iAt * 3, :) * sqrt(atomicMasses(iAt))
+    end do
+
+    ! normalise non-null vectors
+    do ii = 1, nToNull
+      if (sum(vectorsToNull(:,ii)**2) > epsilon(1.0_dp)) then
+        vectorsToNull(:,ii) = vectorsToNull(:,ii) / sqrt(sum(vectorsToNull(:,ii)**2))
+      end if
+    end do
+
+    call herk(projector, vectorsToNull, alpha=-1.0_dp, beta=1.0_dp)
+
+    deallocate(vectorsToNull)
+
+    ! copy to other triangle
+    do jj = 1, nDerivs
+      projector(jj,jj+1:) = projector(jj+1:,jj)
+    end do
+
+    ! project out removed degrees of freedom
+    dynMatrix = matmul(projector, matmul(dynMatrix, projector))
+
+    deallocate(projector)
+
+  end subroutine project
+
+  !> Principle moment of inertia axes
+  subroutine principleAxes(I, ei, coords, masses, centreOfMass, nMovedAtom)
+
+    !> Intertia axes
+    real(dp), intent(out) :: I(3,3)
+
+    !> Moments
+    real(dp), intent(out) :: ei(3)
+
+    !> coordinates
+    real(dp), intent(in) :: coords(:,:)
+
+    !> masses
+    real(dp), intent(in) :: masses(:)
+
+    !> the centre of mass
+    real(dp), intent(in) :: centreOfMass(3)
+
+    !> number of moving atoms
+    integer, intent(in) :: nMovedAtom
+
+    integer :: ii, jj, iAt
+
+    I(:,:) = 0.0_dp
+    ei(:) = 0.0_dp
+
+    do iAt = 1, nMovedAtom
+      do ii = 1, 3
+        I(ii, ii) = I(ii, ii) + masses(iAt) * sum((coords(:,iAt) - centreOfMass(:))**2)
+      end do
+    end do
+    do iAt = 1, nMovedAtom
+      do ii = 1, 3
+        do jj = 1, 3
+          I(jj, ii) = I(jj, ii) - masses(iAt) * (coords(jj,iAt) - centreOfMass(jj))&
+              & * (coords(ii,iAt) - centreOfMass(ii))
+        end do
+      end do
+    end do
+
+    call heev(I(:,:), ei(:), 'U', 'V')
+
+  end subroutine principleAxes
+
+end module projectOutNullModes


### PR DESCRIPTION
Removes translation and/or rotation from vibrational modes. May not be fully correct for rotations of linear molecules, but apparently works otherwise.