### PR TITLE
Repulsive cutoff

### DIFF
--- a/doc/dftb+/manual/disp_constants.tex
+++ b/doc/dftb+/manual/disp_constants.tex
@@ -8,7 +8,7 @@ systems, C, N, O and H predominantly for DNA \cite{elstner-jcp-114-5149}. If you
 would like to calculate different systems or you're looking for other elements,
 check references \cite{miller-JAmChemSoc-112-8533} and
 \cite{kang-TheorChimActa-61-41}. The values of the atomic polarisabilities and
-cutoffs are given for zero, one, two, three, four and more than four neighbors.
+cutoffs are given for zero, one, two, three, four and more than four neighbours.
 
 \begin{center}
 \begin{tabular}{|c|c|c|c|c|} \hline

--- a/prog/dftb+/lib_common/accuracy.F90
+++ b/prog/dftb+/lib_common/accuracy.F90
@@ -70,14 +70,14 @@ module accuracy
   real(dp), parameter :: tolSameDist2 = tolSameDist**2
 
 
-  !> Minimal distance between neihbors. (Neighbor distances smaller than that
+  !> Minimal distance between neihbors. (Neighbour distances smaller than that
   !> are meaningless because the parametrisation usually do not cover this
 
   !> region.)
   real(dp), parameter :: minNeighDist = 1.0e-2_dp
 
 
-  !> Minimal square distance between neighbors
+  !> Minimal square distance between neighbours
   real(dp), parameter :: minNeighDist2 = minNeighDist**2
 
 

--- a/prog/dftb+/lib_dftb/coulomb.F90
+++ b/prog/dftb+/lib_dftb/coulomb.F90
@@ -57,7 +57,7 @@ module coulomb
   !> Maximal argument value of erf, after which it is constant
   real(dp), parameter :: erfArgLimit = 10.0_dp
 
-  !> Chunk size to use when obtaining neighbors dynamically via an iterator
+  !> Chunk size to use when obtaining neighbours dynamically via an iterator
   integer, parameter :: iterChunkSize = 1000
 
 
@@ -275,7 +275,7 @@ contains
     !> List of atomic coordinates (all atoms).
     real(dp), intent(in) :: coord(:,:)
 
-    !> Neighbor list for the real space summation of the Ewald.
+    !> Neighbour list for the real space summation of the Ewald.
     type(TDynNeighList), intent(in) :: neighList
 
     !> Contains the points included in the reciprocal sum.  The set should not include the origin or
@@ -330,7 +330,7 @@ contains
     !> List of atomic coordinates (all atoms).
     real(dp), intent(in) :: coord(:,:)
 
-    !> Neighbor list for the real space summation of the Ewald.
+    !> Neighbour list for the real space summation of the Ewald.
     type(TDynNeighList), target, intent(in) :: neighList
 
     !> Contains the points included in the reciprocal sum.  The set should not include the origin or
@@ -367,7 +367,7 @@ contains
       call TNeighIterator_init(neighIter, pNeighList, iAt1)
       nNeigh = iterChunkSize
       do while (nNeigh == iterChunkSize)
-        call neighIter%getNextNeighbors(nNeigh, coords=neighCoords, img2CentCell=neighImages)
+        call neighIter%getNextNeighbours(nNeigh, coords=neighCoords, img2CentCell=neighImages)
         do iNeigh = 1, nNeigh
           iAt2f = neighImages(iNeigh)
           call scalafx_islocal(grid, descInvRMat, iAt2f, iAt1, tLocal, iLoc, jLoc)
@@ -423,7 +423,7 @@ contains
     !> List of atomic coordinates (all atoms).
     real(dp), intent(in) :: coord(:,:)
 
-    !> Neighbor list for the real space summation of the Ewald.
+    !> Neighbour list for the real space summation of the Ewald.
     type(TDynNeighList), target, intent(in) :: neighList
 
     !> Contains the points included in the reciprocal sum.  The set should not include the origin or
@@ -452,7 +452,7 @@ contains
     !$OMP PARALLEL DO&
     !$OMP& DEFAULT(SHARED) SCHEDULE(RUNTIME)
     do iAt1 = 1, nAtom
-      call addNeighborContribsIS(iAt1, pNeighList, coord, alpha, invRMat)
+      call addNeighbourContribsIS(iAt1, pNeighList, coord, alpha, invRMat)
     end do
     !$OMP END PARALLEL DO
 
@@ -478,8 +478,8 @@ contains
 
   end subroutine invRPeriodicSerial
 
-  !> Neighbor summation with local scope for predictable OMP <= 4.0 behaviour
-  subroutine addNeighborContribsIS(iAt1, pNeighList, coords, alpha, invRMat)
+  !> Neighbour summation with local scope for predictable OMP <= 4.0 behaviour
+  subroutine addNeighbourContribsIS(iAt1, pNeighList, coords, alpha, invRMat)
     integer, intent(in) :: iAt1
     type(TDynNeighList), pointer, intent(in) :: pNeighList
     real(dp), intent(in) :: coords(:,:)
@@ -494,7 +494,7 @@ contains
     call TNeighIterator_init(neighIter, pNeighList, iAt1)
     nNeigh = iterChunkSize
     do while (nNeigh == iterChunkSize)
-      call neighIter%getNextNeighbors(nNeigh, coords=neighCoords, img2CentCell=neighImages)
+      call neighIter%getNextNeighbours(nNeigh, coords=neighCoords, img2CentCell=neighImages)
       do iNeigh = 1, nNeigh
         iAt2f = neighImages(iNeigh)
         invRMat(iAt2f, iAt1) = invRMat(iAt2f, iAt1)&
@@ -502,7 +502,7 @@ contains
       end do
     end do
 
-  end subroutine addNeighborContribsIS
+  end subroutine addNeighbourContribsIS
 
 #:endif
 
@@ -804,7 +804,7 @@ contains
     !> List of atomic coordinates (all atoms).
     real(dp), intent(in) :: coord(:,:)
 
-    !> Dynamic neighbor list to be used in the real part of Ewald
+    !> Dynamic neighbour list to be used in the real part of Ewald
     type(TDynNeighList), target, intent(in) :: neighList
 
     !> Contains the points included in the reciprocal sum. The set should not include the origin or
@@ -839,7 +839,7 @@ contains
     !$OMP PARALLEL DO&
     !$OMP& DEFAULT(SHARED) REDUCTION(+:localDeriv) SCHEDULE(RUNTIME)
     do iAtom1 = iAtFirst, iAtLast
-      call addNeighborContribsInvRP(iAtom1, pNeighList, coord, deltaQAtom, alpha, localDeriv)
+      call addNeighbourContribsInvRP(iAtom1, pNeighList, coord, deltaQAtom, alpha, localDeriv)
     end do
     !$OMP END PARALLEL DO
 
@@ -863,8 +863,8 @@ contains
 
   end subroutine addInvRPrimePeriodic
 
-  !> Neighbor summation with local scope for predictable OMP <= 4.0 behaviour
-  subroutine addNeighborContribsInvRP(iAtom1, pNeighList, coords, deltaQAtom, alpha, deriv)
+  !> Neighbour summation with local scope for predictable OMP <= 4.0 behaviour
+  subroutine addNeighbourContribsInvRP(iAtom1, pNeighList, coords, deltaQAtom, alpha, deriv)
     integer, intent(in) :: iAtom1
     type(TDynNeighList), pointer, intent(in) :: pNeighList
     real(dp), intent(in) :: coords(:,:)
@@ -881,7 +881,7 @@ contains
     call TNeighIterator_init(neighIter, pNeighList, iAtom1)
     nNeigh = iterChunkSize
     do while (nNeigh == iterChunkSize)
-      call neighIter%getNextNeighbors(nNeigh, coords=neighCoords, img2CentCell=neighImages)
+      call neighIter%getNextNeighbours(nNeigh, coords=neighCoords, img2CentCell=neighImages)
       do iNeigh = 1, nNeigh
         iAtom2f = neighImages(iNeigh)
         if (iAtom2f /= iAtom1) then
@@ -894,7 +894,7 @@ contains
       end do
     end do
 
-  end subroutine addNeighborContribsInvRP
+  end subroutine addNeighbourContribsInvRP
 
 
   !> Calculates the -1/R**2 deriv contribution for extended lagrangian dynamics forces
@@ -910,7 +910,7 @@ contains
     !> coordinates of atoms
     real(dp), intent(in) :: coord(:,:)
 
-    !> Dynamic neighbor list to be used in the real part of Ewald
+    !> Dynamic neighbour list to be used in the real part of Ewald
     type(TDynNeighList), target, intent(in) :: neighList
 
     !> Contains the points included in the reciprocal sum. The set should not include the origin or
@@ -948,7 +948,7 @@ contains
     !$OMP PARALLEL DO&
     !$OMP& DEFAULT(SHARED) REDUCTION(+:localDeriv) SCHEDULE(RUNTIME)
     do iAt1 = iAtFirst, iAtLast
-      call addNeighborContribsXl(iAt1, pNeighList, coord, dQInAtom, dQOutAtom, alpha, localDeriv)
+      call addNeighbourContribsXl(iAt1, pNeighList, coord, dQInAtom, dQOutAtom, alpha, localDeriv)
     end do
     !$OMP END PARALLEL DO
 
@@ -972,8 +972,8 @@ contains
 
   end subroutine addInvRPrimeXlbomdPeriodic
 
-  !> Neighbor summation with local scope for predictable OMP <= 4.0 behaviour
-  subroutine addNeighborContribsXl(iAt1, pNeighList, coords, dQInAtom, dQOutAtom, alpha, deriv)
+  !> Neighbour summation with local scope for predictable OMP <= 4.0 behaviour
+  subroutine addNeighbourContribsXl(iAt1, pNeighList, coords, dQInAtom, dQOutAtom, alpha, deriv)
     integer, intent(in) :: iAt1
     type(TDynNeighList), pointer, intent(in) :: pNeighList
     real(dp), intent(in) :: coords(:,:)
@@ -992,7 +992,7 @@ contains
     call TNeighIterator_init(neighIter, pNeighList, iAt1)
     nNeigh = iterChunkSize
     do while (nNeigh == iterChunkSize)
-      call neighIter%getNextNeighbors(nNeigh, coords=neighCoords, img2CentCell=neighImages)
+      call neighIter%getNextNeighbours(nNeigh, coords=neighCoords, img2CentCell=neighImages)
       do iNeigh = 1, nNeigh
         iAt2f = neighImages(iNeigh)
         if (iAt2f == iAt1) then
@@ -1007,7 +1007,7 @@ contains
       end do
     end do
 
-  end subroutine addNeighborContribsXl
+  end subroutine addNeighbourContribsXl
 
 
   !> Calculates the -1/R**2 deriv contribution for charged atoms interacting with a group of charged
@@ -1674,7 +1674,7 @@ contains
     !> List of atomic coordinates (all atoms).
     real(dp), intent(in) :: coord(:,:)
 
-    !> Dynamic neighbor list to be used in the real part of Ewald
+    !> Dynamic neighbour list to be used in the real part of Ewald
     type(TDynNeighList), target, intent(in) :: neighList
 
     !> Contains the points included in the reciprocal sum. The set should not include the origin or
@@ -1744,7 +1744,7 @@ contains
     !$OMP PARALLEL DO&
     !$OMP& DEFAULT(SHARED) REDUCTION(+:localStress) SCHEDULE(RUNTIME)
     do iAtom1 = iFirst, iLast
-      call addNeighborContribsStress(iAtom1, pNeighList, coord, alpha, Q, localStress)
+      call addNeighbourContribsStress(iAtom1, pNeighList, coord, alpha, Q, localStress)
     end do
     !$OMP END PARALLEL DO
 
@@ -1755,8 +1755,8 @@ contains
 
   end subroutine invRStress
 
-  !> Neighbor summation with local scope for predictable OMP <= 4.0 behaviour
-  subroutine addNeighborContribsStress(iAtom1, pNeighList, coords, alpha, dQAtom, stress)
+  !> Neighbour summation with local scope for predictable OMP <= 4.0 behaviour
+  subroutine addNeighbourContribsStress(iAtom1, pNeighList, coords, alpha, dQAtom, stress)
     integer, intent(in) :: iAtom1
     type(TDynNeighList), pointer, intent(in) :: pNeighList
     real(dp), intent(in) :: coords(:,:)
@@ -1773,7 +1773,7 @@ contains
     call TNeighIterator_init(neighIter, pNeighList, iAtom1)
     nNeigh = iterChunkSize
     do while (nNeigh == iterChunkSize)
-      call neighIter%getNextNeighbors(nNeigh, coords=neighCoords, img2CentCell=neighImages)
+      call neighIter%getNextNeighbours(nNeigh, coords=neighCoords, img2CentCell=neighImages)
       do iNeigh = 1, nNeigh
         iAtom2f = neighImages(iNeigh)
         r(:) = coords(:,iAtom1) - neighCoords(:,iNeigh)
@@ -1794,7 +1794,7 @@ contains
       end do
     end do
 
-  end subroutine addNeighborContribsStress
+  end subroutine addNeighbourContribsStress
 
 
 

--- a/prog/dftb+/lib_dftb/densitymatrix.F90
+++ b/prog/dftb+/lib_dftb/densitymatrix.F90
@@ -8,7 +8,7 @@
 #:include 'common.fypp'
 
 !> Calculate either the whole single particle density matrix and energy
-!> weighted density matrix or only the elements dictated by a neighbor map.
+!> weighted density matrix or only the elements dictated by a neighbour map.
 !> Calculation of the whole matrix scales as O(N**3), the sparse form as
 !> O(N**2) but with a larger pre-factor.
 !> Note: Dense code based on suggestions from Thomas Heine
@@ -339,7 +339,7 @@ contains
 
 
   !> Make a regular density matrix for the real wave-function case
-  subroutine sp_density_matrix_real(dm, eigenvecs, filling, iNeighbor, nNeighborSK, orb,&
+  subroutine sp_density_matrix_real(dm, eigenvecs, filling, iNeighbour, nNeighbourSK, orb,&
       & iAtomStart, img2CentCell)
 
     !> the resulting nOrb*nOrb density matrix with only the elements of interest
@@ -352,11 +352,11 @@ contains
     !> the occupation numbers of the orbitals
     real(dp), intent(in) :: filling(:)
 
-    !> Neighbor list for each atom (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Neighbour list for each atom (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom (incl. itself).
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Information about the orbitals of the atoms
     type(TOrbitals), intent(in) :: orb
@@ -369,22 +369,22 @@ contains
 
     integer :: iAt1, iNeigh1, nOrb1, nOrb2, jj
     integer :: nAtom, nLevels, start1, start2, ii
-    integer, allocatable :: inCellNeighbor(:,:)
-    integer, allocatable :: nInCellNeighbor(:)
+    integer, allocatable :: inCellNeighbour(:,:)
+    integer, allocatable :: nInCellNeighbour(:)
     real(dp), allocatable :: tmpEigen(:,:)
 
     @:ASSERT(all(shape(eigenvecs) == shape(dm)))
     @:ASSERT(size(eigenvecs,dim=1) == size(eigenvecs,dim=2))
     @:ASSERT(size(eigenvecs,dim=1) == size(filling))
 
-    allocate(inCellNeighbor(0:size(iNeighbor,dim=1),size(iNeighbor,dim=2)))
-    allocate(nInCellNeighbor(size(iNeighbor,dim=2)))
+    allocate(inCellNeighbour(0:size(iNeighbour,dim=1),size(iNeighbour,dim=2)))
+    allocate(nInCellNeighbour(size(iNeighbour,dim=2)))
 
     nAtom = size(orb%nOrbAtom)
     dm(:,:) = 0.0_dp
 
-    inCellNeighbor(:,:) = 0
-    nInCellNeighbor(:) = 0
+    inCellNeighbour(:,:) = 0
+    nInCellNeighbour(:) = 0
 
     do ii =  size(filling), 1, -1
       nLevels = ii
@@ -396,9 +396,10 @@ contains
     allocate(tmpEigen(nLevels,orb%mOrb))
     !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(iAt1) SCHEDULE(RUNTIME)
     do iAt1 = 1, nAtom
-      inCellNeighbor(0:nNeighborSK(iAt1),iAt1) = img2CentCell(iNeighbor(0:nNeighborSK(iAt1),iAt1))
-      call heap_sort(inCellNeighbor(:nNeighborSK(iAt1),iAt1))
-      nInCellNeighbor(iAt1) = unique(inCellNeighbor(:,iAt1), nNeighborSK(iAt1)+1) - 1
+      inCellNeighbour(0:nNeighbourSK(iAt1),iAt1) =&
+          & img2CentCell(iNeighbour(0:nNeighbourSK(iAt1),iAt1))
+      call heap_sort(inCellNeighbour(:nNeighbourSK(iAt1),iAt1))
+      nInCellNeighbour(iAt1) = unique(inCellNeighbour(:,iAt1), nNeighbourSK(iAt1)+1) - 1
     end do
     !$OMP  END PARALLEL DO
 
@@ -412,9 +413,9 @@ contains
       end do
       !$OMP  END PARALLEL DO
       !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(iNeigh1,start2,nOrb2) SCHEDULE(RUNTIME)
-      do iNeigh1 = 0, nInCellNeighbor(iAt1)
-        start2 = iAtomStart(inCellNeighbor(iNeigh1,iAt1))
-        nOrb2 = orb%nOrbAtom(inCellNeighbor(iNeigh1,iAt1))
+      do iNeigh1 = 0, nInCellNeighbour(iAt1)
+        start2 = iAtomStart(inCellNeighbour(iNeigh1,iAt1))
+        nOrb2 = orb%nOrbAtom(inCellNeighbour(iNeigh1,iAt1))
         dm(start2:start2+nOrb2-1, start1:start1+nOrb1-1) =&
             & matmul(eigenvecs(start2:start2+nOrb2-1,1:nLevels), tmpEigen(1:nLevels,1:nOrb1))
       end do
@@ -425,7 +426,7 @@ contains
 
 
   !> Make a regular density matrix for the complex wave-function case
-  subroutine sp_density_matrix_cmplx(dm, eigenvecs, filling, iNeighbor, nNeighborSK, orb,&
+  subroutine sp_density_matrix_cmplx(dm, eigenvecs, filling, iNeighbour, nNeighbourSK, orb,&
       & iAtomStart, img2CentCell)
 
     !> the resulting nOrb*nOrb density matrix with only the elements of interest
@@ -438,11 +439,11 @@ contains
     !> the occupation numbers of the orbitals
     real(dp), intent(in) :: filling(:)
 
-    !> Neighbor list for each atom (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Neighbour list for each atom (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom (incl. itself).
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Informatio about the orbitals.
     type(TOrbitals), intent(in) :: orb
@@ -455,22 +456,22 @@ contains
 
     integer :: iAt1, iNeigh1, nOrb1, nOrb2, jj, nAtom
     integer :: nLevels, start1, start2, ii
-    integer, allocatable :: inCellNeighbor(:,:)
-    integer, allocatable :: nInCellNeighbor(:)
+    integer, allocatable :: inCellNeighbour(:,:)
+    integer, allocatable :: nInCellNeighbour(:)
     complex(dp), allocatable :: tmpEigen(:,:)
 
     @:ASSERT(all(shape(eigenvecs) == shape(dm)))
     @:ASSERT(size(eigenvecs,dim=1) == size(eigenvecs,dim=2))
     @:ASSERT(size(eigenvecs,dim=1) == size(filling))
 
-    allocate(inCellNeighbor(0:size(iNeighbor,dim=1),size(iNeighbor,dim=2)))
-    allocate(nInCellNeighbor(size(iNeighbor,dim=2)))
+    allocate(inCellNeighbour(0:size(iNeighbour,dim=1),size(iNeighbour,dim=2)))
+    allocate(nInCellNeighbour(size(iNeighbour,dim=2)))
 
     nAtom = size(orb%nOrbAtom)
 
     dm(:,:) = cmplx(0.0_dp,0.0_dp,dp)
-    inCellNeighbor(:,:) = 0
-    nInCellNeighbor(:) = 0
+    inCellNeighbour(:,:) = 0
+    nInCellNeighbour(:) = 0
 
     do ii =  size(filling), 1, -1
       nLevels = ii
@@ -482,9 +483,10 @@ contains
     allocate(tmpEigen(nLevels, orb%mOrb))
     !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(iAt1) SCHEDULE(RUNTIME)
     do iAt1 = 1, nAtom
-      inCellNeighbor(0:nNeighborSK(iAt1),iAt1) = img2CentCell(iNeighbor(0:nNeighborSK(iAt1),iAt1))
-      call heap_sort(inCellNeighbor(:nNeighborSK(iAt1),iAt1))
-      nInCellNeighbor(iAt1) = unique(inCellNeighbor(:,iAt1), nNeighborSK(iAt1)+1) - 1
+      inCellNeighbour(0:nNeighbourSK(iAt1),iAt1) =&
+          & img2CentCell(iNeighbour(0:nNeighbourSK(iAt1),iAt1))
+      call heap_sort(inCellNeighbour(:nNeighbourSK(iAt1),iAt1))
+      nInCellNeighbour(iAt1) = unique(inCellNeighbour(:,iAt1), nNeighbourSK(iAt1)+1) - 1
     end do
     !$OMP  END PARALLEL DO
 
@@ -500,9 +502,9 @@ contains
       !$OMP  END PARALLEL DO
 
       !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(iNeigh1,start2,nOrb2) SCHEDULE(RUNTIME)
-      do iNeigh1 = 0, nInCellNeighbor(iAt1)
-        start2 = iAtomStart(inCellNeighbor(iNeigh1,iAt1))
-        nOrb2 = orb%nOrbAtom(inCellNeighbor(iNeigh1,iAt1))
+      do iNeigh1 = 0, nInCellNeighbour(iAt1)
+        start2 = iAtomStart(inCellNeighbour(iNeigh1,iAt1))
+        nOrb2 = orb%nOrbAtom(inCellNeighbour(iNeigh1,iAt1))
         dm(start2:start2+nOrb2-1, start1:start1+nOrb1-1) =&
             & matmul(eigenvecs(start2:start2+nOrb2-1,1:nLevels),&
             & tmpEigen(1:nLevels,1:nOrb1))
@@ -514,7 +516,7 @@ contains
 
 
   !> Make an energy weighted density matrix for the real wave-function case
-  subroutine sp_energy_density_matrix_real(dm, eigenvecs, filling, eigen, iNeighbor, nNeighborSK,&
+  subroutine sp_energy_density_matrix_real(dm, eigenvecs, filling, eigen, iNeighbour, nNeighbourSK,&
       & orb, iAtomStart, img2CentCell)
 
     !> the resulting nOrb*nOrb density matrix with only the elements of interest
@@ -530,11 +532,11 @@ contains
     !> eigenvalues of the system
     real(dp), intent(in) :: eigen(:)
 
-    !> Neighbor list for each atom (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Neighbour list for each atom (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom (incl. itself).
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Information about the orbitals.
     type(TOrbitals), intent(in) :: orb
@@ -547,8 +549,8 @@ contains
 
     integer :: iAt1, iNeigh1, jj, nOrb1, nOrb2, nAtom
     integer :: nLevels, start1, start2, ii
-    integer, allocatable :: inCellNeighbor(:,:)
-    integer, allocatable :: nInCellNeighbor(:)
+    integer, allocatable :: inCellNeighbour(:,:)
+    integer, allocatable :: nInCellNeighbour(:)
     real(dp), allocatable :: tmpEigen(:,:)
 
     @:ASSERT(all(shape(eigenvecs) == shape(dm)))
@@ -556,14 +558,14 @@ contains
     @:ASSERT(size(eigenvecs,dim=1) == size(filling))
     @:ASSERT(size(eigen) == size(filling))
 
-    allocate(inCellNeighbor(0:size(iNeighbor,dim=1),size(iNeighbor,dim=2)))
-    allocate(nInCellNeighbor(size(iNeighbor,dim=2)))
+    allocate(inCellNeighbour(0:size(iNeighbour,dim=1),size(iNeighbour,dim=2)))
+    allocate(nInCellNeighbour(size(iNeighbour,dim=2)))
 
     nAtom = size(orb%nOrbAtom)
     dm(:,:) = 0.0_dp
 
-    inCellNeighbor(:,:) = 0
-    nInCellNeighbor(:) = 0
+    inCellNeighbour(:,:) = 0
+    nInCellNeighbour(:) = 0
 
     do ii =  size(filling), 1, -1
       nLevels = ii
@@ -575,9 +577,10 @@ contains
     allocate(tmpEigen(nLevels,orb%mOrb))
     !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(iAt1) SCHEDULE(RUNTIME)
     do iAt1 = 1, nAtom
-      inCellNeighbor(0:nNeighborSK(iAt1),iAt1) = img2CentCell(iNeighbor(0:nNeighborSK(iAt1),iAt1))
-      call heap_sort(inCellNeighbor(:nNeighborSK(iAt1),iAt1))
-      nInCellNeighbor(iAt1) = unique(inCellNeighbor(:,iAt1), nNeighborSK(iAt1)+1) - 1
+      inCellNeighbour(0:nNeighbourSK(iAt1),iAt1) =&
+          & img2CentCell(iNeighbour(0:nNeighbourSK(iAt1),iAt1))
+      call heap_sort(inCellNeighbour(:nNeighbourSK(iAt1),iAt1))
+      nInCellNeighbour(iAt1) = unique(inCellNeighbour(:,iAt1), nNeighbourSK(iAt1)+1) - 1
     end do
     !$OMP  END PARALLEL DO
 
@@ -592,9 +595,9 @@ contains
       end do
       !$OMP  END PARALLEL DO
       !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(iNeigh1,start2,nOrb2) SCHEDULE(RUNTIME)
-      do iNeigh1 = 0, nInCellNeighbor(iAt1)
-        start2 = iAtomStart(inCellNeighbor(iNeigh1,iAt1))
-        nOrb2 = orb%nOrbAtom(inCellNeighbor(iNeigh1,iAt1))
+      do iNeigh1 = 0, nInCellNeighbour(iAt1)
+        start2 = iAtomStart(inCellNeighbour(iNeigh1,iAt1))
+        nOrb2 = orb%nOrbAtom(inCellNeighbour(iNeigh1,iAt1))
         dm(start2:start2+nOrb2-1, start1:start1+nOrb1-1) =&
             & matmul(eigenvecs(start2:start2+nOrb2-1,1:nLevels), tmpEigen(1:nLevels,1:nOrb1))
       end do
@@ -605,8 +608,8 @@ contains
 
 
   !> Make an energy weighted density matrix for the complex wave-function case
-  subroutine sp_energy_density_matrix_cmplx(dm, eigenvecs, filling, eigen, iNeighbor, nNeighborSK,&
-      & orb, iAtomStart, img2CentCell)
+  subroutine sp_energy_density_matrix_cmplx(dm, eigenvecs, filling, eigen, iNeighbour,&
+      & nNeighbourSK, orb, iAtomStart, img2CentCell)
 
     !> the resulting nOrb*nOrb density matrix with only the elements of interest
     !> calculated, instead of the whole dm
@@ -618,14 +621,14 @@ contains
     !> the occupation numbers of the orbitals
     real(dp), intent(in) :: filling(:)
 
-    !> Neighbor list for each atom (First index from 0!)
+    !> Neighbour list for each atom (First index from 0!)
     real(dp), intent(in) :: eigen(:)
 
-    !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Nr. of neighbours for each atom (incl. itself).
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> Information about the orbitals.
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Atom offset for the squared Hamiltonian
     type(TOrbitals), intent(in) :: orb
@@ -637,8 +640,8 @@ contains
 
     integer :: iAt1, iNeigh1, jj, nOrb1, nOrb2
     integer :: nAtom, nLevels, start1, start2, ii
-    integer, allocatable :: inCellNeighbor(:,:)
-    integer, allocatable :: nInCellNeighbor(:)
+    integer, allocatable :: inCellNeighbour(:,:)
+    integer, allocatable :: nInCellNeighbour(:)
     complex(dp), allocatable :: tmpEigen(:,:)
 
     @:ASSERT(all(shape(eigenvecs) == shape(dm)))
@@ -646,14 +649,14 @@ contains
     @:ASSERT(size(eigenvecs,dim=1) == size(filling))
     @:ASSERT(size(eigen) == size(filling))
 
-    allocate(inCellNeighbor(0:size(iNeighbor,dim=1),size(iNeighbor,dim=2)))
-    allocate(nInCellNeighbor(size(iNeighbor,dim=2)))
+    allocate(inCellNeighbour(0:size(iNeighbour,dim=1),size(iNeighbour,dim=2)))
+    allocate(nInCellNeighbour(size(iNeighbour,dim=2)))
 
     nAtom = size(orb%nOrbAtom)
     dm(:,:) = cmplx(0.0_dp,0.0_dp,dp)
 
-    inCellNeighbor(:,:) = 0
-    nInCellNeighbor(:) = 0
+    inCellNeighbour(:,:) = 0
+    nInCellNeighbour(:) = 0
 
     do ii =  size(filling), 1, -1
       nLevels = ii
@@ -665,9 +668,10 @@ contains
     allocate(tmpEigen(nLevels, orb%mOrb))
     !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(iAt1) SCHEDULE(RUNTIME)
     do iAt1 = 1, nAtom
-      inCellNeighbor(0:nNeighborSK(iAt1),iAt1) = img2CentCell(iNeighbor(0:nNeighborSK(iAt1),iAt1))
-      call heap_sort(inCellNeighbor(:nNeighborSK(iAt1),iAt1))
-      nInCellNeighbor(iAt1) = unique(inCellNeighbor(:,iAt1), nNeighborSK(iAt1)+1) - 1
+      inCellNeighbour(0:nNeighbourSK(iAt1),iAt1) =&
+          & img2CentCell(iNeighbour(0:nNeighbourSK(iAt1),iAt1))
+      call heap_sort(inCellNeighbour(:nNeighbourSK(iAt1),iAt1))
+      nInCellNeighbour(iAt1) = unique(inCellNeighbour(:,iAt1), nNeighbourSK(iAt1)+1) - 1
     end do
     !$OMP  END PARALLEL DO
 
@@ -682,9 +686,9 @@ contains
       end do
       !$OMP  END PARALLEL DO
       !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(iNeigh1,start2,nOrb2) SCHEDULE(RUNTIME)
-      do iNeigh1 = 0, nInCellNeighbor(iAt1)
-        start2 = iAtomStart(inCellNeighbor(iNeigh1,iAt1))
-        nOrb2 = orb%nOrbAtom(inCellNeighbor(iNeigh1,iAt1))
+      do iNeigh1 = 0, nInCellNeighbour(iAt1)
+        start2 = iAtomStart(inCellNeighbour(iNeigh1,iAt1))
+        nOrb2 = orb%nOrbAtom(inCellNeighbour(iNeigh1,iAt1))
         dm(start2:start2+nOrb2-1, start1:start1+nOrb1-1) =&
             &matmul(eigenvecs(start2:start2+nOrb2-1,1:nLevels), tmpEigen(1:nLevels,1:nOrb1))
       end do

--- a/prog/dftb+/lib_dftb/dispcommon.F90
+++ b/prog/dftb+/lib_dftb/dispcommon.F90
@@ -32,7 +32,7 @@ contains
   !> Fast converging Ewald like summation on 1/r^6 type interactions.  For details see the
   !> references in the module description.
   !> Note: the interaction parameter C6 is specified atomwise.
-  subroutine addDispEGr_per_atom(nAtom, coords, nNeighborSK, iNeighbor, neighDist2, img2CentCell,&
+  subroutine addDispEGr_per_atom(nAtom, coords, nNeighbourSK, iNeighbour, neighDist2, img2CentCell,&
       & c6, eta, vol, gLatVecs, energies, gradients, stress)
 
     !> Nr. of atoms (without periodic images)
@@ -41,11 +41,11 @@ contains
     !> Coordinates of the atoms (including images)
     real(dp), intent(in) :: coords(:,:)
 
-    !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom
+    integer, intent(in) :: nNeighbourSK(:)
 
-    !> Neighborlist.
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Neighbourlist.
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> Square distances of the neighbours.
     real(dp), intent(in) :: neighDist2(0:,:)
@@ -89,8 +89,8 @@ contains
     gc = pi**1.5_dp / (12.0_dp * vol)
     g3c = pi**1.5_dp / (6.0_dp * vol)
     do iAt1 = 1, nAtom
-      do iNeigh = 1, nNeighborSK(iAt1)
-        iAt2 = iNeighbor(iNeigh, iAt1)
+      do iNeigh = 1, nNeighbourSK(iAt1)
+        iAt2 = iNeighbour(iNeigh, iAt1)
         vec = coords(:,iAt1) - coords(:,iAt2)
         iAt2f = img2CentCell(iAt2)
         aam2 = (sqrt(neighDist2(iNeigh, iAt1))/eta)**(-2)
@@ -142,7 +142,7 @@ contains
           & - pi**1.5 * sum(c6(:,iAt1))/(6.0_dp * vol)) * etam3
       do ii = 1, 3
         stress(ii,ii) = stress(ii,ii) - gSum/vol&
-            & -(pi**1.5 * sum(c6(:,iAt1))/(6.0_dp * vol*vol)) * etam3
+            & - (pi**1.5 * sum(c6(:,iAt1))/(6.0_dp * vol*vol)) * etam3
       end do
       stress = stress - gSum33 / vol
       gradients(:,iAt1) =  gradients(:,iAt1) +  gSum3
@@ -155,7 +155,7 @@ contains
   !> Fast converging Ewald like summation on 1/r^6 type interactions.  The 1/r^12 term is
   !> summed in direct space.
   !> Note: the interaction coefficients (c6) are specified specieswise.
-  subroutine addDispEGr_per_species(nAtom, coords, species0, nNeighborSK, iNeighbor, neighDist2,&
+  subroutine addDispEGr_per_species(nAtom, coords, species0, nNeighbourSK, iNeighbour, neighDist2,&
       & img2CentCell, c6, eta, vol, gLatVecs, energies, gradients, stress)
 
     !> Nr. of atoms (without periodic images)
@@ -167,11 +167,11 @@ contains
     !> chemical species of atoms
     integer, intent(in) :: species0(:)
 
-    !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom
+    integer, intent(in) :: nNeighbourSK(:)
 
-    !> Neighborlist.
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Neighbourlist.
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> Square distances of the neighbours.
     real(dp), intent(in) :: neighDist2(0:,:)
@@ -216,8 +216,8 @@ contains
     g3c = pi**1.5_dp / (6.0_dp * vol)
     do iAt1 = 1, nAtom
       iSp1 = species0(iAt1)
-      do iNeigh = 1, nNeighborSK(iAt1)
-        iAt2 = iNeighbor(iNeigh, iAt1)
+      do iNeigh = 1, nNeighbourSK(iAt1)
+        iAt2 = iNeighbour(iNeigh, iAt1)
         vec = coords(:,iAt1) - coords(:,iAt2)
         iAt2f = img2CentCell(iAt2)
         iSp2 = species0(iAt2f)
@@ -271,7 +271,7 @@ contains
           & - pi**1.5 * sum(c6(species0(1:nAtom),iSp1))/(6.0_dp * vol)) * etam3
       do ii = 1, 3
         stress(ii,ii) = stress(ii,ii) - gSum/vol&
-            & -(pi**1.5 * sum(c6(species0(1:nAtom),iSp1))/(6.0_dp * vol*vol)) * etam3
+            & - (pi**1.5 * sum(c6(species0(1:nAtom),iSp1))/(6.0_dp * vol*vol)) * etam3
       end do
       stress = stress - gSum33 / vol
       gradients(:,iAt1) =  gradients(:,iAt1) +  gSum3
@@ -480,7 +480,7 @@ contains
     real(dp) :: err
 
     err = c6sum/(6.0_dp * sqrt(pi)) * (1.0_dp / eta**6)&
-        &*(gg * eta * exp(-1.0_dp * (0.5_dp*gg*eta)**2) + sqrt(pi) * erfcwrap(0.5_dp * gg * eta))
+        & * (gg * eta * exp(-1.0_dp * (0.5_dp*gg*eta)**2) + sqrt(pi) * erfcwrap(0.5_dp * gg * eta))
 
   end function getDispReciprocalError
 

--- a/prog/dftb+/lib_dftb/dispcommon.F90
+++ b/prog/dftb+/lib_dftb/dispcommon.F90
@@ -32,7 +32,7 @@ contains
   !> Fast converging Ewald like summation on 1/r^6 type interactions.  For details see the
   !> references in the module description.
   !> Note: the interaction parameter C6 is specified atomwise.
-  subroutine addDispEGr_per_atom(nAtom, coords, nNeighbors, iNeighbor, neighDist2, img2CentCell, &
+  subroutine addDispEGr_per_atom(nAtom, coords, nNeighborSK, iNeighbor, neighDist2, img2CentCell,&
       & c6, eta, vol, gLatVecs, energies, gradients, stress)
 
     !> Nr. of atoms (without periodic images)
@@ -42,7 +42,7 @@ contains
     real(dp), intent(in) :: coords(:,:)
 
     !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighbors(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Neighborlist.
     integer, intent(in) :: iNeighbor(0:,:)
@@ -89,16 +89,14 @@ contains
     gc = pi**1.5_dp / (12.0_dp * vol)
     g3c = pi**1.5_dp / (6.0_dp * vol)
     do iAt1 = 1, nAtom
-      do iNeigh = 1, nNeighbors(iAt1)
+      do iNeigh = 1, nNeighborSK(iAt1)
         iAt2 = iNeighbor(iNeigh, iAt1)
         vec = coords(:,iAt1) - coords(:,iAt2)
         iAt2f = img2CentCell(iAt2)
         aam2 = (sqrt(neighDist2(iNeigh, iAt1))/eta)**(-2)
-        rSum =  rc * c6(iAt2f, iAt1) &
-            &* ((aam2 + 1.0_dp)*aam2 + 0.5_dp)*aam2 * exp(-1.0_dp / aam2)
-        rSum3(:) = r3c * c6(iAt2f, iAt1) * exp(-1.0_dp / aam2) &
-            &* (((6.0_dp*aam2 + 6.0_dp)*aam2 + 3.0_dp)*aam2 + 1.0_dp)*aam2 &
-            & * vec(:)
+        rSum =  rc * c6(iAt2f, iAt1) * ((aam2 + 1.0_dp)*aam2 + 0.5_dp)*aam2 * exp(-1.0_dp / aam2)
+        rSum3(:) = r3c * c6(iAt2f, iAt1) * exp(-1.0_dp / aam2)&
+            & * (((6.0_dp*aam2 + 6.0_dp)*aam2 + 3.0_dp)*aam2 + 1.0_dp)*aam2 * vec(:)
         energies(iAt1) = energies(iAt1) - rSum
         gradients(:,iAt1) = gradients(:,iAt1) + rSum3(:)
         if (iAt1 /= iAt2f) then
@@ -129,8 +127,7 @@ contains
           rTmp = rTmp + cos(ddp) * c6(iAt1, iAt2)
           rTmp2 = rTmp2 + sin(ddp) * c6(iAt1, iAt2)
         end do
-        rTmp3 = sqrt(pi) * erfcwrap(bb) + (0.5_dp * bbm2 - 1.0_dp) / bb &
-            &* exp(-1.0_dp / bbm2)
+        rTmp3 = sqrt(pi) * erfcwrap(bb) + (0.5_dp * bbm2 - 1.0_dp) / bb * exp(-1.0_dp / bbm2)
         rTmp33 = sqrt(pi) * erfcwrap(bb) - exp(-bb*bb)/ bb
         gSum = gSum + rTmp * ggAbs**3 * rTmp3
         gSum3(:) = gSum3(:) + gg(:) * rTmp2 * ggAbs**3 * rTmp3
@@ -141,12 +138,11 @@ contains
       gSum = gSum * gc
       gSum3(:) = gSum3(:) * g3c
       gSum33 = gSum33 * gc
-      energies(iAt1) = energies(iAt1) - gSum &
-          &+ (c6(iAt1,iAt1)/12.0_dp * etam3 &
-          &- pi**1.5 * sum(c6(:,iAt1))/(6.0_dp * vol)) * etam3
+      energies(iAt1) = energies(iAt1) - gSum + (c6(iAt1,iAt1)/12.0_dp * etam3&
+          & - pi**1.5 * sum(c6(:,iAt1))/(6.0_dp * vol)) * etam3
       do ii = 1, 3
-        stress(ii,ii) = stress(ii,ii) - gSum/vol &
-            &-(pi**1.5 * sum(c6(:,iAt1))/(6.0_dp * vol*vol)) * etam3
+        stress(ii,ii) = stress(ii,ii) - gSum/vol&
+            & -(pi**1.5 * sum(c6(:,iAt1))/(6.0_dp * vol*vol)) * etam3
       end do
       stress = stress - gSum33 / vol
       gradients(:,iAt1) =  gradients(:,iAt1) +  gSum3
@@ -159,7 +155,7 @@ contains
   !> Fast converging Ewald like summation on 1/r^6 type interactions.  The 1/r^12 term is
   !> summed in direct space.
   !> Note: the interaction coefficients (c6) are specified specieswise.
-  subroutine addDispEGr_per_species(nAtom, coords, species0, nNeighbors, iNeighbor, neighDist2, &
+  subroutine addDispEGr_per_species(nAtom, coords, species0, nNeighborSK, iNeighbor, neighDist2,&
       & img2CentCell, c6, eta, vol, gLatVecs, energies, gradients, stress)
 
     !> Nr. of atoms (without periodic images)
@@ -172,7 +168,7 @@ contains
     integer, intent(in) :: species0(:)
 
     !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighbors(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Neighborlist.
     integer, intent(in) :: iNeighbor(0:,:)
@@ -220,17 +216,15 @@ contains
     g3c = pi**1.5_dp / (6.0_dp * vol)
     do iAt1 = 1, nAtom
       iSp1 = species0(iAt1)
-      do iNeigh = 1, nNeighbors(iAt1)
+      do iNeigh = 1, nNeighborSK(iAt1)
         iAt2 = iNeighbor(iNeigh, iAt1)
         vec = coords(:,iAt1) - coords(:,iAt2)
         iAt2f = img2CentCell(iAt2)
         iSp2 = species0(iAt2f)
         aam2 = (sqrt(neighDist2(iNeigh, iAt1))/eta)**(-2)
-        rSum =  rc * c6(iSp2, iSp1) &
-            &* ((aam2 + 1.0_dp)*aam2 + 0.5_dp)*aam2 * exp(-1.0_dp / aam2)
-        rSum3(:) = r3c * c6(iSp2, iSp1) * exp(-1.0_dp / aam2) &
-            &* (((6.0_dp*aam2 + 6.0_dp)*aam2 + 3.0_dp)*aam2 + 1.0_dp)*aam2 &
-            & * vec(:)
+        rSum =  rc * c6(iSp2, iSp1) * ((aam2 + 1.0_dp)*aam2 + 0.5_dp)*aam2 * exp(-1.0_dp / aam2)
+        rSum3(:) = r3c * c6(iSp2, iSp1) * exp(-1.0_dp / aam2)&
+            & * (((6.0_dp*aam2 + 6.0_dp)*aam2 + 3.0_dp)*aam2 + 1.0_dp)*aam2 * vec(:)
         energies(iAt1) = energies(iAt1) - rSum
         gradients(:,iAt1) = gradients(:,iAt1) + rSum3(:)
         if (iAt1 /= iAt2f) then
@@ -262,8 +256,7 @@ contains
           rTmp = rTmp + cos(ddp) * c6(iSp1, iSp2)
           rTmp2 = rTmp2 + sin(ddp) * c6(iSp1, iSp2)
         end do
-        rTmp3 = sqrt(pi) * erfcwrap(bb) + (0.5_dp * bbm2 - 1.0_dp) / bb &
-            &* exp(-1.0_dp / bbm2)
+        rTmp3 = sqrt(pi) * erfcwrap(bb) + (0.5_dp * bbm2 - 1.0_dp) / bb * exp(-1.0_dp / bbm2)
         rTmp33 = sqrt(pi) * erfcwrap(bb) - exp(-bb*bb)/ bb
         gSum = gSum + rTmp * ggAbs**3 * rTmp3
         gSum3(:) = gSum3(:) + gg(:) * rTmp2 * ggAbs**3 * rTmp3
@@ -274,12 +267,11 @@ contains
       gSum = gSum * gc
       gSum3(:) = gSum3(:) * g3c
       gSum33 = gSum33 * gc
-      energies(iAt1) = energies(iAt1) - gSum &
-          &+ (c6(iSp1,iSp1)/12.0_dp * etam3 &
-          &- pi**1.5 * sum(c6(species0(1:nAtom),iSp1))/(6.0_dp * vol)) * etam3
+      energies(iAt1) = energies(iAt1) - gSum + (c6(iSp1,iSp1)/12.0_dp * etam3&
+          & - pi**1.5 * sum(c6(species0(1:nAtom),iSp1))/(6.0_dp * vol)) * etam3
       do ii = 1, 3
-        stress(ii,ii) = stress(ii,ii) - gSum/vol &
-            &-(pi**1.5 * sum(c6(species0(1:nAtom),iSp1))/(6.0_dp * vol*vol)) * etam3
+        stress(ii,ii) = stress(ii,ii) - gSum/vol&
+            & -(pi**1.5 * sum(c6(species0(1:nAtom),iSp1))/(6.0_dp * vol*vol)) * etam3
       end do
       stress = stress - gSum33 / vol
       gradients(:,iAt1) =  gradients(:,iAt1) +  gSum3
@@ -466,9 +458,8 @@ contains
     !> Estimated error of the summation.
     real(dp) :: err
 
-    err = (pi**1.5_dp * c6sum / vol) * eta * (1.0_dp/rr**4 &
-        &+ 1.0_dp/(rr**2 * eta**2) + 1.0_dp / (2.0_dp * eta**4)) &
-        &* erfcwrap(rr/eta)
+    err = (pi**1.5_dp * c6sum / vol) * eta * (1.0_dp/rr**4&
+        & + 1.0_dp/(rr**2 * eta**2) + 1.0_dp / (2.0_dp * eta**4)) * erfcwrap(rr/eta)
 
   end function getDispRealError
 
@@ -488,9 +479,8 @@ contains
     !> Estimated error of the summation.
     real(dp) :: err
 
-    err = c6sum/(6.0_dp * sqrt(pi)) * (1.0_dp / eta**6) &
-        &*(gg * eta * exp(-1.0_dp * (0.5_dp*gg*eta)**2) &
-        &+ sqrt(pi) * erfcwrap(0.5_dp * gg * eta))
+    err = c6sum/(6.0_dp * sqrt(pi)) * (1.0_dp / eta**6)&
+        &*(gg * eta * exp(-1.0_dp * (0.5_dp*gg*eta)**2) + sqrt(pi) * erfcwrap(0.5_dp * gg * eta))
 
   end function getDispReciprocalError
 

--- a/prog/dftb+/lib_dftb/dispdftd3.F90
+++ b/prog/dftb+/lib_dftb/dispdftd3.F90
@@ -124,11 +124,9 @@ contains
     allocate(this%calculator)
     call dftd3_init(this%calculator, d3inp)
     if (inp%tBeckeJohnson) then
-      call dftd3_set_params(this%calculator, [inp%s6, inp%a1, inp%s8, &
-          & inp%a2, 0.0_dp], 4)
+      call dftd3_set_params(this%calculator, [inp%s6, inp%a1, inp%s8, inp%a2, 0.0_dp], 4)
     else
-      call dftd3_set_params(this%calculator, [inp%s6, inp%sr6, inp%s8, &
-          & inp%sr8, inp%alpha6], 3)
+      call dftd3_set_params(this%calculator, [inp%s6, inp%sr6, inp%s8, inp%sr8, inp%alpha6], 3)
     end if
 
     allocate(this%izp(nAtom))
@@ -146,8 +144,8 @@ contains
     !> Instance of stress data
     class(DispDftD3), intent(inout) :: this
 
-    !> Updated neighbor list.
-    type(TNeighborList), intent(in) :: neigh
+    !> Updated neighbour list.
+    type(TNeighbourList), intent(in) :: neigh
 
     !> Updated mapping to central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -163,11 +161,10 @@ contains
     if (this%tPeriodic) then
       ! dftd3 calculates the periodic images by itself -> only coords in central cell must be
       ! passed.
-      call dftd3_pbc_dispersion(this%calculator, coords(:, 1:this%nAtom), &
-          & this%izp, this%latVecs, this%dispE, this%gradients, this%stress)
+      call dftd3_pbc_dispersion(this%calculator, coords(:, 1:this%nAtom), this%izp, this%latVecs,&
+          & this%dispE, this%gradients, this%stress)
     else
-      call dftd3_dispersion(this%calculator, coords, this%izp, this%dispE, &
-          & this%gradients)
+      call dftd3_dispersion(this%calculator, coords, this%izp, this%dispE, this%gradients)
     end if
     this%tCoordsUpdated = .true.
 
@@ -256,7 +253,7 @@ contains
     real(dp) :: cutoff
 
     ! Since dftd3-routine uses its own real space summation routines, we do not need any real space
-    ! neighbors from neighbour list -> return 0 cutoff
+    ! neighbours from neighbour list -> return 0 cutoff
     cutoff = 0.0_dp
 
   end function getRCutoff

--- a/prog/dftb+/lib_dftb/dispiface.F90
+++ b/prog/dftb+/lib_dftb/dispiface.F90
@@ -8,7 +8,7 @@
 !> Common interface for all dispersion modules.
 module dispiface
   use accuracy, only : dp
-  use periodic, only : TNeighborList
+  use periodic, only : TNeighbourList
   implicit none
 
 
@@ -40,13 +40,13 @@ module dispiface
 
     !> Update internal stored coordinate
     subroutine updateCoordsIface(this, neigh, img2CentCell, coords, species0)
-      import :: DispersionIface, TNeighborList, dp
+      import :: DispersionIface, TNeighbourList, dp
 
       !> data structure
       class(DispersionIface), intent(inout) :: this
 
       !> list of neighbours to atoms
-      type(TNeighborList), intent(in) :: neigh
+      type(TNeighbourList), intent(in) :: neigh
 
       !> image to central cell atom index
       integer, intent(in) :: img2CentCell(:)

--- a/prog/dftb+/lib_dftb/dispslaterkirkw.F90
+++ b/prog/dftb+/lib_dftb/dispslaterkirkw.F90
@@ -26,7 +26,7 @@ module dispslaterkirkw
   use accuracy
   use simplealgebra, only : determinant33
   use lapackroutines, only : matinv
-  use periodic, only: TNeighborList, getNrOfNeighborsForAll, getLatticePoints
+  use periodic, only: TNeighbourList, getNrOfNeighboursForAll, getLatticePoints
   use constants, only : pi
   use dispiface
   use dispcommon
@@ -173,10 +173,10 @@ subroutine DispSlaKirk_init(this, inp, latVecs)
       cycle
     end if
     do iAt2 = 1, iAt1
-      this%c6(iAt2, iAt1) = 1.5_dp * inp%polar(iAt1) * inp%polar(iAt2)&
-          & / (sqrt(inp%polar(iAt1)/ inp%charges(iAt1)) + sqrt(inp%polar(iAt2)/ inp%charges(iAt2)))
-      rTmp = (inp%rWaals(iAt1)**3 + inp%rWaals(iAt2)**3)&
-          & / (inp%rWaals(iAt1)**2 + inp%rWaals(iAt2)**2)
+      this%c6(iAt2, iAt1) = 1.5_dp * inp%polar(iAt1) * inp%polar(iAt2) / (sqrt(inp%polar(iAt1)&
+          & / inp%charges(iAt1)) + sqrt(inp%polar(iAt2)/ inp%charges(iAt2)))
+      rTmp = (inp%rWaals(iAt1)**3 + inp%rWaals(iAt2)**3) / (inp%rWaals(iAt1)**2&
+          & + inp%rWaals(iAt2)**2)
       this%rVdW2(iAt2, iAt1) = dd_ / rTmp**nn_
       this%maxR = max(this%maxR, rTmp)
       if (iAt1 /= iAt2) then
@@ -222,8 +222,8 @@ subroutine updateCoords(this, neigh, img2CentCell, coords, species0)
   !> The data object for dispersion
   class(DispSlaKirk), intent(inout) :: this
 
-  !> Updated neighbor list.
-  type(TNeighborList), intent(in) :: neigh
+  !> Updated neighbour list.
+  type(TNeighbourList), intent(in) :: neigh
 
   !> Updated mapping to central cell.
   integer, intent(in) :: img2CentCell(:)
@@ -235,30 +235,30 @@ subroutine updateCoords(this, neigh, img2CentCell, coords, species0)
   integer, intent(in) :: species0(:)
 
 
-  !> Neighbors for real space summation
+  !> Neighbours for real space summation
   integer, allocatable :: nNeighReal(:)
 
-  !> Nr. of neighbors with damping
+  !> Nr. of neighbours with damping
   integer, allocatable :: nNeighDamp(:)
 
   allocate(nNeighReal(this%nAtom))
-  call getNrOfNeighborsForAll(nNeighReal, neigh, this%rCutoff)
+  call getNrOfNeighboursForAll(nNeighReal, neigh, this%rCutoff)
   this%energies(:) = 0.0_dp
   this%gradients(:,:) = 0.0_dp
   this%stress(:,:) = 0.0_dp
   if (this%tPeriodic) then
     ! Make Ewald summation for a pure 1/r^6 interaction
-    call addDispEGr_per_atom(this%nAtom, coords, nNeighReal, neigh%iNeighbor, neigh%neighDist2,&
+    call addDispEGr_per_atom(this%nAtom, coords, nNeighReal, neigh%iNeighbour, neigh%neighDist2,&
         & img2CentCell, this%c6, this%eta, this%vol, this%gLatPoint, this%energies, this%gradients,&
         & this%stress)
     ! Correct those terms, where damping is important
     allocate(nNeighDamp(this%nAtom))
-    call getNrOfNeighborsForAll(nNeighDamp, neigh, this%dampCutoff)
-    call addDispEnergyAndGrad_cluster(this%nAtom, coords, nNeighDamp, neigh%iNeighbor,&
+    call getNrOfNeighboursForAll(nNeighDamp, neigh, this%dampCutoff)
+    call addDispEnergyAndGrad_cluster(this%nAtom, coords, nNeighDamp, neigh%iNeighbour,&
         & neigh%neighDist2, img2CentCell, this%c6, this%rVdW2, this%energies, this%gradients,&
         & dampCorrection=-1.0_dp)
   else
-    call addDispEnergyAndGrad_cluster(this%nAtom, coords, nNeighReal, neigh%iNeighbor,&
+    call addDispEnergyAndGrad_cluster(this%nAtom, coords, nNeighReal, neigh%iNeighbour,&
         & neigh%neighDist2, img2CentCell, this%c6, this%rVdW2, this%energies, this%gradients)
   end if
   this%coordsUpdated = .true.
@@ -363,7 +363,7 @@ end function getRCutoff
 
 
 !> Adds the energy per atom and the gradients for the cluster case
-subroutine addDispEnergyAndGrad_cluster(nAtom, coords, nNeighborSK, iNeighbor, neighDist2,&
+subroutine addDispEnergyAndGrad_cluster(nAtom, coords, nNeighbourSK, iNeighbour, neighDist2,&
     & img2CentCell, c6, rVdW2, energies, gradients, dampCorrection)
 
   !> Nr. of atoms (without periodic images)
@@ -372,11 +372,11 @@ subroutine addDispEnergyAndGrad_cluster(nAtom, coords, nNeighborSK, iNeighbor, n
   !> Coordinates of the atoms (including images)
   real(dp), intent(in) :: coords(:,:)
 
-  !> Nr. of neighbors for each atom
-  integer, intent(in) :: nNeighborSK(:)
+  !> Nr. of neighbours for each atom
+  integer, intent(in) :: nNeighbourSK(:)
 
-  !> Neighborlist.
-  integer, intent(in) :: iNeighbor(0:,:)
+  !> Neighbourlist.
+  integer, intent(in) :: iNeighbour(0:,:)
 
   !> Square distances of the neighbours.
   real(dp), intent(in) :: neighDist2(0:,:)
@@ -414,11 +414,11 @@ subroutine addDispEnergyAndGrad_cluster(nAtom, coords, nNeighborSK, iNeighbor, n
   end if
 
   ! Cluster case => explicit sum of the contributions NOTE: the cluster summation also (ab)used in
-  ! the periodic case, neighbors may go over the cell boundary -> img2CentCell needed for folding
+  ! the periodic case, neighbours may go over the cell boundary -> img2CentCell needed for folding
   ! back.
   do iAt1 = 1, nAtom
-    do iNeigh = 1, nNeighborSK(iAt1)
-      iAt2 = iNeighbor(iNeigh, iAt1)
+    do iNeigh = 1, nNeighbourSK(iAt1)
+      iAt2 = iNeighbour(iNeigh, iAt1)
       iAt2f = img2CentCell(iAt2)
       if (c6(iAt2f, iAt1) == 0.0_dp) then
         cycle

--- a/prog/dftb+/lib_dftb/dispuff.F90
+++ b/prog/dftb+/lib_dftb/dispuff.F90
@@ -322,7 +322,7 @@ contains
   end function getRCutoff
 
   !> Returns the energy per atom and the gradients for the cluster case
-  subroutine getDispEnergyAndGrad_cluster(nAtom, coords, species, nNeighbors, iNeighbor, &
+  subroutine getDispEnergyAndGrad_cluster(nAtom, coords, species, nNeighborSK, iNeighbor, &
       & neighDist2, img2CentCell, c6, c12, cPoly, r0, energies, gradients, removeR6, stress, vol)
 
     !> Nr. of atoms (without periodic images)
@@ -335,7 +335,7 @@ contains
     integer, intent(in) :: species(:)
 
     !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighbors(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Neighborlist.
     integer, intent(in) :: iNeighbor(0:,:)
@@ -398,7 +398,7 @@ contains
     end if
     do iAt1 = 1, nAtom
       iSp1 = species(iAt1)
-      do iNeigh = 1, nNeighbors(iAt1)
+      do iNeigh = 1, nNeighborSK(iAt1)
         iAt2 = iNeighbor(iNeigh, iAt1)
         vec = coords(:,iAt1)-coords(:,iAt2)
         iAt2f = img2CentCell(iAt2)

--- a/prog/dftb+/lib_dftb/dispuff.F90
+++ b/prog/dftb+/lib_dftb/dispuff.F90
@@ -20,7 +20,7 @@ module dispuff_module
   use accuracy
   use simplealgebra, only : determinant33
   use lapackroutines, only : matinv
-  use periodic, only: TNeighborList, getNrOfNeighborsForAll, getLatticePoints
+  use periodic, only: TNeighbourList, getNrOfNeighboursForAll, getLatticePoints
   use constants, only: pi
   use dispiface
   use dispcommon
@@ -168,8 +168,7 @@ contains
     if (this%tPeriodic) then
       ! Cutoff for the direct summation of r^(-12) terms. To be sure, it is delivering the required
       ! accuracy, dispTol is strengthened by two orders of magnitude more.
-      this%rCutoff = (maxval(this%c12) &
-          & / (tolDispersion * 1.0e-2_dp))**(1.0_dp / 12.0_dp)
+      this%rCutoff = (maxval(this%c12) / (tolDispersion * 1.0e-2_dp))**(1.0_dp / 12.0_dp)
       ! Summing with loop to avoid creation of (nAtom, nAtom) tmp array.
       c6sum = 0.0_dp
       do iAt1 = 1, nAtom
@@ -194,8 +193,8 @@ contains
     !> Instance of dispersion to update
     class(DispUff), intent(inout) :: this
 
-    !> Updated neighbor list.
-    type(TNeighborList), intent(in) :: neigh
+    !> Updated neighbour list.
+    type(TNeighbourList), intent(in) :: neigh
 
     !> Updated mapping to central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -209,21 +208,19 @@ contains
     integer, allocatable :: nNeigh(:)
 
     allocate(nNeigh(this%nAtom))
-    call getNrOfNeighborsForAll(nNeigh, neigh, this%rCutoff)
+    call getNrOfNeighboursForAll(nNeigh, neigh, this%rCutoff)
     if (this%tPeriodic) then
-      call getDispEnergyAndGrad_cluster(this%nAtom, coords, species0, nNeigh, &
-          & neigh%iNeighbor, neigh%neighDist2, img2CentCell, this%c6, &
-          & this%c12, this%cPoly, this%r0, this%energies, this%gradients, &
-          & removeR6=.true., stress=this%stress, vol=this%vol)
-      call getNrOfNeighborsForAll(nNeigh, neigh, this%ewaldRCut)
-      call addDispEGr_per_species(this%nAtom, coords, species0, nNeigh, &
-          &neigh%iNeighbor, neigh%neighDist2, img2CentCell, &
-          &this%c6, this%eta, this%vol, this%gLatPoints, this%energies, &
-          & this%gradients, this%stress)
+      call getDispEnergyAndGrad_cluster(this%nAtom, coords, species0, nNeigh, neigh%iNeighbour,&
+          & neigh%neighDist2, img2CentCell, this%c6, this%c12, this%cPoly, this%r0, this%energies,&
+          & this%gradients, removeR6=.true., stress=this%stress, vol=this%vol)
+      call getNrOfNeighboursForAll(nNeigh, neigh, this%ewaldRCut)
+      call addDispEGr_per_species(this%nAtom, coords, species0, nNeigh, neigh%iNeighbour,&
+          & neigh%neighDist2, img2CentCell, this%c6, this%eta, this%vol, this%gLatPoints,&
+          & this%energies, this%gradients, this%stress)
     else
-      call getDispEnergyAndGrad_cluster(this%nAtom, coords, species0, nNeigh, &
-          & neigh%iNeighbor, neigh%neighDist2, img2CentCell, this%c6, &
-          & this%c12, this%cPoly, this%r0, this%energies, this%gradients)
+      call getDispEnergyAndGrad_cluster(this%nAtom, coords, species0, nNeigh, neigh%iNeighbour,&
+          & neigh%neighDist2, img2CentCell, this%c6, this%c12, this%cPoly, this%r0, this%energies,&
+          & this%gradients)
     end if
 
     this%coordsUpdated = .true.
@@ -249,12 +246,10 @@ contains
     recVecs(:,:) = transpose(invRecVecs)
     call matinv(invRecVecs)
     this%eta =  getOptimalEta(latVecs, this%vol) / sqrt(2.0_dp)
-    this%ewaldRCut = getMaxRDispersion(this%eta, this%c6sum, this%vol, &
-        & tolDispersion)
+    this%ewaldRCut = getMaxRDispersion(this%eta, this%c6sum, this%vol, tolDispersion)
     this%ewaldGCut = getMaxGDispersion(this%eta, this%c6sum, tolDispersion)
-    call getLatticePoints(this%gLatPoints, recVecs, invRecVecs, &
-        &this%ewaldGCut, onlyInside=.true., reduceByInversion=.true., &
-        &withoutOrigin=.true.)
+    call getLatticePoints(this%gLatPoints, recVecs, invRecVecs, this%ewaldGCut, onlyInside=.true.,&
+        & reduceByInversion=.true., withoutOrigin=.true.)
     this%gLatPoints = matmul(recVecs, this%gLatPoints)
     this%coordsUpdated = .false.
 
@@ -322,7 +317,7 @@ contains
   end function getRCutoff
 
   !> Returns the energy per atom and the gradients for the cluster case
-  subroutine getDispEnergyAndGrad_cluster(nAtom, coords, species, nNeighborSK, iNeighbor, &
+  subroutine getDispEnergyAndGrad_cluster(nAtom, coords, species, nNeighbourSK, iNeighbour,&
       & neighDist2, img2CentCell, c6, c12, cPoly, r0, energies, gradients, removeR6, stress, vol)
 
     !> Nr. of atoms (without periodic images)
@@ -334,11 +329,11 @@ contains
     !> Species of every atom.
     integer, intent(in) :: species(:)
 
-    !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom
+    integer, intent(in) :: nNeighbourSK(:)
 
-    !> Neighborlist.
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Neighbourlist.
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> Square distances of the neighbours.
     real(dp), intent(in) :: neighDist2(0:,:)
@@ -398,8 +393,8 @@ contains
     end if
     do iAt1 = 1, nAtom
       iSp1 = species(iAt1)
-      do iNeigh = 1, nNeighborSK(iAt1)
-        iAt2 = iNeighbor(iNeigh, iAt1)
+      do iNeigh = 1, nNeighbourSK(iAt1)
+        iAt2 = iNeighbour(iNeigh, iAt1)
         vec = coords(:,iAt1)-coords(:,iAt2)
         iAt2f = img2CentCell(iAt2)
         iSp2 = species(iAt2f)
@@ -421,8 +416,7 @@ contains
           u1 = cPoly(2, iSp2, iSp1)
           u2 = cPoly(3, iSp2, iSp1)
           dE = 0.5_dp * ((u0 - u1 * r5 - u2 * r10) + (1.0_dp - f6) * k1 / r6)
-          dGr = (-5.0_dp * u1 * r5 - 10.0_dp * u2 * r10 &
-              &- 6.0_dp * k1 * (1.0_dp - f6) / r6) / rr
+          dGr = (-5.0_dp * u1 * r5 - 10.0_dp * u2 * r10 - 6.0_dp * k1 * (1.0_dp - f6) / r6) / rr
         else
           ! Two atoms at the same position -> forget it
           dE = 0.0_dp

--- a/prog/dftb+/lib_dftb/forces.F90
+++ b/prog/dftb+/lib_dftb/forces.F90
@@ -44,7 +44,7 @@ contains
   !> The non-SCC electronic force contribution for all atoms from the matrix derivatives and the
   !> density and energy-density matrices
   subroutine derivative_nonSCC(env, deriv, derivator, DM, EDM, skHamCont, skOverCont, coords,&
-      & species, iNeighbor, nNeighborSK, img2CentCell, iPair, orb)
+      & species, iNeighbour, nNeighbourSK, img2CentCell, iPair, orb)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -73,11 +73,11 @@ contains
     !> list of all atomic species
     integer, intent(in) :: species(:)
 
-    !> neighbor list for atoms
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> neighbour list for atoms
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> number of neighbors of each atom
-    integer, intent(in) :: nNeighborSK(:)
+    !> number of neighbours of each atom
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> indexing array for periodic image atoms
     integer, intent(in) :: img2CentCell(:)
@@ -107,8 +107,8 @@ contains
     do iAtom1 = iAtFirst, iAtLast
       nOrb1 = orb%nOrbAtom(iAtom1)
       !! loop from 1 as no contribution from the atom itself
-      do iNeigh = 1, nNeighborSK(iAtom1)
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+      do iNeigh = 1, nNeighbourSK(iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         if (iAtom1 /= iAtom2f) then
           nOrb2 = orb%nOrbAtom(iAtom2f)
@@ -117,25 +117,21 @@ contains
           sqrEDMTmp(:,:) = 0.0_dp
           hPrimeTmp(:,:,:) = 0.0_dp
           sPrimeTmp(:,:,:) = 0.0_dp
-          sqrDMTmp(1:nOrb2,1:nOrb1) = &
-              & reshape(DM(iOrig+1:iOrig+nOrb1*nOrb2), (/nOrb2,nOrb1/))
-          sqrEDMTmp(1:nOrb2,1:nOrb1) = &
-              & reshape(EDM(iOrig+1:iOrig+nOrb1*nOrb2), (/nOrb2,nOrb1/))
-          call derivator%getFirstDeriv(hPrimeTmp, skHamCont, coords, species,&
-              & iAtom1, iAtom2, orb)
-          call derivator%getFirstDeriv(sPrimeTmp, skOverCont, coords, species,&
-              & iAtom1, iAtom2, orb)
+          sqrDMTmp(1:nOrb2,1:nOrb1) = reshape(DM(iOrig+1:iOrig+nOrb1*nOrb2), (/nOrb2,nOrb1/))
+          sqrEDMTmp(1:nOrb2,1:nOrb1) = reshape(EDM(iOrig+1:iOrig+nOrb1*nOrb2), (/nOrb2,nOrb1/))
+          call derivator%getFirstDeriv(hPrimeTmp, skHamCont, coords, species, iAtom1, iAtom2, orb)
+          call derivator%getFirstDeriv(sPrimeTmp, skOverCont, coords, species, iAtom1, iAtom2, orb)
           ! note factor of 2 for implicit summation over lower triangle of density matrix:
           do ii = 1, 3
             deriv(ii,iAtom1) = deriv(ii,iAtom1)&
-                & + sum(sqrDMTmp(1:nOrb2,1:nOrb1) * 2.0_dp*hPrimeTmp(1:nOrb2,1:nOrb1,ii)) &
+                & + sum(sqrDMTmp(1:nOrb2,1:nOrb1) * 2.0_dp*hPrimeTmp(1:nOrb2,1:nOrb1,ii))&
                 & - sum(sqrEDMTmp(1:nOrb2,1:nOrb1) * 2.0_dp*sPrimeTmp(1:nOrb2,1:nOrb1,ii))
           end do
           ! Add contribution to the force from atom 1 onto atom 2f using the symmetry in the blocks,
           ! and note that the skew symmetry in the derivatives is being used
           do ii = 1, 3
-            deriv(ii,iAtom2f) = deriv(ii,iAtom2f) &
-                & - sum(sqrDMTmp(1:nOrb2,1:nOrb1) * 2.0_dp*hPrimeTmp(1:nOrb2,1:nOrb1,ii)) &
+            deriv(ii,iAtom2f) = deriv(ii,iAtom2f)&
+                & - sum(sqrDMTmp(1:nOrb2,1:nOrb1) * 2.0_dp*hPrimeTmp(1:nOrb2,1:nOrb1,ii))&
                 & + sum(sqrEDMTmp(1:nOrb2,1:nOrb1) * 2.0_dp*sPrimeTmp(1:nOrb2,1:nOrb1,ii))
           end do
         end if
@@ -151,7 +147,7 @@ contains
   !> The SCC and spin electronic force contribution for all atoms from the matrix derivatives, self
   !> consistent potential and the density and energy-density matrices
   subroutine derivative_block(env, deriv, derivator, DM, EDM, skHamCont, skOverCont, coords,&
-      & species, iNeighbor, nNeighborSK, img2CentCell, iPair, orb, shift)
+      & species, iNeighbour, nNeighbourSK, img2CentCell, iPair, orb, shift)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -180,11 +176,11 @@ contains
     !> list of all atomic species
     integer, intent(in) :: species(:)
 
-    !> neighbor list for atoms
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> neighbour list for atoms
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> number of neighbors of each atom
-    integer, intent(in) :: nNeighborSK(:)
+    !> number of neighbours of each atom
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> indexing array for periodic image atoms
     integer, intent(in) :: img2CentCell(:)
@@ -229,42 +225,34 @@ contains
     do iAtom1 = iAtFirst, iAtLast
       iSp1 = species(iAtom1)
       nOrb1 = orb%nOrbSpecies(iSp1)
-      do iNeigh = 1, nNeighborSK(iAtom1)
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+      do iNeigh = 1, nNeighbourSK(iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         iSp2 = species(iAtom2f)
         if (iAtom1 /= iAtom2f) then
           nOrb2 = orb%nOrbSpecies(iSp2)
           iOrig = iPair(iNeigh,iAtom1) + 1
-          sqrDMTmp(1:nOrb2,1:nOrb1) = &
-              & reshape(DM(iOrig:iOrig+nOrb1*nOrb2-1,1),(/nOrb2,nOrb1/))
-          sqrEDMTmp(1:nOrb2,1:nOrb1) = &
-              & reshape(EDM(iOrig:iOrig+nOrb1*nOrb2-1),(/nOrb2,nOrb1/))
-          call derivator%getFirstDeriv(hPrimeTmp, skHamCont, coords, species,&
-              & iAtom1, iAtom2, orb)
-          call derivator%getFirstDeriv(sPrimeTmp, skOverCont, coords, species,&
-              & iAtom1, iAtom2, orb)
+          sqrDMTmp(1:nOrb2,1:nOrb1) = reshape(DM(iOrig:iOrig+nOrb1*nOrb2-1,1),(/nOrb2,nOrb1/))
+          sqrEDMTmp(1:nOrb2,1:nOrb1) = reshape(EDM(iOrig:iOrig+nOrb1*nOrb2-1),(/nOrb2,nOrb1/))
+          call derivator%getFirstDeriv(hPrimeTmp, skHamCont, coords, species, iAtom1, iAtom2, orb)
+          call derivator%getFirstDeriv(sPrimeTmp, skOverCont, coords, species, iAtom1, iAtom2, orb)
 
           derivTmp(:) = 0.0_dp
           ! note factor of 2 for implicit summation over lower triangle of density matrix:
           do ii = 1, 3
             derivTmp(ii) = 2.0_dp * (&
                 & sum(sqrDMTmp(1:nOrb2,1:nOrb1)*hPrimeTmp(1:nOrb2,1:nOrb1,ii))&
-                &-sum(sqrEDMTmp(1:nOrb2,1:nOrb1)*sPrimeTmp(1:nOrb2,1:nOrb1,ii)))
+                & - sum(sqrEDMTmp(1:nOrb2,1:nOrb1)*sPrimeTmp(1:nOrb2,1:nOrb1,ii)))
           end do
 
           do iSpin = 1, nSpin
             do ii = 1, 3
-              shiftSprime(1:nOrb2,1:nOrb1) = 0.5_dp * ( &
-                  & matmul(sPrimeTmp(1:nOrb2,1:nOrb1,ii), &
-                  & shift(1:nOrb1,1:nOrb1,iAtom1,iSpin) ) &
-                  & + matmul(shift(1:nOrb2,1:nOrb2,iAtom2f,iSpin), &
-                  & sPrimeTmp(1:nOrb2,1:nOrb1,ii)) )
+              shiftSprime(1:nOrb2,1:nOrb1) = 0.5_dp * (&
+                  & matmul(sPrimeTmp(1:nOrb2,1:nOrb1,ii), shift(1:nOrb1,1:nOrb1,iAtom1,iSpin) )&
+                  & + matmul(shift(1:nOrb2,1:nOrb2,iAtom2f,iSpin), sPrimeTmp(1:nOrb2,1:nOrb1,ii)) )
               ! again factor of 2 from lower triangle, cf published force expressions for SCC:
-              derivTmp(ii) = derivTmp(ii) + 2.0_dp * ( &
-                  &sum(shiftSprime(1:nOrb2,1:nOrb1) * &
-                  &reshape(DM(iOrig:iOrig+nOrb1*nOrb2-1,iSpin),(/nOrb2,nOrb1/))&
-                  & ) )
+              derivTmp(ii) = derivTmp(ii) + 2.0_dp * ( sum(shiftSprime(1:nOrb2,1:nOrb1) *&
+                  & reshape(DM(iOrig:iOrig+nOrb1*nOrb2-1,iSpin),(/nOrb2,nOrb1/)) ) )
             end do
           end do
 
@@ -285,7 +273,7 @@ contains
   !> The SCC and spin electronic force contribution for all atoms, including complex contributions,
   !> for example from spin-orbit
   subroutine derivative_iBlock(env, deriv, derivator, DM, iDM, EDM, skHamCont, skOverCont, coords,&
-      & species, iNeighbor, nNeighborSK, img2CentCell, iPair, orb, shift, iShift)
+      & species, iNeighbour, nNeighbourSK, img2CentCell, iPair, orb, shift, iShift)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -317,11 +305,11 @@ contains
     !> list of all atomic species
     integer, intent(in) :: species(:)
 
-    !> neighbor list for atoms
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> neighbour list for atoms
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> number of neighbors of each atom
-    integer, intent(in) :: nNeighborSK(:)
+    !> number of neighbours of each atom
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> indexing array for periodic image atoms
     integer, intent(in) :: img2CentCell(:)
@@ -373,56 +361,46 @@ contains
     do iAtom1 = iAtFirst, iAtLast
       iSp1 = species(iAtom1)
       nOrb1 = orb%nOrbSpecies(iSp1)
-      do iNeigh = 1, nNeighborSK(iAtom1)
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+      do iNeigh = 1, nNeighbourSK(iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         iSp2 = species(iAtom2f)
         if (iAtom1 /= iAtom2f) then
           nOrb2 = orb%nOrbSpecies(iSp2)
           iOrig = iPair(iNeigh,iAtom1) + 1
-          sqrDMTmp(1:nOrb2,1:nOrb1) = &
-              & reshape(DM(iOrig:iOrig+nOrb1*nOrb2-1,1),(/nOrb2,nOrb1/))
-          sqrEDMTmp(1:nOrb2,1:nOrb1) = &
-              & reshape(EDM(iOrig:iOrig+nOrb1*nOrb2-1),(/nOrb2,nOrb1/))
-          call derivator%getFirstDeriv(hPrimeTmp, skHamCont, coords, species,&
-              & iAtom1, iAtom2, orb)
-          call derivator%getFirstDeriv(sPrimeTmp, skOverCont, coords, species,&
-              & iAtom1, iAtom2, orb)
+          sqrDMTmp(1:nOrb2,1:nOrb1) = reshape(DM(iOrig:iOrig+nOrb1*nOrb2-1,1),(/nOrb2,nOrb1/))
+          sqrEDMTmp(1:nOrb2,1:nOrb1) = reshape(EDM(iOrig:iOrig+nOrb1*nOrb2-1),(/nOrb2,nOrb1/))
+          call derivator%getFirstDeriv(hPrimeTmp, skHamCont, coords, species, iAtom1, iAtom2, orb)
+          call derivator%getFirstDeriv(sPrimeTmp, skOverCont, coords, species, iAtom1, iAtom2, orb)
 
           derivTmp(:) = 0.0_dp
           ! note factor of 2 for implicit summation over lower triangle of density matrix:
           do ii = 1, 3
             derivTmp(ii) = 2.0_dp * (&
                 & sum(sqrDMTmp(1:nOrb2,1:nOrb1)*hPrimeTmp(1:nOrb2,1:nOrb1,ii))&
-                &-sum(sqrEDMTmp(1:nOrb2,1:nOrb1)*sPrimeTmp(1:nOrb2,1:nOrb1,ii)))
+                & - sum(sqrEDMTmp(1:nOrb2,1:nOrb1)*sPrimeTmp(1:nOrb2,1:nOrb1,ii)))
           end do
 
           do iSpin = 1, nSpin
             do ii = 1, 3
-              shiftSprime(1:nOrb2,1:nOrb1) = 0.5_dp * ( &
-                  & matmul(sPrimeTmp(1:nOrb2,1:nOrb1,ii), &
-                  & shift(1:nOrb1,1:nOrb1,iAtom1,iSpin) ) &
-                  & + matmul(shift(1:nOrb2,1:nOrb2,iAtom2f,iSpin), &
-                  & sPrimeTmp(1:nOrb2,1:nOrb1,ii)) )
+              shiftSprime(1:nOrb2,1:nOrb1) = 0.5_dp * (&
+                  & matmul(sPrimeTmp(1:nOrb2,1:nOrb1,ii), shift(1:nOrb1,1:nOrb1,iAtom1,iSpin) )&
+                  & + matmul(shift(1:nOrb2,1:nOrb2,iAtom2f,iSpin), sPrimeTmp(1:nOrb2,1:nOrb1,ii)) )
               ! again factor of 2 from lower triangle sum of DM
-              derivTmp(ii) = derivTmp(ii) &
+              derivTmp(ii) = derivTmp(ii)&
                   & + 2.0_dp* ( real(sum(shiftSprime(1:nOrb2,1:nOrb1)&
-                  & * reshape(DM(iOrig:iOrig+nOrb1*nOrb2-1,iSpin),&
-                  & (/nOrb2,nOrb1/)))) )
+                  & * reshape(DM(iOrig:iOrig+nOrb1*nOrb2-1,iSpin), (/nOrb2,nOrb1/)))) )
             end do
           end do
 
           do iSpin = 1, nSpin
             do ii = 1, 3
-              shiftSprime(1:nOrb2,1:nOrb1) = 0.5_dp *  ( &
-                  & matmul(sPrimeTmp(1:nOrb2,1:nOrb1,ii), &
-                  & ishift(1:nOrb1,1:nOrb1,iAtom1,iSpin) ) &
-                  & + matmul(ishift(1:nOrb2,1:nOrb2,iAtom2f,iSpin), &
-                  & sPrimeTmp(1:nOrb2,1:nOrb1,ii)) )
+              shiftSprime(1:nOrb2,1:nOrb1) = 0.5_dp *  (&
+                  & matmul(sPrimeTmp(1:nOrb2,1:nOrb1,ii), ishift(1:nOrb1,1:nOrb1,iAtom1,iSpin) )&
+                  & + matmul(ishift(1:nOrb2,1:nOrb2,iAtom2f,iSpin), sPrimeTmp(1:nOrb2,1:nOrb1,ii)) )
               derivTmp(ii) = derivTmp(ii)&
                   & + real(sum(shiftSprime(1:nOrb2,1:nOrb1) *&
-                  & reshape(iDM(iOrig:iOrig+nOrb1*nOrb2-1,iSpin),&
-                  & (/nOrb2,nOrb1/))))
+                  & reshape(iDM(iOrig:iOrig+nOrb1*nOrb2-1,iSpin), (/nOrb2,nOrb1/))))
             end do
           end do
 

--- a/prog/dftb+/lib_dftb/forces.F90
+++ b/prog/dftb+/lib_dftb/forces.F90
@@ -44,7 +44,7 @@ contains
   !> The non-SCC electronic force contribution for all atoms from the matrix derivatives and the
   !> density and energy-density matrices
   subroutine derivative_nonSCC(env, deriv, derivator, DM, EDM, skHamCont, skOverCont, coords,&
-      & species, iNeighbor, nNeighbor, img2CentCell, iPair, orb)
+      & species, iNeighbor, nNeighborSK, img2CentCell, iPair, orb)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -77,7 +77,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> number of neighbors of each atom
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> indexing array for periodic image atoms
     integer, intent(in) :: img2CentCell(:)
@@ -107,7 +107,7 @@ contains
     do iAtom1 = iAtFirst, iAtLast
       nOrb1 = orb%nOrbAtom(iAtom1)
       !! loop from 1 as no contribution from the atom itself
-      do iNeigh = 1, nNeighbor(iAtom1)
+      do iNeigh = 1, nNeighborSK(iAtom1)
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         if (iAtom1 /= iAtom2f) then
@@ -151,7 +151,7 @@ contains
   !> The SCC and spin electronic force contribution for all atoms from the matrix derivatives, self
   !> consistent potential and the density and energy-density matrices
   subroutine derivative_block(env, deriv, derivator, DM, EDM, skHamCont, skOverCont, coords,&
-      & species, iNeighbor, nNeighbor, img2CentCell, iPair, orb, shift)
+      & species, iNeighbor, nNeighborSK, img2CentCell, iPair, orb, shift)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -184,7 +184,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> number of neighbors of each atom
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> indexing array for periodic image atoms
     integer, intent(in) :: img2CentCell(:)
@@ -229,7 +229,7 @@ contains
     do iAtom1 = iAtFirst, iAtLast
       iSp1 = species(iAtom1)
       nOrb1 = orb%nOrbSpecies(iSp1)
-      do iNeigh = 1, nNeighbor(iAtom1)
+      do iNeigh = 1, nNeighborSK(iAtom1)
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         iSp2 = species(iAtom2f)
@@ -285,7 +285,7 @@ contains
   !> The SCC and spin electronic force contribution for all atoms, including complex contributions,
   !> for example from spin-orbit
   subroutine derivative_iBlock(env, deriv, derivator, DM, iDM, EDM, skHamCont, skOverCont, coords,&
-      & species, iNeighbor, nNeighbor, img2CentCell, iPair, orb, shift, iShift)
+      & species, iNeighbor, nNeighborSK, img2CentCell, iPair, orb, shift, iShift)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -321,7 +321,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> number of neighbors of each atom
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> indexing array for periodic image atoms
     integer, intent(in) :: img2CentCell(:)
@@ -373,7 +373,7 @@ contains
     do iAtom1 = iAtFirst, iAtLast
       iSp1 = species(iAtom1)
       nOrb1 = orb%nOrbSpecies(iSp1)
-      do iNeigh = 1, nNeighbor(iAtom1)
+      do iNeigh = 1, nNeighborSK(iAtom1)
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         iSp2 = species(iAtom2f)

--- a/prog/dftb+/lib_dftb/nonscc.F90
+++ b/prog/dftb+/lib_dftb/nonscc.F90
@@ -57,8 +57,8 @@ module nonscc
 contains
 
   !> Driver for making the non-SCC Hamiltonian in the primitive sparse format.
-  subroutine buildH0(env, ham, skHamCont, selfegy, coords, nNeighbors, iNeighbors,&
-      & species, iPair, orb)
+  subroutine buildH0(env, ham, skHamCont, selfegy, coords, nNeighborSK, iNeighbors, species, iPair,&
+      & orb)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -76,7 +76,7 @@ contains
     real(dp), intent(in) :: coords(:,:)
 
     !> Number of surrounding neighbors for each atom
-    integer, intent(in) :: nNeighbors(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> List of surrounding neighbors for each atom
     integer, intent(in) :: iNeighbors(0:,:)
@@ -92,7 +92,7 @@ contains
 
     integer :: nAtom, iAt1, iSp1, ind, iOrb1, iAtFirst, iAtLast
 
-    nAtom = size(nNeighbors)
+    nAtom = size(nNeighborSK)
     ham(:) = 0.0_dp
 
     call distributeRangeInChunks(env, 1, nAtom, iAtFirst, iAtLast)
@@ -110,16 +110,15 @@ contains
     end do
     !$OMP  END PARALLEL DO
 
-    call buildDiatomicBlocks(iAtFirst, iAtLast, skHamCont, coords, nNeighbors, iNeighbors, species,&
-        & iPair, orb, ham)
+    call buildDiatomicBlocks(iAtFirst, iAtLast, skHamCont, coords, nNeighborSK, iNeighbors,&
+        & species, iPair, orb, ham)
 
     call assembleChunks(env, ham)
 
   end subroutine buildH0
 
   !> Driver for making the overlap matrix in the primitive sparse format.
-  subroutine buildS(env, over, skOverCont, coords, nNeighbors, iNeighbors, species,&
-      & iPair, orb)
+  subroutine buildS(env, over, skOverCont, coords, nNeighborSK, iNeighbors, species, iPair, orb)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -134,7 +133,7 @@ contains
     real(dp), intent(in) :: coords(:,:)
 
     !> Number of surrounding neighbors for each atom
-    integer, intent(in) :: nNeighbors(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> List of surrounding neighbors for each atom
     integer, intent(in) :: iNeighbors(0:,:)
@@ -150,7 +149,7 @@ contains
 
     integer :: nAtom, iAt1, iSp1, ind, iOrb1, iAtFirst, iAtLast
 
-    nAtom = size(nNeighbors)
+    nAtom = size(nNeighborSK)
     over(:) = 0.0_dp
 
     call distributeRangeInChunks(env, 1, nAtom, iAtFirst, iAtLast)
@@ -167,7 +166,7 @@ contains
     end do
     !$OMP  END PARALLEL DO
 
-    call buildDiatomicBlocks(iAtFirst, iAtLast, skOverCont, coords, nNeighbors, iNeighbors,&
+    call buildDiatomicBlocks(iAtFirst, iAtLast, skOverCont, coords, nNeighborSK, iNeighbors,&
         & species, iPair, orb, over)
 
     call assembleChunks(env, over)
@@ -199,8 +198,7 @@ contains
   end subroutine NonSccDiff_init
 
   !> Calculates the first derivative of H0 or S.
-  subroutine getFirstDeriv(this, deriv, skCont,coords, species, atomI, atomJ,&
-      & orb)
+  subroutine getFirstDeriv(this, deriv, skCont,coords, species, atomI, atomJ, orb)
 
     !> Instance
     class(NonSccDiff), intent(in) :: this
@@ -228,18 +226,16 @@ contains
 
     select case (this%diffType)
     case (diffTypes%finiteDiff)
-      call getFirstDerivFiniteDiff(deriv, skCont, coords, species, atomI,&
-          & atomJ, orb, this%deltaXDiff)
+      call getFirstDerivFiniteDiff(deriv, skCont, coords, species, atomI, atomJ, orb,&
+          & this%deltaXDiff)
     case (diffTypes%richardson)
-      call getFirstDerivRichardson(deriv, skCont, coords, species, atomI,&
-          & atomJ, orb)
+      call getFirstDerivRichardson(deriv, skCont, coords, species, atomI, atomJ, orb)
     end select
 
   end subroutine getFirstDeriv
 
   !> Calculates the numerical second derivative of a diatomic block of H0 or S.
-  subroutine getSecondDeriv(this, deriv, skCont, coords, species, atomI, atomJ,&
-      & orb)
+  subroutine getSecondDeriv(this, deriv, skCont, coords, species, atomI, atomJ, orb)
 
     !> Instance.
     class(NonSccDiff), intent(in) :: this
@@ -269,24 +265,24 @@ contains
     ! invoked instead.
     select case (this%diffType)
     case (diffTypes%finiteDiff)
-      call getSecondDerivFiniteDiff(deriv, skCont, coords, species, atomI,&
-          & atomJ, orb, this%deltaXDiff)
+      call getSecondDerivFiniteDiff(deriv, skCont, coords, species, atomI, atomJ, orb,&
+          & this%deltaXDiff)
     case (diffTypes%richardson)
-      call getSecondDerivFiniteDiff(deriv, skCont, coords, species, atomI,&
-          & atomJ, orb, this%deltaXDiff)
+      call getSecondDerivFiniteDiff(deriv, skCont, coords, species, atomI, atomJ, orb,&
+          & this%deltaXDiff)
     end select
 
   end subroutine getSecondDeriv
 
 
   !> Helper routine to calculate the diatomic blocks for the routines buildH0 and buildS.
-  subroutine buildDiatomicBlocks(firstAtom, lastAtom, skCont, coords, nNeighbors, &
-      & iNeighbors, species, iPair, orb, out)
+  subroutine buildDiatomicBlocks(firstAtom, lastAtom, skCont, coords, nNeighborSK, iNeighbors,&
+      & species, iPair, orb, out)
     integer, intent(in) :: firstAtom
     integer, intent(in) :: lastAtom
     type(OSlakoCont), intent(in) :: skCont
     real(dp), intent(in) :: coords(:,:)
-    integer, intent(in) :: nNeighbors(:)
+    integer, intent(in) :: nNeighborSK(:)
     integer, intent(in) :: iNeighbors(0:,:)
     integer, intent(in) :: species(:)
     integer, intent(in) :: iPair(0:,:)
@@ -299,13 +295,13 @@ contains
     integer :: nOrb1, nOrb2
     integer :: iAt1, iAt2, iSp1, iSp2, iNeigh1, ind
 
-    ! Do the diatomic blocks for each of the atoms with its nNeighbors
+    ! Do the diatomic blocks for each of the atoms with its nNeighborSK
     !$OMP PARALLEL DO PRIVATE(iAt1,iSp1,nOrb1,iNeigh1,iAt2,iSp2,nOrb2,ind,vect,dist,tmp,interSK) &
     !$OMP& DEFAULT(SHARED) SCHEDULE(RUNTIME)
     do iAt1 = firstAtom, lastAtom
       iSp1 = species(iAt1)
       nOrb1 = orb%nOrbSpecies(iSp1)
-      do iNeigh1 = 1, nNeighbors(iAt1)
+      do iNeigh1 = 1, nNeighborSK(iAt1)
         iAt2 = iNeighbors(iNeigh1, iAt1)
         iSp2 = species(iAt2)
         nOrb2 = orb%nOrbSpecies(iSp2)
@@ -324,8 +320,7 @@ contains
 
 
   !> Calculates the numerical derivative of a diatomic block H0 or S by finite differences.
-  subroutine getFirstDerivFiniteDiff(deriv, skCont, coords, species, atomI,&
-      & atomJ, orb, deltaXDiff)
+  subroutine getFirstDerivFiniteDiff(deriv, skCont, coords, species, atomI, atomJ, orb, deltaXDiff)
     real(dp), intent(out) :: deriv(:,:,:)
     type(OSlakoCont), intent(in) :: skCont
     real(dp), intent(in) :: coords(:,:)
@@ -356,8 +351,7 @@ contains
         dist = sqrt(sum(vect**2))
         vect(:) = vect / dist
         call getSKIntegrals(skCont, interSk, dist, sp1, sp2)
-        call rotateH0(tmp(:,:,ii,jj), interSk, vect(1), vect(2), &
-            &vect(3), sp1, sp2, orb)
+        call rotateH0(tmp(:,:,ii,jj), interSk, vect(1), vect(2), vect(3), sp1, sp2, orb)
       end do
     end do
 
@@ -368,8 +362,7 @@ contains
   end subroutine getFirstDerivFiniteDiff
 
   !> Calculates the numerical derivative of a diatomic block H0 or S by Richardsons method.
-  subroutine getFirstDerivRichardson(deriv, skCont, coords, species, atomI,&
-      & atomJ, orb)
+  subroutine getFirstDerivRichardson(deriv, skCont, coords, species, atomI, atomJ, orb)
     real(dp), intent(out) :: deriv(:,:,:)
     type(OSlakoCont), intent(in) :: skCont
     real(dp), intent(in) :: coords(:,:)
@@ -386,8 +379,7 @@ contains
     integer :: sp1, sp2
     real(dp) :: tmp(size(deriv, dim=1), size(deriv, dim=2),2)
     real(dp) :: diff
-    real(dp) :: dd(size(deriv, dim=1), size(deriv, dim=2), 0:maxcolumns,&
-        & 0:maxrows)
+    real(dp) :: dd(size(deriv, dim=1), size(deriv, dim=2), 0:maxcolumns, 0:maxrows)
     logical :: tConverged(size(deriv, dim=1), size(deriv, dim=2))
     real(dp) :: hh
     integer :: ii, iCart, kk, ll, mm, nk
@@ -410,8 +402,7 @@ contains
         dist = sqrt(sum(vect(:)**2))
         vect(:) = vect / dist
         call getSKIntegrals(skCont, interSk, dist, sp1, sp2)
-        call rotateH0(tmp(:,:,kk), interSk, vect(1), vect(2), vect(3),&
-            & sp1, sp2, orb)
+        call rotateH0(tmp(:,:,kk), interSk, vect(1), vect(2), vect(3), sp1, sp2, orb)
       end do
 
       ! row number
@@ -437,8 +428,7 @@ contains
           dist = sqrt(sum(vect**2))
           vect(:) = vect / dist
           call getSKIntegrals(skCont, interSk, dist, sp1, sp2)
-          call rotateH0(tmp(:,:,kk), interSk, vect(1), vect(2),&
-              & vect(3), sp1, sp2, orb)
+          call rotateH0(tmp(:,:,kk), interSk, vect(1), vect(2), vect(3), sp1, sp2, orb)
         end do
         where (.not.tConverged)
           dd(:,:,0,ii) = (tmp(:,:,2) - tmp(:,:,1)) / (2.0_dp * hh)
@@ -448,8 +438,7 @@ contains
           ! as central difference derivative formula
           nk = 2 * kk
           where (.not.tConverged)
-            dd(:,:,kk,ii) = ((2**(nk)) * dd(:,:,kk-1,ii) - dd(:,:,kk-1,ii-1))&
-                & / real(2**nk - 1, dp)
+            dd(:,:,kk,ii) = ((2**(nk)) * dd(:,:,kk-1,ii) - dd(:,:,kk-1,ii-1)) / real(2**nk - 1, dp)
           end where
         end do
         do ll = 1, size(dd, dim=2)
@@ -474,8 +463,7 @@ contains
 
   !> Contains code to calculate the numerical second derivative of a diatomic block of the H0
   !> Hamiltonian and overlap.
-  subroutine getSecondDerivFiniteDiff(deriv, skCont, coords, species, atomI,&
-      & atomJ, orb, deltaXDiff)
+  subroutine getSecondDerivFiniteDiff(deriv, skCont, coords, species, atomI, atomJ, orb, deltaXDiff)
     real(dp), intent(out) :: deriv(:,:,:,:)
     type(OSlakoCont), intent(in) :: skCont
     real(dp), intent(in) :: coords(:,:)

--- a/prog/dftb+/lib_dftb/nonscc.F90
+++ b/prog/dftb+/lib_dftb/nonscc.F90
@@ -57,8 +57,8 @@ module nonscc
 contains
 
   !> Driver for making the non-SCC Hamiltonian in the primitive sparse format.
-  subroutine buildH0(env, ham, skHamCont, selfegy, coords, nNeighborSK, iNeighbors, species, iPair,&
-      & orb)
+  subroutine buildH0(env, ham, skHamCont, selfegy, coords, nNeighbourSK, iNeighbours, species,&
+      & iPair, orb)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -75,11 +75,11 @@ contains
     !> List of all coordinates, including possible periodic images of atoms
     real(dp), intent(in) :: coords(:,:)
 
-    !> Number of surrounding neighbors for each atom
-    integer, intent(in) :: nNeighborSK(:)
+    !> Number of surrounding neighbours for each atom
+    integer, intent(in) :: nNeighbourSK(:)
 
-    !> List of surrounding neighbors for each atom
-    integer, intent(in) :: iNeighbors(0:,:)
+    !> List of surrounding neighbours for each atom
+    integer, intent(in) :: iNeighbours(0:,:)
 
     !> Chemical species of each atom
     integer, intent(in) :: species(:)
@@ -92,7 +92,7 @@ contains
 
     integer :: nAtom, iAt1, iSp1, ind, iOrb1, iAtFirst, iAtLast
 
-    nAtom = size(nNeighborSK)
+    nAtom = size(nNeighbourSK)
     ham(:) = 0.0_dp
 
     call distributeRangeInChunks(env, 1, nAtom, iAtFirst, iAtLast)
@@ -110,7 +110,7 @@ contains
     end do
     !$OMP  END PARALLEL DO
 
-    call buildDiatomicBlocks(iAtFirst, iAtLast, skHamCont, coords, nNeighborSK, iNeighbors,&
+    call buildDiatomicBlocks(iAtFirst, iAtLast, skHamCont, coords, nNeighbourSK, iNeighbours,&
         & species, iPair, orb, ham)
 
     call assembleChunks(env, ham)
@@ -118,7 +118,7 @@ contains
   end subroutine buildH0
 
   !> Driver for making the overlap matrix in the primitive sparse format.
-  subroutine buildS(env, over, skOverCont, coords, nNeighborSK, iNeighbors, species, iPair, orb)
+  subroutine buildS(env, over, skOverCont, coords, nNeighbourSK, iNeighbours, species, iPair, orb)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -132,11 +132,11 @@ contains
     !> List of all coordinates, including possible periodic images of atoms
     real(dp), intent(in) :: coords(:,:)
 
-    !> Number of surrounding neighbors for each atom
-    integer, intent(in) :: nNeighborSK(:)
+    !> Number of surrounding neighbours for each atom
+    integer, intent(in) :: nNeighbourSK(:)
 
-    !> List of surrounding neighbors for each atom
-    integer, intent(in) :: iNeighbors(0:,:)
+    !> List of surrounding neighbours for each atom
+    integer, intent(in) :: iNeighbours(0:,:)
 
     !> Chemical species of each atom
     integer, intent(in) :: species(:)
@@ -149,7 +149,7 @@ contains
 
     integer :: nAtom, iAt1, iSp1, ind, iOrb1, iAtFirst, iAtLast
 
-    nAtom = size(nNeighborSK)
+    nAtom = size(nNeighbourSK)
     over(:) = 0.0_dp
 
     call distributeRangeInChunks(env, 1, nAtom, iAtFirst, iAtLast)
@@ -166,7 +166,7 @@ contains
     end do
     !$OMP  END PARALLEL DO
 
-    call buildDiatomicBlocks(iAtFirst, iAtLast, skOverCont, coords, nNeighborSK, iNeighbors,&
+    call buildDiatomicBlocks(iAtFirst, iAtLast, skOverCont, coords, nNeighbourSK, iNeighbours,&
         & species, iPair, orb, over)
 
     call assembleChunks(env, over)
@@ -276,14 +276,14 @@ contains
 
 
   !> Helper routine to calculate the diatomic blocks for the routines buildH0 and buildS.
-  subroutine buildDiatomicBlocks(firstAtom, lastAtom, skCont, coords, nNeighborSK, iNeighbors,&
+  subroutine buildDiatomicBlocks(firstAtom, lastAtom, skCont, coords, nNeighbourSK, iNeighbours,&
       & species, iPair, orb, out)
     integer, intent(in) :: firstAtom
     integer, intent(in) :: lastAtom
     type(OSlakoCont), intent(in) :: skCont
     real(dp), intent(in) :: coords(:,:)
-    integer, intent(in) :: nNeighborSK(:)
-    integer, intent(in) :: iNeighbors(0:,:)
+    integer, intent(in) :: nNeighbourSK(:)
+    integer, intent(in) :: iNeighbours(0:,:)
     integer, intent(in) :: species(:)
     integer, intent(in) :: iPair(0:,:)
     type(TOrbitals), intent(in) :: orb
@@ -295,14 +295,14 @@ contains
     integer :: nOrb1, nOrb2
     integer :: iAt1, iAt2, iSp1, iSp2, iNeigh1, ind
 
-    ! Do the diatomic blocks for each of the atoms with its nNeighborSK
+    ! Do the diatomic blocks for each of the atoms with its nNeighbourSK
     !$OMP PARALLEL DO PRIVATE(iAt1,iSp1,nOrb1,iNeigh1,iAt2,iSp2,nOrb2,ind,vect,dist,tmp,interSK) &
     !$OMP& DEFAULT(SHARED) SCHEDULE(RUNTIME)
     do iAt1 = firstAtom, lastAtom
       iSp1 = species(iAt1)
       nOrb1 = orb%nOrbSpecies(iSp1)
-      do iNeigh1 = 1, nNeighborSK(iAt1)
-        iAt2 = iNeighbors(iNeigh1, iAt1)
+      do iNeigh1 = 1, nNeighbourSK(iAt1)
+        iAt2 = iNeighbours(iNeigh1, iAt1)
         iSp2 = species(iAt2)
         nOrb2 = orb%nOrbSpecies(iSp2)
         ind = iPair(iNeigh1,iAt1)

--- a/prog/dftb+/lib_dftb/periodic.F90
+++ b/prog/dftb+/lib_dftb/periodic.F90
@@ -26,9 +26,9 @@ module periodic
 
   public :: getCellTranslations, getLatticePoints, foldCoordToUnitCell
   public :: reallocateHS, buildSquaredAtomIndex
-  public :: TNeighborList, init
-  public :: updateNeighborList, updateNeighborListAndSpecies
-  public :: getNrOfNeighbors, getNrOfNeighborsForAll
+  public :: TNeighbourList, init
+  public :: updateNeighbourList, updateNeighbourListAndSpecies
+  public :: getNrOfNeighbours, getNrOfNeighboursForAll
   public :: getSuperSampling
   public :: frac2cart, cart2frac
   public :: getSparseDescriptor
@@ -44,7 +44,7 @@ module periodic
 
   !> Initializes ADTs defined in this module
   interface init
-    module procedure init_TNeighborList
+    module procedure init_TNeighbourList
   end interface init
 
 
@@ -60,16 +60,16 @@ module periodic
   end interface cart2frac
 
 
-  !> Contains essential data for the neighborlist
-  type TNeighborList
+  !> Contains essential data for the neighbourlist
+  type TNeighbourList
 
-    !> index of neighbor atoms
-    integer, allocatable :: iNeighbor(:,:)
+    !> index of neighbour atoms
+    integer, allocatable :: iNeighbour(:,:)
 
-    !> nr. of neighbors
-    integer, allocatable :: nNeighborSK(:)
+    !> nr. of neighbours
+    integer, allocatable :: nNeighbourSK(:)
 
-    !> temporary array for neighbor distances
+    !> temporary array for neighbour distances
     real(dp), allocatable :: neighDist2(:,:)
 
     !> cutoff it was generated for
@@ -77,35 +77,35 @@ module periodic
 
     !> initialised data
     logical :: initialized = .false.
-  end type TNeighborList
+  end type TNeighbourList
 
 contains
 
 
-  !> Initializes a neighborlist instance.
-  subroutine init_TNeighborList(neighborList, nAtom, nInitNeighbor)
+  !> Initializes a neighbourlist instance.
+  subroutine init_TNeighbourList(neighbourList, nAtom, nInitNeighbour)
 
-    !> Neighborlist data.
-    type(TNeighborList), intent(out) :: neighborList
+    !> Neighbourlist data.
+    type(TNeighbourList), intent(out) :: neighbourList
 
     !> Nr. of atoms in the system.
     integer, intent(in) :: nAtom
 
-    !> Expected nr. of neighbors per atom.
-    integer, intent(in) :: nInitNeighbor
+    !> Expected nr. of neighbours per atom.
+    integer, intent(in) :: nInitNeighbour
 
-    @:ASSERT(.not. neighborList%initialized)
+    @:ASSERT(.not. neighbourList%initialized)
     @:ASSERT(nAtom > 0)
-    @:ASSERT(nInitNeighbor > 0)
+    @:ASSERT(nInitNeighbour > 0)
 
-    allocate(neighborList%nNeighborSK(nAtom))
-    allocate(neighborList%iNeighbor(0:nInitNeighbor, nAtom))
-    allocate(neighborList%neighDist2(0:nInitNeighbor, nAtom))
+    allocate(neighbourList%nNeighbourSK(nAtom))
+    allocate(neighbourList%iNeighbour(0:nInitNeighbour, nAtom))
+    allocate(neighbourList%neighDist2(0:nInitNeighbour, nAtom))
 
-    neighborList%cutoff = -1.0_dp
-    neighborList%initialized = .true.
+    neighbourList%cutoff = -1.0_dp
+    neighbourList%initialized = .true.
 
-  end subroutine init_TNeighborList
+  end subroutine init_TNeighbourList
 
 
   !> Calculates the translation vectors for cells, which could contain atoms interacting with any of
@@ -263,8 +263,8 @@ contains
   end subroutine foldCoordToUnitCell
 
 
-  !> Updates the neighbor list and the species arrays.
-  subroutine updateNeighborListAndSpecies(coord, species, img2CentCell, iCellVec, neigh, nAllAtom,&
+  !> Updates the neighbour list and the species arrays.
+  subroutine updateNeighbourListAndSpecies(coord, species, img2CentCell, iCellVec, neigh, nAllAtom,&
       & coord0, species0, cutoff, rCellVec)
 
     !> Coordinates of all interacting atoms on exit
@@ -279,8 +279,8 @@ contains
     !> Shift vector index for every interacting atom
     integer, allocatable, intent(inout) :: iCellVec(:)
 
-    !> Updated neighbor list.
-    type(TNeighborList), intent(inout) :: neigh
+    !> Updated neighbour list.
+    type(TNeighbourList), intent(inout) :: neigh
 
     !> Number of all interacting atoms
     integer, intent(out) :: nAllAtom
@@ -291,13 +291,13 @@ contains
     !> Species of the atoms in the central cell
     integer, intent(in) :: species0(:)
 
-    !> Cutoff until neighborlist should be created
+    !> Cutoff until neighbourlist should be created
     real(dp), intent(in) :: cutoff
 
     !> Cell vector for the translated cells to consider.
     real(dp), intent(in) :: rCellVec(:,:)
 
-    call updateNeighborList(coord, img2CentCell, iCellVec, neigh, nAllAtom, coord0, cutoff,&
+    call updateNeighbourList(coord, img2CentCell, iCellVec, neigh, nAllAtom, coord0, cutoff,&
         & rCellVec)
     if (size(species) < nAllAtom) then
       deallocate(species)
@@ -305,14 +305,14 @@ contains
     end if
     species(1:nAllAtom) = species0(img2CentCell(1:nAllAtom))
 
-  end subroutine updateNeighborListAndSpecies
+  end subroutine updateNeighbourListAndSpecies
 
 
-  !> Updates the neighbor list according a given geometry.
-  !> The neighborlist for the given cutoff is calculated. Arrays are resized if necessary. The
-  !> neighbor list determination is a simple N^2 algorithm, calculating the distance between the
+  !> Updates the neighbour list according a given geometry.
+  !> The neighbourlist for the given cutoff is calculated. Arrays are resized if necessary. The
+  !> neighbour list determination is a simple N^2 algorithm, calculating the distance between the
   !> possible atom pairs.
-  subroutine updateNeighborList(coord, img2CentCell, iCellVec, neigh, nAllAtom, coord0, cutoff,&
+  subroutine updateNeighbourList(coord, img2CentCell, iCellVec, neigh, nAllAtom, coord0, cutoff,&
       & rCellVec)
 
     !> Coordinates of the objects interacting with the objects in the central cell (on exit).
@@ -325,8 +325,8 @@ contains
     !> Returns the index of the translating superlattice vector for each object.
     integer, allocatable, intent(inout) :: iCellVec(:)
 
-    !> Neighborlist.
-    type(TNeighborList), intent(inout) :: neigh
+    !> Neighbourlist.
+    type(TNeighbourList), intent(inout) :: neigh
 
     !> Returns the nr. of all objects (including those in the translated cells.)
     integer, intent(out) :: nAllAtom
@@ -348,8 +348,8 @@ contains
     !> Max. nr. of atom without reallocation
     integer :: mAtom
 
-    !> Max. nr. of neighbors without reallocation
-    integer :: maxNeighbor
+    !> Max. nr. of neighbours without reallocation
+    integer :: maxNeighbour
 
     !> Nr. of cell translation vectors
     integer :: nCellVec
@@ -365,9 +365,9 @@ contains
     integer, allocatable :: indx(:)
     character(len=100) :: strError
 
-    nAtom = size(neigh%nNeighborSK, dim=1)
+    nAtom = size(neigh%nNeighbourSK, dim=1)
     mAtom = size(coord, dim=2)
-    maxNeighbor = ubound(neigh%iNeighbor, dim=1)
+    maxNeighbour = ubound(neigh%iNeighbour, dim=1)
     nCellVec = size(rCellVec, dim=2)
 
     @:ASSERT(nAtom <= mAtom)
@@ -377,7 +377,7 @@ contains
     @:ASSERT(size(img2CentCell) == mAtom)
     @:ASSERT(allocated(iCellVec))
     @:ASSERT(size(iCellVec) == mAtom)
-    @:ASSERT(size(neigh%iNeighbor, dim=2) == nAtom)
+    @:ASSERT(size(neigh%iNeighbour, dim=2) == nAtom)
     @:ASSERT((size(coord0, dim=1) == 3) .and. size(coord0, dim=2) >= nAtom)
     @:ASSERT((size(rCellVec, dim=1) == 3))
     @:ASSERT(cutoff >= 0.0_dp)
@@ -387,16 +387,16 @@ contains
     nAllAtom = 0
 
     ! Clean arrays.
-    !  (Every atom is the 0th neighbor of itself with zero distance square.)
-    neigh%nNeighborSK(:) = 0
-    neigh%iNeighbor(:,:) = 0
+    !  (Every atom is the 0th neighbour of itself with zero distance square.)
+    neigh%nNeighbourSK(:) = 0
+    neigh%iNeighbour(:,:) = 0
     do ii = 1, nAtom
-      neigh%iNeighbor(0, ii) = ii
+      neigh%iNeighbour(0, ii) = ii
     end do
     neigh%neighDist2(:,:) = 0.0_dp
 
-    ! Loop over all possible neighbors for all atoms in the central cell.
-    ! Only those neighbors are considered which map on atom with a higher
+    ! Loop over all possible neighbours for all atoms in the central cell.
+    ! Only those neighbours are considered which map on atom with a higher
     ! or equal index in the central cell.
     ! Outer two loops: all atoms in all cells.
     ! Inner loop: all atoms in the central cell.
@@ -441,95 +441,95 @@ contains
             end if
           end if
 
-          neigh%nNeighborSK(iAtom2) = neigh%nNeighborSK(iAtom2) + 1
-          if (neigh%nNeighborSK(iAtom2) > maxNeighbor) then
-            maxNeighbor = incrmntOfArray(maxNeighbor)
-            call reallocateArrays3(neigh%iNeighbor, neigh%neighDist2, maxNeighbor)
+          neigh%nNeighbourSK(iAtom2) = neigh%nNeighbourSK(iAtom2) + 1
+          if (neigh%nNeighbourSK(iAtom2) > maxNeighbour) then
+            maxNeighbour = incrmntOfArray(maxNeighbour)
+            call reallocateArrays3(neigh%iNeighbour, neigh%neighDist2, maxNeighbour)
 
           end if
-          neigh%iNeighbor(neigh%nNeighborSK(iAtom2), iAtom2) = nAllAtom
-          neigh%neighDist2(neigh%nNeighborSK(iAtom2), iAtom2) = dist2
+          neigh%iNeighbour(neigh%nNeighbourSK(iAtom2), iAtom2) = nAllAtom
+          neigh%neighDist2(neigh%nNeighbourSK(iAtom2), iAtom2) = dist2
 
         end do lpIAtom2
       end do lpIAtom1
     end do lpCellVec
 
-    ! Sort neighbors for all atom by distance
-    allocate(indx(maxNeighbor))
+    ! Sort neighbours for all atom by distance
+    allocate(indx(maxNeighbour))
     do iAtom1 = 1, nAtom
-      nn1 = neigh%nNeighborSK(iAtom1)
+      nn1 = neigh%nNeighbourSK(iAtom1)
       call index_heap_sort(indx(1:nn1), neigh%neighDist2(1:nn1, iAtom1), tolSameDist2)
-      neigh%iNeighbor(1:nn1, iAtom1) = neigh%iNeighbor(indx(:nn1), iAtom1)
+      neigh%iNeighbour(1:nn1, iAtom1) = neigh%iNeighbour(indx(:nn1), iAtom1)
       neigh%neighDist2(1:nn1, iAtom1) = neigh%neighDist2(indx(:nn1), iAtom1)
     end do
     coord(:,nAllAtom+1:size(coord, dim=2)) = 0.0_dp
 
-  end subroutine updateNeighborList
+  end subroutine updateNeighbourList
 
 
-  !> Returns the nr. of neighbors for a given cutoff for all atoms.
-  subroutine getNrOfNeighborsForAll(nNeighborSK, neigh, cutoff)
+  !> Returns the nr. of neighbours for a given cutoff for all atoms.
+  subroutine getNrOfNeighboursForAll(nNeighbourSK, neigh, cutoff)
 
-    !> Contains the nr. of neighbors for each atom on exit.
-    integer, intent(out) :: nNeighborSK(:)
+    !> Contains the nr. of neighbours for each atom on exit.
+    integer, intent(out) :: nNeighbourSK(:)
 
-    !> Initialized neighborlist
-    type(TNeighborList), intent(in) :: neigh
+    !> Initialized neighbourlist
+    type(TNeighbourList), intent(in) :: neigh
 
-    !> Maximal neighbor distance to consider.
+    !> Maximal neighbour distance to consider.
     real(dp),            intent(in) :: cutoff
 
     integer :: nAtom, iAtom
 
-    nAtom = size(nNeighborSK)
+    nAtom = size(nNeighbourSK)
 
-    @:ASSERT(size(neigh%iNeighbor, dim=2) == nAtom)
-    @:ASSERT(size(neigh%nNeighborSK) == nAtom)
-    @:ASSERT(maxval(neigh%nNeighborSK) <= size(neigh%iNeighbor, dim=1))
-    @:ASSERT(all(shape(neigh%neighDist2) == shape(neigh%iNeighbor)))
+    @:ASSERT(size(neigh%iNeighbour, dim=2) == nAtom)
+    @:ASSERT(size(neigh%nNeighbourSK) == nAtom)
+    @:ASSERT(maxval(neigh%nNeighbourSK) <= size(neigh%iNeighbour, dim=1))
+    @:ASSERT(all(shape(neigh%neighDist2) == shape(neigh%iNeighbour)))
     @:ASSERT(cutoff >= 0.0_dp)
 
-    ! Get last interacting neighbor for given cutoff
+    ! Get last interacting neighbour for given cutoff
     do iAtom = 1, nAtom
-      nNeighborSK(iAtom) = getNrOfNeighbors(neigh, cutoff, iAtom)
+      nNeighbourSK(iAtom) = getNrOfNeighbours(neigh, cutoff, iAtom)
     end do
 
-  end subroutine getNrOfNeighborsForAll
+  end subroutine getNrOfNeighboursForAll
 
 
-  !> Returns the nr. of neighbors for a given atom.
-  function getNrOfNeighbors(neigh, cutoff, iAtom) result(nNeighborSK)
+  !> Returns the nr. of neighbours for a given atom.
+  function getNrOfNeighbours(neigh, cutoff, iAtom) result(nNeighbourSK)
 
     !> Intialised neihgborlist.
-    type(TNeighborList), intent(in) :: neigh
+    type(TNeighbourList), intent(in) :: neigh
 
-    !> Maximal neighbor distance to consider.
+    !> Maximal neighbour distance to consider.
     real(dp),            intent(in) :: cutoff
 
-    !> Index of the atom to get the nr. of neighbors for.
+    !> Index of the atom to get the nr. of neighbours for.
     integer, intent(in) :: iAtom
 
-    !> Nr. of neighbors for the specified atom.
-    integer :: nNeighborSK
+    !> Nr. of neighbours for the specified atom.
+    integer :: nNeighbourSK
 
     character(len=100) :: strError
 
     @:ASSERT(cutoff >= 0.0_dp)
-    @:ASSERT(iAtom <= size(neigh%nNeighborSK))
+    @:ASSERT(iAtom <= size(neigh%nNeighbourSK))
 
-    ! Issue warning, if cutoff is bigger as used for the neighborlist.
+    ! Issue warning, if cutoff is bigger as used for the neighbourlist.
     if (cutoff > neigh%cutoff) then
 99010 format ('Cutoff (', E16.6, ') greater then last cutoff ', '(', E13.6,&
-          & ') passed to updateNeighborList!')
+          & ') passed to updateNeighbourList!')
       write (strError, 99010) cutoff, neigh%cutoff
       call warning(strError)
     end if
 
-    ! Get last interacting neighbor for given cutoff
-    call bisection(nNeighborSK, neigh%neighDist2(1:neigh%nNeighborSK(iAtom), iAtom), cutoff**2,&
+    ! Get last interacting neighbour for given cutoff
+    call bisection(nNeighbourSK, neigh%neighDist2(1:neigh%nNeighbourSK(iAtom), iAtom), cutoff**2,&
         & tolSameDist2)
 
-  end function getNrOfNeighbors
+  end function getNrOfNeighbours
 
 
   !> Reallocate arrays which depends on the maximal nr. of all atoms.
@@ -574,48 +574,48 @@ contains
   end subroutine reallocateArrays1
 
 
-  !> Reallocate array which depends on the maximal nr. of neighbors.
-  subroutine reallocateArrays3(iNeighbor, neighDist2, mNewNeighbor)
+  !> Reallocate array which depends on the maximal nr. of neighbours.
+  subroutine reallocateArrays3(iNeighbour, neighDist2, mNewNeighbour)
 
     !> list of neighbours
-    integer, allocatable, intent(inout) :: iNeighbor(:, :)
+    integer, allocatable, intent(inout) :: iNeighbour(:, :)
 
     !> square of distances between atoms
     real(dp), allocatable, intent(inout) :: neighDist2(:,:)
 
     !> maximum number of new atoms
-    integer, intent(in) :: mNewNeighbor
+    integer, intent(in) :: mNewNeighbour
 
-    integer :: mNeighbor, mAtom
+    integer :: mNeighbour, mAtom
     integer, allocatable :: tmpIntR2(:,:)
     real(dp), allocatable :: tmpRealR2(:,:)
 
-    mNeighbor = ubound(iNeighbor, dim=1)
-    mAtom = size(iNeighbor, dim=2)
+    mNeighbour = ubound(iNeighbour, dim=1)
+    mAtom = size(iNeighbour, dim=2)
 
-    @:ASSERT(mNewNeighbor > 0 .and. mNewNeighbor > mNeighbor)
-    @:ASSERT(all(shape(neighDist2) == shape(iNeighbor)))
+    @:ASSERT(mNewNeighbour > 0 .and. mNewNeighbour > mNeighbour)
+    @:ASSERT(all(shape(neighDist2) == shape(iNeighbour)))
 
-    call move_alloc(iNeighbor, tmpIntR2)
-    allocate(iNeighbor(0:mNewNeighbor, mAtom))
-    iNeighbor(:,:) = 0
-    iNeighbor(:mNeighbor, :mAtom) = tmpIntR2
+    call move_alloc(iNeighbour, tmpIntR2)
+    allocate(iNeighbour(0:mNewNeighbour, mAtom))
+    iNeighbour(:,:) = 0
+    iNeighbour(:mNeighbour, :mAtom) = tmpIntR2
 
     call move_alloc(neighDist2, tmpRealR2)
-    allocate(neighDist2(0:mNewNeighbor, mAtom))
+    allocate(neighDist2(0:mNewNeighbour, mAtom))
     neighDist2(:,:) = 0.0_dp
-    neighDist2(:mNeighbor, :mAtom) = tmpRealR2
+    neighDist2(:mNeighbour, :mAtom) = tmpRealR2
 
   end subroutine reallocateArrays3
 
   !> Calculate indexing array and number of elements in sparse arrays like the real space overlap
-  subroutine getSparseDescriptor(iNeighbor, nNeighborSK, img2CentCell, orb, iPair, sparseSize)
+  subroutine getSparseDescriptor(iNeighbour, nNeighbourSK, img2CentCell, orb, iPair, sparseSize)
 
     !> Neighbours of each atom
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> Number of neighbours of each atom
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Indexing for mapping image atoms to central cell
     integer, intent(in) :: img2CentCell(:)
@@ -629,26 +629,26 @@ contains
     !> Total number of elements in a sparse structure (ignoring extra indices like spin)
     integer, intent(out) :: sparseSize
 
-    integer :: nAtom, mNeighbor
+    integer :: nAtom, mNeighbour
     integer :: ind, iAt1, nOrb1, iNeigh1, nOrb2
 
-    nAtom = size(iNeighbor, dim=2)
-    mNeighbor = size(iNeighbor, dim=1)
+    nAtom = size(iNeighbour, dim=2)
+    mNeighbour = size(iNeighbour, dim=1)
 
     @:ASSERT(allocated(iPair))
     @:ASSERT(size(iPair, dim=2) == nAtom)
 
-    if (mNeighbor > size(iPair, dim=1)) then
+    if (mNeighbour > size(iPair, dim=1)) then
       deallocate(iPair)
-      allocate(iPair(0 : mNeighbor - 1, nAtom))
+      allocate(iPair(0 : mNeighbour - 1, nAtom))
       iPair(:,:) = 0
     end if
     ind = 0
     do iAt1 = 1, nAtom
       nOrb1 = orb%nOrbAtom(iAt1)
-      do iNeigh1 = 0, nNeighborSK(iAt1)
+      do iNeigh1 = 0, nNeighbourSK(iAt1)
         iPair(iNeigh1, iAt1) = ind
-        nOrb2 = orb%nOrbAtom(img2CentCell(iNeighbor(iNeigh1, iAt1)))
+        nOrb2 = orb%nOrbAtom(img2CentCell(iNeighbour(iNeigh1, iAt1)))
         ind = ind + nOrb1 * nOrb2
       end do
     end do
@@ -658,7 +658,7 @@ contains
 
 
   !> Allocate (reallocate) space for the sparse hamiltonian and overlap matrix.
-  subroutine reallocateHS_1(ham, over, iPair, iNeighbor, nNeighborSK, orb, img2Centcell)
+  subroutine reallocateHS_1(ham, over, iPair, iNeighbour, nNeighbourSK, orb, img2Centcell)
 
     !> Hamiltonian
     real(dp), allocatable, intent(inout):: ham(:)
@@ -667,14 +667,14 @@ contains
     real(dp), allocatable, intent(inout) :: over(:)
 
     !> Pair indexing array (specifying the offset for the interaction between atoms in the central
-    !> cell and their neighbors)
+    !> cell and their neighbours)
     integer, allocatable, intent(inout) :: iPair(:,:)
 
-    !> List of neighbors for each atom in the central cell. (Note: first index runs from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> List of neighbours for each atom in the central cell. (Note: first index runs from 0!)
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> Nr. of neighbors for each atom in the central cell.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom in the central cell.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Orbitals in the system.
     type(TOrbitals), intent(in) :: orb
@@ -688,14 +688,14 @@ contains
     !> nr. of elements in the sparse H/S before and after resizing
     integer :: nOldElem, nElem
 
-    !> nr. of max. possible neighbors (incl. itself)
-    integer :: mNeighbor
+    !> nr. of max. possible neighbours (incl. itself)
+    integer :: mNeighbour
 
     integer :: ind
     integer :: iAt1, iNeigh1, nOrb1
 
-    nAtom = size(iNeighbor, dim=2)
-    mNeighbor = size(iNeighbor, dim=1)
+    nAtom = size(iNeighbour, dim=2)
+    mNeighbour = size(iNeighbour, dim=1)
     nOldElem = size(ham, dim=1)
 
     @:ASSERT(allocated(ham))
@@ -704,18 +704,18 @@ contains
     @:ASSERT(allocated(iPair))
     @:ASSERT(size(iPair, dim=2) == nAtom)
 
-    if (mNeighbor > size(iPair, dim=1)) then
+    if (mNeighbour > size(iPair, dim=1)) then
       deallocate(iPair)
-      allocate(iPair(0:mNeighbor-1, nAtom))
+      allocate(iPair(0:mNeighbour-1, nAtom))
       iPair(:,:) = 0
     end if
     nElem = 0
     ind = 0
     do iAt1 = 1, nAtom
       nOrb1 = orb%nOrbAtom(iAt1)
-      do iNeigh1 = 0, nNeighborSK(iAt1)
+      do iNeigh1 = 0, nNeighbourSK(iAt1)
         iPair(iNeigh1, iAt1) = ind
-        ind = ind + nOrb1 * orb%nOrbAtom(img2CentCell(iNeighbor(iNeigh1, iAt1)))
+        ind = ind + nOrb1 * orb%nOrbAtom(img2CentCell(iNeighbour(iNeigh1, iAt1)))
       end do
     end do
     nElem = ind
@@ -732,7 +732,7 @@ contains
 
 
   !> Allocate (reallocate) space for the sparse hamiltonian and overlap matrix.
-  subroutine reallocateHS_2(ham, over, iPair, iNeighbor, nNeighborSK, orb, img2CentCell)
+  subroutine reallocateHS_2(ham, over, iPair, iNeighbour, nNeighbourSK, orb, img2CentCell)
 
     !> Hamiltonian.
     real(dp), allocatable, intent(inout) :: ham(:,:)
@@ -741,14 +741,14 @@ contains
     real(dp), allocatable, intent(inout) :: over(:)
 
     !> Pair indexing array (specifying the offset for the interaction between atoms in the central
-    !> cell and their neighbors).
+    !> cell and their neighbours).
     integer, allocatable, intent(inout) :: iPair(:,:)
 
-    !> List of neighbors for each atom in the central cell. (Note: first index runs from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> List of neighbours for each atom in the central cell. (Note: first index runs from 0!)
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> Nr. of neighbors for each atom in the central cell.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom in the central cell.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Orbitals in the system.
     type(TOrbitals), intent(in) :: orb
@@ -766,14 +766,14 @@ contains
     !> nr. of elements in the spare H/S
     integer :: nElem, nOldElem
 
-    !> nr. of max. possible neighbors (incl. itself)
-    integer :: mNeighbor
+    !> nr. of max. possible neighbours (incl. itself)
+    integer :: mNeighbour
 
     integer :: ind
     integer :: iAt1, iNeigh1, nOrb1
 
-    nAtom = size(iNeighbor, dim=2)
-    mNeighbor = size(iNeighbor, dim=1)
+    nAtom = size(iNeighbour, dim=2)
+    mNeighbour = size(iNeighbour, dim=1)
     nSpin = size(ham, dim=2)
     nOldElem = size(ham, dim=1)
 
@@ -783,18 +783,18 @@ contains
     @:ASSERT(allocated(iPair))
     @:ASSERT(size(iPair, dim=2) == nAtom)
 
-    if (mNeighbor > size(iPair, dim=1)) then
+    if (mNeighbour > size(iPair, dim=1)) then
       deallocate(iPair)
-      allocate(iPair(0:mNeighbor-1, nAtom))
+      allocate(iPair(0:mNeighbour-1, nAtom))
       iPair(:,:) = 0
     end if
     nElem = 0
     ind = 0
     do iAt1 = 1, nAtom
       nOrb1 = orb%nOrbAtom(iAt1)
-      do iNeigh1 = 0, nNeighborSK(iAt1)
+      do iNeigh1 = 0, nNeighbourSK(iAt1)
         iPair(iNeigh1, iAt1) = ind
-        ind = ind +  nOrb1 * orb%nOrbAtom(img2CentCell(iNeighbor(iNeigh1,iAt1)))
+        ind = ind +  nOrb1 * orb%nOrbAtom(img2CentCell(iNeighbour(iNeigh1,iAt1)))
       end do
     end do
     nElem = ind
@@ -811,7 +811,7 @@ contains
 
 
   !> Allocate (reallocate) space for the sparse hamiltonian and overlap matrix.
-  subroutine reallocateHS_Single(ham, iPair, iNeighbor, nNeighborSK, orb, img2CentCell)
+  subroutine reallocateHS_Single(ham, iPair, iNeighbour, nNeighbourSK, orb, img2CentCell)
 
     !> Hamiltonian.
     real(dp), allocatable, intent(inout) :: ham(:)
@@ -820,11 +820,11 @@ contains
     !> cell and their neigbhors).
     integer, allocatable, intent(inout) :: iPair(:,:)
 
-    !> List of neighbors for each atom in the central cell. (Note: first index runs from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> List of neighbours for each atom in the central cell. (Note: first index runs from 0!)
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> Nr. of neighbors for each atom in the central cell.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom in the central cell.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Information about the orbitals in the system.
     type(TOrbitals), intent(in) :: orb
@@ -839,32 +839,32 @@ contains
     !> nr. of elements in the spare H/S before and after resizing
     integer :: nOldElem, nElem
 
-    !> nr. of max. possible neighbors (incl. itself)
-    integer :: mNeighbor
+    !> nr. of max. possible neighbours (incl. itself)
+    integer :: mNeighbour
 
     integer :: ind
     integer :: iAt1, iNeigh1, nOrb1
 
-    nAtom = size(iNeighbor, dim=2)
-    mNeighbor = size(iNeighbor, dim=1)
+    nAtom = size(iNeighbour, dim=2)
+    mNeighbour = size(iNeighbour, dim=1)
     nOldElem = size(ham, dim=1)
 
     @:ASSERT(allocated(ham))
     @:ASSERT(allocated(iPair))
     @:ASSERT(size(iPair, dim=2) == nAtom)
 
-    if (mNeighbor > size(iPair, dim=1)) then
+    if (mNeighbour > size(iPair, dim=1)) then
       deallocate(iPair)
-      allocate(iPair(0:mNeighbor-1, nAtom))
+      allocate(iPair(0:mNeighbour-1, nAtom))
       iPair(:,:) = 0
     end if
     nElem = 0
     ind = 0
     do iAt1 = 1, nAtom
       nOrb1 = orb%nOrbAtom(iAt1)
-      do iNeigh1 = 0, nNeighborSK(iAt1)
+      do iNeigh1 = 0, nNeighbourSK(iAt1)
         iPair(iNeigh1, iAt1) = ind
-        ind = ind +  nOrb1 * orb%nOrbAtom(img2CentCell(iNeighbor(iNeigh1,iAt1)))
+        ind = ind +  nOrb1 * orb%nOrbAtom(img2CentCell(iNeighbour(iNeigh1,iAt1)))
       end do
     end do
     nElem = ind

--- a/prog/dftb+/lib_dftb/pmlocalisation.F90
+++ b/prog/dftb+/lib_dftb/pmlocalisation.F90
@@ -18,7 +18,7 @@ module pmlocalisation
   use sparse2dense, only :unpackHS
   use sorting
   use message
-  use periodic, only : TNeighborList
+  use periodic, only : TNeighbourList
   implicit none
   private
 
@@ -137,7 +137,7 @@ contains
 
 
   !> Performs Pipek-Mezey localisation for a periodic system at a specified k-point.
-  subroutine calcCoeffsKPoint(this, ci, SSqrCplx, over, kPoint, neighborList, nNeighborSK,&
+  subroutine calcCoeffsKPoint(this, ci, SSqrCplx, over, kPoint, neighbourList, nNeighbourSK,&
       & iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
 
     !> Instance.
@@ -156,10 +156,10 @@ contains
     real(dp), intent(in) :: kPoint(:)
 
     !> neighbour list
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> number of neighbours
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> list of which image cells atoms outside the central cell fall into
     integer, intent(in) :: iCellVec(:)
@@ -176,7 +176,7 @@ contains
     !> index array back to central cell
     integer, intent(in) :: img2CentCell(:)
 
-    call PipekMezeyOld_kpoint(ci, SSqrCplx, over, kPoint, neighborList%iNeighbor, nNeighborSK,&
+    call PipekMezeyOld_kpoint(ci, SSqrCplx, over, kPoint, neighbourList%iNeighbour, nNeighbourSK,&
         & iCellVec, cellVec, iAtomStart, iPair, img2CentCell, this%tolerance, this%maxIter)
 
   end subroutine calcCoeffsKPoint
@@ -204,7 +204,7 @@ contains
 
 
   !> Localisation value of square of Mulliken charges summed over all levels for each k-point.
-  function getLocalisationKPoint(ci, SSqrCplx, over, kpoint, neighborList, nNeighborSK,&
+  function getLocalisationKPoint(ci, SSqrCplx, over, kpoint, neighbourList, nNeighbourSK,&
       & iCellVec, cellVec, iAtomStart, iPair, img2CentCell)  result (locality)
 
     !> wavefunction coefficients
@@ -220,10 +220,10 @@ contains
     real(dp), intent(in) :: kpoint(:)
 
     !> neighbour list
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> number of neighbours
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> list of which image cells atoms outside the central cell fall into
     integer, intent(in) :: iCellVec(:)
@@ -243,8 +243,8 @@ contains
     !> Locality for current k-point
     real(dp) :: locality
 
-    locality = PipekMezyLocality_kpoint(ci, SSqrCplx, over, kpoint, neighborList%iNeighbor,&
-        & nNeighborSK, iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
+    locality = PipekMezyLocality_kpoint(ci, SSqrCplx, over, kpoint, neighbourList%iNeighbour,&
+        & nNeighbourSK, iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
 
   end function getLocalisationKPoint
 
@@ -736,8 +736,8 @@ contains
 
 
   !> Localisation value of square of Mulliken charges at a k-point
-  function PipekMezyLocality_kpoint(ci, S, over, kpoint, iNeighbor, nNeighborSK, iCellVec, cellVec,&
-      & iAtomStart, iPair, img2CentCell)  result (PipekMezyLocality)
+  function PipekMezyLocality_kpoint(ci, S, over, kpoint, iNeighbour, nNeighbourSK, iCellVec,&
+      & cellVec, iAtomStart, iPair, img2CentCell)  result (PipekMezyLocality)
 
     !> wavefunction coefficients
     complex(dp), intent(in) :: ci(:,:)
@@ -752,10 +752,10 @@ contains
     real(dp), intent(in) :: kpoint(:)
 
     !> neighbour list
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> number of neighbours
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> list of which image cells atoms outside the central cell fall into
     integer, intent(in) :: iCellVec(:)
@@ -795,7 +795,7 @@ contains
 
     tmp = 0.0_dp
 
-    call unpackHS(S, over, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec, iAtomStart,&
+    call unpackHS(S, over, kPoint, iNeighbour, nNeighbourSK, iCellVec, cellVec, iAtomStart,&
         & iPair, img2CentCell)
 
     call hemm(Sci,'L',S,ci,'L')
@@ -815,7 +815,7 @@ contains
 
   !> Performs conventional Pipek-Mezey localisation for a supercell using iterative sweeps over each
   !> pair of orbitals for a particular k and spin sub-matrix
-  subroutine PipekMezeyOld_kpoint(ci, S, over, kpoint, iNeighbor, nNeighborSK, iCellVec, cellVec,&
+  subroutine PipekMezeyOld_kpoint(ci, S, over, kpoint, iNeighbour, nNeighbourSK, iCellVec, cellVec,&
       & iAtomStart, iPair, img2CentCell, convergence, mIter)
 
     !> wavefunction coefficients
@@ -831,10 +831,10 @@ contains
     real(dp), intent(in) :: kpoint(:)
 
     !> neighbour list
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> number of neighbours
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> list of which image cells atoms outside the central cell fall into
     integer, intent(in) :: iCellVec(:)
@@ -898,7 +898,7 @@ contains
     allocate(ciTmp2(nOrb))
 
     S = cmplx(0,0,dp)
-    call unpackHS(S, over, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec, iAtomStart, iPair,&
+    call unpackHS(S, over, kPoint, iNeighbour, nNeighbourSK, iCellVec, cellVec, iAtomStart, iPair,&
         & img2CentCell)
 
     lpLocalise: do iIter = 1, nIter
@@ -971,11 +971,11 @@ contains
     !write(stdout, *)'Localisations at each k-point'
     !write(stdout, "(6E12.4)") &
     !    & PipekMezyLocality_kpoint(ci, S, over, kpoint, kweights, &
-    !    & iNeighbor, nNeighborSK, iCellVec, cellVec, iAtomStart, iPair, &
+    !    & iNeighbour, nNeighbourSK, iCellVec, cellVec, iAtomStart, iPair, &
     !    & img2CentCell)
     !write(stdout, "(1X,A,E12.4)")'Total', &
     !    & sum(PipekMezyLocality_kpoint(ci, S, over, kpoint, kweights, &
-    !    & iNeighbor, nNeighborSK, iCellVec, cellVec, iAtomStart, iPair, &
+    !    & iNeighbour, nNeighbourSK, iCellVec, cellVec, iAtomStart, iPair, &
     !    & img2CentCell))
 
     if (.not.tConverged) then

--- a/prog/dftb+/lib_dftb/pmlocalisation.F90
+++ b/prog/dftb+/lib_dftb/pmlocalisation.F90
@@ -137,7 +137,7 @@ contains
 
 
   !> Performs Pipek-Mezey localisation for a periodic system at a specified k-point.
-  subroutine calcCoeffsKPoint(this, ci, SSqrCplx, over, kPoint, neighborList, nNeighbor,&
+  subroutine calcCoeffsKPoint(this, ci, SSqrCplx, over, kPoint, neighborList, nNeighborSK,&
       & iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
 
     !> Instance.
@@ -159,7 +159,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> number of neighbours
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> list of which image cells atoms outside the central cell fall into
     integer, intent(in) :: iCellVec(:)
@@ -176,7 +176,7 @@ contains
     !> index array back to central cell
     integer, intent(in) :: img2CentCell(:)
 
-    call PipekMezeyOld_kpoint(ci, SSqrCplx, over, kPoint, neighborList%iNeighbor, nNeighbor,&
+    call PipekMezeyOld_kpoint(ci, SSqrCplx, over, kPoint, neighborList%iNeighbor, nNeighborSK,&
         & iCellVec, cellVec, iAtomStart, iPair, img2CentCell, this%tolerance, this%maxIter)
 
   end subroutine calcCoeffsKPoint
@@ -204,7 +204,7 @@ contains
 
 
   !> Localisation value of square of Mulliken charges summed over all levels for each k-point.
-  function getLocalisationKPoint(ci, SSqrCplx, over, kpoint, neighborList, nNeighbor, &
+  function getLocalisationKPoint(ci, SSqrCplx, over, kpoint, neighborList, nNeighborSK,&
       & iCellVec, cellVec, iAtomStart, iPair, img2CentCell)  result (locality)
 
     !> wavefunction coefficients
@@ -223,7 +223,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> number of neighbours
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> list of which image cells atoms outside the central cell fall into
     integer, intent(in) :: iCellVec(:)
@@ -244,7 +244,7 @@ contains
     real(dp) :: locality
 
     locality = PipekMezyLocality_kpoint(ci, SSqrCplx, over, kpoint, neighborList%iNeighbor,&
-        & nNeighbor, iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
+        & nNeighborSK, iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
 
   end function getLocalisationKPoint
 
@@ -540,7 +540,7 @@ contains
           ! Find atomic sites that appear in both localised orbitals
           union = 0
           union(:nSitesLev(iLev1)) = SitesLev(:nSitesLev(iLev1),iLev1)
-          union(nSitesLev(iLev1)+1:nSitesLev(iLev1)+nSitesLev(iLev2)) = &
+          union(nSitesLev(iLev1)+1:nSitesLev(iLev1)+nSitesLev(iLev2)) =&
               & SitesLev(:nSitesLev(iLev2),iLev2)
           call heap_sort(union(:nSitesLev(iLev1)+nSitesLev(iLev2)))
           kk = unique(union,nSitesLev(iLev1)+nSitesLev(iLev2))
@@ -630,7 +630,7 @@ contains
                   end if
                 end do
                 if (.not.tPresent) then
-                  LevAtAtom(kk:nLevAtAtom(iAtom1)-1,iAtom1) = &
+                  LevAtAtom(kk:nLevAtAtom(iAtom1)-1,iAtom1) =&
                       & LevAtAtom(kk+1:nLevAtAtom(iAtom1),iAtom1)
                   nLevAtAtom(iAtom1) = nLevAtAtom(iAtom1) -1
                 end if
@@ -651,7 +651,7 @@ contains
                   end if
                 end do
                 if (.not.tPresent) then
-                  LevAtAtom(kk:nLevAtAtom(iAtom1)-1,iAtom1) = &
+                  LevAtAtom(kk:nLevAtAtom(iAtom1)-1,iAtom1) =&
                       & LevAtAtom(kk+1:nLevAtAtom(iAtom1),iAtom1)
                   nLevAtAtom(iAtom1) = nLevAtAtom(iAtom1) -1
                 end if
@@ -729,15 +729,14 @@ contains
     do iAtom = 1, nAtom
       iOrbStart = iAtomStart(iAtom)
       iOrbEnd = iAtomStart(iAtom+1) - 1
-      PipekMezyLocality = PipekMezyLocality &
-          & + sum(sum(Sci(iOrbStart:iOrbEnd,1:nLev),dim=1)**2)
+      PipekMezyLocality = PipekMezyLocality + sum(sum(Sci(iOrbStart:iOrbEnd,1:nLev),dim=1)**2)
     end do
 
   end function PipekMezyLocality_real
 
 
   !> Localisation value of square of Mulliken charges at a k-point
-  function PipekMezyLocality_kpoint(ci, S, over, kpoint, iNeighbor, nNeighbor, iCellVec, cellVec,&
+  function PipekMezyLocality_kpoint(ci, S, over, kpoint, iNeighbor, nNeighborSK, iCellVec, cellVec,&
       & iAtomStart, iPair, img2CentCell)  result (PipekMezyLocality)
 
     !> wavefunction coefficients
@@ -756,7 +755,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> number of neighbours
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> list of which image cells atoms outside the central cell fall into
     integer, intent(in) :: iCellVec(:)
@@ -796,7 +795,7 @@ contains
 
     tmp = 0.0_dp
 
-    call unpackHS(S, over, kPoint, iNeighbor, nNeighbor, iCellVec, cellVec, iAtomStart,&
+    call unpackHS(S, over, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec, iAtomStart,&
         & iPair, img2CentCell)
 
     call hemm(Sci,'L',S,ci,'L')
@@ -816,7 +815,7 @@ contains
 
   !> Performs conventional Pipek-Mezey localisation for a supercell using iterative sweeps over each
   !> pair of orbitals for a particular k and spin sub-matrix
-  subroutine PipekMezeyOld_kpoint(ci, S, over, kpoint, iNeighbor, nNeighbor, iCellVec, cellVec,&
+  subroutine PipekMezeyOld_kpoint(ci, S, over, kpoint, iNeighbor, nNeighborSK, iCellVec, cellVec,&
       & iAtomStart, iPair, img2CentCell, convergence, mIter)
 
     !> wavefunction coefficients
@@ -835,7 +834,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> number of neighbours
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> list of which image cells atoms outside the central cell fall into
     integer, intent(in) :: iCellVec(:)
@@ -899,7 +898,7 @@ contains
     allocate(ciTmp2(nOrb))
 
     S = cmplx(0,0,dp)
-    call unpackHS(S, over, kPoint, iNeighbor, nNeighbor, iCellVec, cellVec, iAtomStart, iPair,&
+    call unpackHS(S, over, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec, iAtomStart, iPair,&
         & img2CentCell)
 
     lpLocalise: do iIter = 1, nIter
@@ -972,11 +971,11 @@ contains
     !write(stdout, *)'Localisations at each k-point'
     !write(stdout, "(6E12.4)") &
     !    & PipekMezyLocality_kpoint(ci, S, over, kpoint, kweights, &
-    !    & iNeighbor, nNeighbor, iCellVec, cellVec, iAtomStart, iPair, &
+    !    & iNeighbor, nNeighborSK, iCellVec, cellVec, iAtomStart, iPair, &
     !    & img2CentCell)
     !write(stdout, "(1X,A,E12.4)")'Total', &
     !    & sum(PipekMezyLocality_kpoint(ci, S, over, kpoint, kweights, &
-    !    & iNeighbor, nNeighbor, iCellVec, cellVec, iAtomStart, iPair, &
+    !    & iNeighbor, nNeighborSK, iCellVec, cellVec, iAtomStart, iPair, &
     !    & img2CentCell))
 
     if (.not.tConverged) then

--- a/prog/dftb+/lib_dftb/populations.F90
+++ b/prog/dftb+/lib_dftb/populations.F90
@@ -40,7 +40,7 @@ contains
 
   !> Calculate the Mulliken population for each atom in the system, by summing
   !> the individual orbital contriutions on each atom
-  subroutine mullikenPerAtom(qq, over, rho, orb, iNeighbor, nNeighborSK, img2CentCell, iPair)
+  subroutine mullikenPerAtom(qq, over, rho, orb, iNeighbour, nNeighbourSK, img2CentCell, iPair)
 
     !> The charge per atom
     real(dp), intent(inout) :: qq(:)
@@ -55,10 +55,10 @@ contains
     type(TOrbitals), intent(in) :: orb
 
     !> Number of neighbours of each real atom (central cell)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> List of neighbours for each atom, starting at 0 for itself
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> indexing array to convert images of atoms back into their number in the central cell
     integer, intent(in) :: img2CentCell(:)
@@ -76,7 +76,7 @@ contains
     allocate(qPerOrbital(orb%mOrb, nAtom))
     qPerOrbital(:,:) = 0.0_dp
 
-    call mullikenPerOrbital( qPerOrbital,over,rho,orb,iNeighbor,nNeighborSK, img2CentCell,iPair )
+    call mullikenPerOrbital( qPerOrbital,over,rho,orb,iNeighbour,nNeighbourSK, img2CentCell,iPair )
 
     qq(:) = qq(:) + sum(qPerOrbital, dim=1)
     deallocate(qPerOrbital)
@@ -89,7 +89,7 @@ contains
   !> one triangle of real space extended matrices
   !>
   !> To do: add description of algorithm to programer manual / documentation.
-  subroutine mullikenPerOrbital(qq, over, rho, orb, iNeighbor, nNeighborSK, img2CentCell, iPair)
+  subroutine mullikenPerOrbital(qq, over, rho, orb, iNeighbour, nNeighbourSK, img2CentCell, iPair)
 
     !> The charge per orbital
     real(dp), intent(inout) :: qq(:,:)
@@ -104,10 +104,10 @@ contains
     type(TOrbitals), intent(in) :: orb
 
     !> Number of neighbours of each real atom (central cell)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> List of neighbours for each atom, starting at 0 for itself
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> indexing array to convert images of atoms back into their number in the central cell
     integer, intent(in) :: img2CentCell(:)
@@ -129,10 +129,10 @@ contains
 
     do iAtom1 = 1, nAtom
       nOrb1 = orb%nOrbAtom(iAtom1)
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         sqrTmp(:,:) = 0.0_dp
         mulTmp(:) = 0.0_dp
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         nOrb2 = orb%nOrbAtom(iAtom2f)
         iOrig = iPair(iNeigh,iAtom1) + 1
@@ -154,7 +154,7 @@ contains
   !> using purely real-space overlap and density matrix values.
   !>
   !> To do: add description of algorithm to programer manual / documentation.
-  subroutine mullikenPerBlock(qq, over, rho, orb, iNeighbor, nNeighborSK, img2CentCell, iPair)
+  subroutine mullikenPerBlock(qq, over, rho, orb, iNeighbour, nNeighbourSK, img2CentCell, iPair)
 
     !> The charge per atom block
     real(dp), intent(inout) :: qq(:,:,:)
@@ -169,10 +169,10 @@ contains
     type(TOrbitals), intent(in) :: orb
 
     !> Number of neighbours of each real atom (central cell)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> List of neighbours for each atom, starting at 0 for itself
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> indexing array to convert images of atoms back into their number in the central cell
     integer, intent(in) :: img2CentCell(:)
@@ -194,20 +194,20 @@ contains
 
     do iAtom1 = 1, nAtom
       nOrb1 = orb%nOrbAtom(iAtom1)
-      do iNeigh = 0, nNeighborSK(iAtom1)
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         nOrb2 = orb%nOrbAtom(iAtom2f)
         iOrig = iPair(iNeigh,iAtom1) + 1
         sTmp(1:nOrb2,1:nOrb1) = reshape(over(iOrig:iOrig+nOrb1*nOrb2-1), (/nOrb2,nOrb1/))
         rhoTmp(1:nOrb2,1:nOrb1) = reshape(rho(iOrig:iOrig+nOrb1*nOrb2-1), (/nOrb2,nOrb1/))
-        qq(1:nOrb1,1:nOrb1,iAtom1) = qq(1:nOrb1,1:nOrb1,iAtom1) &
-            & + 0.5_dp*( matmul(transpose(rhoTmp(1:nOrb2,1:nOrb1)), sTmp(1:nOrb2,1:nOrb1) ) &
+        qq(1:nOrb1,1:nOrb1,iAtom1) = qq(1:nOrb1,1:nOrb1,iAtom1)&
+            & + 0.5_dp*( matmul(transpose(rhoTmp(1:nOrb2,1:nOrb1)), sTmp(1:nOrb2,1:nOrb1) )&
             & + matmul(transpose(sTmp(1:nOrb2,1:nOrb1)), rhoTmp(1:nOrb2,1:nOrb1) ) )
         ! Add contribution to the other triangle sum, using the symmetry but only when off diagonal
         if (iAtom1 /= iAtom2f) then
-          qq(1:nOrb2,1:nOrb2,iAtom2f) = qq(1:nOrb2,1:nOrb2,iAtom2f) &
-              & + 0.5_dp*( matmul( rhoTmp(1:nOrb2,1:nOrb1), transpose(sTmp(1:nOrb2,1:nOrb1)) ) &
+          qq(1:nOrb2,1:nOrb2,iAtom2f) = qq(1:nOrb2,1:nOrb2,iAtom2f)&
+              & + 0.5_dp*( matmul( rhoTmp(1:nOrb2,1:nOrb1), transpose(sTmp(1:nOrb2,1:nOrb1)) )&
               & + matmul( sTmp(1:nOrb2,1:nOrb1), transpose(rhoTmp(1:nOrb2,1:nOrb1)) ) )
         end if
       end do
@@ -220,7 +220,7 @@ contains
   !> system using purely real-space overlap and density matrix values.
   !>
   !> To do: add description of algorithm to programer manual / documentation.
-  subroutine skewMullikenPerBlock(qq, over, rho, orb, iNeighbor, nNeighborSK, img2CentCell, iPair)
+  subroutine skewMullikenPerBlock(qq, over, rho, orb, iNeighbour, nNeighbourSK, img2CentCell, iPair)
 
     !> The charge per atom block
     real(dp), intent(inout) :: qq(:,:,:)
@@ -235,10 +235,10 @@ contains
     type(TOrbitals), intent(in) :: orb
 
     !> Number of neighbours of each real atom (central cell)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> List of neighbours for each atom, starting at 0 for itself
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> indexing array to convert images of atoms back into their number in the central cell
     integer, intent(in) :: img2CentCell(:)
@@ -260,20 +260,20 @@ contains
 
     do iAtom1 = 1, nAtom
       nOrb1 = orb%nOrbAtom(iAtom1)
-      do iNeigh = 0, nNeighborSK(iAtom1)
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         nOrb2 = orb%nOrbAtom(iAtom2f)
         iOrig = iPair(iNeigh,iAtom1) + 1
         sTmp(1:nOrb2,1:nOrb1) = reshape(over(iOrig:iOrig+nOrb1*nOrb2-1), (/nOrb2,nOrb1/))
         rhoTmp(1:nOrb2,1:nOrb1) = reshape(rho(iOrig:iOrig+nOrb1*nOrb2-1), (/nOrb2,nOrb1/))
-        qq(1:nOrb1,1:nOrb1,iAtom1) = qq(1:nOrb1,1:nOrb1,iAtom1) &
-            & - 0.5_dp*( matmul(transpose(rhoTmp(1:nOrb2,1:nOrb1)), sTmp(1:nOrb2,1:nOrb1) ) &
+        qq(1:nOrb1,1:nOrb1,iAtom1) = qq(1:nOrb1,1:nOrb1,iAtom1)&
+            & - 0.5_dp*( matmul(transpose(rhoTmp(1:nOrb2,1:nOrb1)), sTmp(1:nOrb2,1:nOrb1) )&
             & - matmul(transpose(sTmp(1:nOrb2,1:nOrb1)), rhoTmp(1:nOrb2,1:nOrb1) ) )
         ! Add contribution to the other triangle sum, using the symmetry but only when off diagonal
         if (iAtom1 /= iAtom2f) then
-          qq(1:nOrb2,1:nOrb2,iAtom2f) = qq(1:nOrb2,1:nOrb2,iAtom2f) &
-              & + 0.5_dp*( matmul( rhoTmp(1:nOrb2,1:nOrb1), transpose(sTmp(1:nOrb2,1:nOrb1)) ) &
+          qq(1:nOrb2,1:nOrb2,iAtom2f) = qq(1:nOrb2,1:nOrb2,iAtom2f)&
+              & + 0.5_dp*( matmul( rhoTmp(1:nOrb2,1:nOrb1), transpose(sTmp(1:nOrb2,1:nOrb1)) )&
               & - matmul( sTmp(1:nOrb2,1:nOrb1), transpose(rhoTmp(1:nOrb2,1:nOrb1)) ) )
         end if
       end do

--- a/prog/dftb+/lib_dftb/populations.F90
+++ b/prog/dftb+/lib_dftb/populations.F90
@@ -40,7 +40,7 @@ contains
 
   !> Calculate the Mulliken population for each atom in the system, by summing
   !> the individual orbital contriutions on each atom
-  subroutine mullikenPerAtom(qq, over, rho, orb, iNeighbor, nNeighbor, img2CentCell, iPair)
+  subroutine mullikenPerAtom(qq, over, rho, orb, iNeighbor, nNeighborSK, img2CentCell, iPair)
 
     !> The charge per atom
     real(dp), intent(inout) :: qq(:)
@@ -58,7 +58,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> List of neighbours for each atom, starting at 0 for itself
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> indexing array to convert images of atoms back into their number in the central cell
     integer, intent(in) :: img2CentCell(:)
@@ -76,8 +76,7 @@ contains
     allocate(qPerOrbital(orb%mOrb, nAtom))
     qPerOrbital(:,:) = 0.0_dp
 
-    call mullikenPerOrbital( qPerOrbital,over,rho,orb,iNeighbor,nNeighbor, &
-        &img2CentCell,iPair )
+    call mullikenPerOrbital( qPerOrbital,over,rho,orb,iNeighbor,nNeighborSK, img2CentCell,iPair )
 
     qq(:) = qq(:) + sum(qPerOrbital, dim=1)
     deallocate(qPerOrbital)
@@ -90,7 +89,7 @@ contains
   !> one triangle of real space extended matrices
   !>
   !> To do: add description of algorithm to programer manual / documentation.
-  subroutine mullikenPerOrbital(qq, over, rho, orb, iNeighbor, nNeighbor, img2CentCell, iPair)
+  subroutine mullikenPerOrbital(qq, over, rho, orb, iNeighbor, nNeighborSK, img2CentCell, iPair)
 
     !> The charge per orbital
     real(dp), intent(inout) :: qq(:,:)
@@ -108,7 +107,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> List of neighbours for each atom, starting at 0 for itself
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> indexing array to convert images of atoms back into their number in the central cell
     integer, intent(in) :: img2CentCell(:)
@@ -130,24 +129,20 @@ contains
 
     do iAtom1 = 1, nAtom
       nOrb1 = orb%nOrbAtom(iAtom1)
-      do iNeigh = 0, nNeighbor(iAtom1)
+      do iNeigh = 0, nNeighborSK(iAtom1)
         sqrTmp(:,:) = 0.0_dp
         mulTmp(:) = 0.0_dp
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         nOrb2 = orb%nOrbAtom(iAtom2f)
         iOrig = iPair(iNeigh,iAtom1) + 1
-        mulTmp(1:nOrb1*nOrb2) = over(iOrig:iOrig+nOrb1*nOrb2-1) &
-            &* rho(iOrig:iOrig+nOrb1*nOrb2-1)
-        sqrTmp(1:nOrb2,1:nOrb1) = &
-            & reshape(mulTmp(1:nOrb1*nOrb2), (/nOrb2,nOrb1/))
-        qq(1:nOrb1,iAtom1) = qq(1:nOrb1,iAtom1) &
-            &+ sum(sqrTmp(1:nOrb2,1:nOrb1), dim=1)
+        mulTmp(1:nOrb1*nOrb2) = over(iOrig:iOrig+nOrb1*nOrb2-1) * rho(iOrig:iOrig+nOrb1*nOrb2-1)
+        sqrTmp(1:nOrb2,1:nOrb1) = reshape(mulTmp(1:nOrb1*nOrb2), (/nOrb2,nOrb1/))
+        qq(1:nOrb1,iAtom1) = qq(1:nOrb1,iAtom1) + sum(sqrTmp(1:nOrb2,1:nOrb1), dim=1)
         ! Add contribution to the other triangle sum, using the symmetry
         ! but only when off diagonal
         if (iAtom1 /= iAtom2f) then
-          qq(1:nOrb2,iAtom2f) = qq(1:nOrb2,iAtom2f) &
-              &+ sum(sqrTmp(1:nOrb2,1:nOrb1), dim=2)
+          qq(1:nOrb2,iAtom2f) = qq(1:nOrb2,iAtom2f) + sum(sqrTmp(1:nOrb2,1:nOrb1), dim=2)
         end if
       end do
     end do
@@ -159,7 +154,7 @@ contains
   !> using purely real-space overlap and density matrix values.
   !>
   !> To do: add description of algorithm to programer manual / documentation.
-  subroutine mullikenPerBlock(qq, over, rho, orb, iNeighbor, nNeighbor, img2CentCell, iPair)
+  subroutine mullikenPerBlock(qq, over, rho, orb, iNeighbor, nNeighborSK, img2CentCell, iPair)
 
     !> The charge per atom block
     real(dp), intent(inout) :: qq(:,:,:)
@@ -177,7 +172,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> List of neighbours for each atom, starting at 0 for itself
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> indexing array to convert images of atoms back into their number in the central cell
     integer, intent(in) :: img2CentCell(:)
@@ -199,27 +194,21 @@ contains
 
     do iAtom1 = 1, nAtom
       nOrb1 = orb%nOrbAtom(iAtom1)
-      do iNeigh = 0, nNeighbor(iAtom1)
+      do iNeigh = 0, nNeighborSK(iAtom1)
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         nOrb2 = orb%nOrbAtom(iAtom2f)
         iOrig = iPair(iNeigh,iAtom1) + 1
-        sTmp(1:nOrb2,1:nOrb1) = &
-            & reshape(over(iOrig:iOrig+nOrb1*nOrb2-1), (/nOrb2,nOrb1/))
-        rhoTmp(1:nOrb2,1:nOrb1) = &
-            & reshape(rho(iOrig:iOrig+nOrb1*nOrb2-1), (/nOrb2,nOrb1/))
+        sTmp(1:nOrb2,1:nOrb1) = reshape(over(iOrig:iOrig+nOrb1*nOrb2-1), (/nOrb2,nOrb1/))
+        rhoTmp(1:nOrb2,1:nOrb1) = reshape(rho(iOrig:iOrig+nOrb1*nOrb2-1), (/nOrb2,nOrb1/))
         qq(1:nOrb1,1:nOrb1,iAtom1) = qq(1:nOrb1,1:nOrb1,iAtom1) &
-            & + 0.5_dp*( matmul(transpose(rhoTmp(1:nOrb2,1:nOrb1)), &
-            & sTmp(1:nOrb2,1:nOrb1) ) &
-            & + matmul(transpose(sTmp(1:nOrb2,1:nOrb1)), &
-            & rhoTmp(1:nOrb2,1:nOrb1) ) )
+            & + 0.5_dp*( matmul(transpose(rhoTmp(1:nOrb2,1:nOrb1)), sTmp(1:nOrb2,1:nOrb1) ) &
+            & + matmul(transpose(sTmp(1:nOrb2,1:nOrb1)), rhoTmp(1:nOrb2,1:nOrb1) ) )
         ! Add contribution to the other triangle sum, using the symmetry but only when off diagonal
         if (iAtom1 /= iAtom2f) then
           qq(1:nOrb2,1:nOrb2,iAtom2f) = qq(1:nOrb2,1:nOrb2,iAtom2f) &
-              & + 0.5_dp*( matmul( rhoTmp(1:nOrb2,1:nOrb1), &
-              & transpose(sTmp(1:nOrb2,1:nOrb1)) ) &
-              & + matmul( sTmp(1:nOrb2,1:nOrb1), &
-              & transpose(rhoTmp(1:nOrb2,1:nOrb1)) ) )
+              & + 0.5_dp*( matmul( rhoTmp(1:nOrb2,1:nOrb1), transpose(sTmp(1:nOrb2,1:nOrb1)) ) &
+              & + matmul( sTmp(1:nOrb2,1:nOrb1), transpose(rhoTmp(1:nOrb2,1:nOrb1)) ) )
         end if
       end do
     end do
@@ -231,7 +220,7 @@ contains
   !> system using purely real-space overlap and density matrix values.
   !>
   !> To do: add description of algorithm to programer manual / documentation.
-  subroutine skewMullikenPerBlock(qq, over, rho, orb, iNeighbor, nNeighbor, img2CentCell, iPair)
+  subroutine skewMullikenPerBlock(qq, over, rho, orb, iNeighbor, nNeighborSK, img2CentCell, iPair)
 
     !> The charge per atom block
     real(dp), intent(inout) :: qq(:,:,:)
@@ -249,7 +238,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> List of neighbours for each atom, starting at 0 for itself
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> indexing array to convert images of atoms back into their number in the central cell
     integer, intent(in) :: img2CentCell(:)
@@ -271,27 +260,21 @@ contains
 
     do iAtom1 = 1, nAtom
       nOrb1 = orb%nOrbAtom(iAtom1)
-      do iNeigh = 0, nNeighbor(iAtom1)
+      do iNeigh = 0, nNeighborSK(iAtom1)
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         nOrb2 = orb%nOrbAtom(iAtom2f)
         iOrig = iPair(iNeigh,iAtom1) + 1
-        sTmp(1:nOrb2,1:nOrb1) = &
-            & reshape(over(iOrig:iOrig+nOrb1*nOrb2-1), (/nOrb2,nOrb1/))
-        rhoTmp(1:nOrb2,1:nOrb1) = &
-            & reshape(rho(iOrig:iOrig+nOrb1*nOrb2-1), (/nOrb2,nOrb1/))
+        sTmp(1:nOrb2,1:nOrb1) = reshape(over(iOrig:iOrig+nOrb1*nOrb2-1), (/nOrb2,nOrb1/))
+        rhoTmp(1:nOrb2,1:nOrb1) = reshape(rho(iOrig:iOrig+nOrb1*nOrb2-1), (/nOrb2,nOrb1/))
         qq(1:nOrb1,1:nOrb1,iAtom1) = qq(1:nOrb1,1:nOrb1,iAtom1) &
-            & - 0.5_dp*( matmul(transpose(rhoTmp(1:nOrb2,1:nOrb1)), &
-            & sTmp(1:nOrb2,1:nOrb1) ) &
-            & - matmul(transpose(sTmp(1:nOrb2,1:nOrb1)), &
-            & rhoTmp(1:nOrb2,1:nOrb1) ) )
+            & - 0.5_dp*( matmul(transpose(rhoTmp(1:nOrb2,1:nOrb1)), sTmp(1:nOrb2,1:nOrb1) ) &
+            & - matmul(transpose(sTmp(1:nOrb2,1:nOrb1)), rhoTmp(1:nOrb2,1:nOrb1) ) )
         ! Add contribution to the other triangle sum, using the symmetry but only when off diagonal
         if (iAtom1 /= iAtom2f) then
           qq(1:nOrb2,1:nOrb2,iAtom2f) = qq(1:nOrb2,1:nOrb2,iAtom2f) &
-              & + 0.5_dp*( matmul( rhoTmp(1:nOrb2,1:nOrb1), &
-              & transpose(sTmp(1:nOrb2,1:nOrb1)) ) &
-              & - matmul( sTmp(1:nOrb2,1:nOrb1), &
-              & transpose(rhoTmp(1:nOrb2,1:nOrb1)) ) )
+              & + 0.5_dp*( matmul( rhoTmp(1:nOrb2,1:nOrb1), transpose(sTmp(1:nOrb2,1:nOrb1)) ) &
+              & - matmul( sTmp(1:nOrb2,1:nOrb1), transpose(rhoTmp(1:nOrb2,1:nOrb1)) ) )
         end if
       end do
     end do

--- a/prog/dftb+/lib_dftb/repulsive.F90
+++ b/prog/dftb+/lib_dftb/repulsive.F90
@@ -28,8 +28,7 @@ contains
 
 
   !> Subroutine for calculating total energy contribution of the repulsives.
-  subroutine getERep_total(reslt, coords, nNeighbors, iNeighbors, species, &
-      &img2CentCell, repCont)
+  subroutine getERep_total(reslt, coords, nNeighborSK, iNeighbors, species, img2CentCell, repCont)
 
     !> Total energy contribution.
     real(dp), intent(out) :: reslt
@@ -38,7 +37,7 @@ contains
     real(dp), intent(in) :: coords(:,:)
 
     !> Number of neighbors for atoms in the central cell
-    integer, intent(in) :: nNeighbors(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index of neighbors for a given atom.
     integer, intent(in) :: iNeighbors(0:,:)
@@ -56,8 +55,8 @@ contains
     real(dp) :: vect(3), dist, intermed
 
     reslt = 0.0_dp
-    do iAt1 = 1, size(nNeighbors)
-      do iNeigh = 1, nNeighbors(iAt1)
+    do iAt1 = 1, size(nNeighborSK)
+      do iNeigh = 1, nNeighborSK(iAt1)
         iAt2 = iNeighbors(iNeigh,iAt1)
         iAt2f = img2CentCell(iAt2)
         vect(:) = coords(:,iAt1) - coords(:,iAt2)
@@ -75,8 +74,7 @@ contains
 
 
   !> Subroutine for repulsive energy contributions for each atom
-  subroutine getERep_atoms(reslt, coords, nNeighbors, iNeighbors, species,&
-      &repCont, img2CentCell)
+  subroutine getERep_atoms(reslt, coords, nNeighborSK, iNeighbors, species, repCont, img2CentCell)
 
     !> Energy for each atom.
     real(dp), intent(out) :: reslt(:)
@@ -85,7 +83,7 @@ contains
     real(dp), intent(in) :: coords(:,:)
 
     !> Number of neighbors for atoms in the central cell
-    integer, intent(in) :: nNeighbors(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index of neighbors for a given atom.
     integer, intent(in) :: iNeighbors(0:,:)
@@ -102,11 +100,11 @@ contains
     integer :: iAt1, iNeigh, iAt2, iAt2f
     real(dp) :: vect(3), dist, intermed
 
-    @:ASSERT(size(reslt) == size(nNeighbors))
+    @:ASSERT(size(reslt) == size(nNeighborSK))
 
     reslt(:) = 0.0_dp
-    do iAt1 = 1, size(nNeighbors)
-      do iNeigh = 1, nNeighbors(iAt1)
+    do iAt1 = 1, size(nNeighborSK)
+      do iNeigh = 1, nNeighborSK(iAt1)
         iAt2 = iNeighbors(iNeigh,iAt1)
         iAt2f = img2CentCell(iAt2)
         vect(:) = coords(:,iAt1) - coords(:,iAt2)
@@ -123,8 +121,7 @@ contains
 
 
   !> Subroutine for force contributions of the repulsives.
-  subroutine getERepDeriv(reslt, coords, nNeighbors, iNeighbors, species, &
-      &repCont, img2CentCell)
+  subroutine getERepDeriv(reslt, coords, nNeighborSK, iNeighbors, species, repCont, img2CentCell)
 
     !> Energy for each atom.
     real(dp), intent(out) :: reslt(:,:)
@@ -133,7 +130,7 @@ contains
     real(dp), intent(in) :: coords(:,:)
 
     !> Number of neighbors for atoms in the central cell
-    integer, intent(in) :: nNeighbors(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index of neighbors for a given atom.
     integer, intent(in) :: iNeighbors(0:,:)
@@ -153,16 +150,15 @@ contains
     @:ASSERT(size(reslt,dim=1) == 3)
 
     reslt(:,:) = 0.0_dp
-    do iAt1 = 1, size(nNeighbors)
-      lpNeigh: do iNeigh = 1, nNeighbors(iAt1)
+    do iAt1 = 1, size(nNeighborSK)
+      lpNeigh: do iNeigh = 1, nNeighborSK(iAt1)
         iAt2 = iNeighbors(iNeigh,iAt1)
         iAt2f = img2CentCell(iAt2)
         if (iAt2f == iAt1) then
           cycle lpNeigh
         end if
         vect(:) = coords(:,iAt1) - coords(:,iAt2)
-        call getEnergyDeriv(repCont, intermed, vect, species(iAt1), &
-            &species(iAt2))
+        call getEnergyDeriv(repCont, intermed, vect, species(iAt1), species(iAt2))
         reslt(:,iAt1) = reslt(:,iAt1) + intermed(:)
         reslt(:,iAt2f) = reslt(:,iAt2f) - intermed(:)
       end do lpNeigh

--- a/prog/dftb+/lib_dftb/repulsive.F90
+++ b/prog/dftb+/lib_dftb/repulsive.F90
@@ -28,7 +28,7 @@ contains
 
 
   !> Subroutine for calculating total energy contribution of the repulsives.
-  subroutine getERep_total(reslt, coords, nNeighborSK, iNeighbors, species, img2CentCell, repCont)
+  subroutine getERep_total(reslt, coords, nNeighbourSK, iNeighbours, species, img2CentCell, repCont)
 
     !> Total energy contribution.
     real(dp), intent(out) :: reslt
@@ -36,11 +36,11 @@ contains
     !> coordinates (x,y,z, all atoms including possible images)
     real(dp), intent(in) :: coords(:,:)
 
-    !> Number of neighbors for atoms in the central cell
-    integer, intent(in) :: nNeighborSK(:)
+    !> Number of neighbours for atoms in the central cell
+    integer, intent(in) :: nNeighbourSK(:)
 
-    !> Index of neighbors for a given atom.
-    integer, intent(in) :: iNeighbors(0:,:)
+    !> Index of neighbours for a given atom.
+    integer, intent(in) :: iNeighbours(0:,:)
 
     !> Species of atoms in the central cell.
     integer, intent(in) :: species(:)
@@ -55,9 +55,9 @@ contains
     real(dp) :: vect(3), dist, intermed
 
     reslt = 0.0_dp
-    do iAt1 = 1, size(nNeighborSK)
-      do iNeigh = 1, nNeighborSK(iAt1)
-        iAt2 = iNeighbors(iNeigh,iAt1)
+    do iAt1 = 1, size(nNeighbourSK)
+      do iNeigh = 1, nNeighbourSK(iAt1)
+        iAt2 = iNeighbours(iNeigh,iAt1)
         iAt2f = img2CentCell(iAt2)
         vect(:) = coords(:,iAt1) - coords(:,iAt2)
         dist = sqrt(sum(vect**2))
@@ -74,7 +74,7 @@ contains
 
 
   !> Subroutine for repulsive energy contributions for each atom
-  subroutine getERep_atoms(reslt, coords, nNeighborSK, iNeighbors, species, repCont, img2CentCell)
+  subroutine getERep_atoms(reslt, coords, nNeighbourSK, iNeighbours, species, repCont, img2CentCell)
 
     !> Energy for each atom.
     real(dp), intent(out) :: reslt(:)
@@ -82,11 +82,11 @@ contains
     !> coordinates (x,y,z, all atoms including possible images)
     real(dp), intent(in) :: coords(:,:)
 
-    !> Number of neighbors for atoms in the central cell
-    integer, intent(in) :: nNeighborSK(:)
+    !> Number of neighbours for atoms in the central cell
+    integer, intent(in) :: nNeighbourSK(:)
 
-    !> Index of neighbors for a given atom.
-    integer, intent(in) :: iNeighbors(0:,:)
+    !> Index of neighbours for a given atom.
+    integer, intent(in) :: iNeighbours(0:,:)
 
     !> Species of atoms in the central cell.
     integer, intent(in) :: species(:)
@@ -100,12 +100,12 @@ contains
     integer :: iAt1, iNeigh, iAt2, iAt2f
     real(dp) :: vect(3), dist, intermed
 
-    @:ASSERT(size(reslt) == size(nNeighborSK))
+    @:ASSERT(size(reslt) == size(nNeighbourSK))
 
     reslt(:) = 0.0_dp
-    do iAt1 = 1, size(nNeighborSK)
-      do iNeigh = 1, nNeighborSK(iAt1)
-        iAt2 = iNeighbors(iNeigh,iAt1)
+    do iAt1 = 1, size(nNeighbourSK)
+      do iNeigh = 1, nNeighbourSK(iAt1)
+        iAt2 = iNeighbours(iNeigh,iAt1)
         iAt2f = img2CentCell(iAt2)
         vect(:) = coords(:,iAt1) - coords(:,iAt2)
         dist = sqrt(sum(vect**2))
@@ -121,7 +121,7 @@ contains
 
 
   !> Subroutine for force contributions of the repulsives.
-  subroutine getERepDeriv(reslt, coords, nNeighborSK, iNeighbors, species, repCont, img2CentCell)
+  subroutine getERepDeriv(reslt, coords, nNeighbourSK, iNeighbours, species, repCont, img2CentCell)
 
     !> Energy for each atom.
     real(dp), intent(out) :: reslt(:,:)
@@ -129,11 +129,11 @@ contains
     !> coordinates (x,y,z, all atoms including possible images)
     real(dp), intent(in) :: coords(:,:)
 
-    !> Number of neighbors for atoms in the central cell
-    integer, intent(in) :: nNeighborSK(:)
+    !> Number of neighbours for atoms in the central cell
+    integer, intent(in) :: nNeighbourSK(:)
 
-    !> Index of neighbors for a given atom.
-    integer, intent(in) :: iNeighbors(0:,:)
+    !> Index of neighbours for a given atom.
+    integer, intent(in) :: iNeighbours(0:,:)
 
     !> Species of atoms in the central cell.
     integer, intent(in) :: species(:)
@@ -150,9 +150,9 @@ contains
     @:ASSERT(size(reslt,dim=1) == 3)
 
     reslt(:,:) = 0.0_dp
-    do iAt1 = 1, size(nNeighborSK)
-      lpNeigh: do iNeigh = 1, nNeighborSK(iAt1)
-        iAt2 = iNeighbors(iNeigh,iAt1)
+    do iAt1 = 1, size(nNeighbourSK)
+      lpNeigh: do iNeigh = 1, nNeighbourSK(iAt1)
+        iAt2 = iNeighbours(iNeigh,iAt1)
         iAt2f = img2CentCell(iAt2)
         if (iAt2f == iAt1) then
           cycle lpNeigh

--- a/prog/dftb+/lib_dftb/scc.F90
+++ b/prog/dftb+/lib_dftb/scc.F90
@@ -113,8 +113,8 @@ module scc
     !> Short range interaction
     real(dp), allocatable :: shortGamma(:,:,:,:)
 
-    !> Cutoff for short range int.
-    real(dp), allocatable :: shortCutoff(:,:,:,:)
+    !> CutOff for short range int.
+    real(dp), allocatable :: shortCutOff(:,:,:,:)
 
     !> Maximal cutoff
     real(dp) :: cutoff
@@ -125,7 +125,7 @@ module scc
     !> Real lattice points for asymmetric Ewald sum
     real(dp), allocatable :: rCellVec(:,:)
 
-    !> Nr. of neighbors for short range interaction
+    !> Nr. of neighbors for short range part of gamma
     integer, allocatable :: nNeighShort(:,:,:,:)
 
     !> Dynamic neighbor list for the real space Ewald summation
@@ -215,7 +215,7 @@ module scc
 #:endif
 
   contains
-    procedure :: getCutoff
+    procedure :: getCutOff
     procedure :: getEwaldPar
     procedure :: updateCoords
     procedure :: updateLatVecs
@@ -327,20 +327,20 @@ contains
     this%mHubbU = maxval(this%nHubbU)
 
     ! Get cutoff for short range coulomb
-    allocate(this%shortCutoff(this%mHubbU, this%mHubbU, this%nSpecies, this%nSpecies))
-    this%shortCutoff(:,:,:,:) = 0.0_dp
+    allocate(this%shortCutOff(this%mHubbU, this%mHubbU, this%nSpecies, this%nSpecies))
+    this%shortCutOff(:,:,:,:) = 0.0_dp
     do iSp1 = 1, this%nSpecies
       do iSp2 = iSp1, this%nSpecies
         do iU1 = 1, this%nHubbU(iSp1)
           do iU2 = 1, this%nHubbU(iSp2)
-            this%shortCutoff(iU2, iU1, iSp2, iSp1) = &
-                & expGammaCutoff(this%uniqHubbU(iU2, iSp2), this%uniqHubbU(iU1, iSp1))
-            this%shortCutoff(iU1, iU2, iSp1, iSp2) = this%shortCutoff(iU2, iU1, iSp2, iSp1)
+            this%shortCutOff(iU2, iU1, iSp2, iSp1) = &
+                & expGammaCutOff(this%uniqHubbU(iU2, iSp2), this%uniqHubbU(iU1, iSp1))
+            this%shortCutOff(iU1, iU2, iSp1, iSp2) = this%shortCutOff(iU2, iU1, iSp2, iSp1)
           end do
         end do
       end do
     end do
-    this%cutoff = maxval(this%shortCutoff)
+    this%cutoff = maxval(this%shortCutOff)
 
     ! Initialize Ewald summation for the periodic case
     if (this%tPeriodic) then
@@ -425,7 +425,7 @@ contains
 
   !> Returns a minimal cutoff for the neighborlist, which must be passed to various functions in
   !> this module.
-  function getCutoff(this) result(cutoff)
+  function getCutOff(this) result(cutoff)
 
     !> Instance
     class(TScc), intent(in) :: this
@@ -437,7 +437,7 @@ contains
     @:ASSERT(this%tInitialised)
     cutoff = this%cutoff
 
-  end function getCutoff
+  end function getCutOff
 
 
   !> Returns the currenty used alpha parameter of the Ewald-summation
@@ -1063,8 +1063,8 @@ contains
       do iSp2 = 1, this%nSpecies
         do iU1 = 1, this%nHubbU(species(iAt1))
           do iU2 = 1, this%nHubbU(iSp2)
-            this%nNeighShort(iU2, iU1, iSp2, iAt1) = &
-                &getNrOfNeighbors(neighList, this%shortCutoff(iU2, iU1, iSp2, species(iAt1)), iAt1)
+            this%nNeighShort(iU2, iU1, iSp2, iAt1) =&
+                & getNrOfNeighbors(neighList, this%shortCutOff(iU2, iU1, iSp2, species(iAt1)), iAt1)
           end do
         end do
       end do

--- a/prog/dftb+/lib_dftb/scc.F90
+++ b/prog/dftb+/lib_dftb/scc.F90
@@ -125,10 +125,10 @@ module scc
     !> Real lattice points for asymmetric Ewald sum
     real(dp), allocatable :: rCellVec(:,:)
 
-    !> Nr. of neighbors for short range part of gamma
+    !> Nr. of neighbours for short range part of gamma
     integer, allocatable :: nNeighShort(:,:,:,:)
 
-    !> Dynamic neighbor list for the real space Ewald summation
+    !> Dynamic neighbour list for the real space Ewald summation
     type(TDynNeighList), allocatable :: ewaldNeighList
 
     !> Atomic coordinates
@@ -333,7 +333,7 @@ contains
       do iSp2 = iSp1, this%nSpecies
         do iU1 = 1, this%nHubbU(iSp1)
           do iU2 = 1, this%nHubbU(iSp2)
-            this%shortCutOff(iU2, iU1, iSp2, iSp1) = &
+            this%shortCutOff(iU2, iU1, iSp2, iSp1) =&
                 & expGammaCutOff(this%uniqHubbU(iU2, iSp2), this%uniqHubbU(iU1, iSp1))
             this%shortCutOff(iU1, iU2, iSp1, iSp2) = this%shortCutOff(iU2, iU1, iSp2, iSp1)
           end do
@@ -356,12 +356,12 @@ contains
       end if
       maxREwald = getMaxREwald(this%alpha, this%tolEwald)
       maxGEwald = getMaxGEwald(this%alpha, this%volume, this%tolEwald)
-      call getLatticePoints(this%gLatPoint, inp%recVecs, inp%latVecs/(2.0_dp*pi), maxGEwald, &
+      call getLatticePoints(this%gLatPoint, inp%recVecs, inp%latVecs/(2.0_dp*pi), maxGEwald,&
           & onlyInside=.true., reduceByInversion=.true., withoutOrigin=.true.)
       this%gLatPoint(:,:) = matmul(inp%recVecs, this%gLatPoint)
     end if
 
-    ! Number of neighbors for short range cutoff and real part of Ewald
+    ! Number of neighbours for short range cutoff and real part of Ewald
     allocate(this%nNeighShort(this%mHubbU, this%mHubbU, this%nSpecies, this%nAtom))
     if (this%tPeriodic) then
       allocate(this%ewaldNeighList)
@@ -423,14 +423,14 @@ contains
   end subroutine Scc_initialize
 
 
-  !> Returns a minimal cutoff for the neighborlist, which must be passed to various functions in
+  !> Returns a minimal cutoff for the neighbourlist, which must be passed to various functions in
   !> this module.
   function getCutOff(this) result(cutoff)
 
     !> Instance
     class(TScc), intent(in) :: this
 
-    !> The neighborlists, passed to scc routines, should contain neighbour information at
+    !> The neighbourlists, passed to scc routines, should contain neighbour information at
     !> least up to that cutoff.
     real(dp) :: cutoff
 
@@ -470,8 +470,8 @@ contains
     !> Species of the atoms (should not change during run)
     integer, intent(in) :: species(:)
 
-    !> Neighbor list for the atoms.
-    type(TNeighborList), intent(in) :: neighList
+    !> Neighbour list for the atoms.
+    type(TNeighbourList), intent(in) :: neighList
 
     @:ASSERT(this%tInitialised)
 
@@ -492,7 +492,7 @@ contains
       end if
     end if
 
-    call initGamma_(this, species, neighList%iNeighbor)
+    call initGamma_(this, species, neighList%iNeighbour)
 
     if (this%tExtChrg) then
       if (this%tPeriodic) then
@@ -533,7 +533,7 @@ contains
       maxREwald = getMaxREwald(this%alpha, this%tolEwald)
     end if
     maxGEwald = getMaxGEwald(this%alpha, this%volume, this%tolEwald)
-    call getLatticePoints(this%gLatPoint, recVec, latVec/(2.0_dp*pi), maxGEwald, &
+    call getLatticePoints(this%gLatPoint, recVec, latVec/(2.0_dp*pi), maxGEwald,&
         &onlyInside=.true., reduceByInversion=.true., withoutOrigin=.true.)
     this%gLatPoint = matmul(recVec, this%gLatPoint)
 
@@ -552,7 +552,7 @@ contains
 
 
   !> Updates the SCC module, if the charges have been changed
-  subroutine updateCharges(this, env, qOrbital, q0, orb, species, iNeighbor, img2CentCell)
+  subroutine updateCharges(this, env, qOrbital, q0, orb, species, iNeighbour, img2CentCell)
 
     !> Resulting module variables
     class(TScc), intent(inout) :: this
@@ -572,8 +572,8 @@ contains
     !> Species of the atoms (should not change during run)
     integer, intent(in) :: species(:)
 
-    !> Neighbor indexes
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Neighbour indexes
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> Mapping on atoms in the central cell
     integer, intent(in) :: img2CentCell(:)
@@ -582,7 +582,7 @@ contains
 
     call getSummedCharges_(this%nAtom, this%iHubbU, species, orb, qOrbital, q0, this%deltaQ,&
         & this%deltaQAtom, this%deltaQPerLShell, this%deltaQUniqU)
-    call buildShifts_(this, env, orb, species, iNeighbor, img2CentCell)
+    call buildShifts_(this, env, orb, species, iNeighbour, img2CentCell)
     if (this%tChrgConstr) then
       call buildShift(this%chrgConstr, this%deltaQAtom)
     end if
@@ -594,7 +594,7 @@ contains
 
 
   !> Routine for returning lower triangle of atomic resolved gamma as a matrix
-  subroutine getAtomicGammaMatrix(this, gammamat, iNeighbor, img2CentCell)
+  subroutine getAtomicGammaMatrix(this, gammamat, iNeighbour, img2CentCell)
 
     !> Instance
     class(TScc), intent(in) :: this
@@ -603,7 +603,7 @@ contains
     real(dp), intent(out) :: gammamat(:,:)
 
     !> neighbours of atoms
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> index array between images and central cell
     integer, intent(in) :: img2CentCell(:)
@@ -620,7 +620,7 @@ contains
     gammamat(:,:) = this%invRMat
     do iAt1 = 1, this%nAtom
       do iNeigh = 0, maxval(this%nNeighShort(:,:,:, iAt1))
-        iAt2 = iNeighbor(iNeigh, iAt1)
+        iAt2 = iNeighbour(iNeigh, iAt1)
         iAt2f = img2CentCell(iAt2)
         gammamat(iAt2f, iAt1) = gammamat(iAt2f, iAt1) - this%shortGamma(1, 1, iNeigh, iAt1)
       end do
@@ -642,7 +642,7 @@ contains
     @:ASSERT(this%tInitialised)
     @:ASSERT(size(eScc) == this%nAtom)
 
-    eScc(:) = 0.5_dp * (this%shiftPerAtom * this%deltaQAtom &
+    eScc(:) = 0.5_dp * (this%shiftPerAtom * this%deltaQAtom&
         & + sum(this%shiftPerL * this%deltaQPerLShell, dim=1))
     if (this%tExtChrg) then
       call this%extCharge%addEnergyPerAtom(this%deltaQAtom, eScc)
@@ -691,11 +691,11 @@ contains
     allocate(dQOutAtom(this%nAtom))
     allocate(dQOutShell(this%mShell, this%nAtom))
 
-    call getSummedCharges_(this%nAtom, this%iHubbU, species, orb, qOut, q0, dQOut, dQOutAtom, &
+    call getSummedCharges_(this%nAtom, this%iHubbU, species, orb, qOut, q0, dQOut, dQOutAtom,&
         & dQOutShell)
 
     ! 1/2 sum_A (2 q_A - n_A) * shift(n_A)
-    eScc(:) = 0.5_dp * (this%shiftPerAtom * (2.0_dp * dQOutAtom - this%deltaQAtom) &
+    eScc(:) = 0.5_dp * (this%shiftPerAtom * (2.0_dp * dQOutAtom - this%deltaQAtom)&
         & + sum(this%shiftPerL * (2.0_dp * dQOutShell - this%deltaQPerLShell), dim=1))
 
     if (this%tExtChrg) then
@@ -716,7 +716,7 @@ contains
 
   !> Calculates the contribution of the charge consistent part to the forces for molecules/clusters,
   !> which is not covered in the term with the shift vectors.
-  subroutine addForceDc(this, env, force, species, iNeighbor, img2CentCell, chrgForce)
+  subroutine addForceDc(this, env, force, species, iNeighbour, img2CentCell, chrgForce)
 
     !> Resulting module variables
     class(TScc), intent(in) :: this
@@ -730,8 +730,8 @@ contains
     !> Species for each atom.
     integer, intent(in) :: species(:)
 
-    !> List of neighbors for each atom.
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> List of neighbours for each atom.
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> Indexing of images of the atoms in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -746,7 +746,7 @@ contains
     @:ASSERT(present(chrgForce) .eqv. this%tExtChrg)
 
     ! Short-range part of gamma contribution
-    call addGammaPrime_(this, force, species, iNeighbor, img2CentCell)
+    call addGammaPrime_(this, force, species, iNeighbour, img2CentCell)
 
     ! 1/R contribution
     if (this%tPeriodic) then
@@ -770,7 +770,7 @@ contains
 
   !> Calculates the contribution of the stress tensor which is not covered in the term with the
   !> shift vectors.
-  subroutine addStressDc(this, st, env, species, iNeighbor, img2CentCell)
+  subroutine addStressDc(this, st, env, species, iNeighbour, img2CentCell)
 
     !> Resulting module variables
     class(TScc), intent(in) :: this
@@ -784,8 +784,8 @@ contains
     !> Species for each atom.
     integer, intent(in) :: species(:)
 
-    !> List of neighbors for each atom.
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> List of neighbours for each atom.
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> Indexing of images of the atoms in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -799,7 +799,7 @@ contains
     stTmp = 0.0_dp
 
     ! Short-range part of gamma contribution
-    call addSTGammaPrime_(stTmp,this,species,iNeighbor,img2CentCell)
+    call addSTGammaPrime_(stTmp,this,species,iNeighbour,img2CentCell)
 
     st(:,:) = st(:,:) - 0.5_dp * stTmp(:,:)
 
@@ -911,7 +911,7 @@ contains
   !> the Hamiltonian, so the charge stored in the module are the input (auxiliary) charges, used to
   !> build the Hamiltonian.  However, the linearized energy expession needs also the output charges,
   !> therefore these are passed in as an extra variable.
-  subroutine addForceDcXlbomd(this, env, species, orb, iNeighbor, img2CentCell, qOrbitalOut,&
+  subroutine addForceDcXlbomd(this, env, species, orb, iNeighbour, img2CentCell, qOrbitalOut,&
       & q0, force)
 
     !> Resulting module variables
@@ -927,7 +927,7 @@ contains
     type(TOrbitals), intent(in) :: orb
 
     !> neighbours surrounding each atom
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> index from image atoms to central cell
     integer, intent(in) :: img2CentCell(:)
@@ -949,11 +949,11 @@ contains
     allocate(dQOutLShell(this%mShell, this%nAtom))
     allocate(dQOutUniqU(this%mHubbU, this%nAtom))
 
-    call getSummedCharges_(this%nAtom, this%iHubbU, species, orb, qOrbitalOut, q0, dQOut, &
+    call getSummedCharges_(this%nAtom, this%iHubbU, species, orb, qOrbitalOut, q0, dQOut,&
         & dQOutAtom, dQOutLShell, dQOutUniqU)
 
     ! Short-range part of gamma contribution
-    call addGammaPrimeXlbomd_(this, this%deltaQUniqU, dQOutUniqU, species, iNeighbor, img2CentCell,&
+    call addGammaPrimeXlbomd_(this, this%deltaQUniqU, dQOutUniqU, species, iNeighbour, img2CentCell,&
         & force)
 
     ! 1/R contribution
@@ -1043,7 +1043,7 @@ contains
 !!! Private routines
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  !> Updates the number of neighbors for the SCC module (local).
+  !> Updates the number of neighbours for the SCC module (local).
   subroutine updateNNeigh_(this, species, neighList)
 
     !> Instance
@@ -1052,8 +1052,8 @@ contains
     !> Species for each atom
     integer, intent(in) :: species(:)
 
-    !> Neighbor list for the atoms in the system.
-    type(TNeighborList), intent(in) :: neighList
+    !> Neighbour list for the atoms in the system.
+    type(TNeighbourList), intent(in) :: neighList
 
 
     integer :: iAt1, iSp2, iU1, iU2
@@ -1064,7 +1064,7 @@ contains
         do iU1 = 1, this%nHubbU(species(iAt1))
           do iU2 = 1, this%nHubbU(iSp2)
             this%nNeighShort(iU2, iU1, iSp2, iAt1) =&
-                & getNrOfNeighbors(neighList, this%shortCutOff(iU2, iU1, iSp2, species(iAt1)), iAt1)
+                & getNrOfNeighbours(neighList, this%shortCutOff(iU2, iU1, iSp2, species(iAt1)), iAt1)
           end do
         end do
       end do
@@ -1075,7 +1075,7 @@ contains
 
   !> Constructs the shift vectors for the SCC contributions.
   !> The full shift vector must be constructed by adding shiftAtom and shiftShell accordingly.
-  subroutine buildShifts_(this, env, orb, species, iNeighbor, img2CentCell)
+  subroutine buildShifts_(this, env, orb, species, iNeighbour, img2CentCell)
 
     !> Resulting module variables
     type(TScc), intent(inout) :: this
@@ -1090,7 +1090,7 @@ contains
     integer, intent(in) :: species(:)
 
     !> List of surrounding neighbours for each atom.
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> Image of each atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -1098,7 +1098,7 @@ contains
     @:ASSERT(this%tInitialised)
 
     call buildShiftPerAtom_(this, env)
-    call buildShiftPerShell_(this, env, orb, species, iNeighbor, img2CentCell)
+    call buildShiftPerShell_(this, env, orb, species, iNeighbour, img2CentCell)
 
   end subroutine buildShifts_
 
@@ -1137,7 +1137,7 @@ contains
 
 
   !> Builds the short range shell resolved part of the shift vector
-  subroutine buildShiftPerShell_(this, env, orb, species, iNeighbor, img2CentCell)
+  subroutine buildShiftPerShell_(this, env, orb, species, iNeighbour, img2CentCell)
 
     !> Resulting module variables
     type(TScc), intent(inout), target :: this
@@ -1152,7 +1152,7 @@ contains
     integer, intent(in) :: species(:)
 
     !> List of surrounding neighbours for each atom.
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> Image of each atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -1180,7 +1180,7 @@ contains
       do iSh1 = 1, orb%nShell(iSp1)
         iU1 = this%iHubbU(iSh1, iSp1)
         do iNeigh = 0, maxval(this%nNeighShort(:,:,:,iAt1))
-          iAt2f = img2CentCell(iNeighbor(iNeigh, iAt1))
+          iAt2f = img2CentCell(iNeighbour(iNeigh, iAt1))
           iSp2 = species(iAt2f)
           do iSh2 = 1, orb%nShell(iSp2)
             iU2 = this%iHubbU(iSh2, iSp2)
@@ -1204,7 +1204,7 @@ contains
 
   !> Calculate the derivative of the short range contributions using the linearized XLBOMD
   !> formulation with auxiliary charges.
-  subroutine addGammaPrimeXlbomd_(this, dQInUniqU, dQOutUniqU, species, iNeighbor, &
+  subroutine addGammaPrimeXlbomd_(this, dQInUniqU, dQOutUniqU, species, iNeighbour,&
       & img2CentCell, force)
 
     !> Resulting module variables
@@ -1220,7 +1220,7 @@ contains
     integer, intent(in) :: species(:)
 
     !> neighbours around atoms
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> image to real atom indexing
     integer, intent(in) :: img2CentCell(:)
@@ -1239,7 +1239,7 @@ contains
     do iAt1 = 1, this%nAtom
       iSp1 = species(iAt1)
       do iNeigh = 1, maxval(this%nNeighShort(:,:,:, iAt1))
-        iAt2 = iNeighbor(iNeigh, iAt1)
+        iAt2 = iNeighbour(iNeigh, iAt1)
         iAt2f = img2CentCell(iAt2)
         iSp2 = species(iAt2f)
         rab = sqrt(sum((this%coord(:,iAt1) - this%coord(:,iAt2))**2))
@@ -1253,8 +1253,8 @@ contains
               else
                 tmpGammaPrime = expGammaPrime(rab, u2, u1)
               end if
-              prefac = dQOutUniqU(iU1, iAt1) * dQInUniqU(iU2, iAt2f) &
-                  & + dQInUniqU(iU1, iAt1) * dQOutUniqU(iU2, iAt2f) &
+              prefac = dQOutUniqU(iU1, iAt1) * dQInUniqU(iU2, iAt2f)&
+                  & + dQInUniqU(iU1, iAt1) * dQOutUniqU(iU2, iAt2f)&
                   & - dQInUniqU(iU1, iAt1) * dQInUniqU(iU2, iAt2f)
               contrib(:) = prefac * tmpGammaPrime / rab  * (this%coord(:,iAt2) - this%coord(:,iAt1))
               force(:,iAt1) = force(:,iAt1) + contrib
@@ -1269,7 +1269,7 @@ contains
 
 
   !> Set up the storage and internal values for the short range part of Gamma.
-  subroutine initGamma_(this, species, iNeighbor)
+  subroutine initGamma_(this, species, iNeighbour)
 
     !> Resulting module variables
     type(TScc), intent(inout) :: this
@@ -1277,18 +1277,18 @@ contains
     !> List of the species for each atom.
     integer, intent(in) :: species(:)
 
-    !> Index of neighboring atoms for each atom.
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Index of neighbouring atoms for each atom.
+    integer, intent(in) :: iNeighbour(0:,:)
 
     integer :: iAt1, iAt2, iU1, iU2, iNeigh, iSp1, iSp2
     real(dp) :: rab, u1, u2
 
     @:ASSERT(this%tInitialised)
 
-    ! Reallocate shortGamma, if it does not contain enough neighbors
+    ! Reallocate shortGamma, if it does not contain enough neighbours
     if (size(this%shortGamma, dim=3) < maxval(this%nNeighShort)+1) then
       deallocate(this%shortGamma)
-      allocate(this%shortGamma(this%mHubbU, this%mHubbU, 0:maxval(this%nNeighShort), &
+      allocate(this%shortGamma(this%mHubbU, this%mHubbU, 0:maxval(this%nNeighShort),&
           & this%nAtom))
     end if
     this%shortGamma(:,:,:,:) = 0.0_dp
@@ -1298,7 +1298,7 @@ contains
     do iAt1 = 1, this%nAtom
       iSp1 = species(iAt1)
       do iNeigh = 0, maxval(this%nNeighShort(:,:,:, iAt1))
-        iAt2 = iNeighbor(iNeigh, iAt1)
+        iAt2 = iNeighbour(iNeigh, iAt1)
         iSp2 = species(iAt2)
         rab = sqrt(sum((this%coord(:,iAt1) - this%coord(:,iAt2))**2))
         do iU1 = 1, this%nHubbU(species(iAt1))
@@ -1307,7 +1307,7 @@ contains
             u2 = this%uniqHubbU(iU2, iSp2)
             if (iNeigh <= this%nNeighShort(iU2,iU1,iSp2,iAt1)) then
               if (this%tDampedShort(iSp1) .or. this%tDampedShort(iSp2)) then
-                this%shortGamma(iU2 ,iU1, iNeigh, iAt1) = expGammaDamped(rab, u2, u1, &
+                this%shortGamma(iU2 ,iU1, iNeigh, iAt1) = expGammaDamped(rab, u2, u1,&
                     & this%dampExp)
               else
                 this%shortGamma(iU2 ,iU1, iNeigh, iAt1) = expGamma(rab, u2, u1)
@@ -1322,7 +1322,7 @@ contains
 
 
   !> Calculate  the derivative of the short range part of Gamma.
-  subroutine addGammaPrime_(this, force, species, iNeighbor, img2CentCell)
+  subroutine addGammaPrime_(this, force, species, iNeighbour, img2CentCell)
 
     !> Resulting module variables
     type(TScc), intent(in) :: this
@@ -1333,8 +1333,8 @@ contains
     !> List of the species for each atom.
     integer, intent(in) :: species(:)
 
-    !> Index of neighboring atoms for each atom.
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Index of neighbouring atoms for each atom.
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> Image of each atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -1350,7 +1350,7 @@ contains
     do iAt1 = 1, this%nAtom
       iSp1 = species(iAt1)
       do iNeigh = 1, maxval(this%nNeighShort(:,:,:, iAt1))
-        iAt2 = iNeighbor(iNeigh, iAt1)
+        iAt2 = iNeighbour(iNeigh, iAt1)
         iAt2f = img2CentCell(iAt2)
         iSp2 = species(iAt2f)
         rab = sqrt(sum((this%coord(:,iAt1) - this%coord(:,iAt2))**2))
@@ -1365,11 +1365,11 @@ contains
                 tmpGammaPrime = expGammaPrime(rab, u2, u1)
               end if
               do ii = 1,3
-                force(ii,iAt1) = force(ii,iAt1) - this%deltaQUniqU(iU1,iAt1) * &
-                    & this%deltaQUniqU(iU2,iAt2f)*tmpGammaPrime*(this%coord(ii,iAt1) &
+                force(ii,iAt1) = force(ii,iAt1) - this%deltaQUniqU(iU1,iAt1) *&
+                    & this%deltaQUniqU(iU2,iAt2f)*tmpGammaPrime*(this%coord(ii,iAt1)&
                     & - this%coord(ii,iAt2))/rab
-                force(ii,iAt2f) = force(ii,iAt2f) + this%deltaQUniqU(iU1,iAt1) * &
-                    & this%deltaQUniqU(iU2,iAt2f)*tmpGammaPrime*(this%coord(ii,iAt1) &
+                force(ii,iAt2f) = force(ii,iAt2f) + this%deltaQUniqU(iU1,iAt1) *&
+                    & this%deltaQUniqU(iU2,iAt2f)*tmpGammaPrime*(this%coord(ii,iAt1)&
                     & - this%coord(ii,iAt2))/rab
               end do
             end if
@@ -1382,7 +1382,7 @@ contains
 
 
   !> Calculate  the derivative of the short range part of Gamma.
-  subroutine addSTGammaPrime_(st, this, species, iNeighbor, img2CentCell)
+  subroutine addSTGammaPrime_(st, this, species, iNeighbour, img2CentCell)
 
     !> Stress tensor component to add the short-range part of the gamma contribution
     real(dp), intent(out) :: st(:,:)
@@ -1393,8 +1393,8 @@ contains
     !> List of the species for each atom.
     integer, intent(in) :: species(:)
 
-    !> Index of neighboring atoms for each atom.
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Index of neighbouring atoms for each atom.
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> Image of each atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -1411,7 +1411,7 @@ contains
     do iAt1 = 1, this%nAtom
       iSp1 = species(iAt1)
       do iNeigh = 1, maxval(this%nNeighShort(:,:,:, iAt1))
-        iAt2 = iNeighbor(iNeigh, iAt1)
+        iAt2 = iNeighbour(iNeigh, iAt1)
         iAt2f = img2CentCell(iAt2)
         iSp2 = species(iAt2f)
         vect(:) = this%coord(:,iAt1) - this%coord(:,iAt2)
@@ -1428,8 +1428,8 @@ contains
                 tmpGammaPrime = expGammaPrime(rab, u2, u1)
               end if
               do ii = 1,3
-                intermed(ii) = intermed(ii) &
-                    & - this%deltaQUniqU(iU1,iAt1) * this%deltaQUniqU(iU2,iAt2f) &
+                intermed(ii) = intermed(ii)&
+                    & - this%deltaQUniqU(iU1,iAt1) * this%deltaQUniqU(iU2,iAt2f)&
                     & *tmpGammaPrime*vect(ii)/rab
               end do
             end if
@@ -1591,7 +1591,7 @@ contains
     do iAt = 1, nAtom
       iSp = species(iAt)
       do iSh = 1, orb%nShell(iSp)
-        deltaQUniqU(iHubbU(iSh, iSp), iAt) =  deltaQUniqU(iHubbU(iSh, iSp), iAt) &
+        deltaQUniqU(iHubbU(iSh, iSp), iAt) =  deltaQUniqU(iHubbU(iSh, iSp), iAt)&
             & + deltaQPerLShell(iSh, iAt)
       end do
     end do

--- a/prog/dftb+/lib_dftb/sparse2dense.F90
+++ b/prog/dftb+/lib_dftb/sparse2dense.F90
@@ -89,11 +89,11 @@ contains
   !> Unpacks sparse matrix to square form (complex version) Note the non on-site blocks are only
   !> filled in the lower triangle part of the matrix. To fill the matrix completely, apply the
   !> blockSymmetrizeHS subroutine.
-  subroutine unpackHS_cmplx(square, orig, kPoint, iNeighbor, nNeighbor, iCellVec, cellVec,&
+  subroutine unpackHS_cmplx(square, orig, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec,&
       & iAtomStart, iPair, img2CentCell)
 
     !> Square form matrix on exit.
-    complex(dp), intent(out) :: square(:,:)
+    complex(dp), intent(out) :: square(:, :)
 
     !> Sparse matrix
     real(dp), intent(in) :: orig(:)
@@ -102,22 +102,22 @@ contains
     real(dp), intent(in) :: kPoint(:)
 
     !> Neighbor list for each atom (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index of the cell translation vector for each atom.
     integer, intent(in) :: iCellVec(:)
 
     !> Relative coordinates of the cell translation vectors.
-    real(dp), intent(in) :: cellVec(:,:)
+    real(dp), intent(in) :: cellVec(:, :)
 
     !> Atom offset for the squared Hamiltonian
     integer, intent(in) :: iAtomStart(:)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Map from images of atoms to central cell atoms
     integer, intent(in) :: img2CentCell(:)
@@ -137,18 +137,18 @@ contains
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == iAtomStart(nAtom+1) - 1)
     @:ASSERT(all(shape(kPoint) == [3]))
-    @:ASSERT(all(shape(nNeighbor) == [nAtom]))
+    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
 
-    square(:,:) = cmplx(0, 0, dp)
+    square(:, :) = cmplx(0, 0, dp)
     kPoint2p(:) = 2.0_dp * pi * kPoint(:)
     iOldVec = 0
     phase = 1.0_dp
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighbor(iAtom1)
-        iOrig = iPair(iNeigh,iAtom1) + 1
+      do iNeigh = 0, nNeighborSK(iAtom1)
+        iOrig = iPair(iNeigh, iAtom1) + 1
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
@@ -171,25 +171,25 @@ contains
   !>
   !> Note: The non on-site blocks are only filled in the lower triangle part of the matrix. To fill
   !> the matrix completely, apply the blockSymmetrizeHS subroutine.
-  subroutine unpackHS_real(square, orig, iNeighbor, nNeighbor, iAtomStart, iPair, img2CentCell)
+  subroutine unpackHS_real(square, orig, iNeighbor, nNeighborSK, iAtomStart, iPair, img2CentCell)
 
     !> Square form matrix on exit.
-    real(dp), intent(out) :: square(:,:)
+    real(dp), intent(out) :: square(:, :)
 
     !> Sparse matrix
     real(dp), intent(in) :: orig(:)
 
     !> Neighbor list for each atom (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Atom offset for the squared Hamiltonian
     integer, intent(in) :: iAtomStart(:)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Map from images of atoms to central cell atoms
     integer, intent(in) :: img2CentCell(:)
@@ -205,23 +205,23 @@ contains
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == iAtomStart(nAtom+1) - 1)
-    @:ASSERT(all(shape(nNeighbor) == [nAtom]))
+    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
 
-    square(:,:) = 0.0_dp
+    square(:, :) = 0.0_dp
 
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighbor(iAtom1)
-        iOrig = iPair(iNeigh,iAtom1) + 1
+      do iNeigh = 0, nNeighborSK(iAtom1)
+        iOrig = iPair(iNeigh, iAtom1) + 1
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
         @:ASSERT(jj >= ii)
         nOrb2 = iAtomStart(iAtom2f + 1) - jj
-        square(jj:jj+nOrb2-1, ii:ii+nOrb1-1) = square(jj:jj+nOrb2-1, ii:ii+nOrb1-1) &
-            & + reshape(orig(iOrig:iOrig+nOrb1*nOrb2-1), [nOrb2,nOrb1])
+        square(jj:jj+nOrb2-1, ii:ii+nOrb1-1) = square(jj:jj+nOrb2-1, ii:ii+nOrb1-1)&
+            & + reshape(orig(iOrig:iOrig+nOrb1*nOrb2-1), [nOrb2, nOrb1])
       end do
     end do
 
@@ -232,23 +232,23 @@ contains
   !>
   !> Note: The non on-site blocks are only filled in the lower triangle part of the matrix. To fill
   !> the matrix completely, apply the blockSymmetrizeHS subroutine.
-  subroutine unpackHPauli(ham, kPoint, iNeighbor, nNeighbor, iPair, iAtomStart, img2CentCell,&
+  subroutine unpackHPauli(ham, kPoint, iNeighbor, nNeighborSK, iPair, iAtomStart, img2CentCell,&
       & iCellVec, cellVec, HSqrCplx, iHam)
 
     !> sparse hamiltonian
-    real(dp), intent(in) :: ham(:,:)
+    real(dp), intent(in) :: ham(:, :)
 
     !> k-point at which to unpack
     real(dp), intent(in) :: kPoint(:)
 
     !> Neighbor list for each atom (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(:,:)
+    integer, intent(in) :: iPair(:, :)
 
     !> Atom offset for the squared Hamiltonian
     integer, intent(in) :: iAtomStart(:)
@@ -260,99 +260,101 @@ contains
     integer, intent(in) :: iCellVec(:)
 
     !> vectors to periodic unit cells
-    real(dp), intent(in) :: cellVec(:,:)
+    real(dp), intent(in) :: cellVec(:, :)
 
     !> dense hamiltonian matrix
-    complex(dp), intent(out) :: HSqrCplx(:,:)
+    complex(dp), intent(out) :: HSqrCplx(:, :)
 
     !> imaginary part of sparse hamiltonian
-    real(dp), intent(in), optional :: iHam(:,:)
+    real(dp), intent(in), optional :: iHam(:, :)
 
-    complex(dp), allocatable :: work(:,:)
+    complex(dp), allocatable :: work(:, :)
     integer :: nOrb
     integer :: ii
 
     nOrb = size(HSqrCplx, dim=1) / 2
 
     ! for the moment, but will use S as workspace in the future
-    allocate(work(nOrb,nOrb))
-    HSqrCplx(:,:) = 0.0_dp
+    allocate(work(nOrb, nOrb))
+    HSqrCplx(:, :) = 0.0_dp
 
     ! 1 0 charge part
     ! 0 1
-    call unpackHS(work,ham(:,1),kPoint,iNeighbor,nNeighbor,iCellVec, &
-        & cellVec,iAtomStart,iPair, img2CentCell)
-    HSqrCplx(1:nOrb,1:nOrb) = 0.5_dp*work(1:nOrb,1:nOrb)
-    HSqrCplx(nOrb+1:2*nOrb,nOrb+1:2*nOrb) = 0.5_dp*work(1:nOrb,1:nOrb)
+    call unpackHS(work, ham(:, 1), kPoint, iNeighbor, nNeighborSK, iCellVec,&
+        & cellVec, iAtomStart, iPair, img2CentCell)
+    HSqrCplx(1:nOrb, 1:nOrb) = 0.5_dp*work(1:nOrb, 1:nOrb)
+    HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb) = 0.5_dp*work(1:nOrb, 1:nOrb)
     if (present(iHam)) then
-      call unpackHS(work,iHam(:,1),kPoint,iNeighbor,nNeighbor,iCellVec, &
-          & cellVec,iAtomStart,iPair, img2CentCell)
-      HSqrCplx(1:nOrb,1:nOrb) = HSqrCplx(1:nOrb,1:nOrb) &
-          & + 0.5_dp*cmplx(0,1,dp)*work(1:nOrb,1:nOrb)
-      HSqrCplx(nOrb+1:2*nOrb,nOrb+1:2*nOrb) = &
-          & HSqrCplx(nOrb+1:2*nOrb,nOrb+1:2*nOrb) &
-          & + 0.5_dp*cmplx(0,1,dp)*work(1:nOrb,1:nOrb)
+      call unpackHS(work, iHam(:, 1), kPoint, iNeighbor, nNeighborSK, iCellVec,&
+          & cellVec, iAtomStart, iPair, img2CentCell)
+      HSqrCplx(1:nOrb, 1:nOrb) = HSqrCplx(1:nOrb, 1:nOrb)&
+          & + 0.5_dp*cmplx(0, 1, dp)*work(1:nOrb, 1:nOrb)
+      HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb) =&
+          & HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb)&
+          & + 0.5_dp*cmplx(0, 1, dp)*work(1:nOrb, 1:nOrb)
     end if
 
     ! 0 1 x part
     ! 1 0
-    call unpackHS(work,ham(:,2),kPoint,iNeighbor,nNeighbor,iCellVec, &
-        & cellVec,iAtomStart,iPair, img2CentCell)
+    call unpackHS(work, ham(:, 2), kPoint, iNeighbor, nNeighborSK, iCellVec,&
+        & cellVec, iAtomStart, iPair, img2CentCell)
     do ii = 1, nOrb
-      work(ii,ii+1:) = conjg(work(ii+1:,ii))
+      work(ii, ii+1:) = conjg(work(ii+1:, ii))
     end do
 
-    HSqrCplx(nOrb+1:2*nOrb,1:nOrb) = HSqrCplx(nOrb+1:2*nOrb,1:nOrb) + 0.5_dp * work(1:nOrb,1:nOrb)
+    HSqrCplx(nOrb+1:2*nOrb, 1:nOrb) = HSqrCplx(nOrb+1:2*nOrb, 1:nOrb)&
+        & + 0.5_dp * work(1:nOrb, 1:nOrb)
     if (present(iHam)) then
-      call unpackHS(work,iHam(:,2),kPoint,iNeighbor,nNeighbor,iCellVec, &
-          & cellVec,iAtomStart,iPair, img2CentCell)
+      call unpackHS(work, iHam(:, 2), kPoint, iNeighbor, nNeighborSK, iCellVec,&
+          & cellVec, iAtomStart, iPair, img2CentCell)
       do ii = 1, nOrb
-        work(ii,ii+1:) = -conjg(work(ii+1:,ii))
+        work(ii, ii+1:) = -conjg(work(ii+1:, ii))
       end do
-      HSqrCplx(nOrb+1:2*nOrb,1:nOrb) = HSqrCplx(nOrb+1:2*nOrb,1:nOrb) + 0.5_dp * cmplx(0,1,dp)&
-          & * work(1:nOrb,1:nOrb)
+      HSqrCplx(nOrb+1:2*nOrb, 1:nOrb) = HSqrCplx(nOrb+1:2*nOrb, 1:nOrb) + 0.5_dp * cmplx(0, 1, dp)&
+          & * work(1:nOrb, 1:nOrb)
     end if
 
     ! 0 -i y part
     ! i  0
-    call unpackHS(work,ham(:,3),kPoint,iNeighbor,nNeighbor,iCellVec, &
-        & cellVec,iAtomStart,iPair, img2CentCell)
+    call unpackHS(work, ham(:, 3), kPoint, iNeighbor, nNeighborSK, iCellVec,&
+        & cellVec, iAtomStart, iPair, img2CentCell)
     do ii = 1, nOrb
-      work(ii,ii+1:) = conjg(work(ii+1:,ii))
+      work(ii, ii+1:) = conjg(work(ii+1:, ii))
     end do
 
-    HSqrCplx(nOrb+1:2*nOrb,1:nOrb) = HSqrCplx(nOrb+1:2*nOrb,1:nOrb) + cmplx(0.0,0.5,dp)&
-        & * work(1:nOrb,1:nOrb)
+    HSqrCplx(nOrb+1:2*nOrb, 1:nOrb) = HSqrCplx(nOrb+1:2*nOrb, 1:nOrb) + cmplx(0.0, 0.5, dp)&
+        & * work(1:nOrb, 1:nOrb)
     if (present(iHam)) then
-      call unpackHS(work,iHam(:,3),kPoint,iNeighbor,nNeighbor,iCellVec, &
-          & cellVec,iAtomStart,iPair, img2CentCell)
+      call unpackHS(work, iHam(:, 3), kPoint, iNeighbor, nNeighborSK, iCellVec,&
+          & cellVec, iAtomStart, iPair, img2CentCell)
       do ii = 1, nOrb
-        work(ii,ii+1:) = -conjg(work(ii+1:,ii))
+        work(ii, ii+1:) = -conjg(work(ii+1:, ii))
       end do
       do ii = 1, nOrb
-        work(ii+1:,ii) = -conjg(work(ii,ii+1:))
+        work(ii+1:, ii) = -conjg(work(ii, ii+1:))
       end do
 
-      HSqrCplx(nOrb+1:2*nOrb,1:nOrb) = HSqrCplx(nOrb+1:2*nOrb,1:nOrb) - 0.5_dp * work(1:nOrb,1:nOrb)
+      HSqrCplx(nOrb+1:2*nOrb, 1:nOrb) = HSqrCplx(nOrb+1:2*nOrb, 1:nOrb)&
+          & - 0.5_dp * work(1:nOrb, 1:nOrb)
     end if
 
     ! 1  0 z part
     ! 0 -1
-    call unpackHS(work,ham(:,4),kPoint,iNeighbor,nNeighbor,iCellVec, &
-        & cellVec,iAtomStart,iPair, img2CentCell)
-    HSqrCplx(1:nOrb,1:nOrb) = HSqrCplx(1:nOrb,1:nOrb) &
-        & + 0.5_dp * work(1:nOrb,1:nOrb)
-    HSqrCplx(nOrb+1:2*nOrb,nOrb+1:2*nOrb) = &
-        & HSqrCplx(nOrb+1:2*nOrb,nOrb+1:2*nOrb) &
-        & - 0.5_dp * work(1:nOrb,1:nOrb)
+    call unpackHS(work, ham(:, 4), kPoint, iNeighbor, nNeighborSK, iCellVec,&
+        & cellVec, iAtomStart, iPair, img2CentCell)
+    HSqrCplx(1:nOrb, 1:nOrb) = HSqrCplx(1:nOrb, 1:nOrb)&
+        & + 0.5_dp * work(1:nOrb, 1:nOrb)
+    HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb) =&
+        & HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb)&
+        & - 0.5_dp * work(1:nOrb, 1:nOrb)
     if (present(iHam)) then
-      call unpackHS(work,iHam(:,4),kPoint,iNeighbor,nNeighbor,iCellVec, &
-          & cellVec,iAtomStart,iPair, img2CentCell)
-      HSqrCplx(1:nOrb,1:nOrb) = HSqrCplx(1:nOrb,1:nOrb) &
-          & + 0.5_dp * cmplx(0,1,dp) * work(1:nOrb,1:nOrb)
-      HSqrCplx(nOrb+1:2*nOrb,nOrb+1:2*nOrb) = &
-          & HSqrCplx(nOrb+1:2*nOrb,nOrb+1:2*nOrb) &
-          & - 0.5_dp * cmplx(0,1,dp) * work(1:nOrb,1:nOrb)
+      call unpackHS(work, iHam(:, 4), kPoint, iNeighbor, nNeighborSK, iCellVec,&
+          & cellVec, iAtomStart, iPair, img2CentCell)
+      HSqrCplx(1:nOrb, 1:nOrb) = HSqrCplx(1:nOrb, 1:nOrb)&
+          & + 0.5_dp * cmplx(0, 1, dp) * work(1:nOrb, 1:nOrb)
+      HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb) =&
+          & HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb)&
+          & - 0.5_dp * cmplx(0, 1, dp) * work(1:nOrb, 1:nOrb)
     end if
 
   end subroutine unpackHPauli
@@ -362,7 +364,7 @@ contains
   !>
   !> Note: The non on-site blocks are only filled in the lower triangle part of the matrix. To fill
   !> the matrix completely, apply the blockSymmetrizeHS subroutine.
-  subroutine unpackSPauli(over, kPoint, iNeighbor, nNeighbor, iAtomStart, iPair, img2CentCell,&
+  subroutine unpackSPauli(over, kPoint, iNeighbor, nNeighborSK, iAtomStart, iPair, img2CentCell,&
       & iCellVec, cellVec, SSqrCplx)
 
     !> sparse overlap matrix
@@ -372,16 +374,16 @@ contains
     real(dp), intent(in) :: kPoint(:)
 
     !> Neighbor list for each atom (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Atom offset for the squared Hamiltonian
     integer, intent(in) :: iAtomStart(:)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(:,:)
+    integer, intent(in) :: iPair(:, :)
 
     !> Map from images of atoms to central cell atoms
     integer, intent(in) :: img2CentCell(:)
@@ -390,19 +392,19 @@ contains
     integer, intent(in) :: iCellVec(:)
 
     !> vectors to periodic unit cells
-    real(dp), intent(in) :: cellVec(:,:)
+    real(dp), intent(in) :: cellVec(:, :)
 
     !> dense overlap matrix
-    complex(dp), intent(out) :: SSqrCplx(:,:)
+    complex(dp), intent(out) :: SSqrCplx(:, :)
 
-    complex(dp), allocatable :: work(:,:)
+    complex(dp), allocatable :: work(:, :)
     integer :: nOrb
 
     nOrb = size(SSqrCplx, dim=1) / 2
     allocate(work(nOrb, nOrb))
-    SSqrCplx(:,:) = 0.0_dp
-    call unpackHS(work, over, kPoint, iNeighbor, nNeighbor, iCellVec, cellVec, iAtomStart, iPair,&
-        & img2CentCell)
+    SSqrCplx(:, :) = 0.0_dp
+    call unpackHS(work, over, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec, iAtomStart,&
+        & iPair, img2CentCell)
     SSqrCplx(1:nOrb, 1:nOrb) = work(1:nOrb, 1:nOrb)
     SSqrCplx(nOrb + 1 : 2 * nOrb, nOrb + 1 : 2 * nOrb) = work(1:nOrb, 1:nOrb)
 
@@ -410,14 +412,14 @@ contains
 
 
   !> Pack squared matrix in the sparse form (complex version).
-  subroutine packHS_cmplx(primitive, square, kPoint, kWeight, iNeighbor, nNeighbor, mOrb,&
+  subroutine packHS_cmplx(primitive, square, kPoint, kWeight, iNeighbor, nNeighborSK, mOrb,&
       & iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
 
     !> Sparse matrix
     real(dp), intent(inout) :: primitive(:)
 
     !> Squared form matrix
-    complex(dp), intent(in) :: square(:,:)
+    complex(dp), intent(in) :: square(:, :)
 
     !> Relative coordinates of the K-point
     real(dp), intent(in) :: kPoint(:)
@@ -426,10 +428,10 @@ contains
     real(dp), intent(in) :: kweight
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -438,13 +440,13 @@ contains
     integer, intent(in) :: iCellVec(:)
 
     !> Relative coordinates of the cell translation vectors.
-    real(dp), intent(in) :: cellVec(:,:)
+    real(dp), intent(in) :: cellVec(:, :)
 
     !> Atom offset for the squared matrix
     integer, intent(in) :: iAtomStart(:)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -457,7 +459,7 @@ contains
     integer :: iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2
     real(dp) :: kPoint2p(3)
-    complex(dp) :: tmpSqr(mOrb,mOrb)
+    complex(dp) :: tmpSqr(mOrb, mOrb)
   #:call ASSERT_CODE
     integer :: sizePrim
   #:endcall ASSERT_CODE
@@ -471,7 +473,7 @@ contains
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == iAtomStart(nAtom+1) - 1)
     @:ASSERT(all(shape(kPoint) == [3]))
-    @:ASSERT(all(shape(nNeighbor) == [nAtom]))
+    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
     @:ASSERT(kWeight > 0.0_dp)
     @:ASSERT(size(iAtomStart) == nAtom + 1)
 
@@ -481,8 +483,8 @@ contains
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighbor(iAtom1)
-        iOrig = iPair(iNeigh,iAtom1) + 1
+      do iNeigh = 0, nNeighborSK(iAtom1)
+        iOrig = iPair(iNeigh, iAtom1) + 1
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
@@ -490,7 +492,7 @@ contains
         nOrb2 = iAtomStart(iAtom2f + 1) - jj
         iVec = iCellVec(iAtom2)
         if (iVec /= iOldVec) then
-          phase = exp(cmplx(0,-1,dp) * dot_product(kPoint2p(:), cellVec(:, iVec)))
+          phase = exp(cmplx(0, -1, dp) * dot_product(kPoint2p(:), cellVec(:, iVec)))
           iOldVec = iVec
         end if
         tmpSqr(1:nOrb2, 1:nOrb1) = square(jj:jj+nOrb2-1, ii:ii+nOrb1-1)
@@ -503,8 +505,8 @@ contains
         end if
 
         @:ASSERT(sizePrim >= iOrig + nOrb1*nOrb2 - 1)
-        primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1) = primitive(iOrig : iOrig + nOrb1*nOrb2 - 1) &
-            &+ kWeight * real(phase * reshape(tmpSqr(1:nOrb2, 1:nOrb1), [nOrb1*nOrb2]), dp)
+        primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1) = primitive(iOrig : iOrig + nOrb1*nOrb2 - 1)&
+            & + kWeight * real(phase * reshape(tmpSqr(1:nOrb2, 1:nOrb1), [nOrb1*nOrb2]), dp)
       end do
     end do
 
@@ -512,20 +514,20 @@ contains
 
 
   !> Pack squared matrix in the sparse form (real version).
-  subroutine packHS_real(primitive, square, iNeighbor, nNeighbor, mOrb, iAtomStart, iPair,&
+  subroutine packHS_real(primitive, square, iNeighbor, nNeighborSK, mOrb, iAtomStart, iPair,&
       & img2CentCell)
 
     !> Sparse matrix
     real(dp), intent(inout) :: primitive(:)
 
     !> Squared form matrix
-    real(dp), intent(in) :: square(:,:)
+    real(dp), intent(in) :: square(:, :)
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -534,7 +536,7 @@ contains
     integer, intent(in) :: iAtomStart(:)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -544,7 +546,7 @@ contains
     integer :: iNeigh
     integer :: iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2
-    real(dp) :: tmpSqr(mOrb,mOrb)
+    real(dp) :: tmpSqr(mOrb, mOrb)
   #:call ASSERT_CODE
     integer :: sizePrim
   #:endcall ASSERT_CODE
@@ -557,13 +559,13 @@ contains
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == iAtomStart(nAtom+1) - 1)
-    @:ASSERT(all(shape(nNeighbor) == [nAtom]))
+    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
 
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighbor(iAtom1)
-        iOrig = iPair(iNeigh,iAtom1) + 1
+      do iNeigh = 0, nNeighborSK(iAtom1)
+        iOrig = iPair(iNeigh, iAtom1) + 1
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
@@ -580,7 +582,7 @@ contains
 
         @:ASSERT(sizePrim >= iOrig + nOrb1*nOrb2 - 1)
         primitive(iOrig : iOrig + nOrb1*nOrb2 - 1) = primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1)&
-            & + reshape(tmpSqr(1:nOrb2,1:nOrb1), [nOrb1 * nOrb2])
+            & + reshape(tmpSqr(1:nOrb2, 1:nOrb1), [nOrb1 * nOrb2])
       end do
     end do
 
@@ -588,20 +590,20 @@ contains
 
 
   !> Pack squared matrix in the sparse form (real Pauli version).
-  subroutine packHSPauli(primitive, square, iNeighbor, nNeighbor, mOrb, iAtomStart, iPair,&
+  subroutine packHSPauli(primitive, square, iNeighbor, nNeighborSK, mOrb, iAtomStart, iPair,&
       & img2CentCell)
 
     !> Sparse matrix
-    real(dp), intent(inout) :: primitive(:,:)
+    real(dp), intent(inout) :: primitive(:, :)
 
     !> Squared form matrix
-    complex(dp), intent(in) :: square(:,:)
+    complex(dp), intent(in) :: square(:, :)
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -610,7 +612,7 @@ contains
     integer, intent(in) :: iAtomStart(:)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -620,7 +622,7 @@ contains
     integer :: iNeigh, iBlock
     integer :: iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2, nOrb
-    complex(dp) :: tmpSqr(mOrb,mOrb)
+    complex(dp) :: tmpSqr(mOrb, mOrb)
   #:call ASSERT_CODE
     integer :: sizePrim
   #:endcall ASSERT_CODE
@@ -630,29 +632,29 @@ contains
     nOrb = (iAtomStart(nAtom+1) - 1)
 
   #:call ASSERT_CODE
-    sizePrim = size(primitive,dim=1)
+    sizePrim = size(primitive, dim=1)
   #:endcall ASSERT_CODE
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == 2 * nOrb )
-    @:ASSERT(all(shape(nNeighbor) == [nAtom]))
+    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
-    @:ASSERT(size(primitive,dim=2)==4)
+    @:ASSERT(size(primitive, dim=2)==4)
 
     do iBlock = 0, 1
       do iAtom1 = 1, nAtom
         ii = iAtomStart(iAtom1)
         nOrb1 = iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighbor(iAtom1)
-          iOrig = iPair(iNeigh,iAtom1) + 1
+        do iNeigh = 0, nNeighborSK(iAtom1)
+          iOrig = iPair(iNeigh, iAtom1) + 1
           iAtom2 = iNeighbor(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
           jj = iAtomStart(iAtom2f)
           @:ASSERT(jj >= ii)
           nOrb2 = iAtomStart(iAtom2f + 1) - jj
-          tmpSqr(1:nOrb2, 1:nOrb1) = &
-              & square(jj+iBlock*nOrb:jj+nOrb2-1+iBlock*nOrb, &
+          tmpSqr(1:nOrb2, 1:nOrb1) =&
+              & square(jj+iBlock*nOrb:jj+nOrb2-1+iBlock*nOrb,&
               & ii+iBlock*nOrb:ii+nOrb1-1+iBlock*nOrb)
           ! Hermitian the on-site block before packing, as only one triangle usually supplied
           if (iAtom1 == iAtom2f) then
@@ -661,13 +663,13 @@ contains
             end do
           end if
           @:ASSERT(sizePrim >= iOrig + nOrb1*nOrb2 - 1)
-          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,1) = &
-              &primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,1) &
-              &+ 0.5_dp*reshape(real(tmpSqr(1:nOrb2,1:nOrb1)), [nOrb1*nOrb2])
-          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,4) = &
-              &primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,4) &
-              & + real(1-2*iBlock,dp) * &
-              & 0.5_dp*reshape(real(tmpSqr(1:nOrb2,1:nOrb1)), [nOrb1*nOrb2])
+          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 1) =&
+              & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 1)&
+              & + 0.5_dp*reshape(real(tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1*nOrb2])
+          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 4) =&
+              &primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 4)&
+              & + real(1-2*iBlock, dp) *&
+              & 0.5_dp*reshape(real(tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1*nOrb2])
         end do
       end do
     end do
@@ -675,23 +677,23 @@ contains
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighbor(iAtom1)
-        iOrig = iPair(iNeigh,iAtom1) + 1
+      do iNeigh = 0, nNeighborSK(iAtom1)
+        iOrig = iPair(iNeigh, iAtom1) + 1
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
         @:ASSERT(jj >= ii)
         nOrb2 = iAtomStart(iAtom2f + 1) - jj
         ! take the Hermitian part of the block
-        tmpSqr(1:nOrb2, 1:nOrb1) = 0.5_dp * (square(jj+nOrb:jj+nOrb2-1+nOrb,ii:ii+nOrb1-1)&
-            & + transpose(square(nOrb+ii:nOrb+ii+nOrb1-1,jj:jj+nOrb2-1)))
+        tmpSqr(1:nOrb2, 1:nOrb1) = 0.5_dp * (square(jj+nOrb:jj+nOrb2-1+nOrb, ii:ii+nOrb1-1)&
+            & + transpose(square(nOrb+ii:nOrb+ii+nOrb1-1, jj:jj+nOrb2-1)))
         @:ASSERT(sizePrim >= iOrig + nOrb1*nOrb2 - 1)
-        primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,2) = &
-            &primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,2) &
-            &+ reshape(real(tmpSqr(1:nOrb2,1:nOrb1)), [nOrb1*nOrb2])
-        primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,3) = &
-            &primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,3) &
-            & +reshape(aimag(tmpSqr(1:nOrb2,1:nOrb1)), [nOrb1*nOrb2])
+        primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 2) =&
+            & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 2)&
+            & + reshape(real(tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1*nOrb2])
+        primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 3) =&
+            &primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 3)&
+            & +reshape(aimag(tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1*nOrb2])
       end do
     end do
 
@@ -699,14 +701,14 @@ contains
 
 
   !> Pack squared matrix into the sparse form (complex Pauli version).
-  subroutine packHSPauli_kpts(primitive, square, kPoint, kWeight, iNeighbor, nNeighbor, mOrb,&
+  subroutine packHSPauli_kpts(primitive, square, kPoint, kWeight, iNeighbor, nNeighborSK, mOrb,&
       & iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
 
     !> Sparse matrix
-    real(dp), intent(inout) :: primitive(:,:)
+    real(dp), intent(inout) :: primitive(:, :)
 
     !> Squared form matrix
-    complex(dp), intent(in) :: square(:,:)
+    complex(dp), intent(in) :: square(:, :)
 
     !> location in the BZ in units of 2pi
     real(dp), intent(in) :: kPoint(:)
@@ -715,10 +717,10 @@ contains
     real(dp), intent(in) :: kweight
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -727,13 +729,13 @@ contains
     integer, intent(in) :: iCellVec(:)
 
     !> Relative coordinates of the cell translation vectors.
-    real(dp), intent(in) :: cellVec(:,:)
+    real(dp), intent(in) :: cellVec(:, :)
 
     !> Atom offset for the squared matrix
     integer, intent(in) :: iAtomStart(:)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -746,7 +748,7 @@ contains
     integer :: iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2, nOrb
     real(dp) :: kPoint2p(3)
-    complex(dp) :: tmpSqr(mOrb,mOrb)
+    complex(dp) :: tmpSqr(mOrb, mOrb)
   #:call ASSERT_CODE
     integer :: sizePrim
   #:endcall ASSERT_CODE
@@ -756,17 +758,17 @@ contains
     nOrb = (iAtomStart(nAtom+1) - 1)
 
   #:call ASSERT_CODE
-    sizePrim = size(primitive,dim=1)
+    sizePrim = size(primitive, dim=1)
   #:endcall ASSERT_CODE
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == 2 * nOrb )
     @:ASSERT(all(shape(kPoint) == [3]))
-    @:ASSERT(all(shape(nNeighbor) == [nAtom]))
+    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
     @:ASSERT(kWeight > 0.0_dp)
-    @:ASSERT(size(primitive,dim=2)==4)
+    @:ASSERT(size(primitive, dim=2)==4)
 
     kPoint2p(:) = 2.0_dp * pi * kPoint(:)
 
@@ -777,8 +779,8 @@ contains
       do iAtom1 = 1, nAtom
         ii = iAtomStart(iAtom1)
         nOrb1 = iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighbor(iAtom1)
-          iOrig = iPair(iNeigh,iAtom1) + 1
+        do iNeigh = 0, nNeighborSK(iAtom1)
+          iOrig = iPair(iNeigh, iAtom1) + 1
           iAtom2 = iNeighbor(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
           jj = iAtomStart(iAtom2f)
@@ -786,7 +788,7 @@ contains
           nOrb2 = iAtomStart(iAtom2f + 1) - jj
           iVec = iCellVec(iAtom2)
           if (iVec /= iOldVec) then
-            phase = exp(cmplx(0,-1,dp) * dot_product(kPoint2p(:), cellVec(:, iVec)))
+            phase = exp(cmplx(0, -1, dp) * dot_product(kPoint2p(:), cellVec(:, iVec)))
             iOldVec = iVec
           end if
           tmpSqr(1:nOrb2, 1:nOrb1) = square(jj+iBlock*nOrb:jj+nOrb2-1+iBlock*nOrb,&
@@ -798,15 +800,15 @@ contains
             end do
           end if
           @:ASSERT(sizePrim >= iOrig + nOrb1*nOrb2 - 1)
-          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,1) = &
-              & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,1) &
-              &+ kWeight * 0.5_dp*reshape(real(phase* &
-              & tmpSqr(1:nOrb2,1:nOrb1)), [nOrb1*nOrb2])
-          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,4) = &
-              & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,4) &
-              & + real(1-2*iBlock,dp) * &
-              & kWeight * 0.5_dp*reshape( &
-              & real(phase*tmpSqr(1:nOrb2,1:nOrb1)), [nOrb1*nOrb2])
+          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 1) =&
+              & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 1)&
+              & + kWeight * 0.5_dp*reshape(real(phase*&
+              & tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1*nOrb2])
+          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 4) =&
+              & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 4)&
+              & + real(1-2*iBlock, dp) *&
+              & kWeight * 0.5_dp*reshape(&
+              & real(phase*tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1*nOrb2])
         end do
       end do
     end do
@@ -817,8 +819,8 @@ contains
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighbor(iAtom1)
-        iOrig = iPair(iNeigh,iAtom1) + 1
+      do iNeigh = 0, nNeighborSK(iAtom1)
+        iOrig = iPair(iNeigh, iAtom1) + 1
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
@@ -826,7 +828,7 @@ contains
         nOrb2 = iAtomStart(iAtom2f + 1) - jj
         iVec = iCellVec(iAtom2)
         if (iVec /= iOldVec) then
-          phase = exp(cmplx(0,-1,dp) * dot_product(kPoint2p(:), cellVec(:, iVec)))
+          phase = exp(cmplx(0, -1, dp) * dot_product(kPoint2p(:), cellVec(:, iVec)))
           iOldVec = iVec
         end if
         @:ASSERT(sizePrim >= iOrig + nOrb1*nOrb2 - 1)
@@ -840,18 +842,18 @@ contains
             tmpSqr(kk, kk+1:nOrb1) = tmpSqr(kk+1:nOrb1, kk)
           end do
         end if
-        primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 2) = &
+        primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 2) =&
             & primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 2)&
             & + kWeight * reshape(real(phase * tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1 * nOrb2])
-        tmpSqr(1:nOrb2, 1:nOrb1) = &
-            & 0.5_dp * (square(jj + nOrb : jj + nOrb2 - 1 + nOrb, ii : ii + nOrb1 - 1) &
+        tmpSqr(1:nOrb2, 1:nOrb1) =&
+            & 0.5_dp * (square(jj + nOrb : jj + nOrb2 - 1 + nOrb, ii : ii + nOrb1 - 1)&
             & - conjg(transpose(square(nOrb +ii : nOrb + ii + nOrb1 - 1, jj : jj + nOrb2 - 1))))
         if (iAtom1 == iAtom2f) then !make up the other side of the on-site block
           do kk = 1, nOrb2
             tmpSqr(kk, kk+1:nOrb1) = tmpSqr(kk+1:nOrb1, kk)
           end do
         end if
-        primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 3) = &
+        primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 3) =&
             & primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 3)&
             & + kWeight*reshape(aimag(phase * tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1 * nOrb2])
       end do
@@ -861,20 +863,20 @@ contains
 
 
   !> Pack imaginary coefficient part of Pauli square matrix into the sparse form.
-  subroutine packHSPauliImag(primitive, square, iNeighbor, nNeighbor, mOrb, iAtomStart, iPair,&
+  subroutine packHSPauliImag(primitive, square, iNeighbor, nNeighborSK, mOrb, iAtomStart, iPair,&
       & img2CentCell)
 
     !> Sparse matrix
-    real(dp), intent(inout) :: primitive(:,:)
+    real(dp), intent(inout) :: primitive(:, :)
 
     !> Squared form matrix
-    complex(dp), intent(in) :: square(:,:)
+    complex(dp), intent(in) :: square(:, :)
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -883,7 +885,7 @@ contains
     integer, intent(in) :: iAtomStart(:)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -893,7 +895,7 @@ contains
     integer :: iNeigh, iBlock
     integer :: iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2, nOrb
-    complex(dp) :: tmpSqr(mOrb,mOrb)
+    complex(dp) :: tmpSqr(mOrb, mOrb)
   #:call ASSERT_CODE
     integer :: sizePrim
   #:endcall ASSERT_CODE
@@ -904,28 +906,28 @@ contains
 
 
   #:call ASSERT_CODE
-    sizePrim = size(primitive,dim=1)
+    sizePrim = size(primitive, dim=1)
   #:endcall ASSERT_CODE
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == 2 * nOrb )
-    @:ASSERT(all(shape(nNeighbor) == [nAtom]))
+    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
-    @:ASSERT(size(primitive,dim=2)==4)
+    @:ASSERT(size(primitive, dim=2)==4)
 
     do iBlock = 0, 1
       do iAtom1 = 1, nAtom
         ii = iAtomStart(iAtom1)
         nOrb1 = iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighbor(iAtom1)
-          iOrig = iPair(iNeigh,iAtom1) + 1
+        do iNeigh = 0, nNeighborSK(iAtom1)
+          iOrig = iPair(iNeigh, iAtom1) + 1
           iAtom2 = iNeighbor(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
           jj = iAtomStart(iAtom2f)
           @:ASSERT(jj >= ii)
           nOrb2 = iAtomStart(iAtom2f + 1) - jj
-          tmpSqr(1:nOrb2, 1:nOrb1) = square(jj + iBlock *nOrb :jj + nOrb2 - 1 + iBlock * nOrb, &
+          tmpSqr(1:nOrb2, 1:nOrb1) = square(jj + iBlock *nOrb :jj + nOrb2 - 1 + iBlock * nOrb,&
               & ii + iBlock * nOrb : ii + nOrb1 - 1 + iBlock * nOrb)
           ! Hermitian the on-site block before packing, as only one triangle usually supplied
           if (iAtom1 == iAtom2f) then
@@ -937,9 +939,9 @@ contains
           primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 1) =&
               & primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 1)&
               & + 0.5_dp * reshape(aimag(tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1 * nOrb2])
-          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,4) =&
-              & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,4)&
-              & + real(1-2*iBlock,dp)&
+          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 4) =&
+              & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 4)&
+              & + real(1-2*iBlock, dp)&
               & * 0.5_dp * reshape(aimag(tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1 * nOrb2])
         end do
       end do
@@ -948,8 +950,8 @@ contains
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighbor(iAtom1)
-        iOrig = iPair(iNeigh,iAtom1) + 1
+      do iNeigh = 0, nNeighborSK(iAtom1)
+        iOrig = iPair(iNeigh, iAtom1) + 1
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
@@ -957,15 +959,15 @@ contains
         nOrb2 = iAtomStart(iAtom2f + 1) - jj
         ! take the anti-Hermitian part of the block
         tmpSqr(1:nOrb2, 1:nOrb1) = 0.5_dp * ( square(nOrb+jj:nOrb+jj+nOrb2-1, ii:ii+nOrb1-1)&
-            & - transpose(square(nOrb+ii:nOrb+ii+nOrb1-1,jj:jj+nOrb2-1)))
+            & - transpose(square(nOrb+ii:nOrb+ii+nOrb1-1, jj:jj+nOrb2-1)))
         @:ASSERT(sizePrim >= iOrig + nOrb1*nOrb2 - 1)
         ! sigma_x : i * 1 = i use + imaginary part of block
-        primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,2) =&
-            & primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1,2) &
+        primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 2) =&
+            & primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 2)&
             & + reshape(aimag(tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1 * nOrb2])
         ! sigma_y : i * i = -1 use - real part of block
-        primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,3) =&
-            & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,3)&
+        primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 3) =&
+            & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 3)&
             & -reshape(real(tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1 * nOrb2])
       end do
     end do
@@ -974,14 +976,14 @@ contains
 
 
   !> Pack imaginary coefficient part of Pauli square matrix into the sparse form (complex version).
-  subroutine packHSPauliImag_kpts(primitive, square, kPoint, kWeight, iNeighbor, nNeighbor, mOrb,&
-      & iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
+  subroutine packHSPauliImag_kpts(primitive, square, kPoint, kWeight, iNeighbor, nNeighborSK,&
+      & mOrb, iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
 
     !> Sparse matrix
-    real(dp), intent(inout) :: primitive(:,:)
+    real(dp), intent(inout) :: primitive(:, :)
 
     !> Squared form matrix
-    complex(dp), intent(in) :: square(:,:)
+    complex(dp), intent(in) :: square(:, :)
 
     !> Relative coordinates of the K-point
     real(dp), intent(in) :: kPoint(:)
@@ -990,10 +992,10 @@ contains
     real(dp), intent(in) :: kweight
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -1002,13 +1004,13 @@ contains
     integer, intent(in) :: iCellVec(:)
 
     !> Relative coordinates of the cell translation vectors.
-    real(dp), intent(in) :: cellVec(:,:)
+    real(dp), intent(in) :: cellVec(:, :)
 
     !> Atom offset for the squared matrix
     integer, intent(in) :: iAtomStart(:)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -1021,7 +1023,7 @@ contains
     integer :: iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2, nOrb
     real(dp) :: kPoint2p(3)
-    complex(dp) :: tmpSqr(mOrb,mOrb)
+    complex(dp) :: tmpSqr(mOrb, mOrb)
   #:call ASSERT_CODE
     integer :: sizePrim
   #:endcall ASSERT_CODE
@@ -1031,17 +1033,17 @@ contains
     nOrb = (iAtomStart(nAtom+1) - 1)
 
   #:call ASSERT_CODE
-    sizePrim = size(primitive,dim=1)
+    sizePrim = size(primitive, dim=1)
   #:endcall ASSERT_CODE
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == 2 * nOrb )
     @:ASSERT(all(shape(kPoint) == [3]))
-    @:ASSERT(all(shape(nNeighbor) == [nAtom]))
+    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
     @:ASSERT(kWeight > 0.0_dp)
-    @:ASSERT(size(primitive,dim=2)==4)
+    @:ASSERT(size(primitive, dim=2)==4)
 
     kPoint2p(:) = 2.0_dp * pi * kPoint(:)
 
@@ -1052,8 +1054,8 @@ contains
       do iAtom1 = 1, nAtom
         ii = iAtomStart(iAtom1)
         nOrb1 = iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighbor(iAtom1)
-          iOrig = iPair(iNeigh,iAtom1) + 1
+        do iNeigh = 0, nNeighborSK(iAtom1)
+          iOrig = iPair(iNeigh, iAtom1) + 1
           iAtom2 = iNeighbor(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
           jj = iAtomStart(iAtom2f)
@@ -1061,7 +1063,7 @@ contains
           nOrb2 = iAtomStart(iAtom2f + 1) - jj
           iVec = iCellVec(iAtom2)
           if (iVec /= iOldVec) then
-            phase = exp(cmplx(0,-1,dp) * dot_product(kPoint2p(:), cellVec(:, iVec)))
+            phase = exp(cmplx(0, -1, dp) * dot_product(kPoint2p(:), cellVec(:, iVec)))
             iOldVec = iVec
           end if
           tmpSqr(1:nOrb2, 1:nOrb1) = square(jj+iBlock*nOrb:jj+nOrb2-1+iBlock*nOrb,&
@@ -1074,13 +1076,13 @@ contains
           end if
           tmpSqr = phase*kWeight*tmpSqr
           @:ASSERT(sizePrim >= iOrig + nOrb1*nOrb2 - 1)
-          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,1) =&
-              & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,1)&
-              & + 0.5_dp*reshape(aimag(tmpSqr(1:nOrb2,1:nOrb1)), [nOrb1*nOrb2])
-          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,4) =&
-              & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,4)&
-              & + real(1-2*iBlock,dp) *&
-              & 0.5_dp*reshape(aimag(tmpSqr(1:nOrb2,1:nOrb1)), [nOrb1*nOrb2])
+          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 1) =&
+              & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 1)&
+              & + 0.5_dp*reshape(aimag(tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1*nOrb2])
+          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 4) =&
+              & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 4)&
+              & + real(1-2*iBlock, dp) *&
+              & 0.5_dp*reshape(aimag(tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1*nOrb2])
         end do
       end do
     end do
@@ -1091,8 +1093,8 @@ contains
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighbor(iAtom1)
-        iOrig = iPair(iNeigh,iAtom1) + 1
+      do iNeigh = 0, nNeighborSK(iAtom1)
+        iOrig = iPair(iNeigh, iAtom1) + 1
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
@@ -1100,27 +1102,27 @@ contains
         nOrb2 = iAtomStart(iAtom2f + 1) - jj
         iVec = iCellVec(iAtom2)
         if (iVec /= iOldVec) then
-          phase = exp(cmplx(0,-1,dp)*dot_product(kPoint2p(:), cellVec(:, iVec)))
+          phase = exp(cmplx(0, -1, dp)*dot_product(kPoint2p(:), cellVec(:, iVec)))
           iOldVec = iVec
         end if
         @:ASSERT(sizePrim >= iOrig + nOrb1*nOrb2 - 1)
 
         ! take the anti-Hermitian part of the block
         tmpSqr(1:nOrb2, 1:nOrb1) = 0.5_dp * ( square(nOrb+jj:nOrb+jj+nOrb2-1, ii:ii+nOrb1-1)&
-            & + conjg(transpose(square(nOrb+ii:nOrb+ii+nOrb1-1,jj:jj+nOrb2-1))))
+            & + conjg(transpose(square(nOrb+ii:nOrb+ii+nOrb1-1, jj:jj+nOrb2-1))))
         tmpSqr = phase*kWeight*tmpSqr
         ! sigma_x : i * 1 = i use + imaginary part of block
-        primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,2) =&
+        primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 2) =&
             & primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 2)&
             & + reshape(aimag(tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1 * nOrb2])
 
         ! take the anti-Hermitian part of the block
         tmpSqr(1:nOrb2, 1:nOrb1) = 0.5_dp * (square(nOrb+jj:nOrb+jj+nOrb2-1, ii:ii+nOrb1-1)&
-            & - conjg(transpose(square(nOrb+ii:nOrb+ii+nOrb1-1,jj:jj+nOrb2-1))))
+            & - conjg(transpose(square(nOrb+ii:nOrb+ii+nOrb1-1, jj:jj+nOrb2-1))))
         tmpSqr = phase*kWeight*tmpSqr
         ! sigma_y : i * i = -1 use - real part of block
-        primitive(iOrig : iOrig + nOrb1*nOrb2 - 1,3) =&
-            & primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 3) &
+        primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 3) =&
+            & primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 3)&
             & -reshape(real(tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1 * nOrb2])
       end do
     end do
@@ -1129,20 +1131,20 @@ contains
 
 
   !> Pack only the charge (spin channel 1) part of a 2 component matrix
-  subroutine packHSPauliERho(primitive, square, iNeighbor, nNeighbor, mOrb, iAtomStart, iPair,&
+  subroutine packHSPauliERho(primitive, square, iNeighbor, nNeighborSK, mOrb, iAtomStart, iPair,&
       & img2CentCell)
 
     !> Sparse matrix
     real(dp), intent(inout) :: primitive(:)
 
     !> Squared form matrix
-    complex(dp), intent(in) :: square(:,:)
+    complex(dp), intent(in) :: square(:, :)
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -1151,7 +1153,7 @@ contains
     integer, intent(in) :: iAtomStart(:)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -1161,7 +1163,7 @@ contains
     integer :: iNeigh, iBlock
     integer :: iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2, nOrb
-    complex(dp) :: tmpSqr(mOrb,mOrb)
+    complex(dp) :: tmpSqr(mOrb, mOrb)
   #:call ASSERT_CODE
     integer :: sizePrim
   #:endcall ASSERT_CODE
@@ -1171,21 +1173,21 @@ contains
     nOrb = (iAtomStart(nAtom+1) - 1)
 
   #:call ASSERT_CODE
-    sizePrim = size(primitive,dim=1)
+    sizePrim = size(primitive, dim=1)
   #:endcall ASSERT_CODE
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == 2 * nOrb )
-    @:ASSERT(all(shape(nNeighbor) == [nAtom]))
+    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
 
     do iBlock = 0, 1
       do iAtom1 = 1, nAtom
         ii = iAtomStart(iAtom1)
         nOrb1 = iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighbor(iAtom1)
-          iOrig = iPair(iNeigh,iAtom1) + 1
+        do iNeigh = 0, nNeighborSK(iAtom1)
+          iOrig = iPair(iNeigh, iAtom1) + 1
           iAtom2 = iNeighbor(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
           jj = iAtomStart(iAtom2f)
@@ -1201,7 +1203,7 @@ contains
           end if
           @:ASSERT(sizePrim >= iOrig + nOrb1*nOrb2 - 1)
           primitive(iOrig : iOrig + nOrb1*nOrb2 - 1) = primitive(iOrig : iOrig + nOrb1*nOrb2 - 1)&
-              & + reshape(real(tmpSqr(1:nOrb2,1:nOrb1)), (/nOrb1*nOrb2/))
+              & + reshape(real(tmpSqr(1:nOrb2, 1:nOrb1)), (/nOrb1*nOrb2/))
         end do
       end do
     end do
@@ -1210,14 +1212,14 @@ contains
 
 
   !> Pack squared matrix in the sparse form (real version).
-  subroutine packHSPauliERho_kpts(primitive, square, kPoint, kWeight, iNeighbor, nNeighbor, mOrb,&
-      & iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
+  subroutine packHSPauliERho_kpts(primitive, square, kPoint, kWeight, iNeighbor, nNeighborSK,&
+      & mOrb, iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
 
     !> Sparse matrix
     real(dp), intent(inout) :: primitive(:)
 
     !> Squared form matrix
-    complex(dp), intent(in) :: square(:,:)
+    complex(dp), intent(in) :: square(:, :)
 
     !> Relative coordinates of the K-point where the sparse matrix should be unfolded.
     real(dp), intent(in) :: kPoint(:)
@@ -1226,10 +1228,10 @@ contains
     real(dp), intent(in) :: kweight
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -1238,13 +1240,13 @@ contains
     integer, intent(in) :: iCellVec(:)
 
     !> Relative coordinates of the cell translation vectors.
-    real(dp), intent(in) :: cellVec(:,:)
+    real(dp), intent(in) :: cellVec(:, :)
 
     !> Atom offset for the squared matrix
     integer, intent(in) :: iAtomStart(:)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -1257,7 +1259,7 @@ contains
     integer :: iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2, nOrb
     real(dp) :: kPoint2p(3)
-    complex(dp) :: tmpSqr(mOrb,mOrb)
+    complex(dp) :: tmpSqr(mOrb, mOrb)
   #:call ASSERT_CODE
     integer :: sizePrim
   #:endcall ASSERT_CODE
@@ -1267,14 +1269,14 @@ contains
     nOrb = (iAtomStart(nAtom+1) - 1)
 
   #:call ASSERT_CODE
-    sizePrim = size(primitive,dim=1)
+    sizePrim = size(primitive, dim=1)
   #:endcall ASSERT_CODE
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == 2 * nOrb )
     @:ASSERT(all(shape(kPoint) == [3]))
-    @:ASSERT(all(shape(nNeighbor) == [nAtom]))
+    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
     @:ASSERT(kWeight > 0.0_dp)
 
@@ -1286,8 +1288,8 @@ contains
       do iAtom1 = 1, nAtom
         ii = iAtomStart(iAtom1)
         nOrb1 = iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighbor(iAtom1)
-          iOrig = iPair(iNeigh,iAtom1) + 1
+        do iNeigh = 0, nNeighborSK(iAtom1)
+          iOrig = iPair(iNeigh, iAtom1) + 1
           iAtom2 = iNeighbor(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
           jj = iAtomStart(iAtom2f)
@@ -1295,7 +1297,7 @@ contains
           nOrb2 = iAtomStart(iAtom2f + 1) - jj
           iVec = iCellVec(iAtom2)
           if (iVec /= iOldVec) then
-            phase = exp(cmplx(0,-1,dp) * dot_product(kPoint2p(:), cellVec(:, iVec)))
+            phase = exp(cmplx(0, -1, dp) * dot_product(kPoint2p(:), cellVec(:, iVec)))
             iOldVec = iVec
           end if
           tmpSqr(1:nOrb2, 1:nOrb1) = square(jj+iBlock*nOrb:jj+nOrb2-1+iBlock*nOrb,&
@@ -1307,9 +1309,9 @@ contains
             end do
           end if
           @:ASSERT(sizePrim >= iOrig + nOrb1*nOrb2 - 1)
-          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1) = &
-              & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1) + kWeight * &
-              & reshape(real(phase*tmpSqr(1:nOrb2,1:nOrb1)), [nOrb1*nOrb2])
+          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1) =&
+              & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1) + kWeight *&
+              & reshape(real(phase*tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1*nOrb2])
         end do
       end do
     end do
@@ -1321,7 +1323,7 @@ contains
   subroutine blockSymmetrizeHS_cmplx(square, iAtomStart)
 
     !> Square form matrix.
-    complex(dp), intent(inout) :: square(:,:)
+    complex(dp), intent(inout) :: square(:, :)
 
     !> Returns the offset array for each atom.
     integer, intent(in) :: iAtomStart(:)
@@ -1339,7 +1341,7 @@ contains
     do iAtom = 1, nAtom
       iStart = iAtomStart(iAtom)
       iEnd = iAtomStart(iAtom+1) - 1
-      square(iStart:iEnd, iEnd+1:mOrb) = transpose(square(iEnd+1:mOrb,iStart:iEnd))
+      square(iStart:iEnd, iEnd+1:mOrb) = transpose(square(iEnd+1:mOrb, iStart:iEnd))
     end do
 
   end subroutine blockSymmetrizeHS_cmplx
@@ -1349,7 +1351,7 @@ contains
   subroutine blockHermitianHS_cmplx(square, iAtomStart)
 
     !> Square form matrix.
-    complex(dp), intent(inout) :: square(:,:)
+    complex(dp), intent(inout) :: square(:, :)
 
     !> Returns the offset array for each atom.
     integer, intent(in) :: iAtomStart(:)
@@ -1367,7 +1369,7 @@ contains
     do iAtom = 1, nAtom
       iStart = iAtomStart(iAtom)
       iEnd = iAtomStart(iAtom+1) - 1
-      square(iStart:iEnd, iEnd+1:mOrb) = transpose(conjg(square(iEnd+1:mOrb,iStart:iEnd)))
+      square(iStart:iEnd, iEnd+1:mOrb) = transpose(conjg(square(iEnd+1:mOrb, iStart:iEnd)))
     end do
 
   end subroutine blockHermitianHS_cmplx
@@ -1377,7 +1379,7 @@ contains
   subroutine blockSymmetrizeHS_real(square, iAtomStart)
 
     !> Square form matrix.
-    real(dp), intent(inout) :: square(:,:)
+    real(dp), intent(inout) :: square(:, :)
 
     !> Returns the offset array for each atom.
     integer, intent(in) :: iAtomStart(:)
@@ -1394,7 +1396,7 @@ contains
     do iAtom = 1, nAtom
       iStart = iAtomStart(iAtom)
       iEnd = iAtomStart(iAtom+1) - 1
-      square(iStart:iEnd, iEnd+1:mOrb) = transpose(square(iEnd+1:mOrb,iStart:iEnd))
+      square(iStart:iEnd, iEnd+1:mOrb) = transpose(square(iEnd+1:mOrb, iStart:iEnd))
     end do
 
   end subroutine blockSymmetrizeHS_real
@@ -1404,7 +1406,7 @@ contains
   subroutine blockAntiSymmetrizeHS_real(square, iAtomStart)
 
     !> Square form matrix.
-    real(dp), intent(inout) :: square(:,:)
+    real(dp), intent(inout) :: square(:, :)
 
     !> Contains the offset in the array for each atom.
     integer, intent(in) :: iAtomStart(:)
@@ -1421,7 +1423,7 @@ contains
     do iAtom = 1, nAtom
       iStart = iAtomStart(iAtom)
       iEnd = iAtomStart(iAtom+1) - 1
-      square(iStart:iEnd, iEnd+1:mOrb) = -transpose(square(iEnd+1:mOrb,iStart:iEnd))
+      square(iStart:iEnd, iEnd+1:mOrb) = -transpose(square(iEnd+1:mOrb, iStart:iEnd))
     end do
 
   end subroutine blockAntiSymmetrizeHS_real
@@ -1437,7 +1439,7 @@ contains
   !>
   !> Note: In contrast to the serial routines, both triangles of the resulting matrix are filled.
   !>
-  subroutine unpackHSRealBlacs(myBlacs, orig, iNeighbor, nNeighbor, iPair, img2CentCell, desc,&
+  subroutine unpackHSRealBlacs(myBlacs, orig, iNeighbor, nNeighborSK, iPair, img2CentCell, desc,&
       & square)
 
     !> BLACS matrix descriptor
@@ -1447,13 +1449,13 @@ contains
     real(dp), intent(in) :: orig(:)
 
     !> Neighbor list for each atom (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Map from images of atoms to central cell atoms
     integer, intent(in) :: img2CentCell(:)
@@ -1462,7 +1464,7 @@ contains
     type(TDenseDescr), intent(in) :: desc
 
     !> dense matrix part of distributed whole
-    real(dp), intent(out) :: square(:,:)
+    real(dp), intent(out) :: square(:, :)
 
     integer :: nAtom
     integer :: iOrig, ii, jj, nOrb1, nOrb2
@@ -1472,16 +1474,16 @@ contains
     nAtom = size(iNeighbor, dim=2)
 
     @:ASSERT(nAtom > 0)
-    @:ASSERT(size(nNeighbor) == nAtom)
+    @:ASSERT(size(nNeighborSK) == nAtom)
     @:ASSERT(size(desc%iAtomStart) == nAtom + 1)
 
-    square(:,:) = 0.0_dp
+    square(:, :) = 0.0_dp
 
     do iAtom1 = 1, nAtom
       ii = desc%iAtomStart(iAtom1)
       nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighbor(iAtom1)
-        iOrig = iPair(iNeigh,iAtom1) + 1
+      do iNeigh = 0, nNeighborSK(iAtom1)
+        iOrig = iPair(iNeigh, iAtom1) + 1
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = desc%iAtomStart(iAtom2f)
@@ -1504,7 +1506,7 @@ contains
   !>
   !> Note: In contrast to the serial routines, both triangles of the resulting matrix are filled.
   !>
-  subroutine unpackHSCplxBlacs(myBlacs, orig, kPoint, iNeighbor, nNeighbor, iCellVec, cellVec,&
+  subroutine unpackHSCplxBlacs(myBlacs, orig, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec,&
       & iPair, img2CentCell, desc, square)
 
     !> BLACS matrix descriptor
@@ -1517,19 +1519,19 @@ contains
     real(dp), intent(in) :: kPoint(:)
 
     !> Neighbor list for each atom (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index of the cell translation vector for each atom.
     integer, intent(in) :: iCellVec(:)
 
     !> Relative coordinates of the cell translation vectors.
-    real(dp), intent(in) :: cellVec(:,:)
+    real(dp), intent(in) :: cellVec(:, :)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -1538,7 +1540,7 @@ contains
     type(TDenseDescr), intent(in) :: desc
 
     !> dense matrix part of distributed whole
-    complex(dp), intent(out) :: square(:,:)
+    complex(dp), intent(out) :: square(:, :)
 
     complex(dp) :: phase
     integer :: nAtom
@@ -1552,18 +1554,18 @@ contains
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(kPoint) == 3)
-    @:ASSERT(size(nNeighbor) == nAtom)
+    @:ASSERT(size(nNeighborSK) == nAtom)
     @:ASSERT(size(desc%iAtomStart) == nAtom + 1)
 
-    square(:,:) = cmplx(0, 0, dp)
+    square(:, :) = cmplx(0, 0, dp)
     kPoint2p(:) = 2.0_dp * pi * kPoint(:)
     iOldVec = 0
     phase = 1.0_dp
     do iAtom1 = 1, nAtom
       ii = desc%iAtomStart(iAtom1)
       nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighbor(iAtom1)
-        iOrig = iPair(iNeigh,iAtom1) + 1
+      do iNeigh = 0, nNeighborSK(iAtom1)
+        iOrig = iPair(iNeigh, iAtom1) + 1
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = desc%iAtomStart(iAtom2f)
@@ -1573,8 +1575,8 @@ contains
           phase = exp((0.0_dp, 1.0_dp) * dot_product(kPoint2p, cellVec(:, iVec)))
           iOldVec = iVec
         end if
-        call scalafx_addl2g(myBlacs%orbitalGrid, phase &
-            & * reshape(orig(iOrig : iOrig + nOrb1 * nOrb2 - 1), [nOrb2, nOrb1]), &
+        call scalafx_addl2g(myBlacs%orbitalGrid, phase&
+            & * reshape(orig(iOrig : iOrig + nOrb1 * nOrb2 - 1), [nOrb2, nOrb1]),&
             & desc%blacsOrbSqr, jj, ii, square)
         if (iAtom1 /= iAtom2f) then
           call scalafx_addl2g(myBlacs%orbitalGrid, transpose(conjg(phase&
@@ -1591,32 +1593,32 @@ contains
   !>
   !> Note: In contrast to the serial routines, both triangles of the resulting matrix are filled.
   !>
-  subroutine unpackHPauliBlacs(myBlacs, orig, kPoint, iNeighbor, nNeighbor, iCellVec, cellVec,&
+  subroutine unpackHPauliBlacs(myBlacs, orig, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec,&
       & iPair, img2CentCell, mOrb, desc, square, iorig)
 
     !> BLACS matrix descriptor
     type(TBlacsEnv), intent(in) :: myBlacs
 
     !> sparse matrix
-    real(dp), intent(in) :: orig(:,:)
+    real(dp), intent(in) :: orig(:, :)
 
     !> Relative coordinates of the K-point where the sparse matrix should be unfolded.
     real(dp), intent(in) :: kPoint(:)
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index of the cell translation vector for each atom.
     integer, intent(in) :: iCellVec(:)
 
     !> Relative coordinates of the cell translation vectors.
-    real(dp), intent(in) :: cellVec(:,:)
+    real(dp), intent(in) :: cellVec(:, :)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -1628,16 +1630,16 @@ contains
     type(TDenseDescr), intent(in) :: desc
 
     !> local part of distributed whole dense matrix
-    complex(dp), intent(out) :: square(:,:)
+    complex(dp), intent(out) :: square(:, :)
 
     !> imaginary part of sparse matrix
-    real(dp), intent(in), optional :: iorig(:,:)
+    real(dp), intent(in), optional :: iorig(:, :)
 
-    square(:,:) = cmplx(0, 0, dp)
-    call unpackHPauliBlacsHelper(myBlacs, orig, kPoint, iNeighbor, nNeighbor, iCellVec, cellVec,&
+    square(:, :) = cmplx(0, 0, dp)
+    call unpackHPauliBlacsHelper(myBlacs, orig, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec,&
         & iPair, img2CentCell, mOrb, cmplx(1, 0, dp), cmplx(1, 0, dp), desc, square)
     if (present(iorig)) then
-      call unpackHPauliBlacsHelper(myBlacs, iorig, kPoint, iNeighbor, nNeighbor, iCellVec,&
+      call unpackHPauliBlacsHelper(myBlacs, iorig, kPoint, iNeighbor, nNeighborSK, iCellVec,&
           & cellVec, iPair, img2CentCell, mOrb, cmplx(0, 1, dp), cmplx(-1, 0, dp), desc, square)
     end if
 
@@ -1647,34 +1649,34 @@ contains
   !> Helper routine for unpacking into Pauli-type Hamiltonians.
   !!
   !! The routine creates the lower triangle of the 2x2 Pauli Hamiltonian
-  !! 1*orig(:,1) + sigma1*orig(:,2) + sigma2*orig(:,3) + sigma3*orig(:,4).
+  !! 1*orig(:, 1) + sigma1*orig(:, 2) + sigma2*orig(:, 3) + sigma3*orig(:, 4).
   !!
-  subroutine unpackHPauliBlacsHelper(myBlacs, orig, kPoint, iNeighbor, nNeighbor, iCellVec,&
+  subroutine unpackHPauliBlacsHelper(myBlacs, orig, kPoint, iNeighbor, nNeighborSK, iCellVec,&
       & cellVec, iPair, img2CentCell, mOrb, imagPrefac, hermPrefac, desc, square)
 
     !> BLACS matrix descriptor
     type(TBlacsEnv), intent(in) :: myBlacs
 
     !> sparse matrix to unpack
-    real(dp), intent(in) :: orig(:,:)
+    real(dp), intent(in) :: orig(:, :)
 
     !> k-point at which to unpack
     real(dp), intent(in) :: kPoint(:)
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index of the cell translation vector for each atom.
     integer, intent(in) :: iCellVec(:)
 
     !> Relative coordinates of the cell translation vectors.
-    real(dp), intent(in) :: cellVec(:,:)
+    real(dp), intent(in) :: cellVec(:, :)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -1692,16 +1694,16 @@ contains
     type(TDenseDescr), intent(in) :: desc
 
     !> local part of distributed whole dense matrix to add to
-    complex(dp), intent(inout) :: square(:,:)
+    complex(dp), intent(inout) :: square(:, :)
 
     integer :: iAtom1, iAtom2, iAtom2f, nAtom, nOrb1, nOrb2, nOrb
     integer :: iNeigh, iOrig, ii, jj, kk, iOldVec, iVec
     complex(dp), target :: tmpSqr(mOrb, mOrb, 4)
-    complex(dp), pointer :: ptmp(:,:,:)
+    complex(dp), pointer :: ptmp(:, :, :)
     real(dp) :: kPoint2p(3)
     complex(dp) :: phase
 
-    nAtom = size(nNeighbor)
+    nAtom = size(nNeighborSK)
     nOrb = desc%iAtomStart(nAtom + 1) - 1
     kPoint2p(:) = 2.0_dp * pi * kPoint
     iOldVec = 0
@@ -1709,31 +1711,31 @@ contains
     do iAtom1 = 1, nAtom
       ii = desc%iAtomStart(iAtom1)
       nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighbor(iAtom1)
-        iOrig = iPair(iNeigh,iAtom1) + 1
+      do iNeigh = 0, nNeighborSK(iAtom1)
+        iOrig = iPair(iNeigh, iAtom1) + 1
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = desc%iAtomStart(iAtom2f)
         nOrb2 = desc%iAtomStart(iAtom2f + 1) - jj
         iVec = iCellVec(iAtom2)
         if (iVec /= iOldVec) then
-          phase = exp(imag * dot_product(kPoint2p, cellVec(:,iVec)))
+          phase = exp(imag * dot_product(kPoint2p, cellVec(:, iVec)))
           iOldVec = iVec
         end if
         ptmp => tmpSqr(1:nOrb2, 1:nOrb1, :)
-        ptmp(:,:,:) = 0.5_dp * phase &
-            & * reshape(orig(iOrig:iOrig+nOrb1*nOrb2-1,:), [nOrb2, nOrb1, 4])
+        ptmp(:, :, :) = 0.5_dp * phase&
+            & * reshape(orig(iOrig:iOrig+nOrb1*nOrb2-1, :), [nOrb2, nOrb1, 4])
         ! up-up component and down-down components
-        call scalafx_addl2g(myBlacs%orbitalGrid, imagPrefac * (ptmp(:,:,1) + ptmp(:,:,4)),&
+        call scalafx_addl2g(myBlacs%orbitalGrid, imagPrefac * (ptmp(:, :, 1) + ptmp(:, :, 4)),&
             & desc%blacsOrbSqr, jj, ii, square)
-        call scalafx_addl2g(myBlacs%orbitalGrid, imagPrefac * (ptmp(:,:,1) - ptmp(:,:,4)),&
+        call scalafx_addl2g(myBlacs%orbitalGrid, imagPrefac * (ptmp(:, :, 1) - ptmp(:, :, 4)),&
             & desc%blacsOrbSqr, jj + nOrb, ii + nOrb, square)
         if (iAtom1 /= iAtom2f) then
           call scalafx_addl2g(myBlacs%orbitalGrid,&
-              & hermPrefac * transpose(conjg(imagPrefac * (ptmp(:,:,1) + ptmp(:,:,4)))),&
+              & hermPrefac * transpose(conjg(imagPrefac * (ptmp(:, :, 1) + ptmp(:, :, 4)))),&
               & desc%blacsOrbSqr, ii, jj, square)
           call scalafx_addl2g(myBlacs%orbitalGrid,&
-              & hermPrefac * transpose(conjg(imagPrefac * (ptmp(:,:,1) - ptmp(:,:,4)))),&
+              & hermPrefac * transpose(conjg(imagPrefac * (ptmp(:, :, 1) - ptmp(:, :, 4)))),&
               & desc%blacsOrbSqr, ii + nOrb, jj + nOrb, square)
         end if
         ! down-up component
@@ -1744,24 +1746,24 @@ contains
             ptmp(kk, kk+1:, 2:3) = hermPrefac * conjg(ptmp(kk+1:, kk, 2:3))
           end do
           call scalafx_addl2g(myBlacs%orbitalGrid,&
-              & imagPrefac * (ptmp(:,:,2) + imag * ptmp(:,:,3)), desc%blacsOrbSqr,&
+              & imagPrefac * (ptmp(:, :, 2) + imag * ptmp(:, :, 3)), desc%blacsOrbSqr,&
               & jj + nOrb, ii, square)
           call scalafx_addl2g(myBlacs%orbitalGrid,&
-              & hermPrefac * transpose(conjg(imagPrefac * (ptmp(:,:,2) + imag * ptmp(:,:,3)))),&
+              & hermPrefac * transpose(conjg(imagPrefac * (ptmp(:, :, 2) + imag * ptmp(:, :, 3)))),&
               & desc%blacsOrbSqr, ii, jj + nOrb, square)
         else
-          call scalafx_addl2g(myBlacs%orbitalGrid, &
-              & imagPrefac * (ptmp(:,:,2) + imag * ptmp(:,:,3)), desc%blacsOrbSqr,&
+          call scalafx_addl2g(myBlacs%orbitalGrid,&
+              & imagPrefac * (ptmp(:, :, 2) + imag * ptmp(:, :, 3)), desc%blacsOrbSqr,&
               & jj + nOrb, ii, square)
-          call scalafx_addl2g(myBlacs%orbitalGrid, &
-              & hermPrefac * transpose(conjg(imagPrefac * (ptmp(:,:,2) + imag * ptmp(:,:,3)))),&
+          call scalafx_addl2g(myBlacs%orbitalGrid,&
+              & hermPrefac * transpose(conjg(imagPrefac * (ptmp(:, :, 2) + imag * ptmp(:, :, 3)))),&
               & desc%blacsOrbSqr, ii, jj + nOrb, square)
-          call scalafx_addl2g(myBlacs%orbitalGrid, imagPrefac * hermPrefac &
-              & * conjg(transpose(ptmp(:,:,2) - imag * ptmp(:,:,3))), desc%blacsOrbSqr,&
+          call scalafx_addl2g(myBlacs%orbitalGrid, imagPrefac * hermPrefac&
+              & * conjg(transpose(ptmp(:, :, 2) - imag * ptmp(:, :, 3))), desc%blacsOrbSqr,&
               & ii + nOrb, jj, square)
           call scalafx_addl2g(myBlacs%orbitalGrid,&
-              & transpose(conjg(imagPrefac * conjg(transpose(ptmp(:,:,2) - imag * ptmp(:,:,3))))),&
-              & desc%blacsOrbSqr, jj, ii + nOrb, square)
+              & transpose(conjg(imagPrefac * conjg(transpose(ptmp(:, :, 2)&
+              & - imag * ptmp(:, :, 3))))), desc%blacsOrbSqr, jj, ii + nOrb, square)
         end if
       end do
     end do
@@ -1773,7 +1775,7 @@ contains
   !>
   !> Note: In contrast to the serial routines, both triangles of the resulting matrix are filled.
   !>
-  subroutine unpackSPauliBlacs(myBlacs, orig, kPoint, iNeighbor, nNeighbor, iCellVec, cellVec,&
+  subroutine unpackSPauliBlacs(myBlacs, orig, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec,&
       & iPair, img2CentCell, mOrb, desc, square)
 
     !> BLACS matrix descriptor
@@ -1786,19 +1788,19 @@ contains
     real(dp), intent(in) :: kPoint(:)
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index of the cell translation vector for each atom.
     integer, intent(in) :: iCellVec(:)
 
     !> Relative coordinates of the cell translation vectors.
-    real(dp), intent(in) :: cellVec(:,:)
+    real(dp), intent(in) :: cellVec(:, :)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -1810,17 +1812,17 @@ contains
     type(TDenseDescr), intent(in) :: desc
 
     !> Local part of of distributed whole dense matrix
-    complex(dp), intent(out) :: square(:,:)
+    complex(dp), intent(out) :: square(:, :)
 
     integer :: iAtom1, iAtom2, iAtom2f, nAtom, nOrb1, nOrb2, nOrb
     integer :: iNeigh, iOrig, ii, jj, iOldVec, iVec
     complex(dp), target :: tmpSqr(mOrb, mOrb)
-    complex(dp), pointer :: ptmp(:,:)
+    complex(dp), pointer :: ptmp(:, :)
     real(dp) :: kPoint2p(3)
     complex(dp) :: phase
 
-    square(:,:) = (0.0_dp, 0.0_dp)
-    nAtom = size(nNeighbor)
+    square(:, :) = (0.0_dp, 0.0_dp)
+    nAtom = size(nNeighborSK)
     nOrb = desc%iAtomStart(nAtom + 1) - 1
     kPoint2p(:) = 2.0_dp * pi * kPoint
     iOldVec = 0
@@ -1828,19 +1830,19 @@ contains
     do iAtom1 = 1, nAtom
       ii = desc%iAtomStart(iAtom1)
       nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighbor(iAtom1)
-        iOrig = iPair(iNeigh,iAtom1) + 1
+      do iNeigh = 0, nNeighborSK(iAtom1)
+        iOrig = iPair(iNeigh, iAtom1) + 1
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = desc%iAtomStart(iAtom2f)
         nOrb2 = desc%iAtomStart(iAtom2f + 1) - jj
         iVec = iCellVec(iAtom2)
         if (iVec /= iOldVec) then
-          phase = exp(imag * dot_product(kPoint2p, cellVec(:,iVec)))
+          phase = exp(imag * dot_product(kPoint2p, cellVec(:, iVec)))
           iOldVec = iVec
         end if
         ptmp => tmpSqr(1:nOrb2, 1:nOrb1)
-        ptmp(:,:) = phase * reshape(orig(iOrig:iOrig+nOrb1*nOrb2-1), [nOrb2, nOrb1])
+        ptmp(:, :) = phase * reshape(orig(iOrig:iOrig+nOrb1*nOrb2-1), [nOrb2, nOrb1])
         ! up-up component
         call scalafx_addl2g(myBlacs%orbitalGrid, ptmp, desc%blacsOrbSqr, jj, ii, square)
         ! down-down component
@@ -1859,7 +1861,7 @@ contains
 
 
   !> Packs distributed dense real matrix into sparse form (real).
-  subroutine packRhoRealBlacs(myBlacs, desc, square, iNeighbor, nNeighbor, mOrb, iPair,&
+  subroutine packRhoRealBlacs(myBlacs, desc, square, iNeighbor, nNeighborSK, mOrb, iPair,&
       & img2CentCell, primitive)
 
     !> BLACS matrix descriptor
@@ -1869,19 +1871,19 @@ contains
     type(TDenseDescr), intent(in) :: desc
 
     !> distributed dense matrix to pack
-    real(dp), intent(in) :: square(:,:)
+    real(dp), intent(in) :: square(:, :)
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -1894,7 +1896,7 @@ contains
     integer :: iNeigh
     integer :: iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2
-    real(dp) :: tmpSqr(mOrb,mOrb)
+    real(dp) :: tmpSqr(mOrb, mOrb)
   #:call ASSERT_CODE
     integer :: sizePrim
   #:endcall ASSERT_CODE
@@ -1904,19 +1906,19 @@ contains
     sizePrim = size(primitive)
   #:endcall ASSERT_CODE
     @:ASSERT(nAtom > 0)
-    @:ASSERT(size(nNeighbor) == nAtom)
+    @:ASSERT(size(nNeighborSK) == nAtom)
 
     do iAtom1 = 1, nAtom
       ii = desc%iAtomStart(iAtom1)
       nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighbor(iAtom1)
-        iOrig = iPair(iNeigh,iAtom1) + 1
+      do iNeigh = 0, nNeighborSK(iAtom1)
+        iOrig = iPair(iNeigh, iAtom1) + 1
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = desc%iAtomStart(iAtom2f)
         nOrb2 = desc%iAtomStart(iAtom2f + 1) - jj
         call scalafx_cpg2l(myBlacs%orbitalGrid, desc%blacsOrbSqr, jj, ii, square,&
-            & tmpSqr(1:nOrb2,1:nOrb1))
+            & tmpSqr(1:nOrb2, 1:nOrb1))
 
         ! Symmetrize the on-site block before packing, just in case
         if (iAtom1 == iAtom2f) then
@@ -1925,8 +1927,8 @@ contains
           end do
         end if
 
-        primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1) = &
-            & primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1) &
+        primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1) =&
+            & primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1)&
             & + reshape(tmpSqr(1:nOrb2, 1:nOrb1), [nOrb1 * nOrb2])
       end do
     end do
@@ -1935,7 +1937,7 @@ contains
 
 
   !> Packs distributed dense real matrix into sparse form (real).
-  subroutine packRhoCplxBlacs(myblacs, desc, square, kPoint, kWeight, iNeighbor, nNeighbor, mOrb,&
+  subroutine packRhoCplxBlacs(myblacs, desc, square, kPoint, kWeight, iNeighbor, nNeighborSK, mOrb,&
       & iCellVec, cellVec, iPair, img2CentCell, primitive)
 
     !> BLACS matrix descriptor
@@ -1945,7 +1947,7 @@ contains
     type(TDenseDescr), intent(in) :: desc
 
     !> Distributed dense matrix to pack
-    complex(dp), intent(in) :: square(:,:)
+    complex(dp), intent(in) :: square(:, :)
 
     !> k-point at which to pack
     real(dp), intent(in) :: kPoint(:)
@@ -1954,10 +1956,10 @@ contains
     real(dp), intent(in) :: kWeight
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -1966,10 +1968,10 @@ contains
     integer, intent(in) :: iCellVec(:)
 
     !> Relative coordinates of the cell translation vectors.
-    real(dp), intent(in) :: cellVec(:,:)
+    real(dp), intent(in) :: cellVec(:, :)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -1985,7 +1987,7 @@ contains
     integer :: iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2
     real(dp) :: kPoint2p(3)
-    complex(dp) :: tmpSqr(mOrb,mOrb)
+    complex(dp) :: tmpSqr(mOrb, mOrb)
   #:call ASSERT_CODE
     integer :: sizePrim
   #:endcall ASSERT_CODE
@@ -1997,7 +1999,7 @@ contains
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(kPoint) == 3)
-    @:ASSERT(size(nNeighbor) == nAtom)
+    @:ASSERT(size(nNeighborSK) == nAtom)
     @:ASSERT(kWeight > 0.0_dp)
     @:ASSERT(size(desc%iAtomStart) == nAtom + 1)
 
@@ -2007,15 +2009,15 @@ contains
     do iAtom1 = 1, nAtom
       ii = desc%iAtomStart(iAtom1)
       nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighbor(iAtom1)
-        iOrig = iPair(iNeigh,iAtom1) + 1
+      do iNeigh = 0, nNeighborSK(iAtom1)
+        iOrig = iPair(iNeigh, iAtom1) + 1
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = desc%iAtomStart(iAtom2f)
         nOrb2 = desc%iAtomStart(iAtom2f + 1) - jj
         iVec = iCellVec(iAtom2)
         if (iVec /= iOldVec) then
-          phase = exp(cmplx(0,-1,dp) * dot_product(kPoint2p(:), cellVec(:, iVec)))
+          phase = exp(cmplx(0, -1, dp) * dot_product(kPoint2p(:), cellVec(:, iVec)))
           iOldVec = iVec
         end if
         call scalafx_cpg2l(myBlacs%orbitalGrid, desc%blacsOrbSqr, jj, ii, square,&
@@ -2028,10 +2030,9 @@ contains
           end do
         end if
 
-        primitive(iOrig : iOrig + nOrb1*nOrb2 - 1) = &
-            & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1) &
-            & + kWeight * real(phase * reshape(tmpSqr(1:nOrb2, 1:nOrb1),&
-            & [nOrb1 * nOrb2]), dp)
+        primitive(iOrig : iOrig + nOrb1*nOrb2 - 1) =&
+            & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1)&
+            & + kWeight * real(phase * reshape(tmpSqr(1:nOrb2, 1:nOrb1), [nOrb1 * nOrb2]), dp)
       end do
     end do
 
@@ -2039,8 +2040,8 @@ contains
 
 
   !> Pack squared matrix into the sparse form (complex Pauli version).
-  subroutine packRhoPauliBlacs(myBlacs, desc, square, kPoint, kWeight, iNeighbor, nNeighbor, mOrb,&
-      & iCellVec, cellVec, iPair, img2CentCell, primitive, iprimitive)
+  subroutine packRhoPauliBlacs(myBlacs, desc, square, kPoint, kWeight, iNeighbor, nNeighborSK,&
+      & mOrb, iCellVec, cellVec, iPair, img2CentCell, primitive, iprimitive)
 
     !> BLACS matrix descriptor
     type(TBlacsEnv), intent(in) :: myBlacs
@@ -2049,7 +2050,7 @@ contains
     type(TDenseDescr), intent(in) :: desc
 
     !> dense distributed matrix to pack
-    complex(dp), intent(in) :: square(:,:)
+    complex(dp), intent(in) :: square(:, :)
 
     !> k-point at which to pack
     real(dp), intent(in) :: kPoint(:)
@@ -2058,10 +2059,10 @@ contains
     real(dp), intent(in) :: kWeight
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -2070,34 +2071,34 @@ contains
     integer, intent(in) :: iCellVec(:)
 
     !> Relative coordinates of the cell translation vectors.
-    real(dp), intent(in) :: cellVec(:,:)
+    real(dp), intent(in) :: cellVec(:, :)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
 
     !> sparse matrix to pack into
-    real(dp), intent(inout) :: primitive(:,:)
+    real(dp), intent(inout) :: primitive(:, :)
 
     !> Imaginary part of sparse matrix
-    real(dp), intent(inout), optional :: iprimitive(:,:)
+    real(dp), intent(inout), optional :: iprimitive(:, :)
 
-    call packRhoPauliBlacsHelper(myBlacs, desc, square, kPoint, kWeight, iNeighbor, nNeighbor,&
-        & mOrb, iCellVec, cellVec, iPair, img2CentCell, cmplx(1,0,dp), .true., primitive)
+    call packRhoPauliBlacsHelper(myBlacs, desc, square, kPoint, kWeight, iNeighbor, nNeighborSK,&
+        & mOrb, iCellVec, cellVec, iPair, img2CentCell, cmplx(1, 0, dp), .true., primitive)
     if (present(iprimitive)) then
-      call packRhoPauliBlacsHelper(myBlacs, desc, square, kPoint, kWeight, iNeighbor, nNeighbor,&
-          & mOrb, iCellVec, cellVec, iPair, img2CentCell, cmplx(0,-1,dp),&
-          & .false., iprimitive)
+      call packRhoPauliBlacsHelper(myBlacs, desc, square, kPoint, kWeight, iNeighbor, nNeighborSK,&
+          & mOrb, iCellVec, cellVec, iPair, img2CentCell, cmplx(0, -1, dp), .false., iprimitive)
     end if
 
   end subroutine packRhoPauliBlacs
 
 
   !> Helper routine for the Pauli packing.
-  subroutine packRhoPauliBlacsHelper(myBlacs, desc, square, kPoint, kWeight, iNeighbor, nNeighbor,&
-      & mOrb, iCellVec, cellVec, iPair, img2CentCell, imagprefac, symmetrize, primitive)
+  subroutine packRhoPauliBlacsHelper(myBlacs, desc, square, kPoint, kWeight, iNeighbor,&
+      & nNeighborSK, mOrb, iCellVec, cellVec, iPair, img2CentCell, imagprefac, symmetrize,&
+      & primitive)
 
     !> BLACS matrix descriptor
     type(TBlacsEnv), intent(in) :: myBlacs
@@ -2106,7 +2107,7 @@ contains
     type(TDenseDescr), intent(in) :: desc
 
     !> distributed sparse matrix to pack
-    complex(dp), intent(in) :: square(:,:)
+    complex(dp), intent(in) :: square(:, :)
 
     !> k-point at which to unpack
     real(dp), intent(in) :: kPoint(:)
@@ -2115,10 +2116,10 @@ contains
     real(dp), intent(in) :: kWeight
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -2127,10 +2128,10 @@ contains
     integer, intent(in) :: iCellVec(:)
 
     !> Relative coordinates of the cell translation vectors.
-    real(dp), intent(in) :: cellVec(:,:)
+    real(dp), intent(in) :: cellVec(:, :)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -2142,7 +2143,7 @@ contains
     logical, intent(in) :: symmetrize
 
     !> sparse matrix to add this contribution to
-    real(dp), intent(inout) :: primitive(:,:)
+    real(dp), intent(inout) :: primitive(:, :)
 
     complex(dp) :: phase
     real(dp) :: zprefac
@@ -2155,7 +2156,7 @@ contains
     real(dp) :: kPoint2p(3)
     complex(dp), target :: tmpSqr(mOrb, mOrb)
     complex(dp), target :: tmpSqr1(mOrb, mOrb), tmpSqr2(mOrb, mOrb)
-    complex(dp), pointer :: ptmp(:,:), ptmp1(:,:), ptmp2(:,:)
+    complex(dp), pointer :: ptmp(:, :), ptmp1(:, :), ptmp2(:, :)
   #:call ASSERT_CODE
     integer :: sizePrim
   #:endcall ASSERT_CODE
@@ -2165,12 +2166,12 @@ contains
     nOrb = desc%iAtomStart(nAtom + 1) - 1
 
   #:call ASSERT_CODE
-    sizePrim = size(primitive,dim=1)
+    sizePrim = size(primitive, dim=1)
   #:endcall ASSERT_CODE
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(all(shape(kPoint) == [3]))
-    @:ASSERT(all(shape(nNeighbor) == [nAtom]))
+    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
     @:ASSERT(size(desc%iAtomStart) == nAtom + 1)
     @:ASSERT(kWeight > 0.0_dp)
     @:ASSERT(size(primitive, dim=2) == 4)
@@ -2185,15 +2186,15 @@ contains
       do iAtom1 = 1, nAtom
         ii = desc%iAtomStart(iAtom1)
         nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighbor(iAtom1)
-          iOrig = iPair(iNeigh,iAtom1) + 1
+        do iNeigh = 0, nNeighborSK(iAtom1)
+          iOrig = iPair(iNeigh, iAtom1) + 1
           iAtom2 = iNeighbor(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
           jj = desc%iAtomStart(iAtom2f)
           nOrb2 = desc%iAtomStart(iAtom2f + 1) - jj
           iVec = iCellVec(iAtom2)
           if (iVec /= iOldVec) then
-            phase = exp(cmplx(0,-1,dp) * dot_product(kPoint2p, cellVec(:, iVec)))
+            phase = exp(cmplx(0, -1, dp) * dot_product(kPoint2p, cellVec(:, iVec)))
             iOldVec = iVec
           end if
           ptmp => tmpSqr(1:nOrb2, 1:nOrb1)
@@ -2206,7 +2207,7 @@ contains
               ptmp(kk, kk+1:) = conjg(ptmp(kk+1:, kk))
             end do
           end if
-          ptmp(:,:) = 0.5_dp * imagprefac * phase * kWeight * ptmp
+          ptmp(:, :) = 0.5_dp * imagprefac * phase * kWeight * ptmp
           primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 1) =&
               & primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 1)&
               & + reshape(real(ptmp), [nOrb1 * nOrb2])
@@ -2223,15 +2224,15 @@ contains
     do iAtom1 = 1, nAtom
       ii = desc%iAtomStart(iAtom1)
       nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighbor(iAtom1)
-        iOrig = iPair(iNeigh,iAtom1) + 1
+      do iNeigh = 0, nNeighborSK(iAtom1)
+        iOrig = iPair(iNeigh, iAtom1) + 1
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = desc%iAtomStart(iAtom2f)
         nOrb2 = desc%iAtomStart(iAtom2f + 1) - jj
         iVec = iCellVec(iAtom2)
         if (iVec /= iOldVec) then
-          phase = exp(cmplx(0,-1,dp) * dot_product(kPoint2p, cellVec(:, iVec)))
+          phase = exp(cmplx(0, -1, dp) * dot_product(kPoint2p, cellVec(:, iVec)))
           iOldVec = iVec
         end if
         ptmp => tmpSqr(1:nOrb2, 1:nOrb1)
@@ -2240,25 +2241,25 @@ contains
         ! take the Pauli part of the block
         call scalafx_cpg2l(myBlacs%orbitalGrid, desc%blacsOrbSqr, jj + nOrb, ii, square, ptmp1)
         call scalafx_cpg2l(myBlacs%orbitalGrid, desc%blacsOrbSqr, ii + nOrb, jj, square, ptmp2)
-        ptmp(:,:) = ptmp1 + conjg(transpose(ptmp2))
+        ptmp(:, :) = ptmp1 + conjg(transpose(ptmp2))
         if (symmetrize .and. iAtom1 == iAtom2f) then
           do kk = 1, nOrb2
             ptmp(kk, kk+1:) = ptmp(kk+1:, kk)
           end do
         end if
-        ptmp(:,:) = 0.5_dp * imagprefac * phase * kWeight * ptmp
-        primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1,2) = &
-            & primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 2) &
+        ptmp(:, :) = 0.5_dp * imagprefac * phase * kWeight * ptmp
+        primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 2) =&
+            & primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 2)&
             & + reshape(real(ptmp), [nOrb1 * nOrb2])
-        ptmp(:,:) = ptmp1 - conjg(transpose(ptmp2))
+        ptmp(:, :) = ptmp1 - conjg(transpose(ptmp2))
         if (symmetrize .and. iAtom1 == iAtom2f) then
           do kk = 1, nOrb2
             ptmp(kk, kk+1:) = ptmp(kk+1:, kk)
           end do
         end if
-        ptmp(:,:) = 0.5_dp * imagprefac * phase * kWeight * ptmp
-        primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1,3) =&
-            & primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 3) &
+        ptmp(:, :) = 0.5_dp * imagprefac * phase * kWeight * ptmp
+        primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 3) =&
+            & primitive(iOrig : iOrig + nOrb1 * nOrb2 - 1, 3)&
             & + reshape(aimag(ptmp), [nOrb1 * nOrb2])
       end do
     end do
@@ -2267,7 +2268,7 @@ contains
 
 
   !> Pack only the charge (spin channel 1) part of a 2 component matrix.
-  subroutine packERhoPauliBlacs(myBlacs, desc, square, kPoint, kWeight, iNeighbor, nNeighbor,&
+  subroutine packERhoPauliBlacs(myBlacs, desc, square, kPoint, kWeight, iNeighbor, nNeighborSK,&
       & mOrb, iCellVec, cellVec, iPair, img2CentCell, primitive)
 
     !> BLACS matrix descriptor
@@ -2277,7 +2278,7 @@ contains
     type(TDenseDescr), intent(in) :: desc
 
     !> local part of the distributed matrix
-    complex(dp), intent(in) :: square(:,:)
+    complex(dp), intent(in) :: square(:, :)
 
     !> k-point at which to pack
     real(dp), intent(in) :: kPoint(:)
@@ -2286,10 +2287,10 @@ contains
     real(dp), intent(in) :: kWeight
 
     !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbor(0:, :)
 
     !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -2298,10 +2299,10 @@ contains
     integer, intent(in) :: iCellVec(:)
 
     !> Relative coordinates of the cell translation vectors.
-    real(dp), intent(in) :: cellVec(:,:)
+    real(dp), intent(in) :: cellVec(:, :)
 
     !> indexing array for the sparse Hamiltonian
-    integer, intent(in) :: iPair(0:,:)
+    integer, intent(in) :: iPair(0:, :)
 
     !> Mapping between image atoms and corresponding atom in the central cell.
     integer, intent(in) :: img2CentCell(:)
@@ -2315,7 +2316,7 @@ contains
     integer :: iOldVec, iVec
     integer :: nOrb1, nOrb2, nOrb
     real(dp) :: kPoint2p(3)
-    complex(dp) :: tmpSqr(mOrb,mOrb)
+    complex(dp) :: tmpSqr(mOrb, mOrb)
   #:call ASSERT_CODE
     integer :: sizePrim
   #:endcall ASSERT_CODE
@@ -2325,12 +2326,12 @@ contains
     nOrb = desc%iAtomStart(nAtom + 1) - 1
 
   #:call ASSERT_CODE
-    sizePrim = size(primitive,dim=1)
+    sizePrim = size(primitive, dim=1)
   #:endcall ASSERT_CODE
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(all(shape(kPoint) == [3]))
-    @:ASSERT(all(shape(nNeighbor) == [nAtom]))
+    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
     @:ASSERT(size(desc%iAtomStart) == nAtom + 1)
     @:ASSERT(kWeight > 0.0_dp)
 
@@ -2342,7 +2343,7 @@ contains
       do iAtom1 = 1, nAtom
         ii = desc%iAtomStart(iAtom1)
         nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighbor(iAtom1)
+        do iNeigh = 0, nNeighborSK(iAtom1)
           iOrig = iPair(iNeigh, iAtom1) + 1
           iAtom2 = iNeighbor(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
@@ -2351,7 +2352,7 @@ contains
           nOrb2 = desc%iAtomStart(iAtom2f + 1) - jj
           iVec = iCellVec(iAtom2)
           if (iVec /= iOldVec) then
-            phase = exp(cmplx(0,-1,dp) * dot_product(kPoint2p, cellVec(:, iVec)))
+            phase = exp(cmplx(0, -1, dp) * dot_product(kPoint2p, cellVec(:, iVec)))
             iOldVec = iVec
           end if
           call scalafx_cpg2l(myBlacs%orbitalGrid, desc%blacsOrbSqr, jj + iBlock * nOrb,&
@@ -2363,9 +2364,9 @@ contains
               tmpSqr(kk, kk+1:nOrb1) = conjg(tmpSqr(kk+1:nOrb1, kk))
             end do
           end if
-          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1) = &
-              & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1) + kWeight * &
-              & reshape(real(phase*tmpSqr(1:nOrb2,1:nOrb1)), [nOrb1*nOrb2])
+          primitive(iOrig : iOrig + nOrb1*nOrb2 - 1) =&
+              & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1) + kWeight *&
+              & reshape(real(phase*tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1*nOrb2])
         end do
       end do
     end do

--- a/prog/dftb+/lib_dftb/sparse2dense.F90
+++ b/prog/dftb+/lib_dftb/sparse2dense.F90
@@ -16,7 +16,7 @@ module sparse2dense
   use constants, only : pi, imag
   use commontypes
   use memman
-  use periodic, only : TNeighborList
+  use periodic, only : TNeighbourList
   use densedescr
 #:if WITH_SCALAPACK
   use scalapackfx
@@ -89,7 +89,7 @@ contains
   !> Unpacks sparse matrix to square form (complex version) Note the non on-site blocks are only
   !> filled in the lower triangle part of the matrix. To fill the matrix completely, apply the
   !> blockSymmetrizeHS subroutine.
-  subroutine unpackHS_cmplx(square, orig, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec,&
+  subroutine unpackHS_cmplx(square, orig, kPoint, iNeighbour, nNeighbourSK, iCellVec, cellVec,&
       & iAtomStart, iPair, img2CentCell)
 
     !> Square form matrix on exit.
@@ -101,11 +101,11 @@ contains
     !> Relative coordinates of the K-point where the sparse matrix should be unfolded.
     real(dp), intent(in) :: kPoint(:)
 
-    !> Neighbor list for each atom (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for each atom (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom (incl. itself).
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index of the cell translation vector for each atom.
     integer, intent(in) :: iCellVec(:)
@@ -131,13 +131,13 @@ contains
     integer :: nOrb1, nOrb2
     real(dp) :: kPoint2p(3)
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == iAtomStart(nAtom+1) - 1)
     @:ASSERT(all(shape(kPoint) == [3]))
-    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
+    @:ASSERT(all(shape(nNeighbourSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
 
     square(:, :) = cmplx(0, 0, dp)
@@ -147,9 +147,9 @@ contains
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         iOrig = iPair(iNeigh, iAtom1) + 1
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
         @:ASSERT(jj >= ii)
@@ -171,7 +171,7 @@ contains
   !>
   !> Note: The non on-site blocks are only filled in the lower triangle part of the matrix. To fill
   !> the matrix completely, apply the blockSymmetrizeHS subroutine.
-  subroutine unpackHS_real(square, orig, iNeighbor, nNeighborSK, iAtomStart, iPair, img2CentCell)
+  subroutine unpackHS_real(square, orig, iNeighbour, nNeighbourSK, iAtomStart, iPair, img2CentCell)
 
     !> Square form matrix on exit.
     real(dp), intent(out) :: square(:, :)
@@ -179,11 +179,11 @@ contains
     !> Sparse matrix
     real(dp), intent(in) :: orig(:)
 
-    !> Neighbor list for each atom (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for each atom (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom (incl. itself).
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Atom offset for the squared Hamiltonian
     integer, intent(in) :: iAtomStart(:)
@@ -200,12 +200,12 @@ contains
     integer :: iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == iAtomStart(nAtom+1) - 1)
-    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
+    @:ASSERT(all(shape(nNeighbourSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
 
     square(:, :) = 0.0_dp
@@ -213,9 +213,9 @@ contains
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         iOrig = iPair(iNeigh, iAtom1) + 1
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
         @:ASSERT(jj >= ii)
@@ -232,7 +232,7 @@ contains
   !>
   !> Note: The non on-site blocks are only filled in the lower triangle part of the matrix. To fill
   !> the matrix completely, apply the blockSymmetrizeHS subroutine.
-  subroutine unpackHPauli(ham, kPoint, iNeighbor, nNeighborSK, iPair, iAtomStart, img2CentCell,&
+  subroutine unpackHPauli(ham, kPoint, iNeighbour, nNeighbourSK, iPair, iAtomStart, img2CentCell,&
       & iCellVec, cellVec, HSqrCplx, iHam)
 
     !> sparse hamiltonian
@@ -241,11 +241,11 @@ contains
     !> k-point at which to unpack
     real(dp), intent(in) :: kPoint(:)
 
-    !> Neighbor list for each atom (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for each atom (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom (incl. itself).
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> indexing array for the sparse Hamiltonian
     integer, intent(in) :: iPair(:, :)
@@ -280,12 +280,12 @@ contains
 
     ! 1 0 charge part
     ! 0 1
-    call unpackHS(work, ham(:, 1), kPoint, iNeighbor, nNeighborSK, iCellVec,&
+    call unpackHS(work, ham(:, 1), kPoint, iNeighbour, nNeighbourSK, iCellVec,&
         & cellVec, iAtomStart, iPair, img2CentCell)
     HSqrCplx(1:nOrb, 1:nOrb) = 0.5_dp*work(1:nOrb, 1:nOrb)
     HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb) = 0.5_dp*work(1:nOrb, 1:nOrb)
     if (present(iHam)) then
-      call unpackHS(work, iHam(:, 1), kPoint, iNeighbor, nNeighborSK, iCellVec,&
+      call unpackHS(work, iHam(:, 1), kPoint, iNeighbour, nNeighbourSK, iCellVec,&
           & cellVec, iAtomStart, iPair, img2CentCell)
       HSqrCplx(1:nOrb, 1:nOrb) = HSqrCplx(1:nOrb, 1:nOrb)&
           & + 0.5_dp*cmplx(0, 1, dp)*work(1:nOrb, 1:nOrb)
@@ -296,8 +296,8 @@ contains
 
     ! 0 1 x part
     ! 1 0
-    call unpackHS(work, ham(:, 2), kPoint, iNeighbor, nNeighborSK, iCellVec,&
-        & cellVec, iAtomStart, iPair, img2CentCell)
+    call unpackHS(work, ham(:, 2), kPoint, iNeighbour, nNeighbourSK, iCellVec, cellVec, iAtomStart,&
+        & iPair, img2CentCell)
     do ii = 1, nOrb
       work(ii, ii+1:) = conjg(work(ii+1:, ii))
     end do
@@ -305,28 +305,28 @@ contains
     HSqrCplx(nOrb+1:2*nOrb, 1:nOrb) = HSqrCplx(nOrb+1:2*nOrb, 1:nOrb)&
         & + 0.5_dp * work(1:nOrb, 1:nOrb)
     if (present(iHam)) then
-      call unpackHS(work, iHam(:, 2), kPoint, iNeighbor, nNeighborSK, iCellVec,&
-          & cellVec, iAtomStart, iPair, img2CentCell)
+      call unpackHS(work, iHam(:, 2), kPoint, iNeighbour, nNeighbourSK, iCellVec, cellVec,&
+          & iAtomStart, iPair, img2CentCell)
       do ii = 1, nOrb
         work(ii, ii+1:) = -conjg(work(ii+1:, ii))
       end do
-      HSqrCplx(nOrb+1:2*nOrb, 1:nOrb) = HSqrCplx(nOrb+1:2*nOrb, 1:nOrb) + 0.5_dp * cmplx(0, 1, dp)&
-          & * work(1:nOrb, 1:nOrb)
+      HSqrCplx(nOrb+1:2*nOrb, 1:nOrb) = HSqrCplx(nOrb+1:2*nOrb, 1:nOrb)&
+          & + 0.5_dp * cmplx(0, 1, dp) * work(1:nOrb, 1:nOrb)
     end if
 
     ! 0 -i y part
     ! i  0
-    call unpackHS(work, ham(:, 3), kPoint, iNeighbor, nNeighborSK, iCellVec,&
+    call unpackHS(work, ham(:, 3), kPoint, iNeighbour, nNeighbourSK, iCellVec,&
         & cellVec, iAtomStart, iPair, img2CentCell)
     do ii = 1, nOrb
       work(ii, ii+1:) = conjg(work(ii+1:, ii))
     end do
 
-    HSqrCplx(nOrb+1:2*nOrb, 1:nOrb) = HSqrCplx(nOrb+1:2*nOrb, 1:nOrb) + cmplx(0.0, 0.5, dp)&
-        & * work(1:nOrb, 1:nOrb)
+    HSqrCplx(nOrb+1:2*nOrb, 1:nOrb) = HSqrCplx(nOrb+1:2*nOrb, 1:nOrb)&
+        & + cmplx(0.0, 0.5, dp) * work(1:nOrb, 1:nOrb)
     if (present(iHam)) then
-      call unpackHS(work, iHam(:, 3), kPoint, iNeighbor, nNeighborSK, iCellVec,&
-          & cellVec, iAtomStart, iPair, img2CentCell)
+      call unpackHS(work, iHam(:, 3), kPoint, iNeighbour, nNeighbourSK, iCellVec, cellVec,&
+          & iAtomStart, iPair, img2CentCell)
       do ii = 1, nOrb
         work(ii, ii+1:) = -conjg(work(ii+1:, ii))
       end do
@@ -340,20 +340,18 @@ contains
 
     ! 1  0 z part
     ! 0 -1
-    call unpackHS(work, ham(:, 4), kPoint, iNeighbor, nNeighborSK, iCellVec,&
+    call unpackHS(work, ham(:, 4), kPoint, iNeighbour, nNeighbourSK, iCellVec,&
         & cellVec, iAtomStart, iPair, img2CentCell)
     HSqrCplx(1:nOrb, 1:nOrb) = HSqrCplx(1:nOrb, 1:nOrb)&
         & + 0.5_dp * work(1:nOrb, 1:nOrb)
-    HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb) =&
-        & HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb)&
+    HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb) = HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb)&
         & - 0.5_dp * work(1:nOrb, 1:nOrb)
     if (present(iHam)) then
-      call unpackHS(work, iHam(:, 4), kPoint, iNeighbor, nNeighborSK, iCellVec,&
+      call unpackHS(work, iHam(:, 4), kPoint, iNeighbour, nNeighbourSK, iCellVec,&
           & cellVec, iAtomStart, iPair, img2CentCell)
       HSqrCplx(1:nOrb, 1:nOrb) = HSqrCplx(1:nOrb, 1:nOrb)&
           & + 0.5_dp * cmplx(0, 1, dp) * work(1:nOrb, 1:nOrb)
-      HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb) =&
-          & HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb)&
+      HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb) = HSqrCplx(nOrb+1:2*nOrb, nOrb+1:2*nOrb)&
           & - 0.5_dp * cmplx(0, 1, dp) * work(1:nOrb, 1:nOrb)
     end if
 
@@ -364,7 +362,7 @@ contains
   !>
   !> Note: The non on-site blocks are only filled in the lower triangle part of the matrix. To fill
   !> the matrix completely, apply the blockSymmetrizeHS subroutine.
-  subroutine unpackSPauli(over, kPoint, iNeighbor, nNeighborSK, iAtomStart, iPair, img2CentCell,&
+  subroutine unpackSPauli(over, kPoint, iNeighbour, nNeighbourSK, iAtomStart, iPair, img2CentCell,&
       & iCellVec, cellVec, SSqrCplx)
 
     !> sparse overlap matrix
@@ -373,11 +371,11 @@ contains
     !> k-point at which to unpack
     real(dp), intent(in) :: kPoint(:)
 
-    !> Neighbor list for each atom (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for each atom (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom (incl. itself).
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Atom offset for the squared Hamiltonian
     integer, intent(in) :: iAtomStart(:)
@@ -403,7 +401,7 @@ contains
     nOrb = size(SSqrCplx, dim=1) / 2
     allocate(work(nOrb, nOrb))
     SSqrCplx(:, :) = 0.0_dp
-    call unpackHS(work, over, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec, iAtomStart,&
+    call unpackHS(work, over, kPoint, iNeighbour, nNeighbourSK, iCellVec, cellVec, iAtomStart,&
         & iPair, img2CentCell)
     SSqrCplx(1:nOrb, 1:nOrb) = work(1:nOrb, 1:nOrb)
     SSqrCplx(nOrb + 1 : 2 * nOrb, nOrb + 1 : 2 * nOrb) = work(1:nOrb, 1:nOrb)
@@ -412,7 +410,7 @@ contains
 
 
   !> Pack squared matrix in the sparse form (complex version).
-  subroutine packHS_cmplx(primitive, square, kPoint, kWeight, iNeighbor, nNeighborSK, mOrb,&
+  subroutine packHS_cmplx(primitive, square, kPoint, kWeight, iNeighbour, nNeighbourSK, mOrb,&
       & iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
 
     !> Sparse matrix
@@ -427,11 +425,11 @@ contains
     !> Weight of the K-point
     real(dp), intent(in) :: kweight
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -464,7 +462,7 @@ contains
     integer :: sizePrim
   #:endcall ASSERT_CODE
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
   #:call ASSERT_CODE
     sizePrim = size(primitive)
   #:endcall ASSERT_CODE
@@ -473,7 +471,7 @@ contains
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == iAtomStart(nAtom+1) - 1)
     @:ASSERT(all(shape(kPoint) == [3]))
-    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
+    @:ASSERT(all(shape(nNeighbourSK) == [nAtom]))
     @:ASSERT(kWeight > 0.0_dp)
     @:ASSERT(size(iAtomStart) == nAtom + 1)
 
@@ -483,9 +481,9 @@ contains
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         iOrig = iPair(iNeigh, iAtom1) + 1
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
         @:ASSERT(jj >= ii)
@@ -514,7 +512,7 @@ contains
 
 
   !> Pack squared matrix in the sparse form (real version).
-  subroutine packHS_real(primitive, square, iNeighbor, nNeighborSK, mOrb, iAtomStart, iPair,&
+  subroutine packHS_real(primitive, square, iNeighbour, nNeighbourSK, mOrb, iAtomStart, iPair,&
       & img2CentCell)
 
     !> Sparse matrix
@@ -523,11 +521,11 @@ contains
     !> Squared form matrix
     real(dp), intent(in) :: square(:, :)
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -551,7 +549,7 @@ contains
     integer :: sizePrim
   #:endcall ASSERT_CODE
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
   #:call ASSERT_CODE
     sizePrim = size(primitive)
   #:endcall ASSERT_CODE
@@ -559,14 +557,14 @@ contains
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == iAtomStart(nAtom+1) - 1)
-    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
+    @:ASSERT(all(shape(nNeighbourSK) == [nAtom]))
 
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         iOrig = iPair(iNeigh, iAtom1) + 1
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
         @:ASSERT(jj >= ii)
@@ -590,7 +588,7 @@ contains
 
 
   !> Pack squared matrix in the sparse form (real Pauli version).
-  subroutine packHSPauli(primitive, square, iNeighbor, nNeighborSK, mOrb, iAtomStart, iPair,&
+  subroutine packHSPauli(primitive, square, iNeighbour, nNeighbourSK, mOrb, iAtomStart, iPair,&
       & img2CentCell)
 
     !> Sparse matrix
@@ -599,11 +597,11 @@ contains
     !> Squared form matrix
     complex(dp), intent(in) :: square(:, :)
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -627,7 +625,7 @@ contains
     integer :: sizePrim
   #:endcall ASSERT_CODE
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
     ! number of orbitals in a regular spin block
     nOrb = (iAtomStart(nAtom+1) - 1)
 
@@ -638,7 +636,7 @@ contains
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == 2 * nOrb )
-    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
+    @:ASSERT(all(shape(nNeighbourSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
     @:ASSERT(size(primitive, dim=2)==4)
 
@@ -646,16 +644,15 @@ contains
       do iAtom1 = 1, nAtom
         ii = iAtomStart(iAtom1)
         nOrb1 = iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighborSK(iAtom1)
+        do iNeigh = 0, nNeighbourSK(iAtom1)
           iOrig = iPair(iNeigh, iAtom1) + 1
-          iAtom2 = iNeighbor(iNeigh, iAtom1)
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
           jj = iAtomStart(iAtom2f)
           @:ASSERT(jj >= ii)
           nOrb2 = iAtomStart(iAtom2f + 1) - jj
           tmpSqr(1:nOrb2, 1:nOrb1) =&
-              & square(jj+iBlock*nOrb:jj+nOrb2-1+iBlock*nOrb,&
-              & ii+iBlock*nOrb:ii+nOrb1-1+iBlock*nOrb)
+              & square(jj+iBlock*nOrb:jj+nOrb2-1+iBlock*nOrb, ii+iBlock*nOrb:ii+nOrb1-1+iBlock*nOrb)
           ! Hermitian the on-site block before packing, as only one triangle usually supplied
           if (iAtom1 == iAtom2f) then
             do kk = 1, nOrb2
@@ -677,9 +674,9 @@ contains
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         iOrig = iPair(iNeigh, iAtom1) + 1
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
         @:ASSERT(jj >= ii)
@@ -701,7 +698,7 @@ contains
 
 
   !> Pack squared matrix into the sparse form (complex Pauli version).
-  subroutine packHSPauli_kpts(primitive, square, kPoint, kWeight, iNeighbor, nNeighborSK, mOrb,&
+  subroutine packHSPauli_kpts(primitive, square, kPoint, kWeight, iNeighbour, nNeighbourSK, mOrb,&
       & iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
 
     !> Sparse matrix
@@ -716,11 +713,11 @@ contains
     !> Weight of the k-point
     real(dp), intent(in) :: kweight
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -753,7 +750,7 @@ contains
     integer :: sizePrim
   #:endcall ASSERT_CODE
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
     ! number of orbitals in a regular spin block
     nOrb = (iAtomStart(nAtom+1) - 1)
 
@@ -765,7 +762,7 @@ contains
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == 2 * nOrb )
     @:ASSERT(all(shape(kPoint) == [3]))
-    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
+    @:ASSERT(all(shape(nNeighbourSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
     @:ASSERT(kWeight > 0.0_dp)
     @:ASSERT(size(primitive, dim=2)==4)
@@ -779,9 +776,9 @@ contains
       do iAtom1 = 1, nAtom
         ii = iAtomStart(iAtom1)
         nOrb1 = iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighborSK(iAtom1)
+        do iNeigh = 0, nNeighbourSK(iAtom1)
           iOrig = iPair(iNeigh, iAtom1) + 1
-          iAtom2 = iNeighbor(iNeigh, iAtom1)
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
           jj = iAtomStart(iAtom2f)
           @:ASSERT(jj >= ii)
@@ -802,13 +799,11 @@ contains
           @:ASSERT(sizePrim >= iOrig + nOrb1*nOrb2 - 1)
           primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 1) =&
               & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 1)&
-              & + kWeight * 0.5_dp*reshape(real(phase*&
-              & tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1*nOrb2])
+              & + kWeight * 0.5_dp*reshape(real(phase* tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1*nOrb2])
           primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 4) =&
               & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 4)&
               & + real(1-2*iBlock, dp) *&
-              & kWeight * 0.5_dp*reshape(&
-              & real(phase*tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1*nOrb2])
+              & kWeight * 0.5_dp*reshape(real(phase*tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1*nOrb2])
         end do
       end do
     end do
@@ -819,9 +814,9 @@ contains
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         iOrig = iPair(iNeigh, iAtom1) + 1
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
         @:ASSERT(jj >= ii)
@@ -863,7 +858,7 @@ contains
 
 
   !> Pack imaginary coefficient part of Pauli square matrix into the sparse form.
-  subroutine packHSPauliImag(primitive, square, iNeighbor, nNeighborSK, mOrb, iAtomStart, iPair,&
+  subroutine packHSPauliImag(primitive, square, iNeighbour, nNeighbourSK, mOrb, iAtomStart, iPair,&
       & img2CentCell)
 
     !> Sparse matrix
@@ -872,11 +867,11 @@ contains
     !> Squared form matrix
     complex(dp), intent(in) :: square(:, :)
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -900,7 +895,7 @@ contains
     integer :: sizePrim
   #:endcall ASSERT_CODE
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
     ! number of orbitals in a regular spin block
     nOrb = (iAtomStart(nAtom+1) - 1)
 
@@ -912,7 +907,7 @@ contains
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == 2 * nOrb )
-    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
+    @:ASSERT(all(shape(nNeighbourSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
     @:ASSERT(size(primitive, dim=2)==4)
 
@@ -920,9 +915,9 @@ contains
       do iAtom1 = 1, nAtom
         ii = iAtomStart(iAtom1)
         nOrb1 = iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighborSK(iAtom1)
+        do iNeigh = 0, nNeighbourSK(iAtom1)
           iOrig = iPair(iNeigh, iAtom1) + 1
-          iAtom2 = iNeighbor(iNeigh, iAtom1)
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
           jj = iAtomStart(iAtom2f)
           @:ASSERT(jj >= ii)
@@ -950,9 +945,9 @@ contains
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         iOrig = iPair(iNeigh, iAtom1) + 1
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
         @:ASSERT(jj >= ii)
@@ -968,7 +963,7 @@ contains
         ! sigma_y : i * i = -1 use - real part of block
         primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 3) =&
             & primitive(iOrig : iOrig + nOrb1*nOrb2 - 1, 3)&
-            & -reshape(real(tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1 * nOrb2])
+            & - reshape(real(tmpSqr(1:nOrb2, 1:nOrb1)), [nOrb1 * nOrb2])
       end do
     end do
 
@@ -976,7 +971,7 @@ contains
 
 
   !> Pack imaginary coefficient part of Pauli square matrix into the sparse form (complex version).
-  subroutine packHSPauliImag_kpts(primitive, square, kPoint, kWeight, iNeighbor, nNeighborSK,&
+  subroutine packHSPauliImag_kpts(primitive, square, kPoint, kWeight, iNeighbour, nNeighbourSK,&
       & mOrb, iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
 
     !> Sparse matrix
@@ -991,11 +986,11 @@ contains
     !> Weight of the K-point
     real(dp), intent(in) :: kweight
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -1028,7 +1023,7 @@ contains
     integer :: sizePrim
   #:endcall ASSERT_CODE
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
     ! number of orbitals in a regular spin block
     nOrb = (iAtomStart(nAtom+1) - 1)
 
@@ -1040,7 +1035,7 @@ contains
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == 2 * nOrb )
     @:ASSERT(all(shape(kPoint) == [3]))
-    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
+    @:ASSERT(all(shape(nNeighbourSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
     @:ASSERT(kWeight > 0.0_dp)
     @:ASSERT(size(primitive, dim=2)==4)
@@ -1054,9 +1049,9 @@ contains
       do iAtom1 = 1, nAtom
         ii = iAtomStart(iAtom1)
         nOrb1 = iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighborSK(iAtom1)
+        do iNeigh = 0, nNeighbourSK(iAtom1)
           iOrig = iPair(iNeigh, iAtom1) + 1
-          iAtom2 = iNeighbor(iNeigh, iAtom1)
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
           jj = iAtomStart(iAtom2f)
           @:ASSERT(jj >= ii)
@@ -1093,9 +1088,9 @@ contains
     do iAtom1 = 1, nAtom
       ii = iAtomStart(iAtom1)
       nOrb1 = iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         iOrig = iPair(iNeigh, iAtom1) + 1
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = iAtomStart(iAtom2f)
         @:ASSERT(jj >= ii)
@@ -1131,7 +1126,7 @@ contains
 
 
   !> Pack only the charge (spin channel 1) part of a 2 component matrix
-  subroutine packHSPauliERho(primitive, square, iNeighbor, nNeighborSK, mOrb, iAtomStart, iPair,&
+  subroutine packHSPauliERho(primitive, square, iNeighbour, nNeighbourSK, mOrb, iAtomStart, iPair,&
       & img2CentCell)
 
     !> Sparse matrix
@@ -1140,11 +1135,11 @@ contains
     !> Squared form matrix
     complex(dp), intent(in) :: square(:, :)
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -1168,7 +1163,7 @@ contains
     integer :: sizePrim
   #:endcall ASSERT_CODE
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
     ! number of orbitals in a regular spin block
     nOrb = (iAtomStart(nAtom+1) - 1)
 
@@ -1179,16 +1174,16 @@ contains
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == 2 * nOrb )
-    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
+    @:ASSERT(all(shape(nNeighbourSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
 
     do iBlock = 0, 1
       do iAtom1 = 1, nAtom
         ii = iAtomStart(iAtom1)
         nOrb1 = iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighborSK(iAtom1)
+        do iNeigh = 0, nNeighbourSK(iAtom1)
           iOrig = iPair(iNeigh, iAtom1) + 1
-          iAtom2 = iNeighbor(iNeigh, iAtom1)
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
           jj = iAtomStart(iAtom2f)
           @:ASSERT(jj >= ii)
@@ -1212,7 +1207,7 @@ contains
 
 
   !> Pack squared matrix in the sparse form (real version).
-  subroutine packHSPauliERho_kpts(primitive, square, kPoint, kWeight, iNeighbor, nNeighborSK,&
+  subroutine packHSPauliERho_kpts(primitive, square, kPoint, kWeight, iNeighbour, nNeighbourSK,&
       & mOrb, iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
 
     !> Sparse matrix
@@ -1227,11 +1222,11 @@ contains
     !> weight for the k-point
     real(dp), intent(in) :: kweight
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -1264,7 +1259,7 @@ contains
     integer :: sizePrim
   #:endcall ASSERT_CODE
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
     ! number of orbitals in a regular spin block
     nOrb = (iAtomStart(nAtom+1) - 1)
 
@@ -1276,7 +1271,7 @@ contains
     @:ASSERT(size(square, dim=1) == size(square, dim=2))
     @:ASSERT(size(square, dim=1) == 2 * nOrb )
     @:ASSERT(all(shape(kPoint) == [3]))
-    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
+    @:ASSERT(all(shape(nNeighbourSK) == [nAtom]))
     @:ASSERT(size(iAtomStart) == nAtom + 1)
     @:ASSERT(kWeight > 0.0_dp)
 
@@ -1288,9 +1283,9 @@ contains
       do iAtom1 = 1, nAtom
         ii = iAtomStart(iAtom1)
         nOrb1 = iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighborSK(iAtom1)
+        do iNeigh = 0, nNeighbourSK(iAtom1)
           iOrig = iPair(iNeigh, iAtom1) + 1
-          iAtom2 = iNeighbor(iNeigh, iAtom1)
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
           jj = iAtomStart(iAtom2f)
           @:ASSERT(jj >= ii)
@@ -1439,7 +1434,7 @@ contains
   !>
   !> Note: In contrast to the serial routines, both triangles of the resulting matrix are filled.
   !>
-  subroutine unpackHSRealBlacs(myBlacs, orig, iNeighbor, nNeighborSK, iPair, img2CentCell, desc,&
+  subroutine unpackHSRealBlacs(myBlacs, orig, iNeighbour, nNeighbourSK, iPair, img2CentCell, desc,&
       & square)
 
     !> BLACS matrix descriptor
@@ -1448,11 +1443,11 @@ contains
     !> sparse matrix
     real(dp), intent(in) :: orig(:)
 
-    !> Neighbor list for each atom (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for each atom (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom (incl. itself).
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> indexing array for the sparse Hamiltonian
     integer, intent(in) :: iPair(0:, :)
@@ -1471,10 +1466,10 @@ contains
     integer :: iNeigh
     integer :: iAtom1, iAtom2, iAtom2f
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
 
     @:ASSERT(nAtom > 0)
-    @:ASSERT(size(nNeighborSK) == nAtom)
+    @:ASSERT(size(nNeighbourSK) == nAtom)
     @:ASSERT(size(desc%iAtomStart) == nAtom + 1)
 
     square(:, :) = 0.0_dp
@@ -1482,9 +1477,9 @@ contains
     do iAtom1 = 1, nAtom
       ii = desc%iAtomStart(iAtom1)
       nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         iOrig = iPair(iNeigh, iAtom1) + 1
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = desc%iAtomStart(iAtom2f)
         nOrb2 = desc%iAtomStart(iAtom2f + 1) - jj
@@ -1506,7 +1501,7 @@ contains
   !>
   !> Note: In contrast to the serial routines, both triangles of the resulting matrix are filled.
   !>
-  subroutine unpackHSCplxBlacs(myBlacs, orig, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec,&
+  subroutine unpackHSCplxBlacs(myBlacs, orig, kPoint, iNeighbour, nNeighbourSK, iCellVec, cellVec,&
       & iPair, img2CentCell, desc, square)
 
     !> BLACS matrix descriptor
@@ -1518,11 +1513,11 @@ contains
     !> Relative coordinates of the K-point where the sparse matrix should be unfolded.
     real(dp), intent(in) :: kPoint(:)
 
-    !> Neighbor list for each atom (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for each atom (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for each atom (incl. itself).
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom (incl. itself).
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index of the cell translation vector for each atom.
     integer, intent(in) :: iCellVec(:)
@@ -1550,11 +1545,11 @@ contains
     integer :: iAtom1, iAtom2, iAtom2f
     real(dp) :: kPoint2p(3)
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(kPoint) == 3)
-    @:ASSERT(size(nNeighborSK) == nAtom)
+    @:ASSERT(size(nNeighbourSK) == nAtom)
     @:ASSERT(size(desc%iAtomStart) == nAtom + 1)
 
     square(:, :) = cmplx(0, 0, dp)
@@ -1564,9 +1559,9 @@ contains
     do iAtom1 = 1, nAtom
       ii = desc%iAtomStart(iAtom1)
       nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         iOrig = iPair(iNeigh, iAtom1) + 1
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = desc%iAtomStart(iAtom2f)
         nOrb2 = desc%iAtomStart(iAtom2f + 1) - jj
@@ -1593,7 +1588,7 @@ contains
   !>
   !> Note: In contrast to the serial routines, both triangles of the resulting matrix are filled.
   !>
-  subroutine unpackHPauliBlacs(myBlacs, orig, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec,&
+  subroutine unpackHPauliBlacs(myBlacs, orig, kPoint, iNeighbour, nNeighbourSK, iCellVec, cellVec,&
       & iPair, img2CentCell, mOrb, desc, square, iorig)
 
     !> BLACS matrix descriptor
@@ -1605,11 +1600,11 @@ contains
     !> Relative coordinates of the K-point where the sparse matrix should be unfolded.
     real(dp), intent(in) :: kPoint(:)
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index of the cell translation vector for each atom.
     integer, intent(in) :: iCellVec(:)
@@ -1636,10 +1631,10 @@ contains
     real(dp), intent(in), optional :: iorig(:, :)
 
     square(:, :) = cmplx(0, 0, dp)
-    call unpackHPauliBlacsHelper(myBlacs, orig, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec,&
-        & iPair, img2CentCell, mOrb, cmplx(1, 0, dp), cmplx(1, 0, dp), desc, square)
+    call unpackHPauliBlacsHelper(myBlacs, orig, kPoint, iNeighbour, nNeighbourSK, iCellVec,&
+        & cellVec, iPair, img2CentCell, mOrb, cmplx(1, 0, dp), cmplx(1, 0, dp), desc, square)
     if (present(iorig)) then
-      call unpackHPauliBlacsHelper(myBlacs, iorig, kPoint, iNeighbor, nNeighborSK, iCellVec,&
+      call unpackHPauliBlacsHelper(myBlacs, iorig, kPoint, iNeighbour, nNeighbourSK, iCellVec,&
           & cellVec, iPair, img2CentCell, mOrb, cmplx(0, 1, dp), cmplx(-1, 0, dp), desc, square)
     end if
 
@@ -1651,7 +1646,7 @@ contains
   !! The routine creates the lower triangle of the 2x2 Pauli Hamiltonian
   !! 1*orig(:, 1) + sigma1*orig(:, 2) + sigma2*orig(:, 3) + sigma3*orig(:, 4).
   !!
-  subroutine unpackHPauliBlacsHelper(myBlacs, orig, kPoint, iNeighbor, nNeighborSK, iCellVec,&
+  subroutine unpackHPauliBlacsHelper(myBlacs, orig, kPoint, iNeighbour, nNeighbourSK, iCellVec,&
       & cellVec, iPair, img2CentCell, mOrb, imagPrefac, hermPrefac, desc, square)
 
     !> BLACS matrix descriptor
@@ -1663,11 +1658,11 @@ contains
     !> k-point at which to unpack
     real(dp), intent(in) :: kPoint(:)
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index of the cell translation vector for each atom.
     integer, intent(in) :: iCellVec(:)
@@ -1703,7 +1698,7 @@ contains
     real(dp) :: kPoint2p(3)
     complex(dp) :: phase
 
-    nAtom = size(nNeighborSK)
+    nAtom = size(nNeighbourSK)
     nOrb = desc%iAtomStart(nAtom + 1) - 1
     kPoint2p(:) = 2.0_dp * pi * kPoint
     iOldVec = 0
@@ -1711,9 +1706,9 @@ contains
     do iAtom1 = 1, nAtom
       ii = desc%iAtomStart(iAtom1)
       nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         iOrig = iPair(iNeigh, iAtom1) + 1
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = desc%iAtomStart(iAtom2f)
         nOrb2 = desc%iAtomStart(iAtom2f + 1) - jj
@@ -1775,7 +1770,7 @@ contains
   !>
   !> Note: In contrast to the serial routines, both triangles of the resulting matrix are filled.
   !>
-  subroutine unpackSPauliBlacs(myBlacs, orig, kPoint, iNeighbor, nNeighborSK, iCellVec, cellVec,&
+  subroutine unpackSPauliBlacs(myBlacs, orig, kPoint, iNeighbour, nNeighbourSK, iCellVec, cellVec,&
       & iPair, img2CentCell, mOrb, desc, square)
 
     !> BLACS matrix descriptor
@@ -1787,11 +1782,11 @@ contains
     !> k-point at which to unpack
     real(dp), intent(in) :: kPoint(:)
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index of the cell translation vector for each atom.
     integer, intent(in) :: iCellVec(:)
@@ -1822,7 +1817,7 @@ contains
     complex(dp) :: phase
 
     square(:, :) = (0.0_dp, 0.0_dp)
-    nAtom = size(nNeighborSK)
+    nAtom = size(nNeighbourSK)
     nOrb = desc%iAtomStart(nAtom + 1) - 1
     kPoint2p(:) = 2.0_dp * pi * kPoint
     iOldVec = 0
@@ -1830,9 +1825,9 @@ contains
     do iAtom1 = 1, nAtom
       ii = desc%iAtomStart(iAtom1)
       nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         iOrig = iPair(iNeigh, iAtom1) + 1
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = desc%iAtomStart(iAtom2f)
         nOrb2 = desc%iAtomStart(iAtom2f + 1) - jj
@@ -1861,7 +1856,7 @@ contains
 
 
   !> Packs distributed dense real matrix into sparse form (real).
-  subroutine packRhoRealBlacs(myBlacs, desc, square, iNeighbor, nNeighborSK, mOrb, iPair,&
+  subroutine packRhoRealBlacs(myBlacs, desc, square, iNeighbour, nNeighbourSK, mOrb, iPair,&
       & img2CentCell, primitive)
 
     !> BLACS matrix descriptor
@@ -1873,11 +1868,11 @@ contains
     !> distributed dense matrix to pack
     real(dp), intent(in) :: square(:, :)
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -1901,19 +1896,19 @@ contains
     integer :: sizePrim
   #:endcall ASSERT_CODE
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
   #:call ASSERT_CODE
     sizePrim = size(primitive)
   #:endcall ASSERT_CODE
     @:ASSERT(nAtom > 0)
-    @:ASSERT(size(nNeighborSK) == nAtom)
+    @:ASSERT(size(nNeighbourSK) == nAtom)
 
     do iAtom1 = 1, nAtom
       ii = desc%iAtomStart(iAtom1)
       nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         iOrig = iPair(iNeigh, iAtom1) + 1
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = desc%iAtomStart(iAtom2f)
         nOrb2 = desc%iAtomStart(iAtom2f + 1) - jj
@@ -1937,8 +1932,8 @@ contains
 
 
   !> Packs distributed dense real matrix into sparse form (real).
-  subroutine packRhoCplxBlacs(myblacs, desc, square, kPoint, kWeight, iNeighbor, nNeighborSK, mOrb,&
-      & iCellVec, cellVec, iPair, img2CentCell, primitive)
+  subroutine packRhoCplxBlacs(myblacs, desc, square, kPoint, kWeight, iNeighbour, nNeighbourSK,&
+      & mOrb, iCellVec, cellVec, iPair, img2CentCell, primitive)
 
     !> BLACS matrix descriptor
     type(TBlacsEnv), intent(in) :: myBlacs
@@ -1955,11 +1950,11 @@ contains
     !> weight for this k-point
     real(dp), intent(in) :: kWeight
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -1992,14 +1987,14 @@ contains
     integer :: sizePrim
   #:endcall ASSERT_CODE
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
   #:call ASSERT_CODE
     sizePrim = size(primitive)
   #:endcall ASSERT_CODE
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(size(kPoint) == 3)
-    @:ASSERT(size(nNeighborSK) == nAtom)
+    @:ASSERT(size(nNeighbourSK) == nAtom)
     @:ASSERT(kWeight > 0.0_dp)
     @:ASSERT(size(desc%iAtomStart) == nAtom + 1)
 
@@ -2009,9 +2004,9 @@ contains
     do iAtom1 = 1, nAtom
       ii = desc%iAtomStart(iAtom1)
       nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         iOrig = iPair(iNeigh, iAtom1) + 1
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = desc%iAtomStart(iAtom2f)
         nOrb2 = desc%iAtomStart(iAtom2f + 1) - jj
@@ -2040,7 +2035,7 @@ contains
 
 
   !> Pack squared matrix into the sparse form (complex Pauli version).
-  subroutine packRhoPauliBlacs(myBlacs, desc, square, kPoint, kWeight, iNeighbor, nNeighborSK,&
+  subroutine packRhoPauliBlacs(myBlacs, desc, square, kPoint, kWeight, iNeighbour, nNeighbourSK,&
       & mOrb, iCellVec, cellVec, iPair, img2CentCell, primitive, iprimitive)
 
     !> BLACS matrix descriptor
@@ -2058,11 +2053,11 @@ contains
     !> weight for this k-point
     real(dp), intent(in) :: kWeight
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -2085,19 +2080,20 @@ contains
     !> Imaginary part of sparse matrix
     real(dp), intent(inout), optional :: iprimitive(:, :)
 
-    call packRhoPauliBlacsHelper(myBlacs, desc, square, kPoint, kWeight, iNeighbor, nNeighborSK,&
+    call packRhoPauliBlacsHelper(myBlacs, desc, square, kPoint, kWeight, iNeighbour, nNeighbourSK,&
         & mOrb, iCellVec, cellVec, iPair, img2CentCell, cmplx(1, 0, dp), .true., primitive)
     if (present(iprimitive)) then
-      call packRhoPauliBlacsHelper(myBlacs, desc, square, kPoint, kWeight, iNeighbor, nNeighborSK,&
-          & mOrb, iCellVec, cellVec, iPair, img2CentCell, cmplx(0, -1, dp), .false., iprimitive)
+      call packRhoPauliBlacsHelper(myBlacs, desc, square, kPoint, kWeight, iNeighbour,&
+          & nNeighbourSK, mOrb, iCellVec, cellVec, iPair, img2CentCell, cmplx(0, -1, dp), .false.,&
+          & iprimitive)
     end if
 
   end subroutine packRhoPauliBlacs
 
 
   !> Helper routine for the Pauli packing.
-  subroutine packRhoPauliBlacsHelper(myBlacs, desc, square, kPoint, kWeight, iNeighbor,&
-      & nNeighborSK, mOrb, iCellVec, cellVec, iPair, img2CentCell, imagprefac, symmetrize,&
+  subroutine packRhoPauliBlacsHelper(myBlacs, desc, square, kPoint, kWeight, iNeighbour,&
+      & nNeighbourSK, mOrb, iCellVec, cellVec, iPair, img2CentCell, imagprefac, symmetrize,&
       & primitive)
 
     !> BLACS matrix descriptor
@@ -2115,11 +2111,11 @@ contains
     !> weight for this k-point
     real(dp), intent(in) :: kWeight
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -2161,7 +2157,7 @@ contains
     integer :: sizePrim
   #:endcall ASSERT_CODE
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
     ! number of orbitals in a regular spin block
     nOrb = desc%iAtomStart(nAtom + 1) - 1
 
@@ -2171,7 +2167,7 @@ contains
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(all(shape(kPoint) == [3]))
-    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
+    @:ASSERT(all(shape(nNeighbourSK) == [nAtom]))
     @:ASSERT(size(desc%iAtomStart) == nAtom + 1)
     @:ASSERT(kWeight > 0.0_dp)
     @:ASSERT(size(primitive, dim=2) == 4)
@@ -2186,9 +2182,9 @@ contains
       do iAtom1 = 1, nAtom
         ii = desc%iAtomStart(iAtom1)
         nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighborSK(iAtom1)
+        do iNeigh = 0, nNeighbourSK(iAtom1)
           iOrig = iPair(iNeigh, iAtom1) + 1
-          iAtom2 = iNeighbor(iNeigh, iAtom1)
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
           jj = desc%iAtomStart(iAtom2f)
           nOrb2 = desc%iAtomStart(iAtom2f + 1) - jj
@@ -2224,9 +2220,9 @@ contains
     do iAtom1 = 1, nAtom
       ii = desc%iAtomStart(iAtom1)
       nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-      do iNeigh = 0, nNeighborSK(iAtom1)
+      do iNeigh = 0, nNeighbourSK(iAtom1)
         iOrig = iPair(iNeigh, iAtom1) + 1
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         jj = desc%iAtomStart(iAtom2f)
         nOrb2 = desc%iAtomStart(iAtom2f + 1) - jj
@@ -2268,7 +2264,7 @@ contains
 
 
   !> Pack only the charge (spin channel 1) part of a 2 component matrix.
-  subroutine packERhoPauliBlacs(myBlacs, desc, square, kPoint, kWeight, iNeighbor, nNeighborSK,&
+  subroutine packERhoPauliBlacs(myBlacs, desc, square, kPoint, kWeight, iNeighbour, nNeighbourSK,&
       & mOrb, iCellVec, cellVec, iPair, img2CentCell, primitive)
 
     !> BLACS matrix descriptor
@@ -2286,11 +2282,11 @@ contains
     !> weight at this k-point
     real(dp), intent(in) :: kWeight
 
-    !> Neighbor list for the atoms (First index from 0!)
-    integer, intent(in) :: iNeighbor(0:, :)
+    !> Neighbour list for the atoms (First index from 0!)
+    integer, intent(in) :: iNeighbour(0:, :)
 
-    !> Nr. of neighbors for the atoms.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for the atoms.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Maximal number of orbitals on an atom.
     integer, intent(in) :: mOrb
@@ -2321,7 +2317,7 @@ contains
     integer :: sizePrim
   #:endcall ASSERT_CODE
 
-    nAtom = size(iNeighbor, dim=2)
+    nAtom = size(iNeighbour, dim=2)
     ! number of orbitals in a regular spin block
     nOrb = desc%iAtomStart(nAtom + 1) - 1
 
@@ -2331,7 +2327,7 @@ contains
 
     @:ASSERT(nAtom > 0)
     @:ASSERT(all(shape(kPoint) == [3]))
-    @:ASSERT(all(shape(nNeighborSK) == [nAtom]))
+    @:ASSERT(all(shape(nNeighbourSK) == [nAtom]))
     @:ASSERT(size(desc%iAtomStart) == nAtom + 1)
     @:ASSERT(kWeight > 0.0_dp)
 
@@ -2343,9 +2339,9 @@ contains
       do iAtom1 = 1, nAtom
         ii = desc%iAtomStart(iAtom1)
         nOrb1 = desc%iAtomStart(iAtom1 + 1) - ii
-        do iNeigh = 0, nNeighborSK(iAtom1)
+        do iNeigh = 0, nNeighbourSK(iAtom1)
           iOrig = iPair(iNeigh, iAtom1) + 1
-          iAtom2 = iNeighbor(iNeigh, iAtom1)
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
           iAtom2f = img2CentCell(iAtom2)
           jj = desc%iAtomStart(iAtom2f)
           @:ASSERT(jj >= ii)

--- a/prog/dftb+/lib_dftb/stress.F90
+++ b/prog/dftb+/lib_dftb/stress.F90
@@ -27,7 +27,7 @@ contains
 
 
   !> The stress tensor contribution from the repulsive energy term
-  subroutine getRepulsiveStress(st, coords, nNeighborSK, iNeighbors, species, img2CentCell,&
+  subroutine getRepulsiveStress(st, coords, nNeighbourSK, iNeighbours, species, img2CentCell,&
       & repCont, cellVol)
 
     !> stress tensor
@@ -36,11 +36,11 @@ contains
     !> coordinates (x,y,z, all atoms including possible images)
     real(dp), intent(in) :: coords(:,:)
 
-    !> Number of neighbors for atoms in the central cell
-    integer, intent(in) :: nNeighborSK(:)
+    !> Number of neighbours for atoms in the central cell
+    integer, intent(in) :: nNeighbourSK(:)
 
-    !> Index of neighbors for a given atom.
-    integer, intent(in) :: iNeighbors(0:,:)
+    !> Index of neighbours for a given atom.
+    integer, intent(in) :: iNeighbours(0:,:)
 
     !> Species of atoms in the central cell.
     integer, intent(in) :: species(:)
@@ -59,12 +59,12 @@ contains
 
     @:ASSERT(all(shape(st) == [3, 3]))
 
-    nAtom = size(nNeighborSK)
+    nAtom = size(nNeighbourSK)
     st(:,:) = 0.0_dp
 
     do iAt1 = 1, nAtom
-      do iNeigh = 1, nNeighborSK(iAt1)
-        iAt2 = iNeighbors(iNeigh,iAt1)
+      do iNeigh = 1, nNeighbourSK(iAt1)
+        iAt2 = iNeighbours(iNeigh,iAt1)
         iAt2f = img2CentCell(iAt2)
         vect(:) = coords(:,iAt1) - coords(:,iAt2)
         call getEnergyDeriv(repCont, intermed, vect, species(iAt1), species(iAt2))
@@ -125,7 +125,7 @@ contains
 
   !> The stress tensor contributions from the non-SCC energy
   subroutine getNonSCCStress(env, st, derivator, DM, EDM, skHamCont, skOverCont, coords, species,&
-      & iNeighbor, nNeighborSK, img2CentCell, iPair, orb, cellVol)
+      & iNeighbour, nNeighbourSK, img2CentCell, iPair, orb, cellVol)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -154,11 +154,11 @@ contains
     !> list of all atomic species
     integer, intent(in) :: species(:)
 
-    !> neighbor list for atoms
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> neighbour list for atoms
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> number of neighbors of each atom
-    integer, intent(in) :: nNeighborSK(:)
+    !> number of neighbours of each atom
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> indexing array for periodic image atoms
     integer, intent(in) :: img2CentCell(:)
@@ -191,8 +191,8 @@ contains
     do iAtom1 = iAtFirst, iAtLast
       nOrb1 = orb%nOrbAtom(iAtom1)
       ! loop from 1 as no contribution from the atom itself
-      do iNeigh = 1, nNeighborSK(iAtom1)
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+      do iNeigh = 1, nNeighbourSK(iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         nOrb2 = orb%nOrbAtom(iAtom2f)
         iOrig = iPair(iNeigh,iAtom1)
@@ -235,7 +235,7 @@ contains
 
   !> The stress tensor contributions from a potential
   subroutine getBlockStress(env, st, derivator, DM, EDM, skHamCont, skOverCont, coords, species,&
-      & iNeighbor, nNeighborSK, img2CentCell, iPair, orb, shift, cellVol)
+      & iNeighbour, nNeighbourSK, img2CentCell, iPair, orb, shift, cellVol)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -261,14 +261,14 @@ contains
     !> list of all atomic species
     real(dp), intent(in) :: coords(:,:)
 
-    !> neighbor list for atoms
+    !> neighbour list for atoms
     integer, intent(in) :: species(:)
 
-    !> number of neighbors of each atom
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> number of neighbours of each atom
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> number of real atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> indexing array for periodic image atoms
     integer, intent(in) :: img2CentCell(:)
@@ -312,8 +312,8 @@ contains
     do iAtom1 = iAtFirst, iAtLast
       iSp1 = species(iAtom1)
       nOrb1 = orb%nOrbSpecies(iSp1)
-      do iNeigh = 1, nNeighborSK(iAtom1)
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+      do iNeigh = 1, nNeighbourSK(iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         iSp2 = species(iAtom2f)
         if (iAtom1 /= iAtom2) then
@@ -328,7 +328,7 @@ contains
           do ii = 1, 3
             ! note factor of 2 for implicit summation over lower triangle of density matrix:
             intermed(ii) = 2.0_dp * (sum(sqrDMTmp(1:nOrb2,1:nOrb1)*hPrimeTmp(1:nOrb2,1:nOrb1,ii))&
-                & -sum(sqrEDMTmp(1:nOrb2,1:nOrb1)*sPrimeTmp(1:nOrb2,1:nOrb1,ii)))
+                & - sum(sqrEDMTmp(1:nOrb2,1:nOrb1)*sPrimeTmp(1:nOrb2,1:nOrb1,ii)))
           end do
 
           do iSpin = 1, nSpin
@@ -370,7 +370,7 @@ contains
 
   !> The stress tensor contributions from a complex potential
   subroutine getBlockiStress(env, st, derivator, DM, iDM, EDM, skHamCont, skOverCont, coords,&
-      & species, iNeighbor, nNeighborSK, img2CentCell, iPair, orb, shift, iShift, cellVol)
+      & species, iNeighbour, nNeighbourSK, img2CentCell, iPair, orb, shift, iShift, cellVol)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -399,14 +399,14 @@ contains
     !> list of all atomic species
     real(dp), intent(in) :: coords(:,:)
 
-    !> neighbor list for atoms
+    !> neighbour list for atoms
     integer, intent(in) :: species(:)
 
-    !> number of neighbors of each atom
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> number of neighbours of each atom
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> number of real atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> indexing array for periodic image atoms
     integer, intent(in) :: img2CentCell(:)
@@ -453,8 +453,8 @@ contains
     do iAtom1 = iAtFirst, iAtLast
       iSp1 = species(iAtom1)
       nOrb1 = orb%nOrbSpecies(iSp1)
-      do iNeigh = 1, nNeighborSK(iAtom1)
-        iAtom2 = iNeighbor(iNeigh, iAtom1)
+      do iNeigh = 1, nNeighbourSK(iAtom1)
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         iSp2 = species(iAtom2f)
         if (iAtom1 /= iAtom2) then
@@ -469,7 +469,7 @@ contains
           do ii = 1, 3
             ! again factor of 2 from lower triangle sum of DM
             intermed(ii) = 2.0_dp * (sum(sqrDMTmp(1:nOrb2,1:nOrb1)*hPrimeTmp(1:nOrb2,1:nOrb1,ii))&
-                & -sum(sqrEDMTmp(1:nOrb2,1:nOrb1)*sPrimeTmp(1:nOrb2,1:nOrb1,ii)))
+                & - sum(sqrEDMTmp(1:nOrb2,1:nOrb1)*sPrimeTmp(1:nOrb2,1:nOrb1,ii)))
           end do
 
           do iSpin = 1, nSpin

--- a/prog/dftb+/lib_dftb/stress.F90
+++ b/prog/dftb+/lib_dftb/stress.F90
@@ -27,7 +27,7 @@ contains
 
 
   !> The stress tensor contribution from the repulsive energy term
-  subroutine getRepulsiveStress(st, coords, nNeighbors, iNeighbors, species, img2CentCell,&
+  subroutine getRepulsiveStress(st, coords, nNeighborSK, iNeighbors, species, img2CentCell,&
       & repCont, cellVol)
 
     !> stress tensor
@@ -37,7 +37,7 @@ contains
     real(dp), intent(in) :: coords(:,:)
 
     !> Number of neighbors for atoms in the central cell
-    integer, intent(in) :: nNeighbors(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index of neighbors for a given atom.
     integer, intent(in) :: iNeighbors(0:,:)
@@ -59,11 +59,11 @@ contains
 
     @:ASSERT(all(shape(st) == [3, 3]))
 
-    nAtom = size(nNeighbors)
+    nAtom = size(nNeighborSK)
     st(:,:) = 0.0_dp
 
     do iAt1 = 1, nAtom
-      do iNeigh = 1, nNeighbors(iAt1)
+      do iNeigh = 1, nNeighborSK(iAt1)
         iAt2 = iNeighbors(iNeigh,iAt1)
         iAt2f = img2CentCell(iAt2)
         vect(:) = coords(:,iAt1) - coords(:,iAt2)
@@ -125,7 +125,7 @@ contains
 
   !> The stress tensor contributions from the non-SCC energy
   subroutine getNonSCCStress(env, st, derivator, DM, EDM, skHamCont, skOverCont, coords, species,&
-      & iNeighbor, nNeighbor, img2CentCell, iPair, orb, cellVol)
+      & iNeighbor, nNeighborSK, img2CentCell, iPair, orb, cellVol)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -158,7 +158,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> number of neighbors of each atom
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> indexing array for periodic image atoms
     integer, intent(in) :: img2CentCell(:)
@@ -191,7 +191,7 @@ contains
     do iAtom1 = iAtFirst, iAtLast
       nOrb1 = orb%nOrbAtom(iAtom1)
       ! loop from 1 as no contribution from the atom itself
-      do iNeigh = 1, nNeighbor(iAtom1)
+      do iNeigh = 1, nNeighborSK(iAtom1)
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         nOrb2 = orb%nOrbAtom(iAtom2f)
@@ -235,7 +235,7 @@ contains
 
   !> The stress tensor contributions from a potential
   subroutine getBlockStress(env, st, derivator, DM, EDM, skHamCont, skOverCont, coords, species,&
-      & iNeighbor, nNeighbor, img2CentCell, iPair, orb, shift, cellVol)
+      & iNeighbor, nNeighborSK, img2CentCell, iPair, orb, shift, cellVol)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -268,7 +268,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> number of real atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> indexing array for periodic image atoms
     integer, intent(in) :: img2CentCell(:)
@@ -312,7 +312,7 @@ contains
     do iAtom1 = iAtFirst, iAtLast
       iSp1 = species(iAtom1)
       nOrb1 = orb%nOrbSpecies(iSp1)
-      do iNeigh = 1, nNeighbor(iAtom1)
+      do iNeigh = 1, nNeighborSK(iAtom1)
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         iSp2 = species(iAtom2f)
@@ -337,8 +337,8 @@ contains
                   & shift(1:nOrb1,1:nOrb1,iAtom1,iSpin) )&
                   & + matmul(shift(1:nOrb2,1:nOrb2,iAtom2f,iSpin), sPrimeTmp(1:nOrb2,1:nOrb1,ii)) )
               ! again factor of 2 from lower triangle sum of DM
-              intermed(ii) = intermed(ii) + 2.0_dp * (sum(shiftSprime(1:nOrb2,1:nOrb1) * &
-                  &reshape(DM(iOrig:iOrig+nOrb1*nOrb2-1,iSpin),(/nOrb2,nOrb1/)) ) )
+              intermed(ii) = intermed(ii) + 2.0_dp * (sum(shiftSprime(1:nOrb2,1:nOrb1) *&
+                  & reshape(DM(iOrig:iOrig+nOrb1*nOrb2-1,iSpin),(/nOrb2,nOrb1/)) ) )
             end do
           end do
 
@@ -370,7 +370,7 @@ contains
 
   !> The stress tensor contributions from a complex potential
   subroutine getBlockiStress(env, st, derivator, DM, iDM, EDM, skHamCont, skOverCont, coords,&
-      & species, iNeighbor, nNeighbor, img2CentCell, iPair, orb, shift, iShift, cellVol)
+      & species, iNeighbor, nNeighborSK, img2CentCell, iPair, orb, shift, iShift, cellVol)
 
     !> Computational environment settings
     type(TEnvironment), intent(in) :: env
@@ -406,7 +406,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> number of real atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> indexing array for periodic image atoms
     integer, intent(in) :: img2CentCell(:)
@@ -453,7 +453,7 @@ contains
     do iAtom1 = iAtFirst, iAtLast
       iSp1 = species(iAtom1)
       nOrb1 = orb%nOrbSpecies(iSp1)
-      do iNeigh = 1, nNeighbor(iAtom1)
+      do iNeigh = 1, nNeighborSK(iAtom1)
         iAtom2 = iNeighbor(iNeigh, iAtom1)
         iAtom2f = img2CentCell(iAtom2)
         iSp2 = species(iAtom2f)
@@ -474,22 +474,22 @@ contains
 
           do iSpin = 1, nSpin
             do ii = 1, 3
-              shiftSprime(1:nOrb2,1:nOrb1) = 0.5_dp *  (matmul(sPrimeTmp(1:nOrb2,1:nOrb1,ii), &
-                  & shift(1:nOrb1,1:nOrb1,iAtom1,iSpin) ) &
+              shiftSprime(1:nOrb2,1:nOrb1) = 0.5_dp *  (matmul(sPrimeTmp(1:nOrb2,1:nOrb1,ii),&
+                  & shift(1:nOrb1,1:nOrb1,iAtom1,iSpin) )&
                   & + matmul(shift(1:nOrb2,1:nOrb2,iAtom2f,iSpin), sPrimeTmp(1:nOrb2,1:nOrb1,ii)) )
               ! again factor of 2 from lower triangle sum of DM
-              intermed(ii) = intermed(ii) + 2.0_dp * (sum(shiftSprime(1:nOrb2,1:nOrb1) * &
-                  &reshape(DM(iOrig:iOrig+nOrb1*nOrb2-1,iSpin),(/nOrb2,nOrb1/)) ) )
+              intermed(ii) = intermed(ii) + 2.0_dp * (sum(shiftSprime(1:nOrb2,1:nOrb1) *&
+                  & reshape(DM(iOrig:iOrig+nOrb1*nOrb2-1,iSpin),(/nOrb2,nOrb1/)) ) )
             end do
           end do
 
           do iSpin = 1, nSpin
             do ii = 1, 3
-              shiftSprime(1:nOrb2,1:nOrb1) = 0.5_dp *  (matmul(sPrimeTmp(1:nOrb2,1:nOrb1,ii), &
-                  & iShift(1:nOrb1,1:nOrb1,iAtom1,iSpin) ) &
+              shiftSprime(1:nOrb2,1:nOrb1) = 0.5_dp *  (matmul(sPrimeTmp(1:nOrb2,1:nOrb1,ii),&
+                  & iShift(1:nOrb1,1:nOrb1,iAtom1,iSpin) )&
                   & + matmul(iShift(1:nOrb2,1:nOrb2,iAtom2f,iSpin), sPrimeTmp(1:nOrb2,1:nOrb1,ii)) )
-              intermed(ii) = intermed(ii) + sum(shiftSprime(1:nOrb2,1:nOrb1) * &
-                  &reshape(iDM(iOrig:iOrig+nOrb1*nOrb2-1,iSpin),(/nOrb2,nOrb1/)) )
+              intermed(ii) = intermed(ii) + sum(shiftSprime(1:nOrb2,1:nOrb1) *&
+                  & reshape(iDM(iOrig:iOrig+nOrb1*nOrb2-1,iSpin),(/nOrb2,nOrb1/)) )
             end do
           end do
 

--- a/prog/dftb+/lib_dftb/thirdorder.F90
+++ b/prog/dftb+/lib_dftb/thirdorder.F90
@@ -13,7 +13,7 @@ module thirdorder_module
   use accuracy
   use commontypes, only : TOrbitals
   use shortgamma, only : expGammaCutoff
-  use periodic, only : TNeighborList, getNrOfNeighbors
+  use periodic, only : TNeighbourList, getNrOfNeighbours
   use charges
   implicit none
   private
@@ -143,8 +143,8 @@ contains
     !> Instance.
     class(ThirdOrder), intent(inout) :: this
 
-    !> Neighbor list.
-    type(TNeighborList), intent(in) :: neighList
+    !> Neighbour list.
+    type(TNeighbourList), intent(in) :: neighList
 
     !> Species for all atoms, shape: [nAllAtom].
     integer, intent(in) :: species(:)
@@ -157,7 +157,7 @@ contains
     do iAt1 = 1, this%nAtoms
       iSp1 = species(iAt1)
       do iSp2 = 1, this%nSpecies
-        this%nNeigh(iSp2, iAt1) = getNrOfNeighbors(neighList, this%cutoffs(iSp2, iSp1), iAt1)
+        this%nNeigh(iSp2, iAt1) = getNrOfNeighbours(neighList, this%cutoffs(iSp2, iSp1), iAt1)
       end do
     end do
     this%nNeighMax = maxval(this%nNeigh, dim=1)
@@ -173,7 +173,7 @@ contains
     do iAt1 = 1, this%nAtoms
       iSp1 = species(iAt1)
       do iNeigh = 0, this%nNeighMax(iAt1)
-        iAt2 = neighList%iNeighbor(iNeigh, iAt1)
+        iAt2 = neighList%iNeighbour(iNeigh, iAt1)
         iSp2 = species(iAt2)
         if (iNeigh <= this%nNeigh(iSp2, iAt1)) then
           rr = sqrt(neighList%neighDist2(iNeigh, iAt1))
@@ -202,8 +202,8 @@ contains
     !> Species, shape: [nAtom]
     integer, intent(in) :: species(:)
 
-    !> Neighbor list.
-    type(TNeighborList), intent(in) :: neighList
+    !> Neighbour list.
+    type(TNeighbourList), intent(in) :: neighList
 
     !> Orbital charges.
     real(dp), intent(in) :: qq(:,:,:)
@@ -242,7 +242,7 @@ contains
     do iAt1 = 1, this%nAtoms
       iSp1 = species(iAt1)
       do iNeigh = 0, this%nNeighMax(iAt1)
-        iAt2f = img2CentCell(neighList%iNeighbor(iNeigh, iAt1))
+        iAt2f = img2CentCell(neighList%iNeighbour(iNeigh, iAt1))
         iSp2 = species(iAt2f)
         do iSh1 = 1, this%nShells(iSp1)
           do iSh2 = 1, this%nShells(iSp2)
@@ -367,8 +367,8 @@ contains
     !> Instance.
     class(ThirdOrder), intent(inout) :: this
 
-    !> Neighbor list.
-    type(TNeighborList), intent(in) :: neighList
+    !> Neighbour list.
+    type(TNeighbourList), intent(in) :: neighList
 
     !> Specie for each atom.
     integer, intent(in) :: species(:)
@@ -389,7 +389,7 @@ contains
     do iAt1 = 1, this%nAtoms
       iSp1 = species(iAt1)
       do iNeigh = 1, this%nNeighMax(iAt1)
-        iAt2 = neighList%iNeighbor(iNeigh, iAt1)
+        iAt2 = neighList%iNeighbour(iNeigh, iAt1)
         iAt2f = img2CentCell(iAt2)
         iSp2 = species(iAt2f)
         if (iAt1 == iAt2f .or. iNeigh > this%nNeigh(iSp2, iAt1)) then
@@ -426,8 +426,8 @@ contains
     !> Instance.
     class(ThirdOrder), intent(inout) :: this
 
-    !> Neighbor list.
-    type(TNeighborList), intent(in) :: neighList
+    !> Neighbour list.
+    type(TNeighbourList), intent(in) :: neighList
 
     !> Specie for each atom.
     integer, intent(in) :: species(:)
@@ -475,7 +475,7 @@ contains
     do iAt1 = 1, this%nAtoms
       iSp1 = species(iAt1)
       do iNeigh = 1, this%nNeighMax(iAt1)
-        iAt2 = neighList%iNeighbor(iNeigh, iAt1)
+        iAt2 = neighList%iNeighbour(iNeigh, iAt1)
         iAt2f = img2CentCell(iAt2)
         iSp2 = species(iAt2f)
         if (iAt1 == iAt2f .or. iNeigh > this%nNeigh(iSp2, iAt1)) then
@@ -523,8 +523,8 @@ contains
     !> Instance.
     class(ThirdOrder), intent(inout) :: this
 
-    !> Neighbor list.
-    type(TNeighborList), intent(in) :: neighList
+    !> Neighbour list.
+    type(TNeighbourList), intent(in) :: neighList
 
     !> Specie for each atom.
     integer, intent(in) :: species(:)
@@ -549,7 +549,7 @@ contains
     do iAt1 = 1, this%nAtoms
       iSp1 = species(iAt1)
       do iNeigh = 1, this%nNeighMax(iAt1)
-        iAt2 = neighList%iNeighbor(iNeigh, iAt1)
+        iAt2 = neighList%iNeighbour(iNeigh, iAt1)
         iAt2f = img2CentCell(iAt2)
         iSp2 = species(iAt2f)
         if (iNeigh > this%nNeigh(iSp2, iAt1)) then

--- a/prog/dftb+/lib_io/formatout.F90
+++ b/prog/dftb+/lib_io/formatout.F90
@@ -339,7 +339,7 @@ contains
 
 
   !> Converts a sparse matrix to its square form and write it to a file.
-  subroutine writeSparseAsSquare_real(env, fname, sparse, iNeighbor, nNeighborSK, iAtomStart,&
+  subroutine writeSparseAsSquare_real(env, fname, sparse, iNeighbour, nNeighbourSK, iAtomStart,&
       & iPair, img2CentCell)
 
     !> Environment settings
@@ -351,11 +351,11 @@ contains
     !> Sparse matrix.
     real(dp), intent(in) :: sparse(:)
 
-    !> Neighbor list index.
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Neighbour list index.
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> Number of neighbors.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Number of neighbours.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Offset array in the square matrix.
     integer, intent(in) :: iAtomStart(:)
@@ -375,7 +375,7 @@ contains
       call error("Writing of HS not working with MPI yet")
     end if
 
-    nOrb = iAtomStart(size(nNeighborSK) + 1) - 1
+    nOrb = iAtomStart(size(nNeighbourSK) + 1) - 1
 
     allocate(square(nOrb, nOrb))
     open(newunit=fd, file=fname, form="formatted", status="replace")
@@ -383,7 +383,7 @@ contains
     write(fd, "(1X,L10,I10,I10,I10)") .true., nOrb, 1
 
     write (strForm, "(A,I0,A)") "(", nOrb, "ES24.15)"
-    call unpackHS(square, sparse, iNeighbor, nNeighborSK, iAtomStart, iPair, img2CentCell)
+    call unpackHS(square, sparse, iNeighbour, nNeighbourSK, iAtomStart, iPair, img2CentCell)
     call blockSymmetrizeHS(square, iAtomStart)
     write(fd, "(A1,A10,A10)") "#", "IKPOINT"
     write(fd, "(1X,I10,I10)") 1
@@ -395,7 +395,7 @@ contains
 
 
   !> Converts a sparse matrix to its square form and write it to a file.
-  subroutine writeSparseAsSquare_cplx(env, fname, sparse, kPoints, iNeighbor, nNeighborSK,&
+  subroutine writeSparseAsSquare_cplx(env, fname, sparse, kPoints, iNeighbour, nNeighbourSK,&
       & iAtomStart, iPair, img2CentCell, iCellVec, cellVec)
 
     !> Environment settings
@@ -410,11 +410,11 @@ contains
     !> List of k-points.
     real(dp), intent(in) :: kPoints(:,:)
 
-    !> Neighbor list index.
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Neighbour list index.
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> Number of neighbors.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Number of neighbours.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Offset array in the square matrix.
     integer, intent(in) :: iAtomStart(:)
@@ -440,7 +440,7 @@ contains
       call error("Writing of HS not working with MPI yet")
     end if
 
-    nOrb = iAtomStart(size(nNeighborSK) + 1) - 1
+    nOrb = iAtomStart(size(nNeighbourSK) + 1) - 1
     nKPoint = size(kPoints, dim =2)
 
     allocate(square(nOrb, nOrb))
@@ -450,7 +450,7 @@ contains
 
     write (strForm, "(A,I0,A)") "(", 2 * nOrb, "ES24.15)"
     do iK = 1, nKPoint
-      call unpackHS(square, sparse, kPoints(:,iK), iNeighbor, nNeighborSK, iCellVec, cellVec,&
+      call unpackHS(square, sparse, kPoints(:,iK), iNeighbour, nNeighbourSK, iCellVec, cellVec,&
           & iAtomStart, iPair, img2CentCell)
       call blockHermitianHS(square, iAtomStart)
       write(fd, "(A1,A10,A10)") "#", "IKPOINT"
@@ -464,7 +464,7 @@ contains
 
 
   !> Writes a sparse matrix to a file.
-  subroutine writeSparse(fname, sparse, iNeighbor, nNeighborSK, iAtomStart, iPair, img2CentCell,&
+  subroutine writeSparse(fname, sparse, iNeighbour, nNeighbourSK, iAtomStart, iPair, img2CentCell,&
       & iCellVec, cellVec)
 
     !> Name of the file to write the matrix to.
@@ -473,11 +473,11 @@ contains
     !> Sparse matrix.
     real(dp), intent(in) :: sparse(:)
 
-    !> Neighbor list index.
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Neighbour list index.
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> Number of neighbors.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Number of neighbours.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Offset array in the square matrix.
     integer, intent(in) :: iAtomStart(:)
@@ -502,22 +502,22 @@ contains
       return
     end if
 
-    nAtom = size(nNeighborSK)
+    nAtom = size(nNeighbourSK)
 
     open(newunit=fd, file=fname, form="formatted", status="replace")
     write(fd, "(A1,A10)") "#", "NATOM"
     write(fd, "(1X,I10)") nAtom
     write(fd, "(A1,A10,A10,A10)") "#", "IATOM", "NNEIGH", "NORB"
     do iAt1 = 1, nAtom
-      write(fd, "(1X,I10,I10,I10)") iAt1, nNeighborSK(iAt1) + 1, iAtomStart(iAt1+1)&
+      write(fd, "(1X,I10,I10,I10)") iAt1, nNeighbourSK(iAt1) + 1, iAtomStart(iAt1+1)&
           & - iAtomStart(iAt1)
     end do
 
     do iAt1 = 1, nAtom
       nOrb1 = iAtomStart(iAt1+1) - iAtomStart(iAt1)
-      do iNeigh = 0, nNeighborSK(iAt1)
+      do iNeigh = 0, nNeighbourSK(iAt1)
         iOrig = iPair(iNeigh,iAt1) + 1
-        iAt2 = iNeighbor(iNeigh, iAt1)
+        iAt2 = iNeighbour(iNeigh, iAt1)
         iAt2f = img2CentCell(iAt2)
         nOrb2 = iAtomStart(iAt2f+1) - iAtomStart(iAt2f)
         write(strForm, "(A,I0,A)") "(", nOrb2, "ES24.15)"

--- a/prog/dftb+/lib_timedep/linresp.F90
+++ b/prog/dftb+/lib_timedep/linresp.F90
@@ -247,7 +247,7 @@ contains
 
   !> Wrapper to call the actual linear response routine for excitation energies
   subroutine LinResp_calcExcitations(this, tSpin, denseDesc, eigVec, eigVal, SSqrReal, filling,&
-      & coords0, sccCalc, dqAt, species0, iNeighbor, img2CentCell, orb, tWriteTagged, fdTagged,&
+      & coords0, sccCalc, dqAt, species0, iNeighbour, img2CentCell, orb, tWriteTagged, fdTagged,&
       & excEnergy)
 
     !> data structure with additional linear response values
@@ -287,7 +287,7 @@ contains
     integer, intent(in) :: img2CentCell(:)
 
     !> folding back to the central cell
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> data type with atomic orbital information
     type(TOrbitals), intent(in) :: orb
@@ -306,24 +306,23 @@ contains
     @:ASSERT(size(orb%nOrbAtom) == this%nAtom)
     call LinRespGrad_old(tSpin, this%nAtom, denseDesc%iAtomStart, eigVec, eigVal, sccCalc, dqAt,&
         & coords0, this%nExc, this%nStat, this%symmetry, SSqrReal, filling, species0,&
-        & this%HubbardU, this%spinW, this%nEl, iNeighbor, img2CentCell, orb, tWriteTagged,&
+        & this%HubbardU, this%spinW, this%nEl, iNeighbour, img2CentCell, orb, tWriteTagged,&
         & fdTagged, this%fdMulliken, this%fdCoeffs, this%tGrndState, this%fdXplusY, this%fdTrans,&
         & this%fdSPTrans, this%fdTradip, this%tArnoldi, this%fdArnoldi,  this%fdArnoldiDiagnosis,&
         & this%fdExc, this%tEnergyWindow, this%energyWindow, this%tOscillatorWindow,&
         & this%oscillatorWindow, excEnergy)
 
 #:else
-    call error('Internal error: Illegal routine call to &
-        &LinResp_calcExcitations')
+    call error('Internal error: Illegal routine call to LinResp_calcExcitations')
 #:endif
 
   end subroutine LinResp_calcExcitations
 
 
   !> Wrapper to call linear response calculations of excitations and forces in excited states
-  subroutine LinResp_addGradients(tSpin, this, iAtomStart, eigVec, eigVal, SSqrReal, filling, &
-      & coords0, sccCalc, dqAt, species0, iNeighbor, img2CentCell, orb, skHamCont, skOverCont, &
-      & tWriteTagged, fdTagged, excEnergy, excgradient, derivator, rhoSqr, occNatural, &
+  subroutine LinResp_addGradients(tSpin, this, iAtomStart, eigVec, eigVal, SSqrReal, filling,&
+      & coords0, sccCalc, dqAt, species0, iNeighbour, img2CentCell, orb, skHamCont, skOverCont,&
+      & tWriteTagged, fdTagged, excEnergy, excgradient, derivator, rhoSqr, occNatural,&
       & naturalOrbs)
 
     !> is this a spin-polarized calculation
@@ -360,7 +359,7 @@ contains
     integer, intent(in) :: species0(:)
 
     !> index array for atoms within cutoff distances
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> folding to central cell (not really needed for non-periodic systems)
     integer, intent(in) :: img2CentCell(:)
@@ -414,22 +413,22 @@ contains
     shiftPerAtom = shiftPerAtom + shiftPerL(1,:)
 
     if (allocated(occNatural)) then
-      call LinRespGrad_old(tSpin, this%nAtom, iAtomStart, eigVec, eigVal, sccCalc, dqAt, coords0, &
-          & this%nExc, this%nStat, this%symmetry, SSqrReal, filling, species0, this%HubbardU, &
-          & this%spinW, this%nEl, iNeighbor, img2CentCell, orb, tWriteTagged, fdTagged, &
-          & this%fdMulliken, this%fdCoeffs, this%tGrndState, this%fdXplusY, this%fdTrans, &
-          & this%fdSPTrans, this%fdTradip, this%tArnoldi, this%fdArnoldi, this%fdArnoldiDiagnosis, &
-          & this%fdExc, this%tEnergyWindow, this%energyWindow, this%tOscillatorWindow, &
-          & this%oscillatorWindow, excEnergy, shiftPerAtom, skHamCont, skOverCont, excgradient, &
+      call LinRespGrad_old(tSpin, this%nAtom, iAtomStart, eigVec, eigVal, sccCalc, dqAt, coords0,&
+          & this%nExc, this%nStat, this%symmetry, SSqrReal, filling, species0, this%HubbardU,&
+          & this%spinW, this%nEl, iNeighbour, img2CentCell, orb, tWriteTagged, fdTagged,&
+          & this%fdMulliken, this%fdCoeffs, this%tGrndState, this%fdXplusY, this%fdTrans,&
+          & this%fdSPTrans, this%fdTradip, this%tArnoldi, this%fdArnoldi, this%fdArnoldiDiagnosis,&
+          & this%fdExc, this%tEnergyWindow, this%energyWindow, this%tOscillatorWindow,&
+          & this%oscillatorWindow, excEnergy, shiftPerAtom, skHamCont, skOverCont, excgradient,&
           & derivator, rhoSqr, occNatural, naturalOrbs)
     else
-      call LinRespGrad_old(tSpin, this%nAtom, iAtomStart, eigVec, eigVal, sccCalc, dqAt, coords0, &
-          & this%nExc, this%nStat, this%symmetry, SSqrReal, filling, species0, this%HubbardU, &
-          & this%spinW, this%nEl, iNeighbor, img2CentCell, orb, tWriteTagged, fdTagged, &
-          & this%fdMulliken, this%fdCoeffs, this%tGrndState, this%fdXplusY, this%fdTrans, &
-          & this%fdSPTrans, this%fdTradip, this%tArnoldi, this%fdArnoldi, this%fdArnoldiDiagnosis, &
-          & this%fdExc, this%tEnergyWindow, this%energyWindow, this%tOscillatorWindow, &
-          & this%oscillatorWindow, excEnergy, shiftPerAtom, skHamCont, skOverCont, excgradient, &
+      call LinRespGrad_old(tSpin, this%nAtom, iAtomStart, eigVec, eigVal, sccCalc, dqAt, coords0,&
+          & this%nExc, this%nStat, this%symmetry, SSqrReal, filling, species0, this%HubbardU,&
+          & this%spinW, this%nEl, iNeighbour, img2CentCell, orb, tWriteTagged, fdTagged,&
+          & this%fdMulliken, this%fdCoeffs, this%tGrndState, this%fdXplusY, this%fdTrans,&
+          & this%fdSPTrans, this%fdTradip, this%tArnoldi, this%fdArnoldi, this%fdArnoldiDiagnosis,&
+          & this%fdExc, this%tEnergyWindow, this%energyWindow, this%tOscillatorWindow,&
+          & this%oscillatorWindow, excEnergy, shiftPerAtom, skHamCont, skOverCont, excgradient,&
           & derivator, rhoSqr)
     end if
 

--- a/prog/dftb+/lib_timedep/linrespgrad.F90
+++ b/prog/dftb+/lib_timedep/linrespgrad.F90
@@ -73,10 +73,10 @@ contains
   !> This subroutine analytically calculates excitations and gradients of excited state energies
   !> based on Time Dependent DFRT
   subroutine LinRespGrad_old(tSpin, natom, iAtomStart, grndEigVecs, grndEigVal, sccCalc, dq,&
-      & coord0, nexc, nstat0, symc, SSqr, filling, species0, HubbardU, spinW, rnel, iNeighbor, &
-      & img2CentCell, orb, tWriteTagged, fdTagged, fdMulliken, fdCoeffs, tGrndState, fdXplusY, &
-      & fdTrans, fdSPTrans, fdTradip, tArnoldi, fdArnoldi, fdArnoldiDiagnosis, fdExc, &
-      & tEnergyWindow, energyWindow,tOscillatorWindow, oscillatorWindow, omega, shift, skHamCont, &
+      & coord0, nexc, nstat0, symc, SSqr, filling, species0, HubbardU, spinW, rnel, iNeighbour,&
+      & img2CentCell, orb, tWriteTagged, fdTagged, fdMulliken, fdCoeffs, tGrndState, fdXplusY,&
+      & fdTrans, fdSPTrans, fdTradip, tArnoldi, fdArnoldi, fdArnoldiDiagnosis, fdExc,&
+      & tEnergyWindow, energyWindow,tOscillatorWindow, oscillatorWindow, omega, shift, skHamCont,&
       & skOverCont, excgrad, derivator, rhoSqr, occNatural, naturalOrbs)
 
     !> spin polarized calculation
@@ -131,7 +131,7 @@ contains
     real(dp), intent(in) :: rnel
 
     !> Atomic neighbour lists
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> Mapping of atom number to central cell atom number
     integer, intent(in) :: img2CentCell(:)
@@ -322,8 +322,8 @@ contains
     nxov = sum(nxov_ud)
 
     if (nexc + 1 >= nxov) then
-      write(tmpStr,"(' Insufficent single particle excitations, ',I0, &
-          &', for required number of excited states ',I0)")nxov, nexc
+      write(tmpStr,"(' Insufficent single particle excitations, ',I0,&
+          & ', for required number of excited states ',I0)")nxov, nexc
       call error(tmpStr)
     end if
 
@@ -390,7 +390,7 @@ contains
     end do
 
     ! ground state Hubbard U softened coulombic interactions
-    call sccCalc%getAtomicGammaMatrix(gammaMat, iNeighbor, img2CentCell)
+    call sccCalc%getAtomicGammaMatrix(gammaMat, iNeighbour, img2CentCell)
 
     ! Oscillator strengths for exited states, when needed.
     ALLOCATE(osz(nexc))
@@ -412,15 +412,15 @@ contains
     wij = wij(win)
 
     ! dipole strength of transitions between K-S states
-    call calcTransitionDipoles(coord0, win, nxov_ud(1), getij, iAtomStart, stimc, grndEigVecs, &
+    call calcTransitionDipoles(coord0, win, nxov_ud(1), getij, iAtomStart, stimc, grndEigVecs,&
         & snglPartTransDip)
 
     ! single particle excitation oscillator strengths
     sposz(:) = twothird * wij(:) * sum(snglPartTransDip**2, dim=2)
 
     if (tOscillatorWindow .and. tZVector ) then
-      call error("Incompabilitity between excited state property evaluation and an oscillator &
-          &strength window at the moment.")
+      call error("Incompabilitity between excited state property evaluation and an oscillator&
+          & strength window at the moment.")
     end if
 
     if (tOscillatorWindow .or. tEnergyWindow) then
@@ -428,7 +428,7 @@ contains
       if (.not. tEnergyWindow) then
 
         ! find transitions that are strongly dipole allowed (> oscillatorWindow)
-        call dipselect(wij, sposz, win, snglPartTransDip,nxov_rd, oscillatorWindow, grndEigVal, &
+        call dipselect(wij, sposz, win, snglPartTransDip,nxov_rd, oscillatorWindow, grndEigVal,&
             & getij)
 
       else
@@ -443,8 +443,8 @@ contains
           ! find transitions that are strongly dipole allowed (> oscillatorWindow)
           if (nxov_r < nxov) then
             ! find transitions that are strongly dipole allowed (> oscillatorWindow)
-            call dipselect(wij(nxov_r+1:), sposz(nxov_r+1:), win(nxov_r+1:), &
-                & snglPartTransDip(nxov_r+1:,:),nxov_d, oscillatorWindow, &
+            call dipselect(wij(nxov_r+1:), sposz(nxov_r+1:), win(nxov_r+1:),&
+                & snglPartTransDip(nxov_r+1:,:),nxov_d, oscillatorWindow,&
                 & grndEigVal, getij)
           end if
 
@@ -486,10 +486,10 @@ contains
     open(fdExc, file=excitationsOut, position="rewind", status="replace")
     write(fdExc,*)
     if (tSpin) then
-      write(fdExc,'(5x,a,7x,a,9x,a,9x,a,6x,a,4x,a)') 'w [eV]', 'Osc.Str.', 'Transition','Weight', &
+      write(fdExc,'(5x,a,7x,a,9x,a,9x,a,6x,a,4x,a)') 'w [eV]', 'Osc.Str.', 'Transition','Weight',&
           & 'KS [eV]','D<S*S>'
     else
-      write(fdExc,'(5x,a,7x,a,9x,a,9x,a,6x,a,4x,a)') 'w [eV]','Osc.Str.', 'Transition','Weight', &
+      write(fdExc,'(5x,a,7x,a,9x,a,9x,a,6x,a,4x,a)') 'w [eV]','Osc.Str.', 'Transition','Weight',&
           & 'KS [eV]','Sym.'
     end if
 
@@ -505,21 +505,21 @@ contains
     do isym = 1, size(symmetries)
 
       sym = symmetries(isym)
-      call buildAndDiagExcMatrix(tSpin, wij(:nxov_rd), sym, win, nxov_ud(1), nxov_rd, iAtomStart, &
-          & stimc, grndEigVecs, filling, getij, gammaMat, species0, spinW, fdArnoldiDiagnosis, &
+      call buildAndDiagExcMatrix(tSpin, wij(:nxov_rd), sym, win, nxov_ud(1), nxov_rd, iAtomStart,&
+          & stimc, grndEigVecs, filling, getij, gammaMat, species0, spinW, fdArnoldiDiagnosis,&
           & eval, evec )
 
       ! Excitation oscillator strengths for resulting states
-      call getOscillatorStrengths(sym, snglPartTransDip(1:nxov_rd,:), wij(:nxov_rd), eval, evec, &
+      call getOscillatorStrengths(sym, snglPartTransDip(1:nxov_rd,:), wij(:nxov_rd), eval, evec,&
           & filling, win, nxov_ud(1), getij, nstat, osz, tTradip, transitionDipoles)
 
       if (tSpin) then
-        call getExcSpin(Ssq, nxov_ud(1), getij, win, eval, evec, wij(:nxov_rd), filling, stimc, &
+        call getExcSpin(Ssq, nxov_ud(1), getij, win, eval, evec, wij(:nxov_rd), filling, stimc,&
             & grndEigVecs)
-        call writeExcitations(sym, osz, nexc, nxov_ud(1), getij, win, eval, evec, wij(:nxov_rd), &
+        call writeExcitations(sym, osz, nexc, nxov_ud(1), getij, win, eval, evec, wij(:nxov_rd),&
             & fdXplusY, fdTrans, fdTradip, transitionDipoles, tWriteTagged, fdTagged, fdExc, Ssq)
       else
-        call writeExcitations(sym, osz, nexc, nxov_ud(1), getij, win, eval, evec, wij(:nxov_rd), &
+        call writeExcitations(sym, osz, nexc, nxov_ud(1), getij, win, eval, evec, wij(:nxov_rd),&
             & fdXplusY, fdTrans, fdTradip, transitionDipoles, tWriteTagged, fdTagged, fdExc)
       end if
 
@@ -566,7 +566,7 @@ contains
       end if
 
       if (any( abs(filling) > elecTolMax .and. abs(filling-2.0_dp) > elecTolMax ) ) then
-        call error("Fractional fillings not currently possible for excited state property &
+        call error("Fractional fillings not currently possible for excited state property&
             & calculations")
       end if
 
@@ -610,17 +610,17 @@ contains
         xmy(:nxov_rd) = evec(:nxov_rd,iLev) * sqrt(omega / wij(:nxov_rd))
 
         ! solve for Z and W to get excited state density matrix
-        call getZVectorEqRHS(xpy, xmy, win, iAtomStart, nocc, nocc_r, &
-            & nxov_ud(1), getij, iatrans, natom, species0,grndEigVal(:,1), &
-            & stimc, grndEigVecs, gammaMat, spinW, omega, sym, rhs, t, &
+        call getZVectorEqRHS(xpy, xmy, win, iAtomStart, nocc, nocc_r,&
+            & nxov_ud(1), getij, iatrans, natom, species0,grndEigVal(:,1),&
+            & stimc, grndEigVecs, gammaMat, spinW, omega, sym, rhs, t,&
             & wov, woo, wvv)
-        call solveZVectorEq(rhs, win, nxov_ud(1), getij, natom, iAtomStart, &
+        call solveZVectorEq(rhs, win, nxov_ud(1), getij, natom, iAtomStart,&
             & stimc, gammaMat, wij(:nxov_rd), grndEigVecs)
-        call calcWVectorZ(rhs, win, nocc, nocc_r, nxov_ud(1), getij, iAtomStart, &
+        call calcWVectorZ(rhs, win, nocc, nocc_r, nxov_ud(1), getij, iAtomStart,&
             & stimc, grndEigVecs, gammaMat, grndEigVal(:,1), wov, woo, wvv)
         call calcPMatrix(t, rhs, win, getij, pc)
 
-        call writeCoeffs(pc, grndEigVecs, filling, nocc, fdCoeffs, &
+        call writeCoeffs(pc, grndEigVecs, filling, nocc, fdCoeffs,&
             & tCoeffs, tGrndState, occNatural, naturalOrbs)
 
         ! Make MO to AO transformation of the excited density matrix
@@ -632,10 +632,10 @@ contains
         end if
 
         if (tForces) then
-          call addGradients(sym, nxov_rd, natom, species0, iAtomStart, norb, &
-              & nocc, nocc_r, nxov_ud(1), getij, win, grndEigVecs, pc, stimc, &
-              & dq, dqex, gammaMat, HubbardU, spinW, shift, woo, wov, wvv, &
-              & xpy, coord0, orb, skHamCont, skOverCont, derivator, &
+          call addGradients(sym, nxov_rd, natom, species0, iAtomStart, norb,&
+              & nocc, nocc_r, nxov_ud(1), getij, win, grndEigVecs, pc, stimc,&
+              & dq, dqex, gammaMat, HubbardU, spinW, shift, woo, wov, wvv,&
+              & xpy, coord0, orb, skHamCont, skOverCont, derivator,&
               & rhoSqr(:,:,1), excgrad)
         end if
 
@@ -651,7 +651,7 @@ contains
 
 
   !> Builds and diagonalizes the excitation matrix via iterative technique.
-  subroutine buildAndDiagExcMatrix(tSpin, wij, sym, win, nmatup, nxov, iAtomStart, stimc, &
+  subroutine buildAndDiagExcMatrix(tSpin, wij, sym, win, nmatup, nxov, iAtomStart, stimc,&
       & grndEigVecs, filling, getij, gammaMat, species0, spinW, fdArnoldiDiagnosis, eval, evec)
 
     !> spin polarisation?
@@ -751,7 +751,7 @@ contains
     do
 
       ! call the reverse communication interface from arpack
-      call saupd (ido, "I", nxov, "SM", nexc, ARTOL, resid, ncv, vv, nxov, iparam, ipntr, workd, &
+      call saupd (ido, "I", nxov, "SM", nexc, ARTOL, resid, ncv, vv, nxov, iparam, ipntr, workd,&
           & workl, lworkl, info)
 
       if (ido == 99) then
@@ -761,14 +761,14 @@ contains
 
       ! still running, test for an error return
       if (abs(ido) /= 1) then
-        write(tmpStr,"(' Unexpected return from arpack routine saupd, IDO ',I0, ' INFO ',I0)") &
+        write(tmpStr,"(' Unexpected return from arpack routine saupd, IDO ',I0, ' INFO ',I0)")&
             & ido,info
         call error(tmpStr)
       end if
 
       ! Action of excitation supermatrix on supervector
       call omegatvec(tSpin, workd(ipntr(1):ipntr(1)+nxov-1), workd(ipntr(2):ipntr(2)+nxov-1),&
-          & wij, sym, win, nmatup, iAtomStart, stimc, grndEigVecs, filling, getij, gammaMat, &
+          & wij, sym, win, nmatup, iAtomStart, stimc, grndEigVecs, filling, getij, gammaMat,&
           & species0, spinW)
 
     end do
@@ -778,8 +778,8 @@ contains
       write(tmpStr,"(' Error with ARPACK routine saupd, info = ',I0)")info
       call error(tmpStr)
     else if (info  ==  1) then
-      call error("Maximum number of iterations reached. Increase the number of excited states to &
-          &solve for (NrOfExcitations).")
+      call error("Maximum number of iterations reached. Increase the number of excited states to&
+          & solve for (NrOfExcitations).")
     else
 
       ! now want Ritz vectors
@@ -788,7 +788,7 @@ contains
       ! everything after the first 6 variables are passed directly to DSEUPD following the last call
       ! to DSAUPD.  These arguments MUST NOT BE MODIFIED between the the last call to DSAUPD and the
       ! call to DSEUPD.
-      call seupd (rvec, "All", selection, eval, evec, nxov, sigma, "I", nxov, "SM", nexc, ARTOL, &
+      call seupd (rvec, "All", selection, eval, evec, nxov, sigma, "I", nxov, "SM", nexc, ARTOL,&
           & resid, ncv, vv, nxov, iparam, ipntr, workd, workl, lworkl, info)
 
       ! check for error on return
@@ -806,13 +806,13 @@ contains
       ALLOCATE(orthnorm(nxov,nxov))
       orthnorm = matmul(transpose(evec(:,:nExc)),evec(:,:nExc))
 
-      write(fdArnoldiDiagnosis,"(A)")'State Ei deviation    Evec deviation  Norm deviation  Max &
-          &non-orthog'
+      write(fdArnoldiDiagnosis,"(A)")'State Ei deviation    Evec deviation  Norm deviation  Max&
+          & non-orthog'
       do iState = 1, nExc
-        call omegatvec(tSpin, evec(:,iState), Hv, wij, sym, win, nmatup, iAtomStart, stimc, &
+        call omegatvec(tSpin, evec(:,iState), Hv, wij, sym, win, nmatup, iAtomStart, stimc,&
             & grndEigVecs, filling, getij, gammaMat, species0, spinW)
         write(fdArnoldiDiagnosis,"(I4,4E16.8)")iState, dot_product(Hv,evec(:,iState))-eval(iState),&
-            & sqrt(sum( (Hv-evec(:,iState)*eval(iState) )**2 )), orthnorm(iState,iState) - 1.0_dp, &
+            & sqrt(sum( (Hv-evec(:,iState)*eval(iState) )**2 )), orthnorm(iState,iState) - 1.0_dp,&
             & max(maxval(orthnorm(:iState-1,iState)), maxval(orthnorm(iState+1:,iState)))
       end do
       close(fdArnoldiDiagnosis)
@@ -822,7 +822,7 @@ contains
 
 
   !> Calculate oscillator strength for a given excitation between KS states
-  subroutine getOscillatorStrengths(sym, snglPartTransDip, wij, eval, evec, filling, win, nmatup, &
+  subroutine getOscillatorStrengths(sym, snglPartTransDip, wij, eval, evec, filling, win, nmatup,&
       & getij, istat, osz, tTradip, transitionDipoles)
 
     !> symmetry of transition
@@ -900,7 +900,7 @@ contains
     end if
 
     if (tTradip) then
-      call transitionDipole(snglPartTransDip, wnij, eval, evec, &
+      call transitionDipole(snglPartTransDip, wnij, eval, evec,&
           & transitionDipoles)
     end if
 
@@ -1049,7 +1049,7 @@ contains
 
           if ( ud_jb ) cycle
 
-          s_iajb = s_iajb + TDvec(ia)*TDvec(jb) * MOoverlap(aa,bb,stimc,grndEigVecs) &
+          s_iajb = s_iajb + TDvec(ia)*TDvec(jb) * MOoverlap(aa,bb,stimc,grndEigVecs)&
               & * MOoverlap(ii,jj,stimc,grndEigVecs)
 
         end do
@@ -1064,7 +1064,7 @@ contains
 
   !> Build right hand side of the equation for the Z-vector and those parts of the W-vectors which
   !> do not depend on Z.
-  subroutine getZVectorEqRHS(xpy, xmy, win, iAtomStart, homo, nocc, nmatup, getij, iatrans, natom, &
+  subroutine getZVectorEqRHS(xpy, xmy, win, iAtomStart, homo, nocc, nmatup, getij, iatrans, natom,&
       & species0, grndEigVal, stimc, c, gammaMat, spinW, omega, sym, rhs, t, wov, woo, wvv)
 
     !> X+Y Furche term
@@ -1379,7 +1379,7 @@ contains
     deallocate(qij)
 
     ! action of matrix on vector
-    call apbw(rkm1, rhs2, wij, nxov, natom, win, nmatup, getij, iAtomStart, &
+    call apbw(rkm1, rhs2, wij, nxov, natom, win, nmatup, getij, iAtomStart,&
         & stimc, c, gammaMat)
 
     rkm1 = rhs - rkm1
@@ -1424,7 +1424,7 @@ contains
 
   !> Calculate Z-dependent parts of the W-vectors and divide diagonal elements of W_ij and W_ab by
   !> 2.
-  subroutine calcWvectorZ(zz, win, homo, nocc, nmatup, getij, iAtomStart, stimc, c, gammaMat, &
+  subroutine calcWvectorZ(zz, win, homo, nocc, nmatup, getij, iAtomStart, stimc, c, gammaMat,&
       & grndEigVal, wov, woo, wvv)
 
     !> Z vector
@@ -1625,7 +1625,7 @@ contains
 
   !> Calculate transition moments for transitions between Kohn-Sham states, including spin-flipping
   !> transitions
-  subroutine calcTransitionDipoles(coord0, win, nmatup, getij, iAtomStart, stimc, grndEigVecs, &
+  subroutine calcTransitionDipoles(coord0, win, nmatup, getij, iAtomStart, stimc, grndEigVecs,&
       & snglPartTransDip)
 
     !> Atomic positions
@@ -1678,9 +1678,9 @@ contains
   !> 2. we need P,(T,Z),W, X + Y from linear response
   !> 3. calculate dsmndr, dhmndr (dS/dR, dh/dR), dgabda (dGamma_{IAt1,IAt2}/dR_{IAt1}),
   !> dgext (dGamma-EXT_{IAt1,k}/dR_{IAt1})
-  subroutine addGradients(sym, nxov, natom, species0, iAtomStart, norb, homo, &
-      & nocc, nmatup, getij, win, grndEigVecs, pc, stimc, dq, dqex, gammaMat, &
-      & HubbardU, spinW, shift, woo, wov, wvv, xpy, coord0, orb, &
+  subroutine addGradients(sym, nxov, natom, species0, iAtomStart, norb, homo,&
+      & nocc, nmatup, getij, win, grndEigVecs, pc, stimc, dq, dqex, gammaMat,&
+      & HubbardU, spinW, shift, woo, wov, wvv, xpy, coord0, orb,&
       & skHamCont, skOverCont, derivator, rhoSqr, excgrad)
 
     !> symmetry of the transition
@@ -1841,7 +1841,7 @@ contains
       do nu = 1, norb
         do mu = 1, norb
           xpycc(mu,nu) = xpycc(mu,nu) + xpy(ia) *&
-              &( grndEigVecs(mu,i,1)*grndEigVecs(nu,a,1) &
+              & ( grndEigVecs(mu,i,1)*grndEigVecs(nu,a,1)&
               & + grndEigVecs(mu,a,1)*grndEigVecs(nu,i,1) )
         end do
       end do
@@ -1859,8 +1859,8 @@ contains
       call indxoo(homo, nocc, ij, i, j)
       do mu = 1, norb
         do nu = 1, norb
-          wcc(mu,nu) = wcc(mu,nu) + woo(ij) * &
-              & ( grndEigVecs(mu,i,1)*grndEigVecs(nu,j,1) &
+          wcc(mu,nu) = wcc(mu,nu) + woo(ij) *&
+              & ( grndEigVecs(mu,i,1)*grndEigVecs(nu,j,1)&
               & + grndEigVecs(mu,j,1)*grndEigVecs(nu,i,1) )
         end do
       end do
@@ -1872,8 +1872,8 @@ contains
       call indxov(win, ia, getij, i, a)
       do nu = 1, norb
         do mu = 1, norb
-          wcc(mu,nu) = wcc(mu,nu) + wov(ia) * &
-              & ( grndEigVecs(mu,i,1)*grndEigVecs(nu,a,1) &
+          wcc(mu,nu) = wcc(mu,nu) + wov(ia) *&
+              & ( grndEigVecs(mu,i,1)*grndEigVecs(nu,a,1)&
               & + grndEigVecs(mu,a,1)*grndEigVecs(nu,i,1) )
         end do
       end do
@@ -1884,9 +1884,9 @@ contains
       call indxvv(homo, ab, a, b)
       do mu = 1, norb
         do nu = 1, norb
-          wcc(mu,nu) = wcc(mu,nu) + wvv(ab) * &
-              &( grndEigVecs(mu,a,1)*grndEigVecs(nu,b,1) &
-              &+ grndEigVecs(mu,b,1)*grndEigVecs(nu,a,1) )
+          wcc(mu,nu) = wcc(mu,nu) + wvv(ab) *&
+              & ( grndEigVecs(mu,a,1)*grndEigVecs(nu,b,1)&
+              & + grndEigVecs(mu,b,1)*grndEigVecs(nu,a,1) )
         end do
       end do
     end do
@@ -1956,9 +1956,9 @@ contains
               tmp6 = tmp6 + tmp7 * dS(n,m,xyz) * xpycc(mu,nu)
             end do
           end do
-          excgrad(xyz,iAt1) = excgrad(xyz,iAt1) &
+          excgrad(xyz,iAt1) = excgrad(xyz,iAt1)&
               & + tmp1 + tmp2 + tmp4 + tmp6 + tmp3
-          excgrad(xyz,iAt2) = excgrad(xyz,iAt2) &
+          excgrad(xyz,iAt2) = excgrad(xyz,iAt2)&
               & - tmp1 - tmp2 - tmp4 - tmp6 - tmp3
         end do
       end do
@@ -1968,7 +1968,7 @@ contains
 
 
   !> Write out excitations projected onto ground state
-  subroutine writeCoeffs(tt, grndEigVecs, occ, nocc, fdCoeffs, tCoeffs, tIncGroundState, &
+  subroutine writeCoeffs(tt, grndEigVecs, occ, nocc, fdCoeffs, tCoeffs, tIncGroundState,&
       & occNatural, naturalOrbs)
 
     !> T part of the matrix
@@ -2034,7 +2034,7 @@ contains
         do ii = 1, norb
           jj = norb - ii + 1
           write(fdCoeffs, '(1x,i3,1x,f13.10,1x,f13.10)') ii, occtmp(jj), 2.0_dp
-          write(fdCoeffs, '(6(f13.10,1x))') (cmplx(t2(mm,jj), kind=dp), &
+          write(fdCoeffs, '(6(f13.10,1x))') (cmplx(t2(mm,jj), kind=dp),&
               & mm = 1, norb)
         end do
         close(fdCoeffs)
@@ -2070,7 +2070,7 @@ contains
 
   !> Write out transitions from ground to excited state along with single particle transitions and
   !> dipole strengths
-  subroutine writeExcitations(sym, osz, nexc, nmatup, getij, win, eval, evec, wij, fdXplusY, &
+  subroutine writeExcitations(sym, osz, nexc, nmatup, getij, win, eval, evec, wij, fdXplusY,&
       & fdTrans, fdTradip, transitionDipoles, tWriteTagged, fdTagged, fdExc, Ssq)
 
     !> Symmetry label for the type of transition
@@ -2178,14 +2178,14 @@ contains
         sign = sym
         if (tSpin) then
           sign = " "
-          write(fdExc, &
-              & '(1x,f10.3,4x,f14.8,2x,i5,3x,a,1x,i5,7x,f6.3,2x,f10.3,4x, &
-              & f6.3)') &
-              & Hartree__eV * sqrt(eval(i)), osz(i), m, '->', n, weight, &
+          write(fdExc,&
+              & '(1x,f10.3,4x,f14.8,2x,i5,3x,a,1x,i5,7x,f6.3,2x,f10.3,4x,&
+              & f6.3)')&
+              & Hartree__eV * sqrt(eval(i)), osz(i), m, '->', n, weight,&
               & Hartree__eV * wij(iweight), Ssq(i)
         else
-          write(fdExc, &
-              & '(1x,f10.3,4x,f14.8,5x,i5,3x,a,1x,i5,7x,f6.3,2x,f10.3,6x,a)') &
+          write(fdExc,&
+              & '(1x,f10.3,4x,f14.8,5x,i5,3x,a,1x,i5,7x,f6.3,2x,f10.3,6x,a)')&
               & Hartree__eV * sqrt(eval(i)), osz(i), m, '->', n, weight,&
               & Hartree__eV * wij(iweight), sign
         end if
@@ -2201,10 +2201,10 @@ contains
         endif
 
         if (fdTrans > 0) then
-          write(fdTrans, '(2x,a,T12,i5,T21,ES17.10,1x,a,2x,a)') &
+          write(fdTrans, '(2x,a,T12,i5,T21,ES17.10,1x,a,2x,a)')&
               & 'Energy ', i,  Hartree__eV * sqrt(eval(i)), 'eV', sign
           write(fdTrans,*)
-          write(fdTrans,'(2x,a,9x,a,8x,a)') &
+          write(fdTrans,'(2x,a,9x,a,8x,a)')&
               & 'Transition', 'Weight', 'KS [eV]'
           write(fdTrans,'(1x,45("="))')
 
@@ -2219,15 +2219,15 @@ contains
               if (updwn) sign = "U"
             end if
             write(fdTrans,&
-                & '(i5,3x,a,1x,i5,1x,1a,T22,f10.8,T33,f14.8)') &
+                & '(i5,3x,a,1x,i5,1x,1a,T22,f10.8,T33,f14.8)')&
                 & m, '->', n, sign, wvec(j), Hartree__eV * wij(wvin(j))
           end do
           write(fdTrans,*)
         end if
 
         if(fdTradip > 0) then
-          write(fdTradip, '(1x,i5,1x,f10.3,2x,3(ES13.6))') &
-              & i, Hartree__eV * sqrt(eval(i)), (transitionDipoles(i,j) &
+          write(fdTradip, '(1x,i5,1x,f10.3,2x,3(ES13.6))')&
+              & i, Hartree__eV * sqrt(eval(i)), (transitionDipoles(i,j)&
               & * au__Debye, j=1,3)
         endif
       else
@@ -2244,13 +2244,13 @@ contains
 
         if (tSpin) then
           sign = " "
-          write(fdExc, &
-              & '(6x,A,T12,4x,f14.8,2x,i5,3x,a,1x,i5,7x,A,2x,f10.3,4x,f6.3)') &
-              & '< 0', osz(i), m, '->', n, '-', Hartree__eV * wij(iweight), &
+          write(fdExc,&
+              & '(6x,A,T12,4x,f14.8,2x,i5,3x,a,1x,i5,7x,A,2x,f10.3,4x,f6.3)')&
+              & '< 0', osz(i), m, '->', n, '-', Hartree__eV * wij(iweight),&
               & Ssq(i)
         else
-          write(fdExc, &
-              & '(6x,A,T12,4x,f14.8,2x,i5,3x,a,1x,i5,7x,f6.3,2x,f10.3,6x,a)') &
+          write(fdExc,&
+              & '(6x,A,T12,4x,f14.8,2x,i5,3x,a,1x,i5,7x,f6.3,2x,f10.3,6x,a)')&
               & '< 0', osz(i), m, '->', n, weight,&
               & Hartree__eV * wij(iweight), sign
         end if
@@ -2265,7 +2265,7 @@ contains
         endif
 
         if (fdTrans > 0) then
-          write(fdTrans, '(2x,a,1x,i5,5x,a,1x,a,3x,a)') &
+          write(fdTrans, '(2x,a,1x,i5,5x,a,1x,a,3x,a)')&
               & 'Energy ', i,  '-', 'eV', sign
           write(fdTrans,*)
         end if
@@ -2371,7 +2371,7 @@ contains
       ! single particle excitations
       open(fdSPTrans, file=singlePartOut, position="rewind", status="replace")
       write(fdSPTrans,*)
-      write(fdSPTrans,'(7x,a,7x,a,8x,a)') '#      w [eV]', &
+      write(fdSPTrans,'(7x,a,7x,a,8x,a)') '#      w [eV]',&
           & 'Osc.Str.', 'Transition'
       write(fdSPTrans,*)
       write(fdSPTrans,'(1x,58("="))')
@@ -2387,8 +2387,8 @@ contains
             sign = "D"
           end if
         end if
-        write(fdSPTrans, &
-            & '(1x,i7,3x,f8.3,3x,f13.7,4x,i5,3x,a,1x,i5,1x,1a)') &
+        write(fdSPTrans,&
+            & '(1x,i7,3x,f8.3,3x,f13.7,4x,i5,3x,a,1x,i5,1x,1a)')&
             & indm, Hartree__eV * wij(indm), sposz(indm), m, '->', n, sign
       end do
       write(fdSPTrans,*)

--- a/prog/dftb+/lib_type/dynneighlist.F90
+++ b/prog/dftb+/lib_type/dynneighlist.F90
@@ -7,10 +7,10 @@
 
 #:include 'common.fypp'
 
-!> Implements dynamic neighbor list with iterator.
+!> Implements dynamic neighbour list with iterator.
 !>
-!> The dynamic neighbor list does not store the entire neighbor list, but creates it on the fly,
-!> allowing for a low memory footprint for large neighbor lists (at the cost of speed).
+!> The dynamic neighbour list does not store the entire neighbour list, but creates it on the fly,
+!> allowing for a low memory footprint for large neighbour lists (at the cost of speed).
 !>
 module dynneighlist
   use accuracy
@@ -24,11 +24,11 @@ module dynneighlist
   public :: TNeighIterator, TNeighIterator_init
 
 
-  !> Dynamic neighbor list
+  !> Dynamic neighbour list
   type :: TDynNeighList
     private
 
-    !> Cutoff for neighbor generation
+    !> Cutoff for neighbour generation
     real(dp) :: cutoff
 
     !> Nr. of atoms 
@@ -52,11 +52,11 @@ module dynneighlist
   end type TDynNeighList
 
 
-  !> Iterator over a dynamic neighbor list
+  !> Iterator over a dynamic neighbour list
   type :: TNeighIterator
     private
 
-    !> Pointer to the original neighbor list
+    !> Pointer to the original neighbour list
     type(TDynNeighList), pointer :: neighList
 
     !> Lattice point generator (if system is periodic)
@@ -71,13 +71,13 @@ module dynneighlist
     !> Number of atoms
     integer :: nAtom
 
-    !> Atom for which neighbors are returned by the iterator
+    !> Atom for which neighbours are returned by the iterator
     integer :: iAtom1
 
     !> Coordinates of the atom
     real(dp) :: coordsAtom1(3)
 
-    !> Neighbor atom to be returned as next
+    !> Neighbour atom to be returned as next
     integer :: iAtom2
 
     !> Current cell shift vector (if system is periodic)
@@ -90,19 +90,19 @@ module dynneighlist
     logical :: tFinished
     
   contains
-    procedure :: getNextNeighbors => TNeighIterator_getNextNeighbors
+    procedure :: getNextNeighbours => TNeighIterator_getNextNeighbours
   end type TNeighIterator
 
 
 contains
 
-  !> Initializes a dynamic neighbor list.
+  !> Initializes a dynamic neighbour list.
   subroutine TDynNeighList_init(this, cutoff, nAtom, tPeriodic)
 
     !> Initialized instance on exit.
     type(TDynNeighList), intent(out) :: this
 
-    !> Cutoff up to which the neighbors should be generated
+    !> Cutoff up to which the neighbours should be generated
     real(dp), intent(in) :: cutoff
 
     !> Nr. of atoms in the system.
@@ -125,7 +125,8 @@ contains
 
   !> Updates the lattice vectors.
   !>
-  !> This routine should be only called, if the neighbor list was initialized for a periodic system.
+  !> This routine should be only called, if the neighbour list was initialized for a periodic
+  !> system.
   !>
   subroutine TDynNeighList_updateLatVecs(this, latVecs, invLatVecs)
 
@@ -160,19 +161,19 @@ contains
   end subroutine TDynNeighList_updateCoords
 
 
-  !> Initializes an iterator for the dynamic neighbors of a given atom.
+  !> Initializes an iterator for the dynamic neighbours of a given atom.
   subroutine TNeighIterator_init(this, neighList, iAtom, includeSelf)
 
     !> Initialized instance on exit.
     type(TNeighIterator), intent(out) :: this
 
-    !> Dynamic neighbor list containing the basic data
+    !> Dynamic neighbour list containing the basic data
     type(TDynNeighList), pointer, intent(in) :: neighList
 
-    !> Index of the atom for which the neighbors should be generated.
+    !> Index of the atom for which the neighbours should be generated.
     integer, intent(in) :: iAtom
 
-    !> Whether the atom itself should be also returned as first neighbor (default: false)
+    !> Whether the atom itself should be also returned as first neighbour (default: false)
     logical, intent(in), optional :: includeSelf
 
     logical :: includeSelf0
@@ -209,38 +210,38 @@ contains
   end subroutine TNeighIterator_init
 
 
-  !> Returns the next group of neighbors.
-  subroutine TNeighIterator_getNextNeighbors(this, nNeighborSK, coords, dists, img2CentCell)
+  !> Returns the next group of neighbours.
+  subroutine TNeighIterator_getNextNeighbours(this, nNeighbourSK, coords, dists, img2CentCell)
 
     !> Instance.
     class(TNeighIterator), intent(inout) :: this
 
-    !> Nr. of neighbors to return on entry, nr. of neighbors found on exit. When entry and exit
-    !> values differ, the iterator has finished and can not return any more neighbors.
-    integer, intent(inout) :: nNeighborSK
+    !> Nr. of neighbours to return on entry, nr. of neighbours found on exit. When entry and exit
+    !> values differ, the iterator has finished and can not return any more neighbours.
+    integer, intent(inout) :: nNeighbourSK
 
-    !> Coordinates of the neighbors. Shape: (3, nNeighborSK)
+    !> Coordinates of the neighbours. Shape: (3, nNeighbourSK)
     real(dp), intent(out), optional :: coords(:,:)
 
-    !> Distances of the neighbors. Shape: (nNeighborSK)
+    !> Distances of the neighbours. Shape: (nNeighbourSK)
     real(dp), intent(out), optional :: dists(:)
 
-    !> Correspoinding images of the neighbors in the central cell. Shape: (nNeighborSK)
+    !> Correspoinding images of the neighbours in the central cell. Shape: (nNeighbourSK)
     integer, intent(out), optional :: img2CentCell(:)
 
     real(dp) :: neighCoords(3)
-    real(dp) :: coordsTmp(3, nNeighborSK), distsTmp(nNeighborSK)
-    integer :: img2CentCellTmp(nNeighborSK)
+    real(dp) :: coordsTmp(3, nNeighbourSK), distsTmp(nNeighbourSK)
+    integer :: img2CentCellTmp(nNeighbourSK)
     real(dp) :: dist2
     integer :: maxNeighs
 
-    maxNeighs = nNeighborSK
-    nNeighborSK = 0
+    maxNeighs = nNeighbourSK
+    nNeighbourSK = 0
     if (this%tFinished) then
       return
     end if
 
-    do while (nNeighborSK < maxNeighs)
+    do while (nNeighbourSK < maxNeighs)
       if (this%iAtom2 > this%nAtom) then
         if (this%tPeriodic) then
           call this%latPointGen%getNextPoint(this%cellVec, this%tFinished)
@@ -257,25 +258,25 @@ contains
       neighCoords(:) = this%neighList%coords0(:, this%iAtom2) + this%cellVec
       dist2 = sum((this%coordsAtom1 - neighCoords)**2)
       if (dist2 <= this%cutoff2) then
-        nNeighborSK = nNeighborSK + 1
-        coordsTmp(:,nNeighborSK) = neighCoords
-        distsTmp(nNeighborSK) = dist2
-        img2CentCellTmp(nNeighborSK) = this%iAtom2
+        nNeighbourSK = nNeighbourSK + 1
+        coordsTmp(:,nNeighbourSK) = neighCoords
+        distsTmp(nNeighbourSK) = dist2
+        img2CentCellTmp(nNeighbourSK) = this%iAtom2
       end if
       this%iAtom2 = this%iAtom2 + 1
     end do
 
     if (present(coords)) then
-      coords(:,1:nNeighborSK) = coordsTmp(:,1:nNeighborSK)
+      coords(:,1:nNeighbourSK) = coordsTmp(:,1:nNeighbourSK)
     end if
     if (present(dists)) then
-      dists(1:nNeighborSK) = sqrt(distsTmp(1:nNeighborSK))
+      dists(1:nNeighbourSK) = sqrt(distsTmp(1:nNeighbourSK))
     end if
     if (present(img2CentCell)) then
-      img2CentCell(1:nNeighborSK) = img2CentCellTmp(1:nNeighborSK)
+      img2CentCell(1:nNeighbourSK) = img2CentCellTmp(1:nNeighbourSK)
     end if
 
-  end subroutine TNeighIterator_getNextNeighbors
+  end subroutine TNeighIterator_getNextNeighbours
 
 
 end module dynneighlist

--- a/prog/dftb+/lib_type/dynneighlist.F90
+++ b/prog/dftb+/lib_type/dynneighlist.F90
@@ -210,37 +210,37 @@ contains
 
 
   !> Returns the next group of neighbors.
-  subroutine TNeighIterator_getNextNeighbors(this, nNeighbors, coords, dists, img2CentCell)
+  subroutine TNeighIterator_getNextNeighbors(this, nNeighborSK, coords, dists, img2CentCell)
 
     !> Instance.
     class(TNeighIterator), intent(inout) :: this
 
     !> Nr. of neighbors to return on entry, nr. of neighbors found on exit. When entry and exit
     !> values differ, the iterator has finished and can not return any more neighbors.
-    integer, intent(inout) :: nNeighbors
+    integer, intent(inout) :: nNeighborSK
 
-    !> Coordinates of the neighbors. Shape: (3, nNeighbors)
+    !> Coordinates of the neighbors. Shape: (3, nNeighborSK)
     real(dp), intent(out), optional :: coords(:,:)
 
-    !> Distances of the neighbors. Shape: (nNeighbors)
+    !> Distances of the neighbors. Shape: (nNeighborSK)
     real(dp), intent(out), optional :: dists(:)
 
-    !> Correspoinding images of the neighbors in the central cell. Shape: (nNeighbors)
+    !> Correspoinding images of the neighbors in the central cell. Shape: (nNeighborSK)
     integer, intent(out), optional :: img2CentCell(:)
 
     real(dp) :: neighCoords(3)
-    real(dp) :: coordsTmp(3, nNeighbors), distsTmp(nNeighbors)
-    integer :: img2CentCellTmp(nNeighbors)
+    real(dp) :: coordsTmp(3, nNeighborSK), distsTmp(nNeighborSK)
+    integer :: img2CentCellTmp(nNeighborSK)
     real(dp) :: dist2
     integer :: maxNeighs
 
-    maxNeighs = nNeighbors
-    nNeighbors = 0
+    maxNeighs = nNeighborSK
+    nNeighborSK = 0
     if (this%tFinished) then
       return
     end if
 
-    do while (nNeighbors < maxNeighs)
+    do while (nNeighborSK < maxNeighs)
       if (this%iAtom2 > this%nAtom) then
         if (this%tPeriodic) then
           call this%latPointGen%getNextPoint(this%cellVec, this%tFinished)
@@ -257,22 +257,22 @@ contains
       neighCoords(:) = this%neighList%coords0(:, this%iAtom2) + this%cellVec
       dist2 = sum((this%coordsAtom1 - neighCoords)**2)
       if (dist2 <= this%cutoff2) then
-        nNeighbors = nNeighbors + 1
-        coordsTmp(:,nNeighbors) = neighCoords
-        distsTmp(nNeighbors) = dist2
-        img2CentCellTmp(nNeighbors) = this%iAtom2
+        nNeighborSK = nNeighborSK + 1
+        coordsTmp(:,nNeighborSK) = neighCoords
+        distsTmp(nNeighborSK) = dist2
+        img2CentCellTmp(nNeighborSK) = this%iAtom2
       end if
       this%iAtom2 = this%iAtom2 + 1
     end do
 
     if (present(coords)) then
-      coords(:,1:nNeighbors) = coordsTmp(:,1:nNeighbors)
+      coords(:,1:nNeighborSK) = coordsTmp(:,1:nNeighborSK)
     end if
     if (present(dists)) then
-      dists(1:nNeighbors) = sqrt(distsTmp(1:nNeighbors))
+      dists(1:nNeighborSK) = sqrt(distsTmp(1:nNeighborSK))
     end if
     if (present(img2CentCell)) then
-      img2CentCell(1:nNeighbors) = img2CentCellTmp(1:nNeighbors)
+      img2CentCell(1:nNeighborSK) = img2CentCellTmp(1:nNeighborSK)
     end if
 
   end subroutine TNeighIterator_getNextNeighbors

--- a/prog/dftb+/prg_dftb/initprogram.F90
+++ b/prog/dftb+/prg_dftb/initprogram.F90
@@ -207,14 +207,14 @@ module initprogram
   integer, allocatable :: iCellVec(:)
 
 
-  !> ADT for neighbor parameters
-  type(TNeighborList), allocatable, save :: neighborList
+  !> ADT for neighbour parameters
+  type(TNeighbourList), allocatable, save :: neighbourList
 
-  !> nr. of neighbors for atoms out to max interaction distance (excluding Ewald terms)
-  integer, allocatable :: nNeighborSK(:)
+  !> nr. of neighbours for atoms out to max interaction distance (excluding Ewald terms)
+  integer, allocatable :: nNeighbourSK(:)
 
-  !> nr. of neighbors for atoms within Erep interaction distance (usually short)
-  integer, allocatable :: nNeighborRep(:)
+  !> nr. of neighbours for atoms within Erep interaction distance (usually short)
+  integer, allocatable :: nNeighbourRep(:)
 
   !> H/S sparse matrices indexing array for atomic blocks
   integer, allocatable :: iSparseStart(:,:)
@@ -889,8 +889,8 @@ contains
     !> Whether seed was randomly created
     logical :: tRandomSeed
 
-    !> First guess for nr. of neighbors.
-    integer, parameter :: nInitNeighbor = 40
+    !> First guess for nr. of neighbours.
+    integer, parameter :: nInitNeighbour = 40
 
 
     @:ASSERT(input%tInitialized)
@@ -2008,11 +2008,11 @@ contains
       rCellVec(:,1) = [0.0_dp, 0.0_dp, 0.0_dp]
     end if
 
-    ! Initialize neighborlist.
-    allocate(neighborList)
-    call init(neighborList, nAtom, nInitNeighbor)
-    allocate(nNeighborSK(nAtom))
-    allocate(nNeighborRep(nAtom))
+    ! Initialize neighbourlist.
+    allocate(neighbourList)
+    call init(neighbourList, nAtom, nInitNeighbour)
+    allocate(nNeighbourSK(nAtom))
+    allocate(nNeighbourRep(nAtom))
 
     ! Set various options
     tWriteAutotest = env%tGlobalMaster .and. input%ctrl%tWriteTagged
@@ -2495,7 +2495,7 @@ contains
             write(strTmp, "(A)") ""
           end if
           write(stdOut, "(A,T30,A2,2X,I1,'(',A1,'): ',E14.6)")trim(strTmp), speciesName(iSp),&
-                &jj, orbitalNames(orb%angShell(jj, iSp)+1), xi(jj, iSp)
+                & jj, orbitalNames(orb%angShell(jj, iSp)+1), xi(jj, iSp)
           if (xi(jj, iSp) /= 0.0_dp .and. orb%angShell(jj, iSp) == 0) then
             call error("Program halt due to non-zero s-orbital spin-orbit coupling constant!")
           end if

--- a/prog/dftb+/prg_dftb/main.F90
+++ b/prog/dftb+/prg_dftb/main.F90
@@ -207,8 +207,8 @@ contains
       if (tCoordsChanged) then
         call handleCoordinateChange(env, coord0, latVec, invLatVec, species0, mCutoff, repCutoff,&
             & skCutoff, orb, tPeriodic, sccCalc, dispersion, thirdOrd, img2CentCell, iCellVec,&
-            & neighborList, nAllAtom, coord0Fold, coord, species, rCellVec, nAllOrb, nNeighborSK,&
-            & nNeighborRep, ham, over, H0, rhoPrim, iRhoPrim, iHam, ERhoPrim, iSparseStart)
+            & neighbourList, nAllAtom, coord0Fold, coord, species, rCellVec, nAllOrb, nNeighbourSK,&
+            & nNeighbourRep, ham, over, H0, rhoPrim, iRhoPrim, iHam, ERhoPrim, iSparseStart)
       end if
 
       if (tSccCalc) then
@@ -216,9 +216,9 @@ contains
       end if
 
       call env%globalTimer%startTimer(globalTimers%sparseH0S)
-      call buildH0(env, H0, skHamCont, atomEigVal, coord, nNeighborSK, neighborList%iNeighbor,&
+      call buildH0(env, H0, skHamCont, atomEigVal, coord, nNeighbourSK, neighbourList%iNeighbour,&
           & species, iSparseStart, orb)
-      call buildS(env, over, skOverCont, coord, nNeighborSK, neighborList%iNeighbor, species,&
+      call buildS(env, over, skOverCont, coord, nNeighbourSK, neighbourList%iNeighbour, species,&
           & iSparseStart, orb)
       call env%globalTimer%stopTimer(globalTimers%sparseH0S)
 
@@ -226,8 +226,8 @@ contains
         call getTemperature(temperatureProfile, tempElec)
       end if
 
-      call calcRepulsiveEnergy(coord, species, img2CentCell, nNeighborRep, neighborList, pRepCont,&
-          & energy%atomRep, energy%ERep)
+      call calcRepulsiveEnergy(coord, species, img2CentCell, nNeighbourRep, neighbourList,&
+          & pRepCont, energy%atomRep, energy%ERep)
 
       if (tDispersion) then
         call calcDispersionEnergy(dispersion, energy%atomDisp, energy%Edisp)
@@ -235,7 +235,7 @@ contains
 
       call resetExternalPotentials(potential)
       call setUpExternalElectricField(tEField, tTDEField, tPeriodic, EFieldStrength,&
-          & EFieldVector, EFieldOmega, EFieldPhase, neighborList, nNeighborSK, iCellVec,&
+          & EFieldVector, EFieldOmega, EFieldPhase, neighbourList, nNeighbourSK, iCellVec,&
           & img2CentCell, cellVec, deltaT, iGeoStep, coord0Fold, coord, EField,&
           & potential%extAtom(:,1), absEField)
 
@@ -251,22 +251,22 @@ contains
         if (tSccCalc) then
           call getChargePerShell(qInput, orb, species, chargePerShell)
           call addChargePotentials(env, sccCalc, qInput, q0, chargePerShell, orb, species,&
-              & neighborList, img2CentCell, spinW, thirdOrd, potential)
+              & neighbourList, img2CentCell, spinW, thirdOrd, potential)
           call addBlockChargePotentials(qBlockIn, qiBlockIn, tDftbU, tImHam, species, orb,&
               & nDftbUFunc, UJ, nUJ, iUJ, niUJ, potential)
         end if
         potential%intBlock = potential%intBlock + potential%extBlock
 
-        call getSccHamiltonian(H0, over, nNeighborSK, neighborList, species, orb, iSparseStart,&
+        call getSccHamiltonian(H0, over, nNeighbourSK, neighbourList, species, orb, iSparseStart,&
             & img2CentCell, potential, ham, iHam)
 
         if (tWriteRealHS .or. tWriteHS) then
-          call writeHSAndStop(env, tWriteHS, tWriteRealHS, tRealHS, over, neighborList,&
-              & nNeighborSK, denseDesc%iAtomStart, iSparseStart, img2CentCell, kPoint, iCellVec,&
+          call writeHSAndStop(env, tWriteHS, tWriteRealHS, tRealHS, over, neighbourList,&
+              & nNeighbourSK, denseDesc%iAtomStart, iSparseStart, img2CentCell, kPoint, iCellVec,&
               & cellVec, ham, iHam)
         end if
 
-        call getDensity(env, denseDesc, ham, over, neighborList, nNeighborSK, iSparseStart,&
+        call getDensity(env, denseDesc, ham, over, neighbourList, nNeighbourSK, iSparseStart,&
             & img2CentCell, iCellVec, cellVec, kPoint, kWeight, orb, species, solver, tRealHS,&
             & tSpinSharedEf, tSpinOrbit, tDualSpinOrbit, tFillKSep, tFixEf, tMulliken, iDistribFn,&
             & tempElec, nEl, parallelKS, Ef, energy, eigen, filling, rhoPrim, Eband, TS, E0, iHam,&
@@ -278,7 +278,7 @@ contains
         end if
 
         if (tMulliken) then
-          call getMullikenPopulation(rhoPrim, over, orb, neighborList, nNeighborSK, img2CentCell,&
+          call getMullikenPopulation(rhoPrim, over, orb, neighbourList, nNeighbourSK, img2CentCell,&
               & iSparseStart, qOutput, iRhoPrim=iRhoPrim, qBlock=qBlockOut, qiBlock=qiBlockOut)
         end if
 
@@ -293,14 +293,14 @@ contains
           call resetInternalPotentials(tDualSpinOrbit, xi, orb, species, potential)
           call getChargePerShell(qOutput, orb, species, chargePerShell)
           call addChargePotentials(env, sccCalc, qOutput, q0, chargePerShell, orb, species,&
-              & neighborList, img2CentCell, spinW, thirdOrd, potential)
+              & neighbourList, img2CentCell, spinW, thirdOrd, potential)
           call addBlockChargePotentials(qBlockOut, qiBlockOut, tDftbU, tImHam, species, orb,&
               & nDftbUFunc, UJ, nUJ, iUJ, niUJ, potential)
           potential%intBlock = potential%intBlock + potential%extBlock
         end if
 
         call getEnergies(sccCalc, qOutput, q0, chargePerShell, species, tEField, tXlbomd,&
-            & tDftbU, tDualSpinOrbit, rhoPrim, H0, orb, neighborList, nNeighborSK, img2CentCell,&
+            & tDftbU, tDualSpinOrbit, rhoPrim, H0, orb, neighbourList, nNeighbourSK, img2CentCell,&
             & iSparseStart, cellVol, extPressure, TS, potential, energy, thirdOrd, qBlockOut,&
             & qiBlockOut, nDftbUFunc, UJ, nUJ, iUJ, niUJ, xi)
 
@@ -313,7 +313,7 @@ contains
               & qiBlockOut, iEqBlockDftbULS, species0, nUJ, iUJ, niUJ, qiBlockIn)
           call getSccInfo(iSccIter, energy%Eelec, Eold, diffElec)
           call printSccInfo(tDftbU, iSccIter, energy%Eelec, diffElec, sccErrorQ)
-          tWriteSccRestart = env%tGlobalMaster .and. &
+          tWriteSccRestart = env%tGlobalMaster .and.&
               & needsSccRestartWriting(restartFreq, iGeoStep, iSccIter, minSccIter, maxSccIter,&
               & tMd, tGeoOpt, tDerivs, tConverged, tReadChrg, tStopScc)
           if (tWriteSccRestart) then
@@ -345,7 +345,7 @@ contains
         call ensureLinRespConditions(t3rd, tRealHS, tPeriodic, tForces)
         call calculateLinRespExcitations(env, lresp, parallelKS, sccCalc, qOutput, q0, over,&
             & eigvecsReal, eigen(:,1,:), filling(:,1,:), coord0, species, speciesName, orb,&
-            & skHamCont, skOverCont, autotestTag, runId, neighborList, nNeighborSK,&
+            & skHamCont, skOverCont, autotestTag, runId, neighbourList, nNeighbourSK,&
             & denseDesc, iSparseStart, img2CentCell, tWriteAutotest, tForces, tLinRespZVect,&
             & tPrintExcitedEigvecs, tPrintEigvecsTxt, nonSccDeriv, energy, SSqrReal, rhoSqrReal,&
             & excitedDerivs, occNatural)
@@ -360,20 +360,20 @@ contains
       if (tDipole) then
         call getDipoleMoment(qOutput, q0, coord, dipoleMoment)
       #:call DEBUG_CODE
-        call checkDipoleViaHellmannFeynman(rhoPrim, q0, coord0, over, orb, neighborList,&
-            & nNeighborSK, species, iSparseStart, img2CentCell)
+        call checkDipoleViaHellmannFeynman(rhoPrim, q0, coord0, over, orb, neighbourList,&
+            & nNeighbourSK, species, iSparseStart, img2CentCell)
       #:endcall DEBUG_CODE
       end if
 
       call env%globalTimer%startTimer(globalTimers%eigvecWriting)
       if (tPrintEigVecs) then
-        call writeEigenvectors(env, runId, neighborList, nNeighborSK, cellVec, iCellVec, denseDesc,&
-            & iSparseStart, img2CentCell, species, speciesName, orb, kPoint, over, parallelKS,&
-            & tPrintEigvecsTxt, eigvecsReal, SSqrReal, eigvecsCplx, SSqrCplx)
+        call writeEigenvectors(env, runId, neighbourList, nNeighbourSK, cellVec, iCellVec,&
+            & denseDesc, iSparseStart, img2CentCell, species, speciesName, orb, kPoint, over,&
+            & parallelKS, tPrintEigvecsTxt, eigvecsReal, SSqrReal, eigvecsCplx, SSqrCplx)
       end if
 
       if (tProjEigenvecs) then
-        call writeProjectedEigenvectors(env, regionLabels, eigen, neighborList, nNeighborSK,&
+        call writeProjectedEigenvectors(env, regionLabels, eigen, neighbourList, nNeighbourSK,&
             & cellVec, iCellVec, denseDesc, iSparseStart, img2CentCell, orb, over, kPoint, kWeight,&
             & iOrbRegion, parallelKS, eigvecsReal, SSqrReal, eigvecsCplx, SSqrCplx)
       end if
@@ -392,13 +392,13 @@ contains
         call env%globalTimer%startTimer(globalTimers%forceCalc)
         call env%globalTimer%startTimer(globalTimers%energyDensityMatrix)
         call getEnergyWeightedDensity(env, denseDesc, forceType, filling, eigen, kPoint, kWeight,&
-            & neighborList, nNeighborSK, orb, iSparseStart, img2CentCell, iCellVec, cellVec,&
+            & neighbourList, nNeighbourSK, orb, iSparseStart, img2CentCell, iCellVec, cellVec,&
             & tRealHS, ham, over, parallelKS, ERhoPrim, eigvecsReal, SSqrReal, eigvecsCplx,&
             & SSqrCplx)
         call env%globalTimer%stopTimer(globalTimers%energyDensityMatrix)
         call getGradients(env, sccCalc, tEField, tXlbomd, nonSccDeriv, Efield, rhoPrim, ERhoPrim,&
-            & qOutput, q0, skHamCont, skOverCont, pRepCont, neighborList, nNeighborSK,&
-            & nNeighborRep, species, img2CentCell, iSparseStart, orb, potential, coord, derivs,&
+            & qOutput, q0, skHamCont, skOverCont, pRepCont, neighbourList, nNeighbourSK,&
+            & nNeighbourRep, species, img2CentCell, iSparseStart, orb, potential, coord, derivs,&
             & iRhoPrim, thirdOrd, chrgForces, dispersion)
         if (tLinResp) then
           derivs(:,:) = derivs + excitedDerivs
@@ -408,8 +408,8 @@ contains
         if (tStress) then
           call env%globalTimer%startTimer(globalTimers%stressCalc)
           call getStress(env, sccCalc, thirdOrd, tEField, nonSccDeriv, EField, rhoPrim, ERhoPrim,&
-              & qOutput, q0, skHamCont, skOverCont, pRepCont, neighborList, nNeighborSK,&
-              & nNeighborRep, species, img2CentCell, iSparseStart, orb, potential, coord, latVec,&
+              & qOutput, q0, skHamCont, skOverCont, pRepCont, neighbourList, nNeighbourSK,&
+              & nNeighbourRep, species, img2CentCell, iSparseStart, orb, potential, coord, latVec,&
               & invLatVec, cellVol, coord0, totalStress, totalLatDeriv, intPressure, iRhoPrim,&
               & dispersion)
           call env%globalTimer%stopTimer(globalTimers%stressCalc)
@@ -424,7 +424,7 @@ contains
 
       if (tWriteDetailedOut) then
         call writeDetailedOut2(fdDetailedOut, tSccCalc, tConverged, tXlbomd, tLinResp, tGeoOpt,&
-            & tMD, tPrintForces, tStress, tPeriodic, energy, totalStress, totalLatDeriv, derivs, &
+            & tMD, tPrintForces, tStress, tPeriodic, energy, totalStress, totalLatDeriv, derivs,&
             & chrgForces, indMovedAtom, cellVol, intPressure, geoOutFile)
       end if
 
@@ -435,7 +435,7 @@ contains
         end if
       end if
 
-      if (tSccCalc .and. allocated(esp) .and. (.not. (tGeoOpt .or. tMD) .or. &
+      if (tSccCalc .and. allocated(esp) .and. (.not. (tGeoOpt .or. tMD) .or.&
           & needsRestartWriting(tGeoOpt, tMd, iGeoStep, nGeoSteps, restartFreq))) then
         call esp%evaluate(env, sccCalc, EField)
         call writeEsp(esp, env, iGeoStep, nGeoSteps)
@@ -613,7 +613,7 @@ contains
         call error("Pipek-Mezey localisation not implemented for non-colinear DFTB")
       end if
       call calcPipekMezeyLocalisation(env, pipekMezey, tPrintEigvecsTxt, nEl, filling, over,&
-          & kPoint, neighborList, nNeighborSK, denseDesc, iSparseStart, img2CentCell, iCellVec,&
+          & kPoint, neighbourList, nNeighbourSK, denseDesc, iSparseStart, img2CentCell, iCellVec,&
           & cellVec, runId, orb, species, speciesName, parallelKS, localisation, eigvecsReal,&
           & SSqrReal, eigvecsCplx, SSqrCplx)
     end if
@@ -783,8 +783,8 @@ contains
   !> Does the operations that are necessary after atomic coordinates change
   subroutine handleCoordinateChange(env, coord0, latVec, invLatVec, species0, mCutOff, repCutOff,&
       & skCutOff, orb, tPeriodic, sccCalc, dispersion, thirdOrd, img2CentCell, iCellVec,&
-      & neighborList, nAllAtom, coord0Fold, coord, species, rCellVec, nAllOrb, nNeighborSK,&
-      & nNeighborRep, ham, over, H0, rhoPrim, iRhoPrim, iHam, ERhoPrim, iSparseStart)
+      & neighbourList, nAllAtom, coord0Fold, coord, species, rCellVec, nAllOrb, nNeighbourSK,&
+      & nNeighbourRep, ham, over, H0, rhoPrim, iRhoPrim, iHam, ERhoPrim, iSparseStart)
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -832,7 +832,7 @@ contains
     integer, allocatable, intent(inout) :: iCellVec(:)
 
     !> List of neighbouring atoms
-    type(TNeighborList), intent(inout) :: neighborList
+    type(TNeighbourList), intent(inout) :: neighbourList
 
     !> Total number of atoms including images
     integer, intent(out) :: nAllAtom
@@ -853,10 +853,10 @@ contains
     real(dp), allocatable, intent(inout) :: rCellVec(:,:)
 
     !> Number of neighbours of each real atom
-    integer, intent(out) :: nNeighborSK(:)
+    integer, intent(out) :: nNeighbourSK(:)
 
     !> Number of neighbours of each real atom close enough for repulsive interactions
-    integer, intent(out) :: nNeighborRep(:)
+    integer, intent(out) :: nNeighbourRep(:)
 
     !> Sparse hamiltonian storage
     real(dp), allocatable, intent(inout) :: ham(:,:)
@@ -891,28 +891,27 @@ contains
       call foldCoordToUnitCell(coord0Fold, latVec, invLatVec)
     end if
 
-    call updateNeighborListAndSpecies(coord, species, img2CentCell, iCellVec, neighborList,&
+    call updateNeighbourListAndSpecies(coord, species, img2CentCell, iCellVec, neighbourList,&
         & nAllAtom, coord0Fold, species0, mCutOff, rCellVec)
     nAllOrb = sum(orb%nOrbSpecies(species(1:nAllAtom)))
-    call getNrOfNeighborsForAll(nNeighborSK, neighborList, skCutOff)
+    call getNrOfNeighboursForAll(nNeighbourSK, neighbourList, skCutOff)
 
-    call getSparseDescriptor(neighborList%iNeighbor, nNeighborSK, img2CentCell, orb, iSparseStart,&
-        & sparseSize)
+    call getSparseDescriptor(neighbourList%iNeighbour, nNeighbourSK, img2CentCell, orb,&
+        & iSparseStart, sparseSize)
     call reallocateSparseArrays(sparseSize, ham, over, H0, rhoPrim, iHam, iRhoPrim, ERhoPrim)
 
     ! count neighbours for repulsive interactions between atoms
-    call getNrOfNeighborsForAll(nNeighborRep, neighborList, repCutOff)
+    call getNrOfNeighboursForAll(nNeighbourRep, neighbourList, repCutOff)
 
     ! Notify various modules about coordinate changes
     if (allocated(sccCalc)) then
-      call sccCalc%updateCoords(env, coord, species, neighborList)
+      call sccCalc%updateCoords(env, coord, species, neighbourList)
     end if
     if (allocated(dispersion)) then
-      call dispersion%updateCoords(neighborList, img2CentCell, coord, &
-          & species0)
+      call dispersion%updateCoords(neighbourList, img2CentCell, coord, species0)
     end if
     if (allocated(thirdOrd)) then
-      call thirdOrd%updateCoords(neighborList, species)
+      call thirdOrd%updateCoords(neighbourList, species)
     end if
 
   end subroutine handleCoordinateChange
@@ -1021,7 +1020,7 @@ contains
 
 
   !> Calculates repulsive energy for current geometry
-  subroutine calcRepulsiveEnergy(coord, species, img2CentCell, nNeighborRep, neighborList,&
+  subroutine calcRepulsiveEnergy(coord, species, img2CentCell, nNeighbourRep, neighbourList,&
       & pRepCont, Eatom, Etotal)
 
     !> All atomic coordinates
@@ -1034,10 +1033,10 @@ contains
     integer, intent(in) :: img2CentCell(:)
 
     !> Number of neighbours for each atom within the repulsive distance
-    integer, intent(in) :: nNeighborRep(:)
+    integer, intent(in) :: nNeighbourRep(:)
 
     !> List of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Repulsive interaction data
     type(ORepCont), intent(in) :: pRepCont
@@ -1048,7 +1047,7 @@ contains
     !> Total energy
     real(dp), intent(out) :: Etotal
 
-    call getERep(Eatom, coord, nNeighborRep, neighborList%iNeighbor, species, pRepCont,&
+    call getERep(Eatom, coord, nNeighbourRep, neighbourList%iNeighbour, species, pRepCont,&
         & img2CentCell)
     Etotal = sum(Eatom)
 
@@ -1106,8 +1105,8 @@ contains
 
   !> Sets up electric external field
   subroutine setUpExternalElectricField(tEfield, tTimeDepEField, tPeriodic, EFieldStrength,&
-      & EFieldVector, EFieldOmega, EFieldPhase, neighborList, nNeighborSK, iCellVec, img2CentCell,&
-      & cellVec, deltaT, iGeoStep, coord0Fold, coord, EField, extAtomPot, absEField)
+      & EFieldVector, EFieldOmega, EFieldPhase, neighbourList, nNeighbourSK, iCellVec,&
+      & img2CentCell, cellVec, deltaT, iGeoStep, coord0Fold, coord, EField, extAtomPot, absEField)
 
     !> Whether electric field should be considered at all
     logical, intent(in) :: tEfield
@@ -1131,10 +1130,10 @@ contains
     integer, intent(in) :: EFieldPhase
 
     !> Atomi neighbours
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each atom
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index for unit cells
     integer, intent(in) :: iCellVec(:)
@@ -1179,7 +1178,7 @@ contains
       return
     end if
 
-    nAtom = size(nNeighborSK)
+    nAtom = size(nNeighbourSK)
 
     Efield(:) = EFieldStrength * EfieldVector
     if (tTimeDepEField) then
@@ -1188,8 +1187,8 @@ contains
     absEfield = sqrt(sum(Efield**2))
     if (tPeriodic) then
       do iAt1 = 1, nAtom
-        do iNeigh = 1, nNeighborSK(iAt1)
-          iAt2 = neighborList%iNeighbor(iNeigh, iAt1)
+        do iNeigh = 1, nNeighbourSK(iAt1)
+          iAt2 = neighbourList%iNeighbour(iNeigh, iAt1)
           ! overlap between atom in central cell and non-central cell
           if (iCellVec(iAt2) /= 0) then
             ! component of electric field projects onto vector between cells
@@ -1282,7 +1281,7 @@ contains
 
   !> Add potentials comming from point charges.
   subroutine addChargePotentials(env, sccCalc, qInput, q0, chargePerShell, orb, species,&
-      & neighborList, img2CentCell, spinW, thirdOrd, potential)
+      & neighbourList, img2CentCell, spinW, thirdOrd, potential)
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -1306,7 +1305,7 @@ contains
     integer, target, intent(in) :: species(:)
 
     !> neighbours to atoms
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> map from image atom to real atoms
     integer, intent(in) :: img2CentCell(:)
@@ -1332,14 +1331,15 @@ contains
     allocate(atomPot(nAtom, nSpin))
     allocate(shellPot(orb%mShell, nAtom, nSpin))
 
-    call sccCalc%updateCharges(env, qInput, q0, orb, species, neighborList%iNeighbor, img2CentCell)
+    call sccCalc%updateCharges(env, qInput, q0, orb, species, neighbourList%iNeighbour,&
+        & img2CentCell)
     call sccCalc%getShiftPerAtom(atomPot(:,1))
     call sccCalc%getShiftPerL(shellPot(:,:,1))
     potential%intAtom(:,1) = potential%intAtom(:,1) + atomPot(:,1)
     potential%intShell(:,:,1) = potential%intShell(:,:,1) + shellPot(:,:,1)
 
     if (allocated(thirdOrd)) then
-      call thirdOrd%updateCharges(pSpecies0, neighborList, qInput, q0, img2CentCell, orb)
+      call thirdOrd%updateCharges(pSpecies0, neighbourList, qInput, q0, img2CentCell, orb)
       call thirdOrd%getShifts(atomPot(:,1), shellPot(:,:,1))
       potential%intAtom(:,1) = potential%intAtom(:,1) + atomPot(:,1)
       potential%intShell(:,:,1) = potential%intShell(:,:,1) + shellPot(:,:,1)
@@ -1413,7 +1413,7 @@ contains
 
 
   !> Returns the Hamiltonian for the given scc iteration
-  subroutine getSccHamiltonian(H0, over, nNeighborSK, neighborList, species, orb, iSparseStart,&
+  subroutine getSccHamiltonian(H0, over, nNeighbourSK, neighbourList, species, orb, iSparseStart,&
       & img2CentCell, potential, ham, iHam)
 
     !> non-SCC hamitonian (sparse)
@@ -1423,10 +1423,10 @@ contains
     real(dp), intent(in) :: over(:)
 
     !> Number of atomic neighbours
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> list of atomic neighbours
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> species of atoms
     integer, intent(in) :: species(:)
@@ -1455,13 +1455,13 @@ contains
 
     ham(:,:) = 0.0_dp
     ham(:,1) = h0
-    call add_shift(ham, over, nNeighborSK, neighborList%iNeighbor, species, orb, iSparseStart,&
+    call add_shift(ham, over, nNeighbourSK, neighbourList%iNeighbour, species, orb, iSparseStart,&
         & nAtom, img2CentCell, potential%intBlock)
 
     if (allocated(iHam)) then
       iHam(:,:) = 0.0_dp
-      call add_shift(iHam, over, nNeighborSK, neighborList%iNeighbor, species, orb, iSparseStart,&
-          & nAtom, img2CentCell, potential%iorbitalBlock)
+      call add_shift(iHam, over, nNeighbourSK, neighbourList%iNeighbour, species, orb,&
+          & iSparseStart, nAtom, img2CentCell, potential%iorbitalBlock)
     end if
 
   end subroutine getSccHamiltonian
@@ -1473,7 +1473,7 @@ contains
   !> Hamiltonian or the full (unpacked) density matrix, must also invoked from within this routine,
   !> as those unpacked quantities do not exist elsewhere.
   !>
-  subroutine getDensity(env, denseDesc, ham, over, neighborList, nNeighborSK, iSparseStart,&
+  subroutine getDensity(env, denseDesc, ham, over, neighbourList, nNeighbourSK, iSparseStart,&
       & img2CentCell, iCellVec, cellVec, kPoint, kWeight, orb, species, solver, tRealHS,&
       & tSpinSharedEf, tSpinOrbit, tDualSpinOrbit, tFillKSep, tFixEf, tMulliken, iDistribFn,&
       & tempElec, nEl, parallelKS, Ef, energy, eigen, filling, rhoPrim, Eband, TS, E0, iHam, xi,&
@@ -1493,10 +1493,10 @@ contains
     real(dp), intent(in) :: over(:)
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index array for the start of atomic blocks in sparse arrays
     integer, intent(in) :: iSparseStart(:,:)
@@ -1631,18 +1631,18 @@ contains
     if (nSpin /= 4) then
       call qm2ud(ham)
       if (tRealHS) then
-        call buildAndDiagDenseRealHam(env, denseDesc, ham, over, neighborList, nNeighborSK,&
+        call buildAndDiagDenseRealHam(env, denseDesc, ham, over, neighbourList, nNeighbourSK,&
             & iSparseStart, img2CentCell, solver, parallelKS, HSqrReal, SSqrReal, eigVecsReal,&
             & eigen(:,1,:))
       else
-        call buildAndDiagDenseCplxHam(env, denseDesc, ham, over, kPoint, neighborList, nNeighborSK,&
-            & iSparseStart, img2CentCell, iCellVec, cellVec, solver, parallelKS, HSqrCplx,&
-            & SSqrCplx, eigVecsCplx, eigen)
+        call buildAndDiagDenseCplxHam(env, denseDesc, ham, over, kPoint, neighbourList,&
+            & nNeighbourSK, iSparseStart, img2CentCell, iCellVec, cellVec, solver, parallelKS,&
+            & HSqrCplx, SSqrCplx, eigVecsCplx, eigen)
       end if
     else
-      call buildAndDiagDensePauliHam(env, denseDesc, ham, over, kPoint, neighborList, nNeighborSK,&
-          & iSparseStart, img2CentCell, iCellVec, cellVec, orb, solver, parallelKS, eigen(:,:,1),&
-          & HSqrCplx, SSqrCplx, eigVecsCplx, iHam, xi, species)
+      call buildAndDiagDensePauliHam(env, denseDesc, ham, over, kPoint, neighbourList,&
+          & nNeighbourSK, iSparseStart, img2CentCell, iCellVec, cellVec, orb, solver, parallelKS,&
+          & eigen(:,:,1), HSqrCplx, SSqrCplx, eigVecsCplx, iHam, xi, species)
     end if
     call env%globalTimer%stopTimer(globalTimers%diagonalization)
 
@@ -1652,12 +1652,12 @@ contains
     call env%globalTimer%startTimer(globalTimers%densityMatrix)
     if (nSpin /= 4) then
       if (tRealHS) then
-        call getDensityFromRealEigvecs(env, denseDesc, filling(:,1,:), neighborList, nNeighborSK,&
+        call getDensityFromRealEigvecs(env, denseDesc, filling(:,1,:), neighbourList, nNeighbourSK,&
             & iSparseStart, img2CentCell, orb, eigVecsReal, parallelKS, rhoPrim, SSqrReal,&
             & rhoSqrReal)
       else
-        call getDensityFromCplxEigvecs(env, denseDesc, filling, kPoint, kWeight, neighborList,&
-            & nNeighborSK, iSparseStart, img2CentCell, iCellVec, cellVec, orb, parallelKS,&
+        call getDensityFromCplxEigvecs(env, denseDesc, filling, kPoint, kWeight, neighbourList,&
+            & nNeighbourSK, iSparseStart, img2CentCell, iCellVec, cellVec, orb, parallelKS,&
             & eigvecsCplx, rhoPrim, SSqrCplx)
       end if
       call ud2qm(rhoPrim)
@@ -1665,7 +1665,7 @@ contains
       ! Pauli structure of eigenvectors
       filling(:,:,1) = 2.0_dp * filling(:,:,1)
       call getDensityFromPauliEigvecs(env, denseDesc, tRealHS, tSpinOrbit, tDualSpinOrbit,&
-          & tMulliken, kPoint, kWeight, filling(:,:,1), neighborList, nNeighborSK, orb,&
+          & tMulliken, kPoint, kWeight, filling(:,:,1), neighbourList, nNeighbourSK, orb,&
           & iSparseStart, img2CentCell, iCellVec, cellVec, species, parallelKS, eigVecsCplx,&
           & SSqrCplx, energy, rhoPrim, xi, orbitalL, iRhoPrim)
       filling(:,:,1) = 0.5_dp * filling(:,:,1)
@@ -1676,7 +1676,7 @@ contains
 
 
   !> Builds and diagonalises dense Hamiltonians.
-  subroutine buildAndDiagDenseRealHam(env, denseDesc, ham, over, neighborList, nNeighborSK,&
+  subroutine buildAndDiagDenseRealHam(env, denseDesc, ham, over, neighbourList, nNeighbourSK,&
       & iSparseStart, img2CentCell, solver, parallelKS, HSqrReal, SSqrReal, eigvecsReal, eigen)
 
     !> Environment settings
@@ -1692,10 +1692,10 @@ contains
     real(dp), intent(in) :: over(:)
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index array for the start of atomic blocks in sparse arrays
     integer, intent(in) :: iSparseStart(:,:)
@@ -1728,18 +1728,18 @@ contains
       iSpin = parallelKS%localKS(2, iKS)
     #:if WITH_SCALAPACK
       call env%globalTimer%startTimer(globalTimers%sparseToDense)
-      call unpackHSRealBlacs(env%blacs, ham(:,iSpin), neighborList%iNeighbor, nNeighborSK,&
+      call unpackHSRealBlacs(env%blacs, ham(:,iSpin), neighbourList%iNeighbour, nNeighbourSK,&
           & iSparseStart, img2CentCell, denseDesc, HSqrReal)
-      call unpackHSRealBlacs(env%blacs, over, neighborList%iNeighbor, nNeighborSK, iSparseStart,&
+      call unpackHSRealBlacs(env%blacs, over, neighbourList%iNeighbour, nNeighbourSK, iSparseStart,&
           & img2CentCell, denseDesc, SSqrReal)
       call env%globalTimer%stopTimer(globalTimers%sparseToDense)
       call diagDenseMtxBlacs(solver, 'V', denseDesc%blacsOrbSqr, HSqrReal, SSqrReal,&
           & eigen(:,iSpin), eigvecsReal(:,:,iKS))
     #:else
       call env%globalTimer%startTimer(globalTimers%sparseToDense)
-      call unpackHS(HSqrReal, ham(:,iSpin), neighborList%iNeighbor, nNeighborSK,&
+      call unpackHS(HSqrReal, ham(:,iSpin), neighbourList%iNeighbour, nNeighbourSK,&
           & denseDesc%iAtomStart, iSparseStart, img2CentCell)
-      call unpackHS(SSqrReal, over, neighborList%iNeighbor, nNeighborSK, denseDesc%iAtomStart,&
+      call unpackHS(SSqrReal, over, neighbourList%iNeighbour, nNeighbourSK, denseDesc%iAtomStart,&
           & iSparseStart, img2CentCell)
       call env%globalTimer%stopTimer(globalTimers%sparseToDense)
       call diagDenseMtx(solver, 'V', HSqrReal, SSqrReal, eigen(:,iSpin))
@@ -1756,9 +1756,9 @@ contains
 
 
   !> Builds and diagonalises dense k-point dependent Hamiltonians.
-  subroutine buildAndDiagDenseCplxHam(env, denseDesc, ham, over, kPoint, neighborList, nNeighborSK,&
-      & iSparseStart, img2CentCell, iCellVec, cellVec, solver, parallelKS, HSqrCplx, SSqrCplx,&
-      & eigvecsCplx, eigen)
+  subroutine buildAndDiagDenseCplxHam(env, denseDesc, ham, over, kPoint, neighbourList,&
+      & nNeighbourSK, iSparseStart, img2CentCell, iCellVec, cellVec, solver, parallelKS, HSqrCplx,&
+      & SSqrCplx, eigvecsCplx, eigen)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
@@ -1776,10 +1776,10 @@ contains
     real(dp), intent(in) :: kPoint(:,:)
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index array for the start of atomic blocks in sparse arrays
     integer, intent(in) :: iSparseStart(:,:)
@@ -1819,18 +1819,18 @@ contains
       iSpin = parallelKS%localKS(2, iKS)
     #:if WITH_SCALAPACK
       call env%globalTimer%startTimer(globalTimers%sparseToDense)
-      call unpackHSCplxBlacs(env%blacs, ham(:,iSpin), kPoint(:,iK), neighborList%iNeighbor,&
-          & nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, HSqrCplx)
-      call unpackHSCplxBlacs(env%blacs, over, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK,&
+      call unpackHSCplxBlacs(env%blacs, ham(:,iSpin), kPoint(:,iK), neighbourList%iNeighbour,&
+          & nNeighbourSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, HSqrCplx)
+      call unpackHSCplxBlacs(env%blacs, over, kPoint(:,iK), neighbourList%iNeighbour, nNeighbourSK,&
           & iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, SSqrCplx)
       call env%globalTimer%stopTimer(globalTimers%sparseToDense)
       call diagDenseMtxBlacs(solver, 'V', denseDesc%blacsOrbSqr, HSqrCplx, SSqrCplx,&
           & eigen(:,iK,iSpin), eigvecsCplx(:,:,iKS))
     #:else
       call env%globalTimer%startTimer(globalTimers%sparseToDense)
-      call unpackHS(HSqrCplx, ham(:,iSpin), kPoint(:,iK), neighborList%iNeighbor, nNeighborSK,&
+      call unpackHS(HSqrCplx, ham(:,iSpin), kPoint(:,iK), neighbourList%iNeighbour, nNeighbourSK,&
           & iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
-      call unpackHS(SSqrCplx, over, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK, iCellVec,&
+      call unpackHS(SSqrCplx, over, kPoint(:,iK), neighbourList%iNeighbour, nNeighbourSK, iCellVec,&
           & cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
       call env%globalTimer%stopTimer(globalTimers%sparseToDense)
       call diagDenseMtx(solver, 'V', HSqrCplx, SSqrCplx, eigen(:,iK,iSpin))
@@ -1846,9 +1846,9 @@ contains
 
 
   !> Builds and diagonalizes Pauli two-component Hamiltonians.
-  subroutine buildAndDiagDensePauliHam(env, denseDesc, ham, over, kPoint, neighborList,&
-      & nNeighborSK, iSparseStart, img2CentCell, iCellVec, cellVec, orb, solver, parallelKS, eigen,&
-      & HSqrCplx, SSqrCplx, eigvecsCplx, iHam, xi, species)
+  subroutine buildAndDiagDensePauliHam(env, denseDesc, ham, over, kPoint, neighbourList,&
+      & nNeighbourSK, iSparseStart, img2CentCell, iCellVec, cellVec, orb, solver, parallelKS,&
+      & eigen, HSqrCplx, SSqrCplx, eigvecsCplx, iHam, xi, species)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
@@ -1866,10 +1866,10 @@ contains
     real(dp), intent(in) :: kPoint(:,:)
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index array for the start of atomic blocks in sparse arrays
     integer, intent(in) :: iSparseStart(:,:)
@@ -1921,24 +1921,25 @@ contains
       call env%globalTimer%startTimer(globalTimers%sparseToDense)
     #:if WITH_SCALAPACK
       if (allocated(iHam)) then
-        call unpackHPauliBlacs(env%blacs, ham, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK,&
-            & iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc, HSqrCplx,&
-            & iorig=iHam)
+        call unpackHPauliBlacs(env%blacs, ham, kPoint(:,iK), neighbourList%iNeighbour,&
+            & nNeighbourSK, iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc,&
+            & HSqrCplx, iorig=iHam)
       else
-        call unpackHPauliBlacs(env%blacs, ham, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK,&
-            & iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc, HSqrCplx)
+        call unpackHPauliBlacs(env%blacs, ham, kPoint(:,iK), neighbourList%iNeighbour,&
+            & nNeighbourSK, iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc,&
+            & HSqrCplx)
       end if
-      call unpackSPauliBlacs(env%blacs, over, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK,&
+      call unpackSPauliBlacs(env%blacs, over, kPoint(:,iK), neighbourList%iNeighbour, nNeighbourSK,&
           & iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc, SSqrCplx)
     #:else
       if (allocated(iHam)) then
-        call unpackHPauli(ham, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK, iSparseStart, &
+        call unpackHPauli(ham, kPoint(:,iK), neighbourList%iNeighbour, nNeighbourSK, iSparseStart,&
             & denseDesc%iAtomStart, img2CentCell, iCellVec, cellVec, HSqrCplx, iHam=iHam)
       else
-        call unpackHPauli(ham, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK, iSparseStart, &
+        call unpackHPauli(ham, kPoint(:,iK), neighbourList%iNeighbour, nNeighbourSK, iSparseStart,&
             & denseDesc%iAtomStart, img2CentCell, iCellVec, cellVec, HSqrCplx)
       end if
-      call unpackSPauli(over, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK,&
+      call unpackSPauli(over, kPoint(:,iK), neighbourList%iNeighbour, nNeighbourSK,&
           & denseDesc%iAtomStart, iSparseStart, img2CentCell, iCellVec, cellVec, SSqrCplx)
     #:endif
       if (allocated(xi) .and. .not. allocated(iHam)) then
@@ -1962,7 +1963,7 @@ contains
 
 
   !> Creates sparse density matrix from real eigenvectors.
-  subroutine getDensityFromRealEigvecs(env, denseDesc, filling, neighborList, nNeighborSK,&
+  subroutine getDensityFromRealEigvecs(env, denseDesc, filling, neighbourList, nNeighbourSK,&
       & iSparseStart, img2CentCell, orb, eigvecs, parallelKS, rhoPrim, work, rhoSqrReal)
 
     !> Environment settings
@@ -1975,10 +1976,10 @@ contains
     real(dp), intent(in) :: filling(:,:)
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index array for the start of atomic blocks in sparse arrays
     integer, intent(in) :: iSparseStart(:,:)
@@ -2014,18 +2015,18 @@ contains
       call makeDensityMtxRealBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,iSpin),&
           & eigvecs(:,:,iKS), work)
       call env%globalTimer%startTimer(globalTimers%denseToSparse)
-      call packRhoRealBlacs(env%blacs, denseDesc, work, neighborList%iNeighbor, nNeighborSK,&
+      call packRhoRealBlacs(env%blacs, denseDesc, work, neighbourList%iNeighbour, nNeighbourSK,&
           & orb%mOrb, iSparseStart, img2CentCell, rhoPrim(:,iSpin))
       call env%globalTimer%stopTimer(globalTimers%denseToSparse)
     #:else
       if (tDensON2) then
         call makeDensityMatrix(work, eigvecs(:,:,iKS), filling(:,iSpin),&
-            & neighborlist%iNeighbor, nNeighborSK, orb, denseDesc%iAtomStart, img2CentCell)
+            & neighbourlist%iNeighbour, nNeighbourSK, orb, denseDesc%iAtomStart, img2CentCell)
       else
         call makeDensityMatrix(work, eigvecs(:,:,iKS), filling(:,iSpin))
       end if
       call env%globalTimer%startTimer(globalTimers%denseToSparse)
-      call packHS(rhoPrim(:,iSpin), work, neighborlist%iNeighbor, nNeighborSK, orb%mOrb,&
+      call packHS(rhoPrim(:,iSpin), work, neighbourlist%iNeighbour, nNeighbourSK, orb%mOrb,&
           & denseDesc%iAtomStart, iSparseStart, img2CentCell)
       call env%globalTimer%stopTimer(globalTimers%denseToSparse)
     #:endif
@@ -2044,8 +2045,8 @@ contains
 
 
   !> Creates sparse density matrix from complex eigenvectors.
-  subroutine getDensityFromCplxEigvecs(env, denseDesc, filling, kPoint, kWeight, neighborList,&
-      & nNeighborSK, iSparseStart, img2CentCell, iCellVec, cellVec, orb, parallelKS, eigvecs,&
+  subroutine getDensityFromCplxEigvecs(env, denseDesc, filling, kPoint, kWeight, neighbourList,&
+      & nNeighbourSK, iSparseStart, img2CentCell, iCellVec, cellVec, orb, parallelKS, eigvecs,&
       & rhoPrim, work)
 
     !> Environment settings
@@ -2064,10 +2065,10 @@ contains
     real(dp), intent(in) :: kWeight(:)
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index array for the start of atomic blocks in sparse arrays
     integer, intent(in) :: iSparseStart(:,:)
@@ -2108,19 +2109,19 @@ contains
           & filling(:,iK,iSpin), eigvecs(:,:,iKS), work)
       call env%globalTimer%startTimer(globalTimers%denseToSparse)
       call packRhoCplxBlacs(env%blacs, denseDesc, work, kPoint(:,iK), kWeight(iK),&
-          & neighborList%iNeighbor, nNeighborSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
+          & neighbourList%iNeighbour, nNeighbourSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
           & img2CentCell, rhoPrim(:,iSpin))
       call env%globalTimer%stopTimer(globalTimers%denseToSparse)
     #:else
       if (tDensON2) then
-        call makeDensityMatrix(work, eigvecs(:,:,iKS), filling(:,iK,iSpin), neighborlist%iNeighbor,&
-            & nNeighborSK, orb, denseDesc%iAtomStart, img2CentCell)
+        call makeDensityMatrix(work, eigvecs(:,:,iKS), filling(:,iK,iSpin),&
+            & neighbourlist%iNeighbour, nNeighbourSK, orb, denseDesc%iAtomStart, img2CentCell)
       else
         call makeDensityMatrix(work, eigvecs(:,:,iKS), filling(:,iK,iSpin))
       end if
       call env%globalTimer%startTimer(globalTimers%denseToSparse)
-      call packHS(rhoPrim(:,iSpin), work, kPoint(:,iK), kWeight(iK), neighborList%iNeighbor,&
-          & nNeighborSK, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
+      call packHS(rhoPrim(:,iSpin), work, kPoint(:,iK), kWeight(iK), neighbourList%iNeighbour,&
+          & nNeighbourSK, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
           & img2CentCell)
       call env%globalTimer%stopTimer(globalTimers%denseToSparse)
     #:endif
@@ -2136,7 +2137,7 @@ contains
 
   !> Creates sparse density matrix from two component complex eigenvectors.
   subroutine getDensityFromPauliEigvecs(env, denseDesc, tRealHS, tSpinOrbit, tDualSpinOrbit,&
-      & tMulliken, kPoint, kWeight, filling, neighborList, nNeighborSK, orb, iSparseStart,&
+      & tMulliken, kPoint, kWeight, filling, neighbourList, nNeighbourSK, orb, iSparseStart,&
       & img2CentCell, iCellVec, cellVec, species, parallelKS, eigvecs, work, energy, rhoPrim, xi,&
       & orbitalL, iRhoPrim)
 
@@ -2168,10 +2169,10 @@ contains
     real(dp), intent(in) :: filling(:,:)
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
@@ -2264,27 +2265,28 @@ contains
     #:if WITH_SCALAPACK
       if (tImHam) then
         call packRhoPauliBlacs(env%blacs, denseDesc, work, kPoint(:,iK), kWeight(iK),&
-            & neighborList%iNeighbor, nNeighborSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
+            & neighbourList%iNeighbour, nNeighbourSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
             & img2CentCell, rhoPrim, iRhoPrim)
       else
         call packRhoPauliBlacs(env%blacs, denseDesc, work, kPoint(:,iK), kWeight(iK),&
-            & neighborList%iNeighbor, nNeighborSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
+            & neighbourList%iNeighbour, nNeighbourSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
             & img2CentCell, rhoPrim)
       end if
     #:else
       if (tRealHS) then
-        call packHSPauli(rhoPrim, work, neighborlist%iNeighbor, nNeighborSK, orb%mOrb,&
+        call packHSPauli(rhoPrim, work, neighbourlist%iNeighbour, nNeighbourSK, orb%mOrb,&
             & denseDesc%iAtomStart, iSparseStart, img2CentCell)
         if (tImHam) then
-          call packHSPauliImag(iRhoPrim, work, neighborlist%iNeighbor, nNeighborSK, orb%mOrb,&
+          call packHSPauliImag(iRhoPrim, work, neighbourlist%iNeighbour, nNeighbourSK, orb%mOrb,&
               & denseDesc%iAtomStart, iSparseStart, img2CentCell)
         end if
       else
-        call packHS(rhoPrim, work, kPoint(:,iK), kWeight(iK), neighborList%iNeighbor, nNeighborSK,&
-            & orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
+        call packHS(rhoPrim, work, kPoint(:,iK), kWeight(iK), neighbourList%iNeighbour,&
+            & nNeighbourSK, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
+            & img2CentCell)
         if (tImHam) then
-          call iPackHS(iRhoPrim, work, kPoint(:,iK), kWeight(iK), neighborlist%iNeighbor, &
-              & nNeighborSK, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
+          call iPackHS(iRhoPrim, work, kPoint(:,iK), kWeight(iK), neighbourlist%iNeighbour,&
+              & nNeighbourSK, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
               & img2CentCell)
         end if
       end if
@@ -2422,7 +2424,7 @@ contains
 
 
   !> Calculate Mulliken population from sparse density matrix.
-  subroutine getMullikenPopulation(rhoPrim, over, orb, neighborList, nNeighborSK, img2CentCell,&
+  subroutine getMullikenPopulation(rhoPrim, over, orb, neighbourList, nNeighbourSK, img2CentCell,&
       & iSparseStart, qOrb, iRhoPrim, qBlock, qiBlock)
 
     !> sparse density matrix
@@ -2435,10 +2437,10 @@ contains
     type(TOrbitals), intent(in) :: orb
 
     !> Atomic neighbours
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each atom within overlap distance
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> image to actual atom indexing
     integer, intent(in) :: img2CentCell(:)
@@ -2462,15 +2464,15 @@ contains
 
     qOrb(:,:,:) = 0.0_dp
     do iSpin = 1, size(qOrb, dim=3)
-      call mulliken(qOrb(:,:,iSpin), over, rhoPrim(:,iSpin), orb, neighborList%iNeighbor,&
-          & nNeighborSK, img2CentCell, iSparseStart)
+      call mulliken(qOrb(:,:,iSpin), over, rhoPrim(:,iSpin), orb, neighbourList%iNeighbour,&
+          & nNeighbourSK, img2CentCell, iSparseStart)
     end do
 
     if (allocated(qBlock)) then
       qBlock(:,:,:,:) = 0.0_dp
       do iSpin = 1, size(qBlock, dim=4)
-        call mulliken(qBlock(:,:,:,iSpin), over, rhoPrim(:,iSpin), orb, neighborList%iNeighbor,&
-            & nNeighborSK, img2CentCell, iSparseStart)
+        call mulliken(qBlock(:,:,:,iSpin), over, rhoPrim(:,iSpin), orb, neighbourList%iNeighbour,&
+            & nNeighbourSK, img2CentCell, iSparseStart)
       end do
     end if
 
@@ -2478,7 +2480,7 @@ contains
       qiBlock(:,:,:,:) = 0.0_dp
       do iSpin = 1, size(qiBlock, dim=4)
         call skewMulliken(qiBlock(:,:,:,iSpin), over, iRhoPrim(:,iSpin), orb,&
-            & neighborList%iNeighbor, nNeighborSK, img2CentCell, iSparseStart)
+            & neighbourList%iNeighbour, nNeighbourSK, img2CentCell, iSparseStart)
       end do
     end if
 
@@ -2487,7 +2489,7 @@ contains
 
   !> Calculates various energy contribution that can potentially update for the same geometry
   subroutine getEnergies(sccCalc, qOrb, q0, chargePerShell, species, tEField, tXlbomd,&
-      & tDftbU, tDualSpinOrbit, rhoPrim, H0, orb, neighborList, nNeighborSK, img2CentCell,&
+      & tDftbU, tDualSpinOrbit, rhoPrim, H0, orb, neighbourList, nNeighbourSK, img2CentCell,&
       & iSparseStart, cellVol, extPressure, TS, potential, energy, thirdOrd, qBlock, qiBlock,&
       & nDftbUFunc, UJ, nUJ, iUJ, niUJ, xi)
 
@@ -2528,10 +2530,10 @@ contains
     type(TOrbitals), intent(in) :: orb
 
     !> neighbour list
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours within cut-off for each atom
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> image to real atom mapping
     integer, intent(in) :: img2CentCell(:)
@@ -2587,7 +2589,7 @@ contains
 
     ! Tr[H0 * Rho] can be done with the same algorithm as Mulliken-analysis
     energy%atomNonSCC(:) = 0.0_dp
-    call mulliken(energy%atomNonSCC, rhoPrim(:,1), H0, orb, neighborList%iNeighbor, nNeighborSK,&
+    call mulliken(energy%atomNonSCC, rhoPrim(:,1), H0, orb, neighbourList%iNeighbour, nNeighbourSK,&
         & img2CentCell, iSparseStart)
     energy%EnonSCC =  sum(energy%atomNonSCC)
 
@@ -2795,8 +2797,8 @@ contains
 
 
   !> Reduce charges according to orbital equivalency rules.
-  subroutine reduceCharges(orb, nIneqOrb, iEqOrbitals, qOrb, qRed, qBlock, iEqBlockDftbu,&
-      & qiBlock, iEqBlockDftbuLS)
+  subroutine reduceCharges(orb, nIneqOrb, iEqOrbitals, qOrb, qRed, qBlock, iEqBlockDftbu, qiBlock,&
+      & iEqBlockDftbuLS)
 
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
@@ -3023,8 +3025,7 @@ contains
       call error("Only real systems are supported for excited state calculations")
     end if
     if (tPeriodic .and. tForces) then
-      call error("Forces in the excited state for periodic geometries are currently&
-          & unavailable")
+      call error("Forces in the excited state for periodic geometries are currently unavailable")
     end if
 
   end subroutine ensureLinRespConditions
@@ -3033,9 +3034,9 @@ contains
  !> Do the linear response excitation calculation.
   subroutine calculateLinRespExcitations(env, lresp, parallelKS, sccCalc, qOutput, q0, over,&
       & eigvecsReal, eigen, filling, coord0, species, speciesName, orb, skHamCont, skOverCont,&
-      & autotestTag, runId, neighborList, nNeighborSK, denseDesc, iSparseStart,&
-      & img2CentCell, tWriteAutotest, tForces, tLinRespZVect, tPrintExcEigvecs,&
-      & tPrintExcEigvecsTxt, nonSccDeriv, energy, work, rhoSqrReal, excitedDerivs, occNatural)
+      & autotestTag, runId, neighbourList, nNeighbourSK, denseDesc, iSparseStart, img2CentCell,&
+      & tWriteAutotest, tForces, tLinRespZVect, tPrintExcEigvecs, tPrintExcEigvecsTxt, nonSccDeriv,&
+      & energy, work, rhoSqrReal, excitedDerivs, occNatural)
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -3092,10 +3093,10 @@ contains
     integer, intent(in) :: runId
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc
@@ -3153,7 +3154,7 @@ contains
     energy%Eexcited = 0.0_dp
     allocate(dQAtom(nAtom))
     dQAtom(:) = sum(qOutput(:,:,1) - q0(:,:,1), dim=1)
-    call unpackHS(work, over, neighborList%iNeighbor, nNeighborSK, denseDesc%iAtomStart,&
+    call unpackHS(work, over, neighbourList%iNeighbour, nNeighbourSK, denseDesc%iAtomStart,&
         & iSparseStart, img2CentCell)
     call blockSymmetrizeHS(work, denseDesc%iAtomStart)
     if (tForces) then
@@ -3170,18 +3171,18 @@ contains
         allocate(naturalOrbs(orb%nOrb, orb%nOrb, 1))
       end if
       call addGradients(tSpin, lresp, denseDesc%iAtomStart, eigvecsReal, eigen, work, filling,&
-          & coord0, sccCalc, dQAtom, pSpecies0, neighborList%iNeighbor, img2CentCell, orb,&
+          & coord0, sccCalc, dQAtom, pSpecies0, neighbourList%iNeighbour, img2CentCell, orb,&
           & skHamCont, skOverCont, tWriteAutotest, fdAutotest, energy%Eexcited, excitedDerivs,&
           & nonSccDeriv, rhoSqrReal, occNatural, naturalOrbs)
       if (tPrintExcEigvecs) then
-        call writeRealEigvecs(env, runId, neighborList, nNeighborSK, denseDesc, iSparseStart,&
+        call writeRealEigvecs(env, runId, neighbourList, nNeighbourSK, denseDesc, iSparseStart,&
             & img2CentCell, pSpecies0, speciesName, orb, over, parallelKS, tPrintExcEigvecsTxt,&
             & naturalOrbs, work, fileName="excitedOrbs")
       end if
     else
       call calcExcitations(lresp, tSpin, denseDesc, eigvecsReal, eigen, work, filling, coord0,&
-          & sccCalc, dQAtom, pSpecies0, neighborList%iNeighbor, img2CentCell, orb, tWriteAutotest,&
-          & fdAutotest, energy%Eexcited)
+          & sccCalc, dQAtom, pSpecies0, neighbourList%iNeighbour, img2CentCell, orb,&
+          & tWriteAutotest, fdAutotest, energy%Eexcited)
     end if
     energy%Etotal = energy%Etotal + energy%Eexcited
     energy%EMermin = energy%EMermin + energy%Eexcited
@@ -3282,7 +3283,7 @@ contains
     nAtom = size(qOutput, dim=2)
     dipoleMoment(:) = 0.0_dp
     do iAtom = 1, nAtom
-      dipoleMoment(:) = dipoleMoment(:) &
+      dipoleMoment(:) = dipoleMoment(:)&
           & + sum(q0(:, iAtom, 1) - qOutput(:, iAtom, 1)) * coord(:,iAtom)
     end do
 
@@ -3290,8 +3291,8 @@ contains
 
 
   !> Prints dipole moment calcululated by the derivative of H with respect of the external field.
-  subroutine checkDipoleViaHellmannFeynman(rhoPrim, q0, coord0, over, orb, neighborList,&
-      & nNeighborSK, species, iSparseStart, img2CentCell)
+  subroutine checkDipoleViaHellmannFeynman(rhoPrim, q0, coord0, over, orb, neighbourList,&
+      & nNeighbourSK, species, iSparseStart, img2CentCell)
 
     !> Density matrix in sparse storage
     real(dp), intent(in) :: rhoPrim(:,:)
@@ -3309,10 +3310,10 @@ contains
     type(TOrbitals), intent(in) :: orb
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> species of all atoms in the system
     integer, intent(in) :: species(:)
@@ -3340,11 +3341,11 @@ contains
       potentialDerivative(:,1) = -coord0(ii,:)
       hprime(:,:) = 0.0_dp
       dipole(:,:) = 0.0_dp
-      call add_shift(hprime, over, nNeighborSK, neighborList%iNeighbor, species, orb, iSparseStart,&
-          & nAtom, img2CentCell, potentialDerivative)
+      call add_shift(hprime, over, nNeighbourSK, neighbourList%iNeighbour, species, orb,&
+          & iSparseStart, nAtom, img2CentCell, potentialDerivative)
 
       ! evaluate <psi| dH/dE | psi>
-      call mulliken(dipole, hprime(:,1), rhoPrim(:,1), orb, neighborList%iNeighbor, nNeighborSK,&
+      call mulliken(dipole, hprime(:,1), rhoPrim(:,1), orb, neighbourList%iNeighbour, nNeighbourSK,&
           & img2CentCell, iSparseStart)
 
       ! add nuclei term for derivative wrt E
@@ -3363,7 +3364,7 @@ contains
   !> NOTE: Dense eigenvector and overlap matrices are overwritten.
   !>
   subroutine getEnergyWeightedDensity(env, denseDesc, forceType, filling, eigen, kPoint, kWeight,&
-      & neighborList, nNeighborSK, orb, iSparseStart, img2CentCell, iCellVEc, cellVec, tRealHS,&
+      & neighbourList, nNeighbourSK, orb, iSparseStart, img2CentCell, iCellVEc, cellVec, tRealHS,&
       & ham, over, parallelKS, ERhoPrim, HSqrReal, SSqrReal, HSqrCplx, SSqrCplx)
 
     !> Environment settings
@@ -3388,10 +3389,10 @@ contains
     real(dp), intent(in) :: kWeight(:)
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
@@ -3441,25 +3442,25 @@ contains
 
     if (nSpin == 4) then
       call getEDensityMtxFromPauliEigvecs(env, denseDesc, filling, eigen, kPoint, kWeight,&
-          & neighborList, nNeighborSK, orb, iSparseStart, img2CentCell, iCellVec, cellVec, tRealHS,&
-          & parallelKS, HSqrCplx, SSqrCplx, ERhoPrim)
+          & neighbourList, nNeighbourSK, orb, iSparseStart, img2CentCell, iCellVec, cellVec,&
+          & tRealHS, parallelKS, HSqrCplx, SSqrCplx, ERhoPrim)
     else if (tRealHS) then
-      call getEDensityMtxFromRealEigvecs(env, denseDesc, forceType, filling, eigen, neighborList,&
-          & nNeighborSK, orb, iSparseStart, img2CentCell, ham, over, parallelKS, HSqrReal,&
+      call getEDensityMtxFromRealEigvecs(env, denseDesc, forceType, filling, eigen, neighbourList,&
+          & nNeighbourSK, orb, iSparseStart, img2CentCell, ham, over, parallelKS, HSqrReal,&
           & SSqrReal, ERhoPrim)
     else
       call getEDensityMtxFromComplexEigvecs(env, denseDesc, forceType, filling, eigen, kPoint,&
-          & kWeight, neighborList, nNeighborSK, orb, iSparseStart, img2CentCell, iCellVec, cellVec,&
-          & ham, over, parallelKS, HSqrCplx, SSqrCplx, ERhoPrim)
+          & kWeight, neighbourList, nNeighbourSK, orb, iSparseStart, img2CentCell, iCellVec,&
+          & cellVec, ham, over, parallelKS, HSqrCplx, SSqrCplx, ERhoPrim)
     end if
 
   end subroutine getEnergyWeightedDensity
 
 
   !> Calculates density matrix from real eigenvectors.
-  subroutine getEDensityMtxFromRealEigvecs(env, denseDesc, forceType, filling, eigen, neighborList,&
-      & nNeighborSK, orb, iSparseStart, img2CentCell, ham, over, parallelKS, eigvecsReal, work,&
-      & ERhoPrim)
+  subroutine getEDensityMtxFromRealEigvecs(env, denseDesc, forceType, filling, eigen,&
+      & neighbourList, nNeighbourSK, orb, iSparseStart, img2CentCell, ham, over, parallelKS,&
+      & eigvecsReal, work, ERhoPrim)
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -3477,10 +3478,10 @@ contains
     real(dp), intent(in) :: eigen(:,:,:)
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
@@ -3535,7 +3536,7 @@ contains
       #:else
         if (tDensON2) then
           call makeDensityMatrix(work, eigvecsReal(:,:,iKS), filling(:,1,iS), eigen(:,1,iS),&
-              & neighborlist%iNeighbor, nNeighborSK, orb, denseDesc%iAtomStart, img2CentCell)
+              & neighbourlist%iNeighbour, nNeighbourSK, orb, denseDesc%iAtomStart, img2CentCell)
         else
           call makeDensityMatrix(work, eigvecsReal(:,:,iKS), filling(:,1,iS), eigen(:,1,iS))
         end if
@@ -3544,7 +3545,7 @@ contains
       case(2)
         ! Correct force for XLBOMD for T=0K (DHD)
       #:if WITH_SCALAPACK
-        call unpackHSRealBlacs(env%blacs, ham(:,iS), neighborList%iNeighbor, nNeighborSK,&
+        call unpackHSRealBlacs(env%blacs, ham(:,iS), neighbourList%iNeighbour, nNeighbourSK,&
             & iSparseStart, img2CentCell, denseDesc, work)
         call makeDensityMtxRealBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,1,iS),&
             & eigVecsReal(:,:,iKS), work2)
@@ -3553,8 +3554,8 @@ contains
         call pblasfx_psymm(work2, denseDesc%blacsOrbSqr, eigvecsReal(:,:,iKS),&
             & denseDesc%blacsOrbSqr, work, denseDesc%blacsOrbSqr, side="R", alpha=0.5_dp)
       #:else
-        call unpackHS(work, ham(:,iS), neighborlist%iNeighbor, nNeighborSK, denseDesc%iAtomStart,&
-            & iSparseStart, img2CentCell)
+        call unpackHS(work, ham(:,iS), neighbourlist%iNeighbour, nNeighbourSK,&
+            & denseDesc%iAtomStart, iSparseStart, img2CentCell)
         call blockSymmetrizeHS(work, denseDesc%iAtomStart)
         call makeDensityMatrix(work2, eigvecsReal(:,:,iKS), filling(:,1,iS))
         ! D H
@@ -3568,12 +3569,12 @@ contains
       #:if WITH_SCALAPACK
         call makeDensityMtxRealBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,1,iS),&
             & eigVecsReal(:,:,iKS), work)
-        call unpackHSRealBlacs(env%blacs, ham(:,iS), neighborlist%iNeighbor, nNeighborSK,&
+        call unpackHSRealBlacs(env%blacs, ham(:,iS), neighbourlist%iNeighbour, nNeighbourSK,&
             & iSparseStart, img2CentCell, denseDesc, work2)
         call pblasfx_psymm(work, denseDesc%blacsOrbSqr, work2, denseDesc%blacsOrbSqr,&
             & eigvecsReal(:,:,iKS), denseDesc%blacsOrbSqr, side="L")
-        call unpackHSRealBlacs(env%blacs, over, neighborlist%iNeighbor, nNeighborSK, iSparseStart,&
-            & img2CentCell, denseDesc, work)
+        call unpackHSRealBlacs(env%blacs, over, neighbourlist%iNeighbour, nNeighbourSK,&
+            & iSparseStart, img2CentCell, denseDesc, work)
         call psymmatinv(denseDesc%blacsOrbSqr, work)
         call pblasfx_psymm(work, denseDesc%blacsOrbSqr, eigvecsReal(:,:,iKS),&
             & denseDesc%blacsOrbSqr, work2, denseDesc%blacsOrbSqr, side="R", alpha=0.5_dp)
@@ -3582,11 +3583,11 @@ contains
             & beta=1.0_dp)
       #:else
         call makeDensityMatrix(work, eigvecsReal(:,:,iKS), filling(:,1,iS))
-        call unpackHS(work2, ham(:,iS), neighborlist%iNeighbor, nNeighborSK, denseDesc%iAtomStart,&
-            & iSparseStart, img2CentCell)
+        call unpackHS(work2, ham(:,iS), neighbourlist%iNeighbour, nNeighbourSK,&
+            & denseDesc%iAtomStart, iSparseStart, img2CentCell)
         call blocksymmetrizeHS(work2, denseDesc%iAtomStart)
         call symm(eigvecsReal(:,:,iKS), "L", work, work2)
-        call unpackHS(work, over, neighborlist%iNeighbor, nNeighborSK, denseDesc%iAtomStart,&
+        call unpackHS(work, over, neighbourlist%iNeighbour, nNeighbourSK, denseDesc%iAtomStart,&
             & iSparseStart, img2CentCell)
         call symmatinv(work)
         call symm(work2, "R", work, eigvecsReal(:,:,iKS), alpha=0.5_dp)
@@ -3595,10 +3596,10 @@ contains
       end select
 
     #:if WITH_SCALAPACK
-      call packRhoRealBlacs(env%blacs, denseDesc, work, neighborList%iNeighbor, nNeighborSK,&
+      call packRhoRealBlacs(env%blacs, denseDesc, work, neighbourList%iNeighbour, nNeighbourSK,&
           & orb%mOrb, iSparseStart, img2CentCell, ERhoPrim)
     #:else
-      call packHS(ERhoPrim, work, neighborList%iNeighbor, nNeighborSK, orb%mOrb,&
+      call packHS(ERhoPrim, work, neighbourList%iNeighbour, nNeighbourSK, orb%mOrb,&
           & denseDesc%iAtomStart, iSparseStart, img2CentCell)
     #:endif
     end do
@@ -3613,7 +3614,7 @@ contains
 
   !> Calculates density matrix from complex eigenvectors.
   subroutine getEDensityMtxFromComplexEigvecs(env, denseDesc, forceType, filling, eigen, kPoint,&
-      & kWeight, neighborList, nNeighborSK, orb, iSparseStart, img2CentCell, iCellVec, cellVec,&
+      & kWeight, neighbourList, nNeighbourSK, orb, iSparseStart, img2CentCell, iCellVec, cellVec,&
       & ham, over, parallelKS, eigvecsCplx, work, ERhoPrim)
 
     !> Environment settings
@@ -3637,10 +3638,10 @@ contains
     real(dp), intent(in) :: kWeight(:)
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
@@ -3702,7 +3703,7 @@ contains
       #:else
         if (tDensON2) then
           call makeDensityMatrix(work, eigvecsCplx(:,:,iKS), filling(:,iK,iS),&
-              & eigen(:,iK, iS), neighborlist%iNeighbor, nNeighborSK, orb, denseDesc%iAtomStart,&
+              & eigen(:,iK, iS), neighbourlist%iNeighbour, nNeighbourSK, orb, denseDesc%iAtomStart,&
               & img2CentCell)
         else
           call makeDensityMatrix(work, eigvecsCplx(:,:,iKS), filling(:,iK,iS), eigen(:,iK, iS))
@@ -3712,8 +3713,8 @@ contains
       case(2)
         ! Correct force for XLBOMD for T=0K (DHD)
       #:if WITH_SCALAPACK
-        call unpackHSCplxBlacs(env%blacs, ham(:,iS), kPoint(:,iK), neighborList%iNeighbor,&
-            & nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, work)
+        call unpackHSCplxBlacs(env%blacs, ham(:,iS), kPoint(:,iK), neighbourList%iNeighbour,&
+            & nNeighbourSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, work)
         call makeDensityMtxCplxBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,1,iS),&
             & eigvecsCplx(:,:,iKS), work2)
         call pblasfx_phemm(work2, denseDesc%blacsOrbSqr, work, denseDesc%blacsOrbSqr,&
@@ -3722,7 +3723,7 @@ contains
             & denseDesc%blacsOrbSqr, work, denseDesc%blacsOrbSqr, side="R", alpha=(0.5_dp, 0.0_dp))
       #:else
         call makeDensityMatrix(work2, eigvecsCplx(:,:,iKS), filling(:,iK,iS))
-        call unpackHS(work, ham(:,iS), kPoint(:,iK), neighborlist%iNeighbor, nNeighborSK,&
+        call unpackHS(work, ham(:,iS), kPoint(:,iK), neighbourlist%iNeighbour, nNeighbourSK,&
             & iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
         call blockHermitianHS(work, denseDesc%iAtomStart)
         call hemm(eigvecsCplx(:,:,iKS), "L", work2, work)
@@ -3734,12 +3735,12 @@ contains
       #:if WITH_SCALAPACK
         call makeDensityMtxCplxBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr,&
             & filling(:,iK,iS), eigVecsCplx(:,:,iKS), work)
-        call unpackHSCplxBlacs(env%blacs, ham(:,iS), kPoint(:,iK), neighborlist%iNeighbor,&
-            & nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, work2)
+        call unpackHSCplxBlacs(env%blacs, ham(:,iS), kPoint(:,iK), neighbourlist%iNeighbour,&
+            & nNeighbourSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, work2)
         call pblasfx_phemm(work, denseDesc%blacsOrbSqr, work2, denseDesc%blacsOrbSqr,&
             & eigvecsCplx(:,:,iKS), denseDesc%blacsOrbSqr, side="L")
-        call unpackHSCplxBlacs(env%blacs, over, kPoint(:,iK), neighborlist%iNeighbor,&
-            & nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, work)
+        call unpackHSCplxBlacs(env%blacs, over, kPoint(:,iK), neighbourlist%iNeighbour,&
+            & nNeighbourSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, work)
         call phermatinv(denseDesc%blacsOrbSqr, work)
         call pblasfx_phemm(work, denseDesc%blacsOrbSqr, eigvecsCplx(:,:,iKS),&
             & denseDesc%blacsOrbSqr, work2, denseDesc%blacsOrbSqr, side="R", alpha=(0.5_dp, 0.0_dp))
@@ -3748,11 +3749,11 @@ contains
             & alpha=(1.0_dp, 0.0_dp), beta=(1.0_dp, 0.0_dp))
       #:else
         call makeDensityMatrix(work, eigvecsCplx(:,:,iKS), filling(:,iK,iS))
-        call unpackHS(work2, ham(:,iS), kPoint(:,iK), neighborlist%iNeighbor, nNeighborSK,&
+        call unpackHS(work2, ham(:,iS), kPoint(:,iK), neighbourlist%iNeighbour, nNeighbourSK,&
             & iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
         call blockHermitianHS(work2, denseDesc%iAtomStart)
         call hemm(eigvecsCplx(:,:,iKS), "L", work, work2)
-        call unpackHS(work, over, kPoint(:,iK), neighborlist%iNeighbor, nNeighborSK, iCellVec,&
+        call unpackHS(work, over, kPoint(:,iK), neighbourlist%iNeighbour, nNeighbourSK, iCellVec,&
             & cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
         call hermatinv(work)
         call hemm(work2, "R", work, eigvecsCplx(:,:,iKS), alpha=(0.5_dp, 0.0_dp))
@@ -3762,11 +3763,11 @@ contains
 
     #:if WITH_SCALAPACK
       call packRhoCplxBlacs(env%blacs, denseDesc, work, kPoint(:,iK), kWeight(iK),&
-          &neighborList%iNeighbor, nNeighborSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
+          &neighbourList%iNeighbour, nNeighbourSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
           & img2CentCell, ERhoPrim)
     #:else
-      call packHS(ERhoPrim, work, kPoint(:,iK), kWeight(iK), neighborList%iNeighbor,&
-          & nNeighborSK, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
+      call packHS(ERhoPrim, work, kPoint(:,iK), kWeight(iK), neighbourList%iNeighbour,&
+          & nNeighbourSK, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
           & img2CentCell)
     #:endif
     end do
@@ -3781,7 +3782,7 @@ contains
 
   !> Calculates density matrix from Pauli-type two component eigenvectors.
   subroutine getEDensityMtxFromPauliEigvecs(env, denseDesc, filling, eigen, kPoint, kWeight,&
-      & neighborList, nNeighborSK, orb, iSparseStart, img2CentCell, iCellVec, cellVec, tRealHS,&
+      & neighbourList, nNeighbourSK, orb, iSparseStart, img2CentCell, iCellVec, cellVec, tRealHS,&
       & parallelKS, eigvecsCplx, work, ERhoPrim)
 
     !> Environment settings
@@ -3803,10 +3804,10 @@ contains
     real(dp), intent(in) :: kWeight(:)
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
@@ -3847,16 +3848,16 @@ contains
       call makeDensityMtxCplxBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,iK,1),&
           & eigvecsCplx(:,:,iKS), work, eigen(:,iK,1))
       call packERhoPauliBlacs(env%blacs, denseDesc, work, kPoint(:,iK), kWeight(iK),&
-          & neighborList%iNeighbor, nNeighborSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
+          & neighbourList%iNeighbour, nNeighbourSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
           & img2CentCell, ERhoPrim)
     #:else
       call makeDensityMatrix(work, eigvecsCplx(:,:,iKS), filling(:,iK,1), eigen(:,iK,1))
       if (tRealHS) then
-        call packERho(ERhoPrim, work, neighborList%iNeighbor, nNeighborSK, orb%mOrb,&
+        call packERho(ERhoPrim, work, neighbourList%iNeighbour, nNeighbourSK, orb%mOrb,&
             & denseDesc%iAtomStart, iSparseStart, img2CentCell)
       else
-        call packERho(ERhoPrim, work, kPoint(:,iK), kWeight(iK), neighborList%iNeighbor,&
-            & nNeighborSK, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
+        call packERho(ERhoPrim, work, kPoint(:,iK), kWeight(iK), neighbourList%iNeighbour,&
+            & nNeighbourSK, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
             & img2CentCell)
       end if
     #:endif
@@ -3872,7 +3873,7 @@ contains
 
   !> Calculates the gradients
   subroutine getGradients(env, sccCalc, tEField, tXlbomd, nonSccDeriv, Efield, rhoPrim, ERhoPrim,&
-      & qOutput, q0, skHamCont, skOverCont, pRepCont, neighborList, nNeighborSK, nNeighborRep,&
+      & qOutput, q0, skHamCont, skOverCont, pRepCont, neighbourList, nNeighbourSK, nNeighbourRep,&
       & species, img2CentCell, iSparseStart, orb, potential, coord, derivs, iRhoPrim, thirdOrd,&
       & chrgForces, dispersion)
 
@@ -3916,13 +3917,13 @@ contains
     type(ORepCont), intent(in) :: pRepCont
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Number of neighbours for each of the atoms closer than the repulsive cut-off
-    integer, intent(in) :: nNeighborRep(:)
+    integer, intent(in) :: nNeighbourRep(:)
 
     !> species of all atoms in the system
     integer, intent(in) :: species(:)
@@ -3973,22 +3974,22 @@ contains
       ! No external or internal potentials
       if (tImHam) then
         call derivative_shift(env, derivs, nonSccDeriv, rhoPrim, iRhoPrim, ERhoPrim, skHamCont,&
-            & skOverCont, coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell,&
+            & skOverCont, coord, species, neighbourList%iNeighbour, nNeighbourSK, img2CentCell,&
             & iSparseStart, orb, potential%intBlock, potential%iorbitalBlock)
       else
         call derivative_shift(env, derivs, nonSccDeriv, rhoPrim(:,1), ERhoPrim, skHamCont,&
-            & skOverCont, coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell,&
+            & skOverCont, coord, species, neighbourList%iNeighbour, nNeighbourSK, img2CentCell,&
             & iSparseStart, orb)
       end if
     else
       if (tImHam) then
         call derivative_shift(env, derivs, nonSccDeriv, rhoPrim, iRhoPrim, ERhoPrim, skHamCont,&
-            & skOverCont, coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell,&
+            & skOverCont, coord, species, neighbourList%iNeighbour, nNeighbourSK, img2CentCell,&
             & iSparseStart, orb, potential%intBlock, potential%iorbitalBlock)
       else
         call derivative_shift(env, derivs, nonSccDeriv, rhoPrim, ERhoPrim, skHamCont, skOverCont,&
-            & coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell, iSparseStart, orb,&
-            & potential%intBlock)
+            & coord, species, neighbourList%iNeighbour, nNeighbourSK, img2CentCell, iSparseStart,&
+            & orb, potential%intBlock)
       end if
 
       if (tExtChrg) then
@@ -3996,24 +3997,24 @@ contains
         if (tXlbomd) then
           call error("XLBOMD does not work with external charges yet!")
         else
-          call sccCalc%addForceDc(env, derivs, species, neighborList%iNeighbor, img2CentCell, &
+          call sccCalc%addForceDc(env, derivs, species, neighbourList%iNeighbour, img2CentCell,&
               & chrgForces)
         end if
       else if (tSccCalc) then
         if (tXlbomd) then
-          call sccCalc%addForceDcXlbomd(env, species, orb, neighborList%iNeighbor, img2CentCell,&
+          call sccCalc%addForceDcXlbomd(env, species, orb, neighbourList%iNeighbour, img2CentCell,&
               & qOutput, q0, derivs)
         else
-          call sccCalc%addForceDc(env, derivs, species, neighborList%iNeighbor, img2CentCell)
+          call sccCalc%addForceDc(env, derivs, species, neighbourList%iNeighbour, img2CentCell)
         end if
       end if
 
       if (allocated(thirdOrd)) then
         if (tXlbomd) then
-          call thirdOrd%addGradientDcXlbomd(neighborList, species, coord, img2CentCell, qOutput,&
+          call thirdOrd%addGradientDcXlbomd(neighbourList, species, coord, img2CentCell, qOutput,&
               & q0, orb, derivs)
         else
-          call thirdOrd%addGradientDc(neighborList, species, coord, img2CentCell, derivs)
+          call thirdOrd%addGradientDc(neighbourList, species, coord, img2CentCell, derivs)
         end if
       end if
 
@@ -4029,7 +4030,7 @@ contains
     end if
 
     allocate(tmpDerivs(3, nAtom))
-    call getERepDeriv(tmpDerivs, coord, nNeighborRep, neighborList%iNeighbor, species, pRepCont,&
+    call getERepDeriv(tmpDerivs, coord, nNeighbourRep, neighbourList%iNeighbour, species, pRepCont,&
         & img2CentCell)
     derivs(:,:) = derivs + tmpDerivs
 
@@ -4038,7 +4039,7 @@ contains
 
   !> Calculates stress tensor and lattice derivatives.
   subroutine getStress(env, sccCalc, thirdOrd, tEField, nonSccDeriv, EField, rhoPrim, ERhoPrim,&
-      & qOutput, q0, skHamCont, skOverCont, pRepCont, neighborList, nNeighborSK, nNeighborRep,&
+      & qOutput, q0, skHamCont, skOverCont, pRepCont, neighbourList, nNeighbourSK, nNeighbourRep,&
       & species, img2CentCell, iSparseStart, orb, potential, coord, latVec, invLatVec, cellVol,&
       & coord0, totalStress, totalLatDeriv, intPressure, iRhoPrim, dispersion)
 
@@ -4082,13 +4083,13 @@ contains
     type(ORepCont), intent(in) :: pRepCont
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Number of neighbours for each of the atoms closer than the repulsive cut-off
-    integer, intent(in) :: nNeighborRep(:)
+    integer, intent(in) :: nNeighbourRep(:)
 
     !> species of all atoms in the system
     integer, intent(in) :: species(:)
@@ -4143,25 +4144,25 @@ contains
     if (allocated(sccCalc)) then
       if (tImHam) then
         call getBlockiStress(env, totalStress, nonSccDeriv, rhoPrim, iRhoPrim, ERhoPrim, skHamCont,&
-            & skOverCont, coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell,&
+            & skOverCont, coord, species, neighbourList%iNeighbour, nNeighbourSK, img2CentCell,&
             & iSparseStart, orb, potential%intBlock, potential%iorbitalBlock, cellVol)
       else
         call getBlockStress(env, totalStress, nonSccDeriv, rhoPrim, ERhoPrim, skHamCont,&
-            & skOverCont, coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell,&
+            & skOverCont, coord, species, neighbourList%iNeighbour, nNeighbourSK, img2CentCell,&
             & iSparseStart, orb, potential%intBlock, cellVol)
       end if
-      call sccCalc%addStressDc(totalStress, env, species, neighborList%iNeighbor, img2CentCell)
+      call sccCalc%addStressDc(totalStress, env, species, neighbourList%iNeighbour, img2CentCell)
       if (allocated(thirdOrd)) then
-        call thirdOrd%addStressDc(neighborList, species, coord, img2CentCell, cellVol, totalStress)
+        call thirdOrd%addStressDc(neighbourList, species, coord, img2CentCell, cellVol, totalStress)
       end if
     else
       if (tImHam) then
         call getBlockiStress(env, totalStress, nonSccDeriv, rhoPrim, iRhoPrim, ERhoPrim, skHamCont,&
-            & skOverCont, coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell,&
+            & skOverCont, coord, species, neighbourList%iNeighbour, nNeighbourSK, img2CentCell,&
             & iSparseStart, orb, potential%intBlock, potential%iorbitalBlock, cellVol)
       else
         call getNonSCCStress(env, totalStress, nonSccDeriv, rhoPrim(:,1), ERhoPrim, skHamCont,&
-            & skOverCont, coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell,&
+            & skOverCont, coord, species, neighbourList%iNeighbour, nNeighbourSK, img2CentCell,&
             & iSparseStart, orb, cellVol)
       end if
     end if
@@ -4176,7 +4177,7 @@ contains
       totalStress(:,:) = totalStress + tmpStress
     end if
 
-    call getRepulsiveStress(tmpStress, coord, nNeighborRep, neighborList%iNeighbor, species,&
+    call getRepulsiveStress(tmpStress, coord, nNeighbourRep, neighbourList%iNeighbour, species,&
         & img2CentCell, pRepCont, cellVol)
     totalStress(:,:) = totalStress + tmpStress
 
@@ -4577,7 +4578,7 @@ contains
 
   !> Calculates and prints Pipek-Mezey localisation
   subroutine calcPipekMezeyLocalisation(env, pipekMezey, tPrintEigvecsTxt, nEl, filling, over,&
-      & kPoint, neighborList, nNeighborSK, denseDesc,  iSparseStart, img2CentCell, iCellVec,&
+      & kPoint, neighbourList, nNeighbourSK, denseDesc,  iSparseStart, img2CentCell, iCellVec,&
       & cellVec, runId, orb, species, speciesName, parallelKS, localisation, eigvecsReal, SSqrReal,&
       & eigvecsCplx, SSqrCplx)
 
@@ -4603,10 +4604,10 @@ contains
     real(dp), intent(in) :: kPoint(:,:)
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc
@@ -4664,7 +4665,7 @@ contains
     end if
 
     if (allocated(eigvecsReal)) then
-      call unpackHS(SSqrReal,over,neighborList%iNeighbor, nNeighborSK, denseDesc%iAtomStart,&
+      call unpackHS(SSqrReal,over,neighbourList%iNeighbour, nNeighbourSK, denseDesc%iAtomStart,&
           & iSparseStart, img2CentCell)
       do iKS = 1, parallelKS%nLocalKS
         iSpin = parallelKS%localKS(2, iKS)
@@ -4679,7 +4680,7 @@ contains
         write(stdOut, "(A, E20.12)") 'Final localisation ', localisation
       end do
 
-      call writeRealEigvecs(env, runId, neighborList, nNeighborSK, denseDesc, iSparseStart,&
+      call writeRealEigvecs(env, runId, neighbourList, nNeighbourSK, denseDesc, iSparseStart,&
           & img2CentCell, species(:nAtom), speciesName, orb, over, parallelKS, tPrintEigvecsTxt,&
           & eigvecsReal, SSqrReal, fileName="localOrbs")
     else
@@ -4689,9 +4690,9 @@ contains
         iK = parallelKS%localKS(1, iKS)
         iSpin = parallelKS%localKS(2, iKS)
         nFilledLev = floor(nEl(iSpin) / real( 3 - nSpin, dp))
-        localisation = localisation + pipekMezey%getLocalisation( &
-            & eigvecsCplx(:,:nFilledLev,iKS), SSqrCplx, over, kpoint(:,iK), neighborList,&
-            & nNeighborSK, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
+        localisation = localisation + pipekMezey%getLocalisation(&
+            & eigvecsCplx(:,:nFilledLev,iKS), SSqrCplx, over, kpoint(:,iK), neighbourList,&
+            & nNeighbourSK, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
       end do
       write(stdOut, "(A, E20.12)") 'Original localisation', localisation
 
@@ -4701,7 +4702,7 @@ contains
         iSpin = parallelKS%localKS(2, iKS)
         nFilledLev = floor(nEl(iSpin) / real( 3 - nSpin, dp))
         call pipekMezey%calcCoeffs(eigvecsCplx(:,:nFilledLev,iKS), SSqrCplx, over, kpoint(:,iK),&
-            & neighborList, nNeighborSK, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
+            & neighbourList, nNeighbourSK, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
             & img2CentCell)
       end do
 
@@ -4710,13 +4711,13 @@ contains
         iK = parallelKS%localKS(1, iKS)
         iSpin = parallelKS%localKS(2, iKS)
         nFilledLev = floor(nEl(iSpin) / real( 3 - nSpin, dp))
-        localisation = localisation + pipekMezey%getLocalisation( &
-            & eigvecsCplx(:,:nFilledLev,iKS), SSqrCplx, over, kpoint(:,iK), neighborList,&
-            & nNeighborSK, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
+        localisation = localisation + pipekMezey%getLocalisation(&
+            & eigvecsCplx(:,:nFilledLev,iKS), SSqrCplx, over, kpoint(:,iK), neighbourList,&
+            & nNeighbourSK, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
       end do
       write(stdOut, "(A, E20.12)") 'Final localisation', localisation
 
-      call writeCplxEigvecs(env, runId, neighborList, nNeighborSK, cellVec, iCellVec, denseDesc,&
+      call writeCplxEigvecs(env, runId, neighbourList, nNeighbourSK, cellVec, iCellVec, denseDesc,&
           & iSparseStart, img2CentCell, species, speciesName, orb, kPoint, over, parallelKS,&
           & tPrintEigvecsTxt, eigvecsCplx, SSqrCplx, fileName="localOrbs")
 

--- a/prog/dftb+/prg_dftb/main.F90
+++ b/prog/dftb+/prg_dftb/main.F90
@@ -206,9 +206,9 @@ contains
 
       if (tCoordsChanged) then
         call handleCoordinateChange(env, coord0, latVec, invLatVec, species0, mCutoff, repCutoff,&
-            & orb, tPeriodic, sccCalc, dispersion, thirdOrd, img2CentCell, iCellVec, neighborList,&
-            & nAllAtom, coord0Fold, coord, species, rCellVec, nAllOrb, nNeighbor, nNeighborRep,&
-            & ham, over, H0, rhoPrim, iRhoPrim, iHam, ERhoPrim, iSparseStart)
+            & skCutoff, orb, tPeriodic, sccCalc, dispersion, thirdOrd, img2CentCell, iCellVec,&
+            & neighborList, nAllAtom, coord0Fold, coord, species, rCellVec, nAllOrb, nNeighbor,&
+            & nNeighborRep, ham, over, H0, rhoPrim, iRhoPrim, iHam, ERhoPrim, iSparseStart)
       end if
 
       if (tSccCalc) then
@@ -782,9 +782,9 @@ contains
 
   !> Does the operations that are necessary after atomic coordinates change
   subroutine handleCoordinateChange(env, coord0, latVec, invLatVec, species0, mCutOff, repCutOff,&
-      & orb, tPeriodic, sccCalc, dispersion, thirdOrd, img2CentCell, iCellVec, neighborList,&
-      & nAllAtom, coord0Fold, coord, species, rCellVec, nAllOrb, nNeighbor, nNeighborRep, ham,&
-      & over, H0, rhoPrim, iRhoPrim, iHam, ERhoPrim, iSparseStart)
+      & skCutOff, orb, tPeriodic, sccCalc, dispersion, thirdOrd, img2CentCell, iCellVec,&
+      & neighborList, nAllAtom, coord0Fold, coord, species, rCellVec, nAllOrb, nNeighbor,&
+      & nNeighborRep, ham, over, H0, rhoPrim, iRhoPrim, iHam, ERhoPrim, iSparseStart)
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -806,6 +806,9 @@ contains
 
     !> Cut-off distance for repulsive interactions
     real(dp), intent(in) :: repCutOff
+
+    !> Cut-off distance for Slater-Koster interactions
+    real(dp), intent(in) :: skCutOff
 
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
@@ -891,7 +894,8 @@ contains
     call updateNeighborListAndSpecies(coord, species, img2CentCell, iCellVec, neighborList,&
         & nAllAtom, coord0Fold, species0, mCutOff, rCellVec)
     nAllOrb = sum(orb%nOrbSpecies(species(1:nAllAtom)))
-    call getNrOfNeighborsForAll(nNeighbor, neighborList, mCutOff)
+    call getNrOfNeighborsForAll(nNeighbor, neighborList, skCutOff)
+
     call getSparseDescriptor(neighborList%iNeighbor, nNeighbor, img2CentCell, orb, iSparseStart,&
         & sparseSize)
     call reallocateSparseArrays(sparseSize, ham, over, H0, rhoPrim, iHam, iRhoPrim, ERhoPrim)

--- a/prog/dftb+/prg_dftb/main.F90
+++ b/prog/dftb+/prg_dftb/main.F90
@@ -207,7 +207,7 @@ contains
       if (tCoordsChanged) then
         call handleCoordinateChange(env, coord0, latVec, invLatVec, species0, mCutoff, repCutoff,&
             & skCutoff, orb, tPeriodic, sccCalc, dispersion, thirdOrd, img2CentCell, iCellVec,&
-            & neighborList, nAllAtom, coord0Fold, coord, species, rCellVec, nAllOrb, nNeighbor,&
+            & neighborList, nAllAtom, coord0Fold, coord, species, rCellVec, nAllOrb, nNeighborSK,&
             & nNeighborRep, ham, over, H0, rhoPrim, iRhoPrim, iHam, ERhoPrim, iSparseStart)
       end if
 
@@ -216,9 +216,9 @@ contains
       end if
 
       call env%globalTimer%startTimer(globalTimers%sparseH0S)
-      call buildH0(env, H0, skHamCont, atomEigVal, coord, nNeighbor, neighborList%iNeighbor,&
+      call buildH0(env, H0, skHamCont, atomEigVal, coord, nNeighborSK, neighborList%iNeighbor,&
           & species, iSparseStart, orb)
-      call buildS(env, over, skOverCont, coord, nNeighbor, neighborList%iNeighbor, species,&
+      call buildS(env, over, skOverCont, coord, nNeighborSK, neighborList%iNeighbor, species,&
           & iSparseStart, orb)
       call env%globalTimer%stopTimer(globalTimers%sparseH0S)
 
@@ -235,7 +235,7 @@ contains
 
       call resetExternalPotentials(potential)
       call setUpExternalElectricField(tEField, tTDEField, tPeriodic, EFieldStrength,&
-          & EFieldVector, EFieldOmega, EFieldPhase, neighborList, nNeighbor, iCellVec,&
+          & EFieldVector, EFieldOmega, EFieldPhase, neighborList, nNeighborSK, iCellVec,&
           & img2CentCell, cellVec, deltaT, iGeoStep, coord0Fold, coord, EField,&
           & potential%extAtom(:,1), absEField)
 
@@ -257,16 +257,16 @@ contains
         end if
         potential%intBlock = potential%intBlock + potential%extBlock
 
-        call getSccHamiltonian(H0, over, nNeighbor, neighborList, species, orb, iSparseStart,&
+        call getSccHamiltonian(H0, over, nNeighborSK, neighborList, species, orb, iSparseStart,&
             & img2CentCell, potential, ham, iHam)
 
         if (tWriteRealHS .or. tWriteHS) then
           call writeHSAndStop(env, tWriteHS, tWriteRealHS, tRealHS, over, neighborList,&
-              & nNeighbor, denseDesc%iAtomStart, iSparseStart, img2CentCell, kPoint, iCellVec,&
+              & nNeighborSK, denseDesc%iAtomStart, iSparseStart, img2CentCell, kPoint, iCellVec,&
               & cellVec, ham, iHam)
         end if
 
-        call getDensity(env, denseDesc, ham, over, neighborList, nNeighbor, iSparseStart,&
+        call getDensity(env, denseDesc, ham, over, neighborList, nNeighborSK, iSparseStart,&
             & img2CentCell, iCellVec, cellVec, kPoint, kWeight, orb, species, solver, tRealHS,&
             & tSpinSharedEf, tSpinOrbit, tDualSpinOrbit, tFillKSep, tFixEf, tMulliken, iDistribFn,&
             & tempElec, nEl, parallelKS, Ef, energy, eigen, filling, rhoPrim, Eband, TS, E0, iHam,&
@@ -278,7 +278,7 @@ contains
         end if
 
         if (tMulliken) then
-          call getMullikenPopulation(rhoPrim, over, orb, neighborList, nNeighbor, img2CentCell,&
+          call getMullikenPopulation(rhoPrim, over, orb, neighborList, nNeighborSK, img2CentCell,&
               & iSparseStart, qOutput, iRhoPrim=iRhoPrim, qBlock=qBlockOut, qiBlock=qiBlockOut)
         end if
 
@@ -300,7 +300,7 @@ contains
         end if
 
         call getEnergies(sccCalc, qOutput, q0, chargePerShell, species, tEField, tXlbomd,&
-            & tDftbU, tDualSpinOrbit, rhoPrim, H0, orb, neighborList, nNeighbor, img2CentCell,&
+            & tDftbU, tDualSpinOrbit, rhoPrim, H0, orb, neighborList, nNeighborSK, img2CentCell,&
             & iSparseStart, cellVol, extPressure, TS, potential, energy, thirdOrd, qBlockOut,&
             & qiBlockOut, nDftbUFunc, UJ, nUJ, iUJ, niUJ, xi)
 
@@ -345,7 +345,7 @@ contains
         call ensureLinRespConditions(t3rd, tRealHS, tPeriodic, tForces)
         call calculateLinRespExcitations(env, lresp, parallelKS, sccCalc, qOutput, q0, over,&
             & eigvecsReal, eigen(:,1,:), filling(:,1,:), coord0, species, speciesName, orb,&
-            & skHamCont, skOverCont, autotestTag, runId, neighborList, nNeighbor,&
+            & skHamCont, skOverCont, autotestTag, runId, neighborList, nNeighborSK,&
             & denseDesc, iSparseStart, img2CentCell, tWriteAutotest, tForces, tLinRespZVect,&
             & tPrintExcitedEigvecs, tPrintEigvecsTxt, nonSccDeriv, energy, SSqrReal, rhoSqrReal,&
             & excitedDerivs, occNatural)
@@ -361,20 +361,20 @@ contains
         call getDipoleMoment(qOutput, q0, coord, dipoleMoment)
       #:call DEBUG_CODE
         call checkDipoleViaHellmannFeynman(rhoPrim, q0, coord0, over, orb, neighborList,&
-            & nNeighbor, species, iSparseStart, img2CentCell)
+            & nNeighborSK, species, iSparseStart, img2CentCell)
       #:endcall DEBUG_CODE
       end if
 
       call env%globalTimer%startTimer(globalTimers%eigvecWriting)
       if (tPrintEigVecs) then
-        call writeEigenvectors(env, runId, neighborList, nNeighbor, cellVec, iCellVec, denseDesc,&
+        call writeEigenvectors(env, runId, neighborList, nNeighborSK, cellVec, iCellVec, denseDesc,&
             & iSparseStart, img2CentCell, species, speciesName, orb, kPoint, over, parallelKS,&
             & tPrintEigvecsTxt, eigvecsReal, SSqrReal, eigvecsCplx, SSqrCplx)
       end if
 
       if (tProjEigenvecs) then
-        call writeProjectedEigenvectors(env, regionLabels, eigen, neighborList, nNeighbor, cellVec,&
-            & iCellVec, denseDesc, iSparseStart, img2CentCell, orb, over, kPoint, kWeight,&
+        call writeProjectedEigenvectors(env, regionLabels, eigen, neighborList, nNeighborSK,&
+            & cellVec, iCellVec, denseDesc, iSparseStart, img2CentCell, orb, over, kPoint, kWeight,&
             & iOrbRegion, parallelKS, eigvecsReal, SSqrReal, eigvecsCplx, SSqrCplx)
       end if
       call env%globalTimer%stopTimer(globalTimers%eigvecWriting)
@@ -392,14 +392,14 @@ contains
         call env%globalTimer%startTimer(globalTimers%forceCalc)
         call env%globalTimer%startTimer(globalTimers%energyDensityMatrix)
         call getEnergyWeightedDensity(env, denseDesc, forceType, filling, eigen, kPoint, kWeight,&
-            & neighborList, nNeighbor, orb, iSparseStart, img2CentCell, iCellVec, cellVec,&
+            & neighborList, nNeighborSK, orb, iSparseStart, img2CentCell, iCellVec, cellVec,&
             & tRealHS, ham, over, parallelKS, ERhoPrim, eigvecsReal, SSqrReal, eigvecsCplx,&
             & SSqrCplx)
         call env%globalTimer%stopTimer(globalTimers%energyDensityMatrix)
         call getGradients(env, sccCalc, tEField, tXlbomd, nonSccDeriv, Efield, rhoPrim, ERhoPrim,&
-            & qOutput, q0, skHamCont, skOverCont, pRepCont, neighborList, nNeighbor, nNeighborRep,&
-            & species, img2CentCell, iSparseStart, orb, potential, coord, derivs, iRhoPrim,&
-            & thirdOrd, chrgForces, dispersion)
+            & qOutput, q0, skHamCont, skOverCont, pRepCont, neighborList, nNeighborSK,&
+            & nNeighborRep, species, img2CentCell, iSparseStart, orb, potential, coord, derivs,&
+            & iRhoPrim, thirdOrd, chrgForces, dispersion)
         if (tLinResp) then
           derivs(:,:) = derivs + excitedDerivs
         end if
@@ -408,7 +408,7 @@ contains
         if (tStress) then
           call env%globalTimer%startTimer(globalTimers%stressCalc)
           call getStress(env, sccCalc, thirdOrd, tEField, nonSccDeriv, EField, rhoPrim, ERhoPrim,&
-              & qOutput, q0, skHamCont, skOverCont, pRepCont, neighborList, nNeighbor,&
+              & qOutput, q0, skHamCont, skOverCont, pRepCont, neighborList, nNeighborSK,&
               & nNeighborRep, species, img2CentCell, iSparseStart, orb, potential, coord, latVec,&
               & invLatVec, cellVol, coord0, totalStress, totalLatDeriv, intPressure, iRhoPrim,&
               & dispersion)
@@ -613,7 +613,7 @@ contains
         call error("Pipek-Mezey localisation not implemented for non-colinear DFTB")
       end if
       call calcPipekMezeyLocalisation(env, pipekMezey, tPrintEigvecsTxt, nEl, filling, over,&
-          & kPoint, neighborList, nNeighbor, denseDesc, iSparseStart, img2CentCell, iCellVec,&
+          & kPoint, neighborList, nNeighborSK, denseDesc, iSparseStart, img2CentCell, iCellVec,&
           & cellVec, runId, orb, species, speciesName, parallelKS, localisation, eigvecsReal,&
           & SSqrReal, eigvecsCplx, SSqrCplx)
     end if
@@ -783,7 +783,7 @@ contains
   !> Does the operations that are necessary after atomic coordinates change
   subroutine handleCoordinateChange(env, coord0, latVec, invLatVec, species0, mCutOff, repCutOff,&
       & skCutOff, orb, tPeriodic, sccCalc, dispersion, thirdOrd, img2CentCell, iCellVec,&
-      & neighborList, nAllAtom, coord0Fold, coord, species, rCellVec, nAllOrb, nNeighbor,&
+      & neighborList, nAllAtom, coord0Fold, coord, species, rCellVec, nAllOrb, nNeighborSK,&
       & nNeighborRep, ham, over, H0, rhoPrim, iRhoPrim, iHam, ERhoPrim, iSparseStart)
 
     !> Environment settings
@@ -853,7 +853,7 @@ contains
     real(dp), allocatable, intent(inout) :: rCellVec(:,:)
 
     !> Number of neighbours of each real atom
-    integer, intent(out) :: nNeighbor(:)
+    integer, intent(out) :: nNeighborSK(:)
 
     !> Number of neighbours of each real atom close enough for repulsive interactions
     integer, intent(out) :: nNeighborRep(:)
@@ -894,9 +894,9 @@ contains
     call updateNeighborListAndSpecies(coord, species, img2CentCell, iCellVec, neighborList,&
         & nAllAtom, coord0Fold, species0, mCutOff, rCellVec)
     nAllOrb = sum(orb%nOrbSpecies(species(1:nAllAtom)))
-    call getNrOfNeighborsForAll(nNeighbor, neighborList, skCutOff)
+    call getNrOfNeighborsForAll(nNeighborSK, neighborList, skCutOff)
 
-    call getSparseDescriptor(neighborList%iNeighbor, nNeighbor, img2CentCell, orb, iSparseStart,&
+    call getSparseDescriptor(neighborList%iNeighbor, nNeighborSK, img2CentCell, orb, iSparseStart,&
         & sparseSize)
     call reallocateSparseArrays(sparseSize, ham, over, H0, rhoPrim, iHam, iRhoPrim, ERhoPrim)
 
@@ -1106,7 +1106,7 @@ contains
 
   !> Sets up electric external field
   subroutine setUpExternalElectricField(tEfield, tTimeDepEField, tPeriodic, EFieldStrength,&
-      & EFieldVector, EFieldOmega, EFieldPhase, neighborList, nNeighbor, iCellVec, img2CentCell,&
+      & EFieldVector, EFieldOmega, EFieldPhase, neighborList, nNeighborSK, iCellVec, img2CentCell,&
       & cellVec, deltaT, iGeoStep, coord0Fold, coord, EField, extAtomPot, absEField)
 
     !> Whether electric field should be considered at all
@@ -1134,7 +1134,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each atom
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index for unit cells
     integer, intent(in) :: iCellVec(:)
@@ -1179,7 +1179,7 @@ contains
       return
     end if
 
-    nAtom = size(nNeighbor)
+    nAtom = size(nNeighborSK)
 
     Efield(:) = EFieldStrength * EfieldVector
     if (tTimeDepEField) then
@@ -1188,7 +1188,7 @@ contains
     absEfield = sqrt(sum(Efield**2))
     if (tPeriodic) then
       do iAt1 = 1, nAtom
-        do iNeigh = 1, nNeighbor(iAt1)
+        do iNeigh = 1, nNeighborSK(iAt1)
           iAt2 = neighborList%iNeighbor(iNeigh, iAt1)
           ! overlap between atom in central cell and non-central cell
           if (iCellVec(iAt2) /= 0) then
@@ -1413,7 +1413,7 @@ contains
 
 
   !> Returns the Hamiltonian for the given scc iteration
-  subroutine getSccHamiltonian(H0, over, nNeighbor, neighborList, species, orb, iSparseStart,&
+  subroutine getSccHamiltonian(H0, over, nNeighborSK, neighborList, species, orb, iSparseStart,&
       & img2CentCell, potential, ham, iHam)
 
     !> non-SCC hamitonian (sparse)
@@ -1423,7 +1423,7 @@ contains
     real(dp), intent(in) :: over(:)
 
     !> Number of atomic neighbours
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> list of atomic neighbours
     type(TNeighborList), intent(in) :: neighborList
@@ -1455,12 +1455,12 @@ contains
 
     ham(:,:) = 0.0_dp
     ham(:,1) = h0
-    call add_shift(ham, over, nNeighbor, neighborList%iNeighbor, species, orb, iSparseStart, nAtom,&
-        & img2CentCell, potential%intBlock)
+    call add_shift(ham, over, nNeighborSK, neighborList%iNeighbor, species, orb, iSparseStart,&
+        & nAtom, img2CentCell, potential%intBlock)
 
     if (allocated(iHam)) then
       iHam(:,:) = 0.0_dp
-      call add_shift(iHam, over, nNeighbor, neighborList%iNeighbor, species, orb, iSparseStart,&
+      call add_shift(iHam, over, nNeighborSK, neighborList%iNeighbor, species, orb, iSparseStart,&
           & nAtom, img2CentCell, potential%iorbitalBlock)
     end if
 
@@ -1473,7 +1473,7 @@ contains
   !> Hamiltonian or the full (unpacked) density matrix, must also invoked from within this routine,
   !> as those unpacked quantities do not exist elsewhere.
   !>
-  subroutine getDensity(env, denseDesc, ham, over, neighborList, nNeighbor, iSparseStart,&
+  subroutine getDensity(env, denseDesc, ham, over, neighborList, nNeighborSK, iSparseStart,&
       & img2CentCell, iCellVec, cellVec, kPoint, kWeight, orb, species, solver, tRealHS,&
       & tSpinSharedEf, tSpinOrbit, tDualSpinOrbit, tFillKSep, tFixEf, tMulliken, iDistribFn,&
       & tempElec, nEl, parallelKS, Ef, energy, eigen, filling, rhoPrim, Eband, TS, E0, iHam, xi,&
@@ -1496,7 +1496,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index array for the start of atomic blocks in sparse arrays
     integer, intent(in) :: iSparseStart(:,:)
@@ -1631,16 +1631,16 @@ contains
     if (nSpin /= 4) then
       call qm2ud(ham)
       if (tRealHS) then
-        call buildAndDiagDenseRealHam(env, denseDesc, ham, over, neighborList, nNeighbor,&
+        call buildAndDiagDenseRealHam(env, denseDesc, ham, over, neighborList, nNeighborSK,&
             & iSparseStart, img2CentCell, solver, parallelKS, HSqrReal, SSqrReal, eigVecsReal,&
             & eigen(:,1,:))
       else
-        call buildAndDiagDenseCplxHam(env, denseDesc, ham, over, kPoint, neighborList, nNeighbor,&
+        call buildAndDiagDenseCplxHam(env, denseDesc, ham, over, kPoint, neighborList, nNeighborSK,&
             & iSparseStart, img2CentCell, iCellVec, cellVec, solver, parallelKS, HSqrCplx,&
             & SSqrCplx, eigVecsCplx, eigen)
       end if
     else
-      call buildAndDiagDensePauliHam(env, denseDesc, ham, over, kPoint, neighborList, nNeighbor,&
+      call buildAndDiagDensePauliHam(env, denseDesc, ham, over, kPoint, neighborList, nNeighborSK,&
           & iSparseStart, img2CentCell, iCellVec, cellVec, orb, solver, parallelKS, eigen(:,:,1),&
           & HSqrCplx, SSqrCplx, eigVecsCplx, iHam, xi, species)
     end if
@@ -1652,12 +1652,12 @@ contains
     call env%globalTimer%startTimer(globalTimers%densityMatrix)
     if (nSpin /= 4) then
       if (tRealHS) then
-        call getDensityFromRealEigvecs(env, denseDesc, filling(:,1,:), neighborList, nNeighbor,&
+        call getDensityFromRealEigvecs(env, denseDesc, filling(:,1,:), neighborList, nNeighborSK,&
             & iSparseStart, img2CentCell, orb, eigVecsReal, parallelKS, rhoPrim, SSqrReal,&
             & rhoSqrReal)
       else
         call getDensityFromCplxEigvecs(env, denseDesc, filling, kPoint, kWeight, neighborList,&
-            & nNeighbor, iSparseStart, img2CentCell, iCellVec, cellVec, orb, parallelKS,&
+            & nNeighborSK, iSparseStart, img2CentCell, iCellVec, cellVec, orb, parallelKS,&
             & eigvecsCplx, rhoPrim, SSqrCplx)
       end if
       call ud2qm(rhoPrim)
@@ -1665,9 +1665,9 @@ contains
       ! Pauli structure of eigenvectors
       filling(:,:,1) = 2.0_dp * filling(:,:,1)
       call getDensityFromPauliEigvecs(env, denseDesc, tRealHS, tSpinOrbit, tDualSpinOrbit,&
-          & tMulliken, kPoint, kWeight, filling(:,:,1), neighborList, nNeighbor, orb, iSparseStart,&
-          & img2CentCell, iCellVec, cellVec, species, parallelKS, eigVecsCplx, SSqrCplx, energy,&
-          & rhoPrim, xi, orbitalL, iRhoPrim)
+          & tMulliken, kPoint, kWeight, filling(:,:,1), neighborList, nNeighborSK, orb,&
+          & iSparseStart, img2CentCell, iCellVec, cellVec, species, parallelKS, eigVecsCplx,&
+          & SSqrCplx, energy, rhoPrim, xi, orbitalL, iRhoPrim)
       filling(:,:,1) = 0.5_dp * filling(:,:,1)
     end if
     call env%globalTimer%stopTimer(globalTimers%densityMatrix)
@@ -1676,7 +1676,7 @@ contains
 
 
   !> Builds and diagonalises dense Hamiltonians.
-  subroutine buildAndDiagDenseRealHam(env, denseDesc, ham, over, neighborList, nNeighbor,&
+  subroutine buildAndDiagDenseRealHam(env, denseDesc, ham, over, neighborList, nNeighborSK,&
       & iSparseStart, img2CentCell, solver, parallelKS, HSqrReal, SSqrReal, eigvecsReal, eigen)
 
     !> Environment settings
@@ -1695,7 +1695,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index array for the start of atomic blocks in sparse arrays
     integer, intent(in) :: iSparseStart(:,:)
@@ -1728,18 +1728,18 @@ contains
       iSpin = parallelKS%localKS(2, iKS)
     #:if WITH_SCALAPACK
       call env%globalTimer%startTimer(globalTimers%sparseToDense)
-      call unpackHSRealBlacs(env%blacs, ham(:,iSpin), neighborList%iNeighbor, nNeighbor,&
+      call unpackHSRealBlacs(env%blacs, ham(:,iSpin), neighborList%iNeighbor, nNeighborSK,&
           & iSparseStart, img2CentCell, denseDesc, HSqrReal)
-      call unpackHSRealBlacs(env%blacs, over, neighborList%iNeighbor, nNeighbor, iSparseStart,&
+      call unpackHSRealBlacs(env%blacs, over, neighborList%iNeighbor, nNeighborSK, iSparseStart,&
           & img2CentCell, denseDesc, SSqrReal)
       call env%globalTimer%stopTimer(globalTimers%sparseToDense)
       call diagDenseMtxBlacs(solver, 'V', denseDesc%blacsOrbSqr, HSqrReal, SSqrReal,&
           & eigen(:,iSpin), eigvecsReal(:,:,iKS))
     #:else
       call env%globalTimer%startTimer(globalTimers%sparseToDense)
-      call unpackHS(HSqrReal, ham(:,iSpin), neighborList%iNeighbor, nNeighbor,&
+      call unpackHS(HSqrReal, ham(:,iSpin), neighborList%iNeighbor, nNeighborSK,&
           & denseDesc%iAtomStart, iSparseStart, img2CentCell)
-      call unpackHS(SSqrReal, over, neighborList%iNeighbor, nNeighbor, denseDesc%iAtomStart,&
+      call unpackHS(SSqrReal, over, neighborList%iNeighbor, nNeighborSK, denseDesc%iAtomStart,&
           & iSparseStart, img2CentCell)
       call env%globalTimer%stopTimer(globalTimers%sparseToDense)
       call diagDenseMtx(solver, 'V', HSqrReal, SSqrReal, eigen(:,iSpin))
@@ -1756,7 +1756,7 @@ contains
 
 
   !> Builds and diagonalises dense k-point dependent Hamiltonians.
-  subroutine buildAndDiagDenseCplxHam(env, denseDesc, ham, over, kPoint, neighborList, nNeighbor,&
+  subroutine buildAndDiagDenseCplxHam(env, denseDesc, ham, over, kPoint, neighborList, nNeighborSK,&
       & iSparseStart, img2CentCell, iCellVec, cellVec, solver, parallelKS, HSqrCplx, SSqrCplx,&
       & eigvecsCplx, eigen)
 
@@ -1779,7 +1779,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index array for the start of atomic blocks in sparse arrays
     integer, intent(in) :: iSparseStart(:,:)
@@ -1820,17 +1820,17 @@ contains
     #:if WITH_SCALAPACK
       call env%globalTimer%startTimer(globalTimers%sparseToDense)
       call unpackHSCplxBlacs(env%blacs, ham(:,iSpin), kPoint(:,iK), neighborList%iNeighbor,&
-          & nNeighbor, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, HSqrCplx)
-      call unpackHSCplxBlacs(env%blacs, over, kPoint(:,iK), neighborList%iNeighbor, nNeighbor,&
+          & nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, HSqrCplx)
+      call unpackHSCplxBlacs(env%blacs, over, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK,&
           & iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, SSqrCplx)
       call env%globalTimer%stopTimer(globalTimers%sparseToDense)
       call diagDenseMtxBlacs(solver, 'V', denseDesc%blacsOrbSqr, HSqrCplx, SSqrCplx,&
           & eigen(:,iK,iSpin), eigvecsCplx(:,:,iKS))
     #:else
       call env%globalTimer%startTimer(globalTimers%sparseToDense)
-      call unpackHS(HSqrCplx, ham(:,iSpin), kPoint(:,iK), neighborList%iNeighbor, nNeighbor,&
+      call unpackHS(HSqrCplx, ham(:,iSpin), kPoint(:,iK), neighborList%iNeighbor, nNeighborSK,&
           & iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
-      call unpackHS(SSqrCplx, over, kPoint(:,iK), neighborList%iNeighbor, nNeighbor, iCellVec,&
+      call unpackHS(SSqrCplx, over, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK, iCellVec,&
           & cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
       call env%globalTimer%stopTimer(globalTimers%sparseToDense)
       call diagDenseMtx(solver, 'V', HSqrCplx, SSqrCplx, eigen(:,iK,iSpin))
@@ -1847,7 +1847,7 @@ contains
 
   !> Builds and diagonalizes Pauli two-component Hamiltonians.
   subroutine buildAndDiagDensePauliHam(env, denseDesc, ham, over, kPoint, neighborList,&
-      & nNeighbor, iSparseStart, img2CentCell, iCellVec, cellVec, orb, solver, parallelKS, eigen,&
+      & nNeighborSK, iSparseStart, img2CentCell, iCellVec, cellVec, orb, solver, parallelKS, eigen,&
       & HSqrCplx, SSqrCplx, eigvecsCplx, iHam, xi, species)
 
     !> Environment settings
@@ -1869,7 +1869,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index array for the start of atomic blocks in sparse arrays
     integer, intent(in) :: iSparseStart(:,:)
@@ -1921,24 +1921,24 @@ contains
       call env%globalTimer%startTimer(globalTimers%sparseToDense)
     #:if WITH_SCALAPACK
       if (allocated(iHam)) then
-        call unpackHPauliBlacs(env%blacs, ham, kPoint(:,iK), neighborList%iNeighbor, nNeighbor,&
+        call unpackHPauliBlacs(env%blacs, ham, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK,&
             & iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc, HSqrCplx,&
             & iorig=iHam)
       else
-        call unpackHPauliBlacs(env%blacs, ham, kPoint(:,iK), neighborList%iNeighbor, nNeighbor,&
+        call unpackHPauliBlacs(env%blacs, ham, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK,&
             & iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc, HSqrCplx)
       end if
-      call unpackSPauliBlacs(env%blacs, over, kPoint(:,iK), neighborList%iNeighbor, nNeighbor,&
+      call unpackSPauliBlacs(env%blacs, over, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK,&
           & iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc, SSqrCplx)
     #:else
       if (allocated(iHam)) then
-        call unpackHPauli(ham, kPoint(:,iK), neighborList%iNeighbor, nNeighbor, iSparseStart, &
+        call unpackHPauli(ham, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK, iSparseStart, &
             & denseDesc%iAtomStart, img2CentCell, iCellVec, cellVec, HSqrCplx, iHam=iHam)
       else
-        call unpackHPauli(ham, kPoint(:,iK), neighborList%iNeighbor, nNeighbor, iSparseStart, &
+        call unpackHPauli(ham, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK, iSparseStart, &
             & denseDesc%iAtomStart, img2CentCell, iCellVec, cellVec, HSqrCplx)
       end if
-      call unpackSPauli(over, kPoint(:,iK), neighborList%iNeighbor, nNeighbor,&
+      call unpackSPauli(over, kPoint(:,iK), neighborList%iNeighbor, nNeighborSK,&
           & denseDesc%iAtomStart, iSparseStart, img2CentCell, iCellVec, cellVec, SSqrCplx)
     #:endif
       if (allocated(xi) .and. .not. allocated(iHam)) then
@@ -1962,7 +1962,7 @@ contains
 
 
   !> Creates sparse density matrix from real eigenvectors.
-  subroutine getDensityFromRealEigvecs(env, denseDesc, filling, neighborList, nNeighbor,&
+  subroutine getDensityFromRealEigvecs(env, denseDesc, filling, neighborList, nNeighborSK,&
       & iSparseStart, img2CentCell, orb, eigvecs, parallelKS, rhoPrim, work, rhoSqrReal)
 
     !> Environment settings
@@ -1978,7 +1978,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index array for the start of atomic blocks in sparse arrays
     integer, intent(in) :: iSparseStart(:,:)
@@ -2014,18 +2014,18 @@ contains
       call makeDensityMtxRealBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,iSpin),&
           & eigvecs(:,:,iKS), work)
       call env%globalTimer%startTimer(globalTimers%denseToSparse)
-      call packRhoRealBlacs(env%blacs, denseDesc, work, neighborList%iNeighbor, nNeighbor,&
+      call packRhoRealBlacs(env%blacs, denseDesc, work, neighborList%iNeighbor, nNeighborSK,&
           & orb%mOrb, iSparseStart, img2CentCell, rhoPrim(:,iSpin))
       call env%globalTimer%stopTimer(globalTimers%denseToSparse)
     #:else
       if (tDensON2) then
         call makeDensityMatrix(work, eigvecs(:,:,iKS), filling(:,iSpin),&
-            & neighborlist%iNeighbor, nNeighbor, orb, denseDesc%iAtomStart, img2CentCell)
+            & neighborlist%iNeighbor, nNeighborSK, orb, denseDesc%iAtomStart, img2CentCell)
       else
         call makeDensityMatrix(work, eigvecs(:,:,iKS), filling(:,iSpin))
       end if
       call env%globalTimer%startTimer(globalTimers%denseToSparse)
-      call packHS(rhoPrim(:,iSpin), work, neighborlist%iNeighbor, nNeighbor, orb%mOrb,&
+      call packHS(rhoPrim(:,iSpin), work, neighborlist%iNeighbor, nNeighborSK, orb%mOrb,&
           & denseDesc%iAtomStart, iSparseStart, img2CentCell)
       call env%globalTimer%stopTimer(globalTimers%denseToSparse)
     #:endif
@@ -2045,7 +2045,7 @@ contains
 
   !> Creates sparse density matrix from complex eigenvectors.
   subroutine getDensityFromCplxEigvecs(env, denseDesc, filling, kPoint, kWeight, neighborList,&
-      & nNeighbor, iSparseStart, img2CentCell, iCellVec, cellVec, orb, parallelKS, eigvecs,&
+      & nNeighborSK, iSparseStart, img2CentCell, iCellVec, cellVec, orb, parallelKS, eigvecs,&
       & rhoPrim, work)
 
     !> Environment settings
@@ -2067,7 +2067,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index array for the start of atomic blocks in sparse arrays
     integer, intent(in) :: iSparseStart(:,:)
@@ -2108,19 +2108,19 @@ contains
           & filling(:,iK,iSpin), eigvecs(:,:,iKS), work)
       call env%globalTimer%startTimer(globalTimers%denseToSparse)
       call packRhoCplxBlacs(env%blacs, denseDesc, work, kPoint(:,iK), kWeight(iK),&
-          & neighborList%iNeighbor, nNeighbor, orb%mOrb, iCellVec, cellVec, iSparseStart,&
+          & neighborList%iNeighbor, nNeighborSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
           & img2CentCell, rhoPrim(:,iSpin))
       call env%globalTimer%stopTimer(globalTimers%denseToSparse)
     #:else
       if (tDensON2) then
         call makeDensityMatrix(work, eigvecs(:,:,iKS), filling(:,iK,iSpin), neighborlist%iNeighbor,&
-            & nNeighbor, orb, denseDesc%iAtomStart, img2CentCell)
+            & nNeighborSK, orb, denseDesc%iAtomStart, img2CentCell)
       else
         call makeDensityMatrix(work, eigvecs(:,:,iKS), filling(:,iK,iSpin))
       end if
       call env%globalTimer%startTimer(globalTimers%denseToSparse)
       call packHS(rhoPrim(:,iSpin), work, kPoint(:,iK), kWeight(iK), neighborList%iNeighbor,&
-          & nNeighbor, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
+          & nNeighborSK, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
           & img2CentCell)
       call env%globalTimer%stopTimer(globalTimers%denseToSparse)
     #:endif
@@ -2136,7 +2136,7 @@ contains
 
   !> Creates sparse density matrix from two component complex eigenvectors.
   subroutine getDensityFromPauliEigvecs(env, denseDesc, tRealHS, tSpinOrbit, tDualSpinOrbit,&
-      & tMulliken, kPoint, kWeight, filling, neighborList, nNeighbor, orb, iSparseStart,&
+      & tMulliken, kPoint, kWeight, filling, neighborList, nNeighborSK, orb, iSparseStart,&
       & img2CentCell, iCellVec, cellVec, species, parallelKS, eigvecs, work, energy, rhoPrim, xi,&
       & orbitalL, iRhoPrim)
 
@@ -2171,7 +2171,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
@@ -2264,27 +2264,27 @@ contains
     #:if WITH_SCALAPACK
       if (tImHam) then
         call packRhoPauliBlacs(env%blacs, denseDesc, work, kPoint(:,iK), kWeight(iK),&
-            & neighborList%iNeighbor, nNeighbor, orb%mOrb, iCellVec, cellVec, iSparseStart,&
+            & neighborList%iNeighbor, nNeighborSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
             & img2CentCell, rhoPrim, iRhoPrim)
       else
         call packRhoPauliBlacs(env%blacs, denseDesc, work, kPoint(:,iK), kWeight(iK),&
-            & neighborList%iNeighbor, nNeighbor, orb%mOrb, iCellVec, cellVec, iSparseStart,&
+            & neighborList%iNeighbor, nNeighborSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
             & img2CentCell, rhoPrim)
       end if
     #:else
       if (tRealHS) then
-        call packHSPauli(rhoPrim, work, neighborlist%iNeighbor, nNeighbor, orb%mOrb,&
+        call packHSPauli(rhoPrim, work, neighborlist%iNeighbor, nNeighborSK, orb%mOrb,&
             & denseDesc%iAtomStart, iSparseStart, img2CentCell)
         if (tImHam) then
-          call packHSPauliImag(iRhoPrim, work, neighborlist%iNeighbor, nNeighbor, orb%mOrb,&
+          call packHSPauliImag(iRhoPrim, work, neighborlist%iNeighbor, nNeighborSK, orb%mOrb,&
               & denseDesc%iAtomStart, iSparseStart, img2CentCell)
         end if
       else
-        call packHS(rhoPrim, work, kPoint(:,iK), kWeight(iK), neighborList%iNeighbor, nNeighbor,&
+        call packHS(rhoPrim, work, kPoint(:,iK), kWeight(iK), neighborList%iNeighbor, nNeighborSK,&
             & orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
         if (tImHam) then
           call iPackHS(iRhoPrim, work, kPoint(:,iK), kWeight(iK), neighborlist%iNeighbor, &
-              & nNeighbor, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
+              & nNeighborSK, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
               & img2CentCell)
         end if
       end if
@@ -2422,7 +2422,7 @@ contains
 
 
   !> Calculate Mulliken population from sparse density matrix.
-  subroutine getMullikenPopulation(rhoPrim, over, orb, neighborList, nNeighbor, img2CentCell,&
+  subroutine getMullikenPopulation(rhoPrim, over, orb, neighborList, nNeighborSK, img2CentCell,&
       & iSparseStart, qOrb, iRhoPrim, qBlock, qiBlock)
 
     !> sparse density matrix
@@ -2438,7 +2438,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each atom within overlap distance
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> image to actual atom indexing
     integer, intent(in) :: img2CentCell(:)
@@ -2463,14 +2463,14 @@ contains
     qOrb(:,:,:) = 0.0_dp
     do iSpin = 1, size(qOrb, dim=3)
       call mulliken(qOrb(:,:,iSpin), over, rhoPrim(:,iSpin), orb, neighborList%iNeighbor,&
-          & nNeighbor, img2CentCell, iSparseStart)
+          & nNeighborSK, img2CentCell, iSparseStart)
     end do
 
     if (allocated(qBlock)) then
       qBlock(:,:,:,:) = 0.0_dp
       do iSpin = 1, size(qBlock, dim=4)
         call mulliken(qBlock(:,:,:,iSpin), over, rhoPrim(:,iSpin), orb, neighborList%iNeighbor,&
-            & nNeighbor, img2CentCell, iSparseStart)
+            & nNeighborSK, img2CentCell, iSparseStart)
       end do
     end if
 
@@ -2478,7 +2478,7 @@ contains
       qiBlock(:,:,:,:) = 0.0_dp
       do iSpin = 1, size(qiBlock, dim=4)
         call skewMulliken(qiBlock(:,:,:,iSpin), over, iRhoPrim(:,iSpin), orb,&
-            & neighborList%iNeighbor, nNeighbor, img2CentCell, iSparseStart)
+            & neighborList%iNeighbor, nNeighborSK, img2CentCell, iSparseStart)
       end do
     end if
 
@@ -2487,7 +2487,7 @@ contains
 
   !> Calculates various energy contribution that can potentially update for the same geometry
   subroutine getEnergies(sccCalc, qOrb, q0, chargePerShell, species, tEField, tXlbomd,&
-      & tDftbU, tDualSpinOrbit, rhoPrim, H0, orb, neighborList, nNeighbor, img2CentCell,&
+      & tDftbU, tDualSpinOrbit, rhoPrim, H0, orb, neighborList, nNeighborSK, img2CentCell,&
       & iSparseStart, cellVol, extPressure, TS, potential, energy, thirdOrd, qBlock, qiBlock,&
       & nDftbUFunc, UJ, nUJ, iUJ, niUJ, xi)
 
@@ -2531,7 +2531,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours within cut-off for each atom
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> image to real atom mapping
     integer, intent(in) :: img2CentCell(:)
@@ -2587,7 +2587,7 @@ contains
 
     ! Tr[H0 * Rho] can be done with the same algorithm as Mulliken-analysis
     energy%atomNonSCC(:) = 0.0_dp
-    call mulliken(energy%atomNonSCC, rhoPrim(:,1), H0, orb, neighborList%iNeighbor, nNeighbor,&
+    call mulliken(energy%atomNonSCC, rhoPrim(:,1), H0, orb, neighborList%iNeighbor, nNeighborSK,&
         & img2CentCell, iSparseStart)
     energy%EnonSCC =  sum(energy%atomNonSCC)
 
@@ -3033,7 +3033,7 @@ contains
  !> Do the linear response excitation calculation.
   subroutine calculateLinRespExcitations(env, lresp, parallelKS, sccCalc, qOutput, q0, over,&
       & eigvecsReal, eigen, filling, coord0, species, speciesName, orb, skHamCont, skOverCont,&
-      & autotestTag, runId, neighborList, nNeighbor, denseDesc, iSparseStart,&
+      & autotestTag, runId, neighborList, nNeighborSK, denseDesc, iSparseStart,&
       & img2CentCell, tWriteAutotest, tForces, tLinRespZVect, tPrintExcEigvecs,&
       & tPrintExcEigvecsTxt, nonSccDeriv, energy, work, rhoSqrReal, excitedDerivs, occNatural)
 
@@ -3095,7 +3095,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc
@@ -3153,7 +3153,7 @@ contains
     energy%Eexcited = 0.0_dp
     allocate(dQAtom(nAtom))
     dQAtom(:) = sum(qOutput(:,:,1) - q0(:,:,1), dim=1)
-    call unpackHS(work, over, neighborList%iNeighbor, nNeighbor, denseDesc%iAtomStart,&
+    call unpackHS(work, over, neighborList%iNeighbor, nNeighborSK, denseDesc%iAtomStart,&
         & iSparseStart, img2CentCell)
     call blockSymmetrizeHS(work, denseDesc%iAtomStart)
     if (tForces) then
@@ -3174,7 +3174,7 @@ contains
           & skHamCont, skOverCont, tWriteAutotest, fdAutotest, energy%Eexcited, excitedDerivs,&
           & nonSccDeriv, rhoSqrReal, occNatural, naturalOrbs)
       if (tPrintExcEigvecs) then
-        call writeRealEigvecs(env, runId, neighborList, nNeighbor, denseDesc, iSparseStart,&
+        call writeRealEigvecs(env, runId, neighborList, nNeighborSK, denseDesc, iSparseStart,&
             & img2CentCell, pSpecies0, speciesName, orb, over, parallelKS, tPrintExcEigvecsTxt,&
             & naturalOrbs, work, fileName="excitedOrbs")
       end if
@@ -3290,8 +3290,8 @@ contains
 
 
   !> Prints dipole moment calcululated by the derivative of H with respect of the external field.
-  subroutine checkDipoleViaHellmannFeynman(rhoPrim, q0, coord0, over, orb, neighborList, nNeighbor,&
-      & species, iSparseStart, img2CentCell)
+  subroutine checkDipoleViaHellmannFeynman(rhoPrim, q0, coord0, over, orb, neighborList,&
+      & nNeighborSK, species, iSparseStart, img2CentCell)
 
     !> Density matrix in sparse storage
     real(dp), intent(in) :: rhoPrim(:,:)
@@ -3312,7 +3312,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> species of all atoms in the system
     integer, intent(in) :: species(:)
@@ -3340,11 +3340,11 @@ contains
       potentialDerivative(:,1) = -coord0(ii,:)
       hprime(:,:) = 0.0_dp
       dipole(:,:) = 0.0_dp
-      call add_shift(hprime, over, nNeighbor, neighborList%iNeighbor, species, orb, iSparseStart,&
+      call add_shift(hprime, over, nNeighborSK, neighborList%iNeighbor, species, orb, iSparseStart,&
           & nAtom, img2CentCell, potentialDerivative)
 
       ! evaluate <psi| dH/dE | psi>
-      call mulliken(dipole, hprime(:,1), rhoPrim(:,1), orb, neighborList%iNeighbor, nNeighbor,&
+      call mulliken(dipole, hprime(:,1), rhoPrim(:,1), orb, neighborList%iNeighbor, nNeighborSK,&
           & img2CentCell, iSparseStart)
 
       ! add nuclei term for derivative wrt E
@@ -3363,8 +3363,8 @@ contains
   !> NOTE: Dense eigenvector and overlap matrices are overwritten.
   !>
   subroutine getEnergyWeightedDensity(env, denseDesc, forceType, filling, eigen, kPoint, kWeight,&
-      & neighborList, nNeighbor, orb, iSparseStart, img2CentCell, iCellVEc, cellVec, tRealHS, ham,&
-      & over, parallelKS, ERhoPrim, HSqrReal, SSqrReal, HSqrCplx, SSqrCplx)
+      & neighborList, nNeighborSK, orb, iSparseStart, img2CentCell, iCellVEc, cellVec, tRealHS,&
+      & ham, over, parallelKS, ERhoPrim, HSqrReal, SSqrReal, HSqrCplx, SSqrCplx)
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -3391,7 +3391,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
@@ -3441,15 +3441,15 @@ contains
 
     if (nSpin == 4) then
       call getEDensityMtxFromPauliEigvecs(env, denseDesc, filling, eigen, kPoint, kWeight,&
-          & neighborList, nNeighbor, orb, iSparseStart, img2CentCell, iCellVec, cellVec, tRealHS,&
+          & neighborList, nNeighborSK, orb, iSparseStart, img2CentCell, iCellVec, cellVec, tRealHS,&
           & parallelKS, HSqrCplx, SSqrCplx, ERhoPrim)
     else if (tRealHS) then
       call getEDensityMtxFromRealEigvecs(env, denseDesc, forceType, filling, eigen, neighborList,&
-          & nNeighbor, orb, iSparseStart, img2CentCell, ham, over, parallelKS, HSqrReal, SSqrReal,&
-          & ERhoPrim)
+          & nNeighborSK, orb, iSparseStart, img2CentCell, ham, over, parallelKS, HSqrReal,&
+          & SSqrReal, ERhoPrim)
     else
       call getEDensityMtxFromComplexEigvecs(env, denseDesc, forceType, filling, eigen, kPoint,&
-          & kWeight, neighborList, nNeighbor, orb, iSparseStart, img2CentCell, iCellVec, cellVec,&
+          & kWeight, neighborList, nNeighborSK, orb, iSparseStart, img2CentCell, iCellVec, cellVec,&
           & ham, over, parallelKS, HSqrCplx, SSqrCplx, ERhoPrim)
     end if
 
@@ -3458,7 +3458,7 @@ contains
 
   !> Calculates density matrix from real eigenvectors.
   subroutine getEDensityMtxFromRealEigvecs(env, denseDesc, forceType, filling, eigen, neighborList,&
-      & nNeighbor, orb, iSparseStart, img2CentCell, ham, over, parallelKS, eigvecsReal, work,&
+      & nNeighborSK, orb, iSparseStart, img2CentCell, ham, over, parallelKS, eigvecsReal, work,&
       & ERhoPrim)
 
     !> Environment settings
@@ -3480,7 +3480,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
@@ -3535,7 +3535,7 @@ contains
       #:else
         if (tDensON2) then
           call makeDensityMatrix(work, eigvecsReal(:,:,iKS), filling(:,1,iS), eigen(:,1,iS),&
-              & neighborlist%iNeighbor, nNeighbor, orb, denseDesc%iAtomStart, img2CentCell)
+              & neighborlist%iNeighbor, nNeighborSK, orb, denseDesc%iAtomStart, img2CentCell)
         else
           call makeDensityMatrix(work, eigvecsReal(:,:,iKS), filling(:,1,iS), eigen(:,1,iS))
         end if
@@ -3544,7 +3544,7 @@ contains
       case(2)
         ! Correct force for XLBOMD for T=0K (DHD)
       #:if WITH_SCALAPACK
-        call unpackHSRealBlacs(env%blacs, ham(:,iS), neighborList%iNeighbor, nNeighbor,&
+        call unpackHSRealBlacs(env%blacs, ham(:,iS), neighborList%iNeighbor, nNeighborSK,&
             & iSparseStart, img2CentCell, denseDesc, work)
         call makeDensityMtxRealBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,1,iS),&
             & eigVecsReal(:,:,iKS), work2)
@@ -3553,7 +3553,7 @@ contains
         call pblasfx_psymm(work2, denseDesc%blacsOrbSqr, eigvecsReal(:,:,iKS),&
             & denseDesc%blacsOrbSqr, work, denseDesc%blacsOrbSqr, side="R", alpha=0.5_dp)
       #:else
-        call unpackHS(work, ham(:,iS), neighborlist%iNeighbor, nNeighbor, denseDesc%iAtomStart,&
+        call unpackHS(work, ham(:,iS), neighborlist%iNeighbor, nNeighborSK, denseDesc%iAtomStart,&
             & iSparseStart, img2CentCell)
         call blockSymmetrizeHS(work, denseDesc%iAtomStart)
         call makeDensityMatrix(work2, eigvecsReal(:,:,iKS), filling(:,1,iS))
@@ -3568,11 +3568,11 @@ contains
       #:if WITH_SCALAPACK
         call makeDensityMtxRealBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,1,iS),&
             & eigVecsReal(:,:,iKS), work)
-        call unpackHSRealBlacs(env%blacs, ham(:,iS), neighborlist%iNeighbor, nNeighbor,&
+        call unpackHSRealBlacs(env%blacs, ham(:,iS), neighborlist%iNeighbor, nNeighborSK,&
             & iSparseStart, img2CentCell, denseDesc, work2)
         call pblasfx_psymm(work, denseDesc%blacsOrbSqr, work2, denseDesc%blacsOrbSqr,&
             & eigvecsReal(:,:,iKS), denseDesc%blacsOrbSqr, side="L")
-        call unpackHSRealBlacs(env%blacs, over, neighborlist%iNeighbor, nNeighbor, iSparseStart,&
+        call unpackHSRealBlacs(env%blacs, over, neighborlist%iNeighbor, nNeighborSK, iSparseStart,&
             & img2CentCell, denseDesc, work)
         call psymmatinv(denseDesc%blacsOrbSqr, work)
         call pblasfx_psymm(work, denseDesc%blacsOrbSqr, eigvecsReal(:,:,iKS),&
@@ -3582,11 +3582,11 @@ contains
             & beta=1.0_dp)
       #:else
         call makeDensityMatrix(work, eigvecsReal(:,:,iKS), filling(:,1,iS))
-        call unpackHS(work2, ham(:,iS), neighborlist%iNeighbor, nNeighbor, denseDesc%iAtomStart,&
+        call unpackHS(work2, ham(:,iS), neighborlist%iNeighbor, nNeighborSK, denseDesc%iAtomStart,&
             & iSparseStart, img2CentCell)
         call blocksymmetrizeHS(work2, denseDesc%iAtomStart)
         call symm(eigvecsReal(:,:,iKS), "L", work, work2)
-        call unpackHS(work, over, neighborlist%iNeighbor, nNeighbor, denseDesc%iAtomStart,&
+        call unpackHS(work, over, neighborlist%iNeighbor, nNeighborSK, denseDesc%iAtomStart,&
             & iSparseStart, img2CentCell)
         call symmatinv(work)
         call symm(work2, "R", work, eigvecsReal(:,:,iKS), alpha=0.5_dp)
@@ -3595,10 +3595,10 @@ contains
       end select
 
     #:if WITH_SCALAPACK
-      call packRhoRealBlacs(env%blacs, denseDesc, work, neighborList%iNeighbor, nNeighbor,&
+      call packRhoRealBlacs(env%blacs, denseDesc, work, neighborList%iNeighbor, nNeighborSK,&
           & orb%mOrb, iSparseStart, img2CentCell, ERhoPrim)
     #:else
-      call packHS(ERhoPrim, work, neighborList%iNeighbor, nNeighbor, orb%mOrb,&
+      call packHS(ERhoPrim, work, neighborList%iNeighbor, nNeighborSK, orb%mOrb,&
           & denseDesc%iAtomStart, iSparseStart, img2CentCell)
     #:endif
     end do
@@ -3613,7 +3613,7 @@ contains
 
   !> Calculates density matrix from complex eigenvectors.
   subroutine getEDensityMtxFromComplexEigvecs(env, denseDesc, forceType, filling, eigen, kPoint,&
-      & kWeight, neighborList, nNeighbor, orb, iSparseStart, img2CentCell, iCellVec, cellVec,&
+      & kWeight, neighborList, nNeighborSK, orb, iSparseStart, img2CentCell, iCellVec, cellVec,&
       & ham, over, parallelKS, eigvecsCplx, work, ERhoPrim)
 
     !> Environment settings
@@ -3640,7 +3640,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
@@ -3702,7 +3702,7 @@ contains
       #:else
         if (tDensON2) then
           call makeDensityMatrix(work, eigvecsCplx(:,:,iKS), filling(:,iK,iS),&
-              & eigen(:,iK, iS), neighborlist%iNeighbor, nNeighbor, orb, denseDesc%iAtomStart,&
+              & eigen(:,iK, iS), neighborlist%iNeighbor, nNeighborSK, orb, denseDesc%iAtomStart,&
               & img2CentCell)
         else
           call makeDensityMatrix(work, eigvecsCplx(:,:,iKS), filling(:,iK,iS), eigen(:,iK, iS))
@@ -3713,7 +3713,7 @@ contains
         ! Correct force for XLBOMD for T=0K (DHD)
       #:if WITH_SCALAPACK
         call unpackHSCplxBlacs(env%blacs, ham(:,iS), kPoint(:,iK), neighborList%iNeighbor,&
-            & nNeighbor, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, work)
+            & nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, work)
         call makeDensityMtxCplxBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,1,iS),&
             & eigvecsCplx(:,:,iKS), work2)
         call pblasfx_phemm(work2, denseDesc%blacsOrbSqr, work, denseDesc%blacsOrbSqr,&
@@ -3722,7 +3722,7 @@ contains
             & denseDesc%blacsOrbSqr, work, denseDesc%blacsOrbSqr, side="R", alpha=(0.5_dp, 0.0_dp))
       #:else
         call makeDensityMatrix(work2, eigvecsCplx(:,:,iKS), filling(:,iK,iS))
-        call unpackHS(work, ham(:,iS), kPoint(:,iK), neighborlist%iNeighbor, nNeighbor,&
+        call unpackHS(work, ham(:,iS), kPoint(:,iK), neighborlist%iNeighbor, nNeighborSK,&
             & iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
         call blockHermitianHS(work, denseDesc%iAtomStart)
         call hemm(eigvecsCplx(:,:,iKS), "L", work2, work)
@@ -3735,11 +3735,11 @@ contains
         call makeDensityMtxCplxBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr,&
             & filling(:,iK,iS), eigVecsCplx(:,:,iKS), work)
         call unpackHSCplxBlacs(env%blacs, ham(:,iS), kPoint(:,iK), neighborlist%iNeighbor,&
-            & nNeighbor, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, work2)
+            & nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, work2)
         call pblasfx_phemm(work, denseDesc%blacsOrbSqr, work2, denseDesc%blacsOrbSqr,&
             & eigvecsCplx(:,:,iKS), denseDesc%blacsOrbSqr, side="L")
         call unpackHSCplxBlacs(env%blacs, over, kPoint(:,iK), neighborlist%iNeighbor,&
-            & nNeighbor, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, work)
+            & nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, work)
         call phermatinv(denseDesc%blacsOrbSqr, work)
         call pblasfx_phemm(work, denseDesc%blacsOrbSqr, eigvecsCplx(:,:,iKS),&
             & denseDesc%blacsOrbSqr, work2, denseDesc%blacsOrbSqr, side="R", alpha=(0.5_dp, 0.0_dp))
@@ -3748,11 +3748,11 @@ contains
             & alpha=(1.0_dp, 0.0_dp), beta=(1.0_dp, 0.0_dp))
       #:else
         call makeDensityMatrix(work, eigvecsCplx(:,:,iKS), filling(:,iK,iS))
-        call unpackHS(work2, ham(:,iS), kPoint(:,iK), neighborlist%iNeighbor, nNeighbor,&
+        call unpackHS(work2, ham(:,iS), kPoint(:,iK), neighborlist%iNeighbor, nNeighborSK,&
             & iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
         call blockHermitianHS(work2, denseDesc%iAtomStart)
         call hemm(eigvecsCplx(:,:,iKS), "L", work, work2)
-        call unpackHS(work, over, kPoint(:,iK), neighborlist%iNeighbor, nNeighbor, iCellVec,&
+        call unpackHS(work, over, kPoint(:,iK), neighborlist%iNeighbor, nNeighborSK, iCellVec,&
             & cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
         call hermatinv(work)
         call hemm(work2, "R", work, eigvecsCplx(:,:,iKS), alpha=(0.5_dp, 0.0_dp))
@@ -3762,11 +3762,11 @@ contains
 
     #:if WITH_SCALAPACK
       call packRhoCplxBlacs(env%blacs, denseDesc, work, kPoint(:,iK), kWeight(iK),&
-          &neighborList%iNeighbor, nNeighbor, orb%mOrb, iCellVec, cellVec, iSparseStart,&
+          &neighborList%iNeighbor, nNeighborSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
           & img2CentCell, ERhoPrim)
     #:else
       call packHS(ERhoPrim, work, kPoint(:,iK), kWeight(iK), neighborList%iNeighbor,&
-          & nNeighbor, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
+          & nNeighborSK, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
           & img2CentCell)
     #:endif
     end do
@@ -3781,7 +3781,7 @@ contains
 
   !> Calculates density matrix from Pauli-type two component eigenvectors.
   subroutine getEDensityMtxFromPauliEigvecs(env, denseDesc, filling, eigen, kPoint, kWeight,&
-      & neighborList, nNeighbor, orb, iSparseStart, img2CentCell, iCellVec, cellVec, tRealHS,&
+      & neighborList, nNeighborSK, orb, iSparseStart, img2CentCell, iCellVec, cellVec, tRealHS,&
       & parallelKS, eigvecsCplx, work, ERhoPrim)
 
     !> Environment settings
@@ -3806,7 +3806,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
@@ -3847,16 +3847,16 @@ contains
       call makeDensityMtxCplxBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,iK,1),&
           & eigvecsCplx(:,:,iKS), work, eigen(:,iK,1))
       call packERhoPauliBlacs(env%blacs, denseDesc, work, kPoint(:,iK), kWeight(iK),&
-          & neighborList%iNeighbor, nNeighbor, orb%mOrb, iCellVec, cellVec, iSparseStart,&
+          & neighborList%iNeighbor, nNeighborSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
           & img2CentCell, ERhoPrim)
     #:else
       call makeDensityMatrix(work, eigvecsCplx(:,:,iKS), filling(:,iK,1), eigen(:,iK,1))
       if (tRealHS) then
-        call packERho(ERhoPrim, work, neighborList%iNeighbor, nNeighbor, orb%mOrb,&
+        call packERho(ERhoPrim, work, neighborList%iNeighbor, nNeighborSK, orb%mOrb,&
             & denseDesc%iAtomStart, iSparseStart, img2CentCell)
       else
         call packERho(ERhoPrim, work, kPoint(:,iK), kWeight(iK), neighborList%iNeighbor,&
-            & nNeighbor, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
+            & nNeighborSK, orb%mOrb, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
             & img2CentCell)
       end if
     #:endif
@@ -3872,7 +3872,7 @@ contains
 
   !> Calculates the gradients
   subroutine getGradients(env, sccCalc, tEField, tXlbomd, nonSccDeriv, Efield, rhoPrim, ERhoPrim,&
-      & qOutput, q0, skHamCont, skOverCont, pRepCont, neighborList, nNeighbor, nNeighborRep,&
+      & qOutput, q0, skHamCont, skOverCont, pRepCont, neighborList, nNeighborSK, nNeighborRep,&
       & species, img2CentCell, iSparseStart, orb, potential, coord, derivs, iRhoPrim, thirdOrd,&
       & chrgForces, dispersion)
 
@@ -3919,7 +3919,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Number of neighbours for each of the atoms closer than the repulsive cut-off
     integer, intent(in) :: nNeighborRep(:)
@@ -3973,21 +3973,21 @@ contains
       ! No external or internal potentials
       if (tImHam) then
         call derivative_shift(env, derivs, nonSccDeriv, rhoPrim, iRhoPrim, ERhoPrim, skHamCont,&
-            & skOverCont, coord, species, neighborList%iNeighbor, nNeighbor, img2CentCell,&
+            & skOverCont, coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell,&
             & iSparseStart, orb, potential%intBlock, potential%iorbitalBlock)
       else
         call derivative_shift(env, derivs, nonSccDeriv, rhoPrim(:,1), ERhoPrim, skHamCont,&
-            & skOverCont, coord, species, neighborList%iNeighbor, nNeighbor, img2CentCell,&
+            & skOverCont, coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell,&
             & iSparseStart, orb)
       end if
     else
       if (tImHam) then
         call derivative_shift(env, derivs, nonSccDeriv, rhoPrim, iRhoPrim, ERhoPrim, skHamCont,&
-            & skOverCont, coord, species, neighborList%iNeighbor, nNeighbor, img2CentCell,&
+            & skOverCont, coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell,&
             & iSparseStart, orb, potential%intBlock, potential%iorbitalBlock)
       else
         call derivative_shift(env, derivs, nonSccDeriv, rhoPrim, ERhoPrim, skHamCont, skOverCont,&
-            & coord, species, neighborList%iNeighbor, nNeighbor, img2CentCell, iSparseStart, orb,&
+            & coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell, iSparseStart, orb,&
             & potential%intBlock)
       end if
 
@@ -4038,7 +4038,7 @@ contains
 
   !> Calculates stress tensor and lattice derivatives.
   subroutine getStress(env, sccCalc, thirdOrd, tEField, nonSccDeriv, EField, rhoPrim, ERhoPrim,&
-      & qOutput, q0, skHamCont, skOverCont, pRepCont, neighborList, nNeighbor, nNeighborRep,&
+      & qOutput, q0, skHamCont, skOverCont, pRepCont, neighborList, nNeighborSK, nNeighborRep,&
       & species, img2CentCell, iSparseStart, orb, potential, coord, latVec, invLatVec, cellVol,&
       & coord0, totalStress, totalLatDeriv, intPressure, iRhoPrim, dispersion)
 
@@ -4085,7 +4085,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Number of neighbours for each of the atoms closer than the repulsive cut-off
     integer, intent(in) :: nNeighborRep(:)
@@ -4143,11 +4143,11 @@ contains
     if (allocated(sccCalc)) then
       if (tImHam) then
         call getBlockiStress(env, totalStress, nonSccDeriv, rhoPrim, iRhoPrim, ERhoPrim, skHamCont,&
-            & skOverCont, coord, species, neighborList%iNeighbor, nNeighbor, img2CentCell,&
+            & skOverCont, coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell,&
             & iSparseStart, orb, potential%intBlock, potential%iorbitalBlock, cellVol)
       else
         call getBlockStress(env, totalStress, nonSccDeriv, rhoPrim, ERhoPrim, skHamCont,&
-            & skOverCont, coord, species, neighborList%iNeighbor, nNeighbor, img2CentCell,&
+            & skOverCont, coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell,&
             & iSparseStart, orb, potential%intBlock, cellVol)
       end if
       call sccCalc%addStressDc(totalStress, env, species, neighborList%iNeighbor, img2CentCell)
@@ -4157,11 +4157,11 @@ contains
     else
       if (tImHam) then
         call getBlockiStress(env, totalStress, nonSccDeriv, rhoPrim, iRhoPrim, ERhoPrim, skHamCont,&
-            & skOverCont, coord, species, neighborList%iNeighbor, nNeighbor, img2CentCell,&
+            & skOverCont, coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell,&
             & iSparseStart, orb, potential%intBlock, potential%iorbitalBlock, cellVol)
       else
         call getNonSCCStress(env, totalStress, nonSccDeriv, rhoPrim(:,1), ERhoPrim, skHamCont,&
-            & skOverCont, coord, species, neighborList%iNeighbor, nNeighbor, img2CentCell,&
+            & skOverCont, coord, species, neighborList%iNeighbor, nNeighborSK, img2CentCell,&
             & iSparseStart, orb, cellVol)
       end if
     end if
@@ -4577,7 +4577,7 @@ contains
 
   !> Calculates and prints Pipek-Mezey localisation
   subroutine calcPipekMezeyLocalisation(env, pipekMezey, tPrintEigvecsTxt, nEl, filling, over,&
-      & kPoint, neighborList, nNeighbor, denseDesc,  iSparseStart, img2CentCell, iCellVec,&
+      & kPoint, neighborList, nNeighborSK, denseDesc,  iSparseStart, img2CentCell, iCellVec,&
       & cellVec, runId, orb, species, speciesName, parallelKS, localisation, eigvecsReal, SSqrReal,&
       & eigvecsCplx, SSqrCplx)
 
@@ -4606,7 +4606,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc
@@ -4664,7 +4664,7 @@ contains
     end if
 
     if (allocated(eigvecsReal)) then
-      call unpackHS(SSqrReal,over,neighborList%iNeighbor, nNeighbor, denseDesc%iAtomStart,&
+      call unpackHS(SSqrReal,over,neighborList%iNeighbor, nNeighborSK, denseDesc%iAtomStart,&
           & iSparseStart, img2CentCell)
       do iKS = 1, parallelKS%nLocalKS
         iSpin = parallelKS%localKS(2, iKS)
@@ -4679,7 +4679,7 @@ contains
         write(stdOut, "(A, E20.12)") 'Final localisation ', localisation
       end do
 
-      call writeRealEigvecs(env, runId, neighborList, nNeighbor, denseDesc, iSparseStart,&
+      call writeRealEigvecs(env, runId, neighborList, nNeighborSK, denseDesc, iSparseStart,&
           & img2CentCell, species(:nAtom), speciesName, orb, over, parallelKS, tPrintEigvecsTxt,&
           & eigvecsReal, SSqrReal, fileName="localOrbs")
     else
@@ -4691,7 +4691,7 @@ contains
         nFilledLev = floor(nEl(iSpin) / real( 3 - nSpin, dp))
         localisation = localisation + pipekMezey%getLocalisation( &
             & eigvecsCplx(:,:nFilledLev,iKS), SSqrCplx, over, kpoint(:,iK), neighborList,&
-            & nNeighbor, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
+            & nNeighborSK, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
       end do
       write(stdOut, "(A, E20.12)") 'Original localisation', localisation
 
@@ -4701,7 +4701,7 @@ contains
         iSpin = parallelKS%localKS(2, iKS)
         nFilledLev = floor(nEl(iSpin) / real( 3 - nSpin, dp))
         call pipekMezey%calcCoeffs(eigvecsCplx(:,:nFilledLev,iKS), SSqrCplx, over, kpoint(:,iK),&
-            & neighborList, nNeighbor, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
+            & neighborList, nNeighborSK, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart,&
             & img2CentCell)
       end do
 
@@ -4712,11 +4712,11 @@ contains
         nFilledLev = floor(nEl(iSpin) / real( 3 - nSpin, dp))
         localisation = localisation + pipekMezey%getLocalisation( &
             & eigvecsCplx(:,:nFilledLev,iKS), SSqrCplx, over, kpoint(:,iK), neighborList,&
-            & nNeighbor, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
+            & nNeighborSK, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
       end do
       write(stdOut, "(A, E20.12)") 'Final localisation', localisation
 
-      call writeCplxEigvecs(env, runId, neighborList, nNeighbor, cellVec, iCellVec, denseDesc,&
+      call writeCplxEigvecs(env, runId, neighborList, nNeighborSK, cellVec, iCellVec, denseDesc,&
           & iSparseStart, img2CentCell, species, speciesName, orb, kPoint, over, parallelKS,&
           & tPrintEigvecsTxt, eigvecsCplx, SSqrCplx, fileName="localOrbs")
 

--- a/prog/dftb+/prg_dftb/mainio.F90
+++ b/prog/dftb+/prg_dftb/mainio.F90
@@ -105,7 +105,7 @@ module mainio
 contains
 
   !> Writes the eigenvectors to disc.
-  subroutine writeEigenvectors(env, runId, neighborList, nNeighborSK, cellVec, iCellVec,&
+  subroutine writeEigenvectors(env, runId, neighbourList, nNeighbourSK, cellVec, iCellVec,&
       & denseDesc, iPair, img2CentCell, species, speciesName, orb, kPoint, over, parallelKS,&
       & tPrintEigvecsTxt, eigvecsReal, SSqrReal, eigvecsCplx, SSqrCplx)
 
@@ -116,10 +116,10 @@ contains
     integer, intent(in) :: runId
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index for which unit cell atoms are associated with
     integer, intent(in) :: iCellVec(:)
@@ -173,11 +173,11 @@ contains
     @:ASSERT(allocated(SSqrReal) .neqv. allocated(SSqrCplx))
 
     if (allocated(eigvecsCplx)) then
-      call writeCplxEigvecs(env, runId, neighborList, nNeighborSK, cellVec, iCellVec, denseDesc,&
+      call writeCplxEigvecs(env, runId, neighbourList, nNeighbourSK, cellVec, iCellVec, denseDesc,&
           & iPair, img2CentCell, species, speciesName, orb, kPoint, over, parallelKS,&
           & tPrintEigvecsTxt, eigvecsCplx, SSqrCplx)
     else
-      call writeRealEigvecs(env, runId, neighborList, nNeighborSK, denseDesc, iPair,&
+      call writeRealEigvecs(env, runId, neighbourList, nNeighbourSK, denseDesc, iPair,&
           & img2CentCell, species, speciesName, orb, over, parallelKS, tPrintEigvecsTxt,&
           & eigvecsReal, SSqrReal)
     end if
@@ -186,7 +186,7 @@ contains
 
 
   !> Writes real eigenvectors
-  subroutine writeRealEigvecs(env, runId, neighborList, nNeighborSK, denseDesc, iPair,&
+  subroutine writeRealEigvecs(env, runId, neighbourList, nNeighbourSK, denseDesc, iPair,&
       & img2CentCell, species, speciesName, orb, over, parallelKS, tPrintEigvecsTxt, eigvecsReal,&
       & SSqrReal, fileName)
 
@@ -197,10 +197,10 @@ contains
     integer, intent(in) :: runId
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index of start of atom blocks in dense matrices
     type(TDenseDescr), intent(in) :: denseDesc
@@ -242,13 +242,13 @@ contains
     call writeRealEigvecsBinBlacs(env, denseDesc, eigvecsReal, runId, parallelKS, fileName=fileName)
     if (tPrintEigvecsTxt) then
       call writeRealEigvecsTxtBlacs(env, denseDesc, eigvecsReal, parallelKS, orb, over,&
-          & neighborList%iNeighbor, nNeighborSK, iPair, img2CentCell, species, speciesName,&
+          & neighbourList%iNeighbour, nNeighbourSK, iPair, img2CentCell, species, speciesName,&
           & fileName=fileName)
     end if
   #:else
     call writeRealEigvecsBinSerial(eigvecsReal, runId, parallelKS, fileName=fileName)
     if (tPrintEigvecsTxt) then
-      call writeRealEigvecsTxtSerial(neighborList, nNeighborSK, denseDesc, iPair, img2CentCell,&
+      call writeRealEigvecsTxtSerial(neighbourList, nNeighbourSK, denseDesc, iPair, img2CentCell,&
           & orb, species, speciesName, over, parallelKS, eigvecsReal, SSqrReal, fileName=fileName)
     end if
   #:endif
@@ -257,9 +257,9 @@ contains
 
 
   !> Writes complex eigenvectors.
-  subroutine writeCplxEigvecs(env, runId, neighborList, nNeighborSK, cellVec, iCellVec, denseDesc,&
-      & iPair, img2CentCell, species, speciesName, orb, kPoint, over, parallelKS, tPrintEigvecsTxt,&
-      & eigvecsCplx, SSqrCplx, fileName)
+  subroutine writeCplxEigvecs(env, runId, neighbourList, nNeighbourSK, cellVec, iCellVec,&
+      & denseDesc, iPair, img2CentCell, species, speciesName, orb, kPoint, over, parallelKS,&
+      & tPrintEigvecsTxt, eigvecsCplx, SSqrCplx, fileName)
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -268,10 +268,10 @@ contains
     integer, intent(in) :: runId
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Vectors (in units of the lattice constants) to cells of the lattice
     real(dp), intent(in) :: cellVec(:,:)
@@ -323,23 +323,23 @@ contains
     if (tPrintEigvecsTxt) then
       if (denseDesc%t2Component) then
         call writePauliEigvecsTxtBlacs(env, denseDesc, eigvecsCplx, parallelKS, orb, over, kPoint,&
-            & neighborList%iNeighbor, nNeighborSK, iCellVec, cellVec, iPair, img2CentCell, species,&
-            & speciesName, fileName=fileName)
+            & neighbourList%iNeighbour, nNeighbourSK, iCellVec, cellVec, iPair, img2CentCell,&
+            & species, speciesName, fileName=fileName)
       else
         call writeCplxEigvecsTxtBlacs(env, denseDesc, eigvecsCplx, parallelKS, orb, over, kPoint,&
-            & neighborList%iNeighbor, nNeighborSK, iCellVec, cellVec, iPair, img2CentCell, species,&
-            & speciesName, fileName=fileName)
+            & neighbourList%iNeighbour, nNeighbourSK, iCellVec, cellVec, iPair, img2CentCell,&
+            & species, speciesName, fileName=fileName)
       end if
     end if
   #:else
     call writeCplxEigvecsBinSerial(eigvecsCplx, runId, parallelKS, fileName=fileName)
     if (tPrintEigvecsTxt) then
       if (denseDesc%t2Component) then
-        call writePauliEigvecsTxtSerial(neighborList, nNeighborSK, denseDesc, iPair, img2CentCell,&
-            & iCellVec, cellVec, orb, species, speciesName, over, parallelKS, kPoint, eigvecsCplx,&
-            & SSqrCplx, fileName=fileName)
+        call writePauliEigvecsTxtSerial(neighbourList, nNeighbourSK, denseDesc, iPair,&
+            & img2CentCell, iCellVec, cellVec, orb, species, speciesName, over, parallelKS, kPoint,&
+            & eigvecsCplx, SSqrCplx, fileName=fileName)
       else
-        call writeCplxEigvecsTxtSerial(neighborList, nNeighborSK, denseDesc, iPair, img2CentCell,&
+        call writeCplxEigvecsTxtSerial(neighbourList, nNeighbourSK, denseDesc, iPair, img2CentCell,&
             & iCellVec, cellVec, orb, species, speciesName, over, parallelKS, kPoint, eigvecsCplx,&
             & SSqrCplx, fileName=fileName)
       end if
@@ -469,8 +469,8 @@ contains
 #:if WITH_SCALAPACK
 
   !> Write the real eigvectors into human readible output file (BLACS version).
-  subroutine writeRealEigvecsTxtBlacs(env, denseDesc, eigvecs, parallelKS, orb, over, iNeighbor,&
-      & nNeighborSK, iSparseStart, img2CentCell, species, speciesName, fileName)
+  subroutine writeRealEigvecsTxtBlacs(env, denseDesc, eigvecs, parallelKS, orb, over, iNeighbour,&
+      & nNeighbourSK, iSparseStart, img2CentCell, species, speciesName, fileName)
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -490,11 +490,11 @@ contains
     !> Sparse overlap
     real(dp), intent(in) :: over(:)
 
-    !> Neighbors of each atom
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Neighbours of each atom
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index array for sparse matrices
     integer, intent(in) :: iSparseStart(:,:)
@@ -518,7 +518,7 @@ contains
     integer :: iKS, iS, iGroup, iEig, fd
 
     nOrb = denseDesc%fullSize
-    nAtom = size(nNeighborSK)
+    nAtom = size(nNeighbourSK)
     allocate(globalS(size(eigvecs, dim=1), size(eigvecs, dim=2)))
     allocate(globalFrac(size(eigvecs, dim=1), size(eigvecs, dim=2)))
     if (env%mpi%tGroupMaster) then
@@ -542,7 +542,7 @@ contains
           end if
           iS = parallelKS%groupKS(2, iKS, iGroup)
           if (iGroup == 0) then
-            call unpackHSRealBlacs(env%blacs, over, iNeighbor, nNeighborSK, iSparseStart,&
+            call unpackHSRealBlacs(env%blacs, over, iNeighbour, nNeighbourSK, iSparseStart,&
                 & img2CentCell, denseDesc, globalS)
             call pblasfx_psymm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
                 & denseDesc%blacsOrbSqr, globalFrac, denseDesc%blacsOrbSqr)
@@ -565,8 +565,8 @@ contains
     else
       ! All processes except the global master process
       do iKS = 1, parallelKS%nLocalKS
-        call unpackHSRealBlacs(env%blacs, over, iNeighbor, nNeighborSK, iSparseStart, img2CentCell,&
-            & denseDesc, globalS)
+        call unpackHSRealBlacs(env%blacs, over, iNeighbour, nNeighbourSK, iSparseStart,&
+            & img2CentCell, denseDesc, globalS)
         call pblasfx_psymm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS), denseDesc%blacsOrbSqr,&
             & globalFrac, denseDesc%blacsOrbSqr)
         globalFrac(:,:) = globalFrac * eigvecs(:,:,iKS)
@@ -594,14 +594,14 @@ contains
 #:else
 
     !> Writes real eigenvectors in text form.
-  subroutine writeRealEigvecsTxtSerial(neighlist, nNeighborSK, denseDesc, iPair, img2CentCell,&
+  subroutine writeRealEigvecsTxtSerial(neighlist, nNeighbourSK, denseDesc, iPair, img2CentCell,&
       & orb, species, speciesName, over, parallelKS, eigvecs, SSqr, fileName)
 
-    !> Neighbor list.
-    type(TNeighborList), intent(in) :: neighlist
+    !> Neighbour list.
+    type(TNeighbourList), intent(in) :: neighlist
 
-    !> Nr. of neighbors for SK-interaction.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for SK-interaction.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Dense descriptor for H and S
     type(TDenseDescr), intent(in) :: denseDesc
@@ -640,10 +640,10 @@ contains
     integer :: nAtom
     integer :: iKS, iS, iEig, fd
 
-    nAtom = size(nNeighborSK)
+    nAtom = size(nNeighbourSK)
     call prepareEigvecFileTxt(fd, .false., fileName)
     allocate(rVecTemp(size(eigvecs, dim=1)))
-    call unpackHS(SSqr, over, neighlist%iNeighbor, nNeighborSK, denseDesc%iAtomStart, iPair,&
+    call unpackHS(SSqr, over, neighlist%iNeighbour, nNeighbourSK, denseDesc%iAtomStart, iPair,&
         & img2CentCell)
     do iKS = 1, parallelKS%nLocalKS
       iS = parallelKS%localKS(2, iKS)
@@ -665,7 +665,7 @@ contains
 
   !> Write the complex eigvectors into human readible output file (BLACS version).
   subroutine writeCplxEigvecsTxtBlacs(env, denseDesc, eigvecs, parallelKS, orb, over, kPoints,&
-      & iNeighbor, nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, species,&
+      & iNeighbour, nNeighbourSK, iCellVec, cellVec, iSparseStart, img2CentCell, species,&
       & speciesName, fileName)
 
     !> Environment settings
@@ -689,11 +689,11 @@ contains
     !> Kpoints
     real(dp), intent(in) :: kPoints(:,:)
 
-    !> Neighbors of each atom
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Neighbours of each atom
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Cell vector index for each atom
     integer, intent(in) :: iCellVec(:)
@@ -724,7 +724,7 @@ contains
     integer :: iKS, iK, iS, iGroup, iEig, fd
 
     nEigvec = denseDesc%nOrb
-    nAtom = size(nNeighborSK)
+    nAtom = size(nNeighbourSK)
     allocate(globalS(size(eigvecs, dim=1), size(eigvecs, dim=2)))
     allocate(globalSDotC(size(eigvecs, dim=1), size(eigvecs, dim=2)))
     allocate(globalFrac(size(eigvecs, dim=1), size(eigvecs, dim=2)))
@@ -747,7 +747,7 @@ contains
           iK = parallelKS%groupKS(1, iKS, iGroup)
           iS = parallelKS%groupKS(2, iKS, iGroup)
           if (iGroup == 0) then
-            call unpackHSCplxBlacs(env%blacs, over, kPoints(:,iK), iNeighbor, nNeighborSK,&
+            call unpackHSCplxBlacs(env%blacs, over, kPoints(:,iK), iNeighbour, nNeighbourSK,&
                 & iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, globalS)
             call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
                 & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
@@ -770,7 +770,7 @@ contains
     else
       do iKS = 1, parallelKS%nLocalKS
         iK = parallelKS%localKS(1, iKS)
-        call unpackHSCplxBlacs(env%blacs, over, kPoints(:,iK), iNeighbor, nNeighborSK, iCellVec,&
+        call unpackHSCplxBlacs(env%blacs, over, kPoints(:,iK), iNeighbour, nNeighbourSK, iCellVec,&
             & cellVec, iSparseStart, img2CentCell, denseDesc, globalS)
         call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
             & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
@@ -799,15 +799,15 @@ contains
 #:else
 
     !> Writes complex eigenvectors in text form.
-  subroutine writeCplxEigvecsTxtSerial(neighlist, nNeighborSK, denseDesc, iPair, img2CentCell,&
+  subroutine writeCplxEigvecsTxtSerial(neighlist, nNeighbourSK, denseDesc, iPair, img2CentCell,&
       & iCellVec, cellVec, orb, species, speciesName, over, parallelKS, kPoints, eigvecs, SSqr,&
       & fileName)
 
-    !> Neighbor list.
-    type(TNeighborList), intent(in) :: neighlist
+    !> Neighbour list.
+    type(TNeighbourList), intent(in) :: neighlist
 
-    !> Nr. of neighbors for SK-interaction.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for SK-interaction.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Dense matrix descriptor for H and S
     type(TDenseDescr), intent(in) :: denseDesc
@@ -856,7 +856,7 @@ contains
     integer :: nEigvecs, nAtom
     integer :: iKS, iK, iS, iEig, fd
 
-    nAtom = size(nNeighborSK)
+    nAtom = size(nNeighbourSK)
     call prepareEigvecFileTxt(fd, denseDesc%t2Component, fileName)
     allocate(cVecTemp(size(eigvecs, dim=1)))
     nEigvecs = size(eigvecs, dim=2)
@@ -865,8 +865,8 @@ contains
     do iKS = 1, parallelKS%nLocalKS
       iK = parallelKS%localKS(1, iKS)
       iS = parallelKS%localKS(2, iKS)
-      call unpackHS(SSqr, over, kPoints(:,iK), neighlist%iNeighbor, nNeighborSK, iCellVec, cellVec,&
-          & denseDesc%iAtomStart, iPair, img2CentCell)
+      call unpackHS(SSqr, over, kPoints(:,iK), neighlist%iNeighbour, nNeighbourSK, iCellVec,&
+          & cellVec, denseDesc%iAtomStart, iPair, img2CentCell)
       do iEig = 1, nEigvecs
         call hemv(cVecTemp, SSqr, eigvecs(:,iEig,iKS))
         fracs(:) = real(conjg(eigvecs(:,iEig,iKS)) * cVecTemp)
@@ -885,7 +885,7 @@ contains
 
   !> Write the complex eigvectors into human readible output file (BLACS version).
   subroutine writePauliEigvecsTxtBlacs(env, denseDesc, eigvecs, parallelKS, orb, over, kPoints,&
-      & iNeighbor, nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, species,&
+      & iNeighbour, nNeighbourSK, iCellVec, cellVec, iSparseStart, img2CentCell, species,&
       & speciesName, fileName)
 
     !> Environment settings
@@ -909,11 +909,11 @@ contains
     !> Kpoints
     real(dp), intent(in) :: kPoints(:,:)
 
-    !> Neighbors of each atom
-    integer, intent(in) :: iNeighbor(0:,:)
+    !> Neighbours of each atom
+    integer, intent(in) :: iNeighbour(0:,:)
 
-    !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Cell vector index for each atom
     integer, intent(in) :: iCellVec(:)
@@ -944,7 +944,7 @@ contains
     integer :: iKS, iK, iGroup, iEig, fd
 
     nOrb = denseDesc%fullSize
-    nAtom = size(nNeighborSK)
+    nAtom = size(nNeighbourSK)
     allocate(globalS(size(eigvecs, dim=1), size(eigvecs, dim=2)))
     allocate(globalSDotC(size(eigvecs, dim=1), size(eigvecs, dim=2)))
     if (env%mpi%tGroupMaster) then
@@ -971,7 +971,7 @@ contains
           end if
           iK = parallelKS%groupKS(1, iKS, iGroup)
           if (iGroup == 0) then
-            call unpackSPauliBlacs(env%blacs, over, kPoints(:,iK), iNeighbor, nNeighborSK,&
+            call unpackSPauliBlacs(env%blacs, over, kPoints(:,iK), iNeighbour, nNeighbourSK,&
                 & iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc, globalS)
             call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
                 & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
@@ -995,7 +995,7 @@ contains
       ! All processes except the global master process
       do iKS = 1, parallelKS%nLocalKS
         iK = parallelKS%localKS(1, iKS)
-        call unpackSPauliBlacs(env%blacs, over, kPoints(:,iK), iNeighbor, nNeighborSK, iCellVec,&
+        call unpackSPauliBlacs(env%blacs, over, kPoints(:,iK), iNeighbour, nNeighbourSK, iCellVec,&
             & cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc, globalS)
         call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
             & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
@@ -1023,15 +1023,15 @@ contains
 #:else
 
     !> Writes complex eigenvectors in text form.
-  subroutine writePauliEigvecsTxtSerial(neighlist, nNeighborSK, denseDesc, iPair, img2CentCell,&
+  subroutine writePauliEigvecsTxtSerial(neighlist, nNeighbourSK, denseDesc, iPair, img2CentCell,&
       & iCellVec, cellVec, orb, species, speciesName, over, parallelKS, kPoints, eigvecs, SSqr,&
       & fileName)
 
-    !> Neighbor list.
-    type(TNeighborList), intent(in) :: neighlist
+    !> Neighbour list.
+    type(TNeighbourList), intent(in) :: neighlist
 
-    !> Nr. of neighbors for SK-interaction.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for SK-interaction.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Dense matrix descriptor for H and S
     type(TDenseDescr), intent(in) :: denseDesc
@@ -1080,7 +1080,7 @@ contains
     integer :: nEigvecs, nAtom
     integer :: iKS, iK, iEig, fd
 
-    nAtom = size(nNeighborSK)
+    nAtom = size(nNeighbourSK)
     call prepareEigvecFileTxt(fd, denseDesc%t2Component, fileName)
     allocate(cVecTemp(size(eigvecs, dim=1)))
     nEigvecs = size(eigvecs, dim=2)
@@ -1088,7 +1088,7 @@ contains
 
     do iKS = 1, parallelKS%nLocalKS
       iK = parallelKS%localKS(1, iKS)
-      call unpackSPauli(over, kPoints(:,iK), neighlist%iNeighbor, nNeighborSK,&
+      call unpackSPauli(over, kPoints(:,iK), neighlist%iNeighbour, nNeighbourSK,&
           & denseDesc%iAtomStart, iPair, img2CentCell, iCellVec, cellVec, SSqr)
       do iEig = 1, nEigvecs
         call hemv(cVecTemp, SSqr, eigvecs(:,iEig,iKS))
@@ -1105,7 +1105,7 @@ contains
 
 
   !> Write projected eigenvectors.
-  subroutine writeProjectedEigenvectors(env, regionLabels, eigen, neighborList, nNeighborSK,&
+  subroutine writeProjectedEigenvectors(env, regionLabels, eigen, neighbourList, nNeighbourSK,&
       & cellVec, iCellVec, denseDesc, iPair, img2CentCell, orb, over, kPoint, kWeight, iOrbRegion,&
       & parallelKS, eigvecsReal, workReal, eigvecsCplx, workCplx)
 
@@ -1119,10 +1119,10 @@ contains
     real(dp), intent(in) :: eigen(:,:,:)
 
     !> list of neighbours for each atom
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Vectors (in units of the lattice constants) to cells of the lattice
     real(dp), intent(in) :: cellVec(:,:)
@@ -1176,30 +1176,30 @@ contains
     if (allocated(eigvecsCplx)) then
       if (denseDesc%t2Component) then
         call writeProjPauliEigvecsBlacs(env, denseDesc, regionLabels, iOrbRegion, eigen,&
-            & eigvecsCplx, orb, parallelKS, kPoint, kWeight, over, neighborList, nNeighborSK,&
+            & eigvecsCplx, orb, parallelKS, kPoint, kWeight, over, neighbourList, nNeighbourSK,&
             & iPair, img2CentCell, iCellVec, cellVec)
       else
         call writeProjCplxEigvecsBlacs(env, denseDesc, regionLabels, iOrbRegion, eigen,&
-            & eigvecsCplx, parallelKS, kPoint, kWeight, over, neighborList, nNeighborSK, iPair,&
+            & eigvecsCplx, parallelKS, kPoint, kWeight, over, neighbourList, nNeighbourSK, iPair,&
             & img2CentCell, iCellVec, cellVec)
       end if
     else
       call writeProjRealEigvecsBlacs(env, denseDesc, regionLabels, iOrbRegion, eigen, eigvecsReal,&
-          & parallelKS, over, neighborList, nNeighborSK, iPair, img2CentCell)
+          & parallelKS, over, neighbourList, nNeighbourSK, iPair, img2CentCell)
     end if
   #:else
     if (allocated(eigvecsCplx)) then
       if (denseDesc%t2Component) then
-        call writeProjPauliEigvecsSerial(regionLabels, eigen, neighborList, nNeighborSK, cellVec,&
+        call writeProjPauliEigvecsSerial(regionLabels, eigen, neighbourList, nNeighbourSK, cellVec,&
             & iCellVec, denseDesc, iPair, img2CentCell, over, kpoint, kWeight, parallelKS,&
             & eigvecsCplx, workCplx, iOrbRegion)
       else
-        call writeProjCplxEigvecsSerial(regionLabels, eigen, neighborList, nNeighborSK, cellVec,&
+        call writeProjCplxEigvecsSerial(regionLabels, eigen, neighbourList, nNeighbourSK, cellVec,&
             & iCellVec, denseDesc, iPair, img2CentCell, over, kpoint, kWeight, parallelKS,&
             & eigvecsCplx, workCplx, iOrbRegion)
       end if
     else
-      call writeProjRealEigvecsSerial(regionLabels, eigen, neighborList, nNeighborSK, denseDesc,&
+      call writeProjRealEigvecsSerial(regionLabels, eigen, neighbourList, nNeighbourSK, denseDesc,&
           & iPair, img2CentCell, over, parallelKS, eigvecsReal, workReal, iOrbRegion)
     end if
   #:endif
@@ -1211,7 +1211,7 @@ contains
 
   !> Write the real eigvectors into human readible output file (BLACS version).
   subroutine writeProjRealEigvecsBlacs(env, denseDesc, fileNames, iOrbRegion, eigvals, eigvecs,&
-      & parallelKS, over, neighborList, nNeighborSK, iSparseStart, img2CentCell)
+      & parallelKS, over, neighbourList, nNeighbourSK, iSparseStart, img2CentCell)
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -1237,11 +1237,11 @@ contains
     !> Sparse overlap
     real(dp), intent(in) :: over(:)
 
-    !> Neighbors of each atom
-    type(TNeighborList), intent(in) :: neighborList
+    !> Neighbours of each atom
+    type(TNeighbourList), intent(in) :: neighbourList
 
-    !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index array for sparse matrices
     integer, intent(in) :: iSparseStart(:,:)
@@ -1280,7 +1280,7 @@ contains
           end if
           iS = parallelKS%groupKS(2, iKS, iGroup)
           if (iGroup == 0) then
-            call unpackHSRealBlacs(env%blacs, over, neighborList%iNeighbor, nNeighborSK,&
+            call unpackHSRealBlacs(env%blacs, over, neighbourList%iNeighbour, nNeighbourSK,&
                 & iSparseStart, img2CentCell, denseDesc, globalS)
             call pblasfx_psymm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
                 & denseDesc%blacsOrbSqr, globalFrac, denseDesc%blacsOrbSqr)
@@ -1301,8 +1301,8 @@ contains
     else
       ! All processes except the global master process
       do iKS = 1, parallelKS%nLocalKS
-        call unpackHSRealBlacs(env%blacs, over, neighborList%iNeighbor, nNeighborSK, iSparseStart,&
-            & img2CentCell, denseDesc, globalS)
+        call unpackHSRealBlacs(env%blacs, over, neighbourList%iNeighbour, nNeighbourSK,&
+            & iSparseStart, img2CentCell, denseDesc, globalS)
         call pblasfx_psymm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS), denseDesc%blacsOrbSqr,&
             & globalFrac, denseDesc%blacsOrbSqr)
         globalFrac(:,:) = eigvecs(:,:,iKS) * globalFrac
@@ -1326,7 +1326,7 @@ contains
 #:else
 
     !> Write the projected eigenstates into text files
-  subroutine writeProjRealEigvecsSerial(fileNames, eigvals, neighlist, nNeighborSK, denseDesc,&
+  subroutine writeProjRealEigvecsSerial(fileNames, eigvals, neighlist, nNeighbourSK, denseDesc,&
       & iPair, img2CentCell, over, parallelKS, eigvecs, work, iOrbRegion)
 
     !> List with fileNames for each region
@@ -1335,11 +1335,11 @@ contains
     !> eigenvalues
     real(dp), intent(in) :: eigvals(:,:,:)
 
-    !> Neighbor list
-    type(TNeighborList), intent(in) :: neighlist
+    !> Neighbour list
+    type(TNeighbourList), intent(in) :: neighlist
 
-    !> Nr. of neighbors for SK-interaction
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for SK-interaction
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Dense matrix descriptor for H and S
     type(TDenseDescr), intent(in) :: denseDesc
@@ -1374,7 +1374,7 @@ contains
     call prepareProjEigvecFiles(fd, fileNames)
 
     allocate(rVecTemp(size(eigvecs, dim=1)))
-    call unpackHS(work, over, neighlist%iNeighbor, nNeighborSK, denseDesc%iAtomStart, iPair,&
+    call unpackHS(work, over, neighlist%iNeighbour, nNeighbourSK, denseDesc%iAtomStart, iPair,&
         & img2CentCell)
     do iKS = 1, parallelKS%nLocalKS
       iS = parallelKS%localKS(2, iKS)
@@ -1398,7 +1398,7 @@ contains
 
   !> Write the complex eigvectors into human readible output file (BLACS version).
   subroutine writeProjCplxEigvecsBlacs(env, denseDesc, fileNames, iOrbRegion, eigvals, eigvecs,&
-      & parallelKS, kPoints, kWeights, over, neighborList, nNeighborSK, iSparseStart,&
+      & parallelKS, kPoints, kWeights, over, neighbourList, nNeighbourSK, iSparseStart,&
       & img2CentCell, iCellVec, cellVec)
 
     !> Environment settings
@@ -1431,11 +1431,11 @@ contains
     !> Sparse overlap
     real(dp), intent(in) :: over(:)
 
-    !> Neighbors of each atom
-    type(TNeighborList), intent(in) :: neighborList
+    !> Neighbours of each atom
+    type(TNeighbourList), intent(in) :: neighbourList
 
-    !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index array for sparse matrices
     integer, intent(in) :: iSparseStart(:,:)
@@ -1483,8 +1483,8 @@ contains
           iK = parallelKS%groupKS(1, iKS, iGroup)
           iS = parallelKS%groupKS(2, iKS, iGroup)
           if (iGroup == 0) then
-            call unpackHSCplxBlacs(env%blacs, over, kPoints(:,iK), neighborList%iNeighbor,&
-                & nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, globalS)
+            call unpackHSCplxBlacs(env%blacs, over, kPoints(:,iK), neighbourList%iNeighbour,&
+                & nNeighbourSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, globalS)
             call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
                 & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
             globalFrac(:,:) = real(globalSDotC * conjg(eigvecs(:,:,iKS)))
@@ -1505,8 +1505,8 @@ contains
       ! All processes except the global master process
       do iKS = 1, parallelKS%nLocalKS
         iK = parallelKS%localKS(1, iKS)
-        call unpackHSCplxBlacs(env%blacs, over, kPoints(:,iK), neighborList%iNeighbor, nNeighborSK,&
-            & iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, globalS)
+        call unpackHSCplxBlacs(env%blacs, over, kPoints(:,iK), neighbourList%iNeighbour,&
+            & nNeighbourSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, globalS)
         call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
             & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
         globalFrac(:,:) = real(conjg(eigvecs(:,:,iKS)) * globalSDotC)
@@ -1530,7 +1530,7 @@ contains
 #:else
 
   !> Write the projected complex eigenstates into text files.
-  subroutine writeProjCplxEigvecsSerial(fileNames, eigvals, neighlist, nNeighborSK, cellVec,&
+  subroutine writeProjCplxEigvecsSerial(fileNames, eigvals, neighlist, nNeighbourSK, cellVec,&
       & iCellVec, denseDesc, iPair, img2CentCell, over, kPoints, kWeights, parallelKS, eigvecs,&
       & work, iOrbRegion)
 
@@ -1540,11 +1540,11 @@ contains
     !> eigenvalues
     real(dp), intent(in) :: eigvals(:,:,:)
 
-    !> Neighbor list.
-    type(TNeighborList), intent(in) :: neighlist
+    !> Neighbour list.
+    type(TNeighbourList), intent(in) :: neighlist
 
-    !> Nr. of neighbors for SK-interaction.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for SK-interaction.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Cell vectors of shifted cells.
     real(dp), intent(in) :: cellVec(:,:)
@@ -1596,7 +1596,7 @@ contains
       iK = parallelKS%localKS(1, iKS)
       iS = parallelKS%localKS(2, iKS)
       call writeProjEigvecHeader(fd, iS, iK, kWeights(iK))
-      call unpackHS(work, over, kPoints(:,iK), neighlist%iNeighbor, nNeighborSK, iCellVec,&
+      call unpackHS(work, over, kPoints(:,iK), neighlist%iNeighbour, nNeighbourSK, iCellVec,&
           & cellVec, denseDesc%iAtomStart, iPair, img2CentCell)
       do iEig = 1, nOrb
         call hemv(cVecTemp, work, eigvecs(:,iEig,iKS))
@@ -1617,7 +1617,7 @@ contains
 
   !> Write the complex eigvectors into human readible output file (BLACS version).
   subroutine writeProjPauliEigvecsBlacs(env, denseDesc, fileNames, iOrbRegion, eigvals, eigvecs,&
-      & orb, parallelKS, kPoints, kWeights, over, neighborList, nNeighborSK, iSparseStart,&
+      & orb, parallelKS, kPoints, kWeights, over, neighbourList, nNeighbourSK, iSparseStart,&
       & img2CentCell, iCellVec, cellVec)
 
     !> Environment settings
@@ -1653,11 +1653,11 @@ contains
     !> Sparse overlap
     real(dp), intent(in) :: over(:)
 
-    !> Neighbors of each atom
-    type(TNeighborList), intent(in) :: neighborList
+    !> Neighbours of each atom
+    type(TNeighbourList), intent(in) :: neighbourList
 
-    !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for each atom
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index array for sparse matrices
     integer, intent(in) :: iSparseStart(:,:)
@@ -1707,8 +1707,8 @@ contains
           end if
           iK = parallelKS%groupKS(1, iKS, iGroup)
           if (iGroup == 0) then
-            call unpackSPauliBlacs(env%blacs, over, kPoints(:,iK), neighborList%iNeighbor,&
-                & nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc,&
+            call unpackSPauliBlacs(env%blacs, over, kPoints(:,iK), neighbourList%iNeighbour,&
+                & nNeighbourSK, iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc,&
                 & globalS)
             call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
                 & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
@@ -1733,8 +1733,9 @@ contains
       ! All processes except the global master process
       do iKS = 1, parallelKS%nLocalKS
         iK = parallelKS%localKS(1, iKS)
-        call unpackSPauliBlacs(env%blacs, over, kPoints(:,iK), neighborList%iNeighbor, nNeighborSK,&
-            & iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc, globalS)
+        call unpackSPauliBlacs(env%blacs, over, kPoints(:,iK), neighbourList%iNeighbour,&
+            & nNeighbourSK, iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc,&
+            & globalS)
         call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
             & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
         do iEig = 1, nOrb
@@ -1761,7 +1762,7 @@ contains
 #:else
 
   !> Write the projected complex eigenstates into text files.
-  subroutine writeProjPauliEigvecsSerial(fileNames, eigvals, neighlist, nNeighborSK, cellVec,&
+  subroutine writeProjPauliEigvecsSerial(fileNames, eigvals, neighlist, nNeighbourSK, cellVec,&
       & iCellVec, denseDesc, iPair, img2CentCell, over, kPoints, kWeights, parallelKS, eigvecs,&
       & work, iOrbRegion)
 
@@ -1771,11 +1772,11 @@ contains
     !> eigenvalues
     real(dp), intent(in) :: eigvals(:,:,:)
 
-    !> Neighbor list.
-    type(TNeighborList), intent(in) :: neighlist
+    !> Neighbour list.
+    type(TNeighbourList), intent(in) :: neighlist
 
-    !> Nr. of neighbors for SK-interaction.
-    integer, intent(in) :: nNeighborSK(:)
+    !> Nr. of neighbours for SK-interaction.
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Cell vectors of shifted cells.
     real(dp), intent(in) :: cellVec(:,:)
@@ -1830,7 +1831,7 @@ contains
     do iKS = 1, parallelKS%nLocalKS
       iK = parallelKS%localKS(1, iKS)
       call writeProjEigvecHeader(fd, 1, iK, kWeights(iK))
-      call unpackSPauli(over, kPoints(:,iK), neighlist%iNeighbor, nNeighborSK,&
+      call unpackSPauli(over, kPoints(:,iK), neighlist%iNeighbour, nNeighbourSK,&
           & denseDesc%iAtomStart, iPair, img2CentCell, iCellVec, cellVec, work)
       do iEig = 1, nOrb
         call hemv(cVecTemp, work, eigvecs(:,iEig,iKS))
@@ -3228,7 +3229,7 @@ contains
 
 
   !> Writes Hamiltonian and overlap matrices and stops program execution.
-  subroutine writeHSAndStop(env, tWriteHS, tWriteRealHS, tRealHS, over, neighborList, nNeighborSK,&
+  subroutine writeHSAndStop(env, tWriteHS, tWriteRealHS, tRealHS, over, neighbourList, nNeighbourSK,&
       & iAtomStart, iPair, img2CentCell, kPoint, iCellVec, cellVec, ham, iHam)
 
     !> Environment settings
@@ -3247,10 +3248,10 @@ contains
     real(dp), intent(in) :: over(:)
 
     !> atomic neighbours
-    type(TNeighborList), intent(in) :: neighborList
+    type(TNeighbourList), intent(in) :: neighbourList
 
     !> number of neighbours for each central cell atom
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Dense matrix indexing for atomic blocks
     integer, intent(in) :: iAtomStart(:)
@@ -3290,8 +3291,8 @@ contains
     call qm2ud(hamUpDown)
 
     ! Write out matrices if necessary and quit.
-    call writeHS(env, tWriteHS, tWriteRealHS, tRealHS, hamUpDown, over, neighborList%iNeighbor,&
-        & nNeighborSK, iAtomStart, iPair, img2CentCell, kPoint, iCellVec, cellVec, iHam)
+    call writeHS(env, tWriteHS, tWriteRealHS, tRealHS, hamUpDown, over, neighbourList%iNeighbour,&
+        & nNeighbourSK, iAtomStart, iPair, img2CentCell, kPoint, iCellVec, cellVec, iHam)
     write(stdOut, "(A)") "Hamilton/Overlap written, exiting program."
     call env%destruct()
     call destructGlobalEnv()
@@ -3301,7 +3302,7 @@ contains
 
 
   !> Invokes the writing routines for the Hamiltonian and overlap matrices.
-  subroutine writeHS(env, tWriteHS, tWriteRealHS, tRealHS, ham, over, iNeighbor, nNeighborSK,&
+  subroutine writeHS(env, tWriteHS, tWriteRealHS, tRealHS, ham, over, iNeighbour, nNeighbourSK,&
       & iAtomStart, iPair, img2CentCell, kPoint, iCellVec, cellVec, iHam)
 
     !> Environment settings
@@ -3323,10 +3324,10 @@ contains
     real(dp), intent(in) :: over(:)
 
     !> Atomic neighbour data
-    integer, intent(in) :: iNeighbor(0:,:)
+    integer, intent(in) :: iNeighbour(0:,:)
 
     !> number of atomic neighbours for each atom
-    integer, intent(in) :: nNeighborSK(:)
+    integer, intent(in) :: nNeighbourSK(:)
 
     !> Index array for start of atomic block in dense matrices
     integer, intent(in) :: iAtomStart(:)
@@ -3355,30 +3356,30 @@ contains
 
     if (tWriteRealHS) then
       do iS = 1, nSpin
-        call writeSparse("hamreal" // i2c(iS) // ".dat", ham(:,iS), iNeighbor, nNeighborSK,&
+        call writeSparse("hamreal" // i2c(iS) // ".dat", ham(:,iS), iNeighbour, nNeighbourSK,&
             & iAtomStart, iPair, img2CentCell, iCellVec, cellVec)
         if (allocated(iHam)) then
-          call writeSparse("hamimag" // i2c(iS) // ".dat", iHam(:,iS), iNeighbor, nNeighborSK,&
+          call writeSparse("hamimag" // i2c(iS) // ".dat", iHam(:,iS), iNeighbour, nNeighbourSK,&
               & iAtomStart, iPair, img2CentCell, iCellVec, cellVec)
         end if
       end do
-      call writeSparse("overreal.dat", over, iNeighbor, nNeighborSK, iAtomStart, iPair,&
+      call writeSparse("overreal.dat", over, iNeighbour, nNeighbourSK, iAtomStart, iPair,&
           & img2CentCell, iCellVec, cellVec)
     end if
     if (tWriteHS) then
       if (tRealHS) then
         do iS = 1, nSpin
-          call writeSparseAsSquare(env, "hamsqr" // i2c(iS) // ".dat", ham(:,iS), iNeighbor,&
-              & nNeighborSK, iAtomStart, iPair, img2CentCell)
+          call writeSparseAsSquare(env, "hamsqr" // i2c(iS) // ".dat", ham(:,iS), iNeighbour,&
+              & nNeighbourSK, iAtomStart, iPair, img2CentCell)
         end do
-        call writeSparseAsSquare(env, "oversqr.dat", over, iNeighbor, nNeighborSK, iAtomStart,&
+        call writeSparseAsSquare(env, "oversqr.dat", over, iNeighbour, nNeighbourSK, iAtomStart,&
             & iPair, img2CentCell)
       else
         do iS = 1, nSpin
           call writeSparseAsSquare(env, "hamsqr" // i2c(iS) // ".dat", ham(:,iS), kPoint,&
-              & iNeighbor, nNeighborSK, iAtomStart, iPair, img2CentCell, iCellVec, cellVec)
+              & iNeighbour, nNeighbourSK, iAtomStart, iPair, img2CentCell, iCellVec, cellVec)
         end do
-        call writeSparseAsSquare(env, "oversqr.dat", over, kPoint, iNeighbor, nNeighborSK,&
+        call writeSparseAsSquare(env, "oversqr.dat", over, kPoint, iNeighbour, nNeighbourSK,&
             & iAtomStart, iPair, img2CentCell, iCellVec, cellVec)
       end if
     end if

--- a/prog/dftb+/prg_dftb/mainio.F90
+++ b/prog/dftb+/prg_dftb/mainio.F90
@@ -105,7 +105,7 @@ module mainio
 contains
 
   !> Writes the eigenvectors to disc.
-  subroutine writeEigenvectors(env, runId, neighborList, nNeighbor, cellVec, iCellVec,&
+  subroutine writeEigenvectors(env, runId, neighborList, nNeighborSK, cellVec, iCellVec,&
       & denseDesc, iPair, img2CentCell, species, speciesName, orb, kPoint, over, parallelKS,&
       & tPrintEigvecsTxt, eigvecsReal, SSqrReal, eigvecsCplx, SSqrCplx)
 
@@ -119,7 +119,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index for which unit cell atoms are associated with
     integer, intent(in) :: iCellVec(:)
@@ -173,11 +173,11 @@ contains
     @:ASSERT(allocated(SSqrReal) .neqv. allocated(SSqrCplx))
 
     if (allocated(eigvecsCplx)) then
-      call writeCplxEigvecs(env, runId, neighborList, nNeighbor, cellVec, iCellVec, denseDesc,&
+      call writeCplxEigvecs(env, runId, neighborList, nNeighborSK, cellVec, iCellVec, denseDesc,&
           & iPair, img2CentCell, species, speciesName, orb, kPoint, over, parallelKS,&
           & tPrintEigvecsTxt, eigvecsCplx, SSqrCplx)
     else
-      call writeRealEigvecs(env, runId, neighborList, nNeighbor, denseDesc, iPair,&
+      call writeRealEigvecs(env, runId, neighborList, nNeighborSK, denseDesc, iPair,&
           & img2CentCell, species, speciesName, orb, over, parallelKS, tPrintEigvecsTxt,&
           & eigvecsReal, SSqrReal)
     end if
@@ -186,7 +186,7 @@ contains
 
 
   !> Writes real eigenvectors
-  subroutine writeRealEigvecs(env, runId, neighborList, nNeighbor, denseDesc, iPair,&
+  subroutine writeRealEigvecs(env, runId, neighborList, nNeighborSK, denseDesc, iPair,&
       & img2CentCell, species, speciesName, orb, over, parallelKS, tPrintEigvecsTxt, eigvecsReal,&
       & SSqrReal, fileName)
 
@@ -200,7 +200,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index of start of atom blocks in dense matrices
     type(TDenseDescr), intent(in) :: denseDesc
@@ -242,13 +242,13 @@ contains
     call writeRealEigvecsBinBlacs(env, denseDesc, eigvecsReal, runId, parallelKS, fileName=fileName)
     if (tPrintEigvecsTxt) then
       call writeRealEigvecsTxtBlacs(env, denseDesc, eigvecsReal, parallelKS, orb, over,&
-          & neighborList%iNeighbor, nNeighbor, iPair, img2CentCell, species, speciesName,&
+          & neighborList%iNeighbor, nNeighborSK, iPair, img2CentCell, species, speciesName,&
           & fileName=fileName)
     end if
   #:else
     call writeRealEigvecsBinSerial(eigvecsReal, runId, parallelKS, fileName=fileName)
     if (tPrintEigvecsTxt) then
-      call writeRealEigvecsTxtSerial(neighborList, nNeighbor, denseDesc, iPair, img2CentCell,&
+      call writeRealEigvecsTxtSerial(neighborList, nNeighborSK, denseDesc, iPair, img2CentCell,&
           & orb, species, speciesName, over, parallelKS, eigvecsReal, SSqrReal, fileName=fileName)
     end if
   #:endif
@@ -257,7 +257,7 @@ contains
 
 
   !> Writes complex eigenvectors.
-  subroutine writeCplxEigvecs(env, runId, neighborList, nNeighbor, cellVec, iCellVec, denseDesc,&
+  subroutine writeCplxEigvecs(env, runId, neighborList, nNeighborSK, cellVec, iCellVec, denseDesc,&
       & iPair, img2CentCell, species, speciesName, orb, kPoint, over, parallelKS, tPrintEigvecsTxt,&
       & eigvecsCplx, SSqrCplx, fileName)
 
@@ -271,7 +271,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Vectors (in units of the lattice constants) to cells of the lattice
     real(dp), intent(in) :: cellVec(:,:)
@@ -323,11 +323,11 @@ contains
     if (tPrintEigvecsTxt) then
       if (denseDesc%t2Component) then
         call writePauliEigvecsTxtBlacs(env, denseDesc, eigvecsCplx, parallelKS, orb, over, kPoint,&
-            & neighborList%iNeighbor, nNeighbor, iCellVec, cellVec, iPair, img2CentCell, species,&
+            & neighborList%iNeighbor, nNeighborSK, iCellVec, cellVec, iPair, img2CentCell, species,&
             & speciesName, fileName=fileName)
       else
         call writeCplxEigvecsTxtBlacs(env, denseDesc, eigvecsCplx, parallelKS, orb, over, kPoint,&
-            & neighborList%iNeighbor, nNeighbor, iCellVec, cellVec, iPair, img2CentCell, species,&
+            & neighborList%iNeighbor, nNeighborSK, iCellVec, cellVec, iPair, img2CentCell, species,&
             & speciesName, fileName=fileName)
       end if
     end if
@@ -335,11 +335,11 @@ contains
     call writeCplxEigvecsBinSerial(eigvecsCplx, runId, parallelKS, fileName=fileName)
     if (tPrintEigvecsTxt) then
       if (denseDesc%t2Component) then
-        call writePauliEigvecsTxtSerial(neighborList, nNeighbor, denseDesc, iPair, img2CentCell,&
+        call writePauliEigvecsTxtSerial(neighborList, nNeighborSK, denseDesc, iPair, img2CentCell,&
             & iCellVec, cellVec, orb, species, speciesName, over, parallelKS, kPoint, eigvecsCplx,&
             & SSqrCplx, fileName=fileName)
       else
-        call writeCplxEigvecsTxtSerial(neighborList, nNeighbor, denseDesc, iPair, img2CentCell,&
+        call writeCplxEigvecsTxtSerial(neighborList, nNeighborSK, denseDesc, iPair, img2CentCell,&
             & iCellVec, cellVec, orb, species, speciesName, over, parallelKS, kPoint, eigvecsCplx,&
             & SSqrCplx, fileName=fileName)
       end if
@@ -469,8 +469,8 @@ contains
 #:if WITH_SCALAPACK
 
   !> Write the real eigvectors into human readible output file (BLACS version).
-  subroutine writeRealEigvecsTxtBlacs(env, denseDesc, eigvecs, parallelKS, orb, over,&
-      & iNeighbor, nNeighbor, iSparseStart, img2CentCell, species, speciesName, fileName)
+  subroutine writeRealEigvecsTxtBlacs(env, denseDesc, eigvecs, parallelKS, orb, over, iNeighbor,&
+      & nNeighborSK, iSparseStart, img2CentCell, species, speciesName, fileName)
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -494,7 +494,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index array for sparse matrices
     integer, intent(in) :: iSparseStart(:,:)
@@ -518,7 +518,7 @@ contains
     integer :: iKS, iS, iGroup, iEig, fd
 
     nOrb = denseDesc%fullSize
-    nAtom = size(nNeighbor)
+    nAtom = size(nNeighborSK)
     allocate(globalS(size(eigvecs, dim=1), size(eigvecs, dim=2)))
     allocate(globalFrac(size(eigvecs, dim=1), size(eigvecs, dim=2)))
     if (env%mpi%tGroupMaster) then
@@ -542,7 +542,7 @@ contains
           end if
           iS = parallelKS%groupKS(2, iKS, iGroup)
           if (iGroup == 0) then
-            call unpackHSRealBlacs(env%blacs, over, iNeighbor, nNeighbor, iSparseStart,&
+            call unpackHSRealBlacs(env%blacs, over, iNeighbor, nNeighborSK, iSparseStart,&
                 & img2CentCell, denseDesc, globalS)
             call pblasfx_psymm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
                 & denseDesc%blacsOrbSqr, globalFrac, denseDesc%blacsOrbSqr)
@@ -565,7 +565,7 @@ contains
     else
       ! All processes except the global master process
       do iKS = 1, parallelKS%nLocalKS
-        call unpackHSRealBlacs(env%blacs, over, iNeighbor, nNeighbor, iSparseStart, img2CentCell,&
+        call unpackHSRealBlacs(env%blacs, over, iNeighbor, nNeighborSK, iSparseStart, img2CentCell,&
             & denseDesc, globalS)
         call pblasfx_psymm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS), denseDesc%blacsOrbSqr,&
             & globalFrac, denseDesc%blacsOrbSqr)
@@ -594,14 +594,14 @@ contains
 #:else
 
     !> Writes real eigenvectors in text form.
-  subroutine writeRealEigvecsTxtSerial(neighlist, nNeighbor, denseDesc, iPair, img2CentCell,&
+  subroutine writeRealEigvecsTxtSerial(neighlist, nNeighborSK, denseDesc, iPair, img2CentCell,&
       & orb, species, speciesName, over, parallelKS, eigvecs, SSqr, fileName)
 
     !> Neighbor list.
     type(TNeighborList), intent(in) :: neighlist
 
     !> Nr. of neighbors for SK-interaction.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Dense descriptor for H and S
     type(TDenseDescr), intent(in) :: denseDesc
@@ -640,10 +640,10 @@ contains
     integer :: nAtom
     integer :: iKS, iS, iEig, fd
 
-    nAtom = size(nNeighbor)
+    nAtom = size(nNeighborSK)
     call prepareEigvecFileTxt(fd, .false., fileName)
     allocate(rVecTemp(size(eigvecs, dim=1)))
-    call unpackHS(SSqr, over, neighlist%iNeighbor, nNeighbor, denseDesc%iAtomStart, iPair,&
+    call unpackHS(SSqr, over, neighlist%iNeighbor, nNeighborSK, denseDesc%iAtomStart, iPair,&
         & img2CentCell)
     do iKS = 1, parallelKS%nLocalKS
       iS = parallelKS%localKS(2, iKS)
@@ -665,8 +665,8 @@ contains
 
   !> Write the complex eigvectors into human readible output file (BLACS version).
   subroutine writeCplxEigvecsTxtBlacs(env, denseDesc, eigvecs, parallelKS, orb, over, kPoints,&
-      & iNeighbor, nNeighbor, iCellVec, cellVec, iSparseStart, img2CentCell, species, speciesName,&
-      & fileName)
+      & iNeighbor, nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, species,&
+      & speciesName, fileName)
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -693,7 +693,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Cell vector index for each atom
     integer, intent(in) :: iCellVec(:)
@@ -724,7 +724,7 @@ contains
     integer :: iKS, iK, iS, iGroup, iEig, fd
 
     nEigvec = denseDesc%nOrb
-    nAtom = size(nNeighbor)
+    nAtom = size(nNeighborSK)
     allocate(globalS(size(eigvecs, dim=1), size(eigvecs, dim=2)))
     allocate(globalSDotC(size(eigvecs, dim=1), size(eigvecs, dim=2)))
     allocate(globalFrac(size(eigvecs, dim=1), size(eigvecs, dim=2)))
@@ -747,8 +747,8 @@ contains
           iK = parallelKS%groupKS(1, iKS, iGroup)
           iS = parallelKS%groupKS(2, iKS, iGroup)
           if (iGroup == 0) then
-            call unpackHSCplxBlacs(env%blacs, over, kPoints(:,iK), iNeighbor, nNeighbor, iCellVec,&
-                & cellVec, iSparseStart, img2CentCell, denseDesc, globalS)
+            call unpackHSCplxBlacs(env%blacs, over, kPoints(:,iK), iNeighbor, nNeighborSK,&
+                & iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, globalS)
             call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
                 & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
             globalFrac(:,:) = real(conjg(eigvecs(:,:,iKS)) * globalSDotC)
@@ -770,7 +770,7 @@ contains
     else
       do iKS = 1, parallelKS%nLocalKS
         iK = parallelKS%localKS(1, iKS)
-        call unpackHSCplxBlacs(env%blacs, over, kPoints(:,iK), iNeighbor, nNeighbor, iCellVec,&
+        call unpackHSCplxBlacs(env%blacs, over, kPoints(:,iK), iNeighbor, nNeighborSK, iCellVec,&
             & cellVec, iSparseStart, img2CentCell, denseDesc, globalS)
         call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
             & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
@@ -799,7 +799,7 @@ contains
 #:else
 
     !> Writes complex eigenvectors in text form.
-  subroutine writeCplxEigvecsTxtSerial(neighlist, nNeighbor, denseDesc, iPair, img2CentCell,&
+  subroutine writeCplxEigvecsTxtSerial(neighlist, nNeighborSK, denseDesc, iPair, img2CentCell,&
       & iCellVec, cellVec, orb, species, speciesName, over, parallelKS, kPoints, eigvecs, SSqr,&
       & fileName)
 
@@ -807,7 +807,7 @@ contains
     type(TNeighborList), intent(in) :: neighlist
 
     !> Nr. of neighbors for SK-interaction.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Dense matrix descriptor for H and S
     type(TDenseDescr), intent(in) :: denseDesc
@@ -856,7 +856,7 @@ contains
     integer :: nEigvecs, nAtom
     integer :: iKS, iK, iS, iEig, fd
 
-    nAtom = size(nNeighbor)
+    nAtom = size(nNeighborSK)
     call prepareEigvecFileTxt(fd, denseDesc%t2Component, fileName)
     allocate(cVecTemp(size(eigvecs, dim=1)))
     nEigvecs = size(eigvecs, dim=2)
@@ -865,8 +865,8 @@ contains
     do iKS = 1, parallelKS%nLocalKS
       iK = parallelKS%localKS(1, iKS)
       iS = parallelKS%localKS(2, iKS)
-      call unpackHS(SSqr, over, kPoints(:,iK), neighlist%iNeighbor, nNeighbor, iCellVec,&
-          & cellVec, denseDesc%iAtomStart, iPair, img2CentCell)
+      call unpackHS(SSqr, over, kPoints(:,iK), neighlist%iNeighbor, nNeighborSK, iCellVec, cellVec,&
+          & denseDesc%iAtomStart, iPair, img2CentCell)
       do iEig = 1, nEigvecs
         call hemv(cVecTemp, SSqr, eigvecs(:,iEig,iKS))
         fracs(:) = real(conjg(eigvecs(:,iEig,iKS)) * cVecTemp)
@@ -885,8 +885,8 @@ contains
 
   !> Write the complex eigvectors into human readible output file (BLACS version).
   subroutine writePauliEigvecsTxtBlacs(env, denseDesc, eigvecs, parallelKS, orb, over, kPoints,&
-      & iNeighbor, nNeighbor, iCellVec, cellVec, iSparseStart, img2CentCell, species, speciesName,&
-      & fileName)
+      & iNeighbor, nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, species,&
+      & speciesName, fileName)
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -913,7 +913,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Cell vector index for each atom
     integer, intent(in) :: iCellVec(:)
@@ -944,7 +944,7 @@ contains
     integer :: iKS, iK, iGroup, iEig, fd
 
     nOrb = denseDesc%fullSize
-    nAtom = size(nNeighbor)
+    nAtom = size(nNeighborSK)
     allocate(globalS(size(eigvecs, dim=1), size(eigvecs, dim=2)))
     allocate(globalSDotC(size(eigvecs, dim=1), size(eigvecs, dim=2)))
     if (env%mpi%tGroupMaster) then
@@ -971,8 +971,8 @@ contains
           end if
           iK = parallelKS%groupKS(1, iKS, iGroup)
           if (iGroup == 0) then
-            call unpackSPauliBlacs(env%blacs, over, kPoints(:,iK), iNeighbor, nNeighbor, iCellVec,&
-                & cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc, globalS)
+            call unpackSPauliBlacs(env%blacs, over, kPoints(:,iK), iNeighbor, nNeighborSK,&
+                & iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc, globalS)
             call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
                 & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
           end if
@@ -995,7 +995,7 @@ contains
       ! All processes except the global master process
       do iKS = 1, parallelKS%nLocalKS
         iK = parallelKS%localKS(1, iKS)
-        call unpackSPauliBlacs(env%blacs, over, kPoints(:,iK), iNeighbor, nNeighbor, iCellVec,&
+        call unpackSPauliBlacs(env%blacs, over, kPoints(:,iK), iNeighbor, nNeighborSK, iCellVec,&
             & cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc, globalS)
         call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
             & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
@@ -1023,7 +1023,7 @@ contains
 #:else
 
     !> Writes complex eigenvectors in text form.
-  subroutine writePauliEigvecsTxtSerial(neighlist, nNeighbor, denseDesc, iPair, img2CentCell,&
+  subroutine writePauliEigvecsTxtSerial(neighlist, nNeighborSK, denseDesc, iPair, img2CentCell,&
       & iCellVec, cellVec, orb, species, speciesName, over, parallelKS, kPoints, eigvecs, SSqr,&
       & fileName)
 
@@ -1031,7 +1031,7 @@ contains
     type(TNeighborList), intent(in) :: neighlist
 
     !> Nr. of neighbors for SK-interaction.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Dense matrix descriptor for H and S
     type(TDenseDescr), intent(in) :: denseDesc
@@ -1080,7 +1080,7 @@ contains
     integer :: nEigvecs, nAtom
     integer :: iKS, iK, iEig, fd
 
-    nAtom = size(nNeighbor)
+    nAtom = size(nNeighborSK)
     call prepareEigvecFileTxt(fd, denseDesc%t2Component, fileName)
     allocate(cVecTemp(size(eigvecs, dim=1)))
     nEigvecs = size(eigvecs, dim=2)
@@ -1088,7 +1088,7 @@ contains
 
     do iKS = 1, parallelKS%nLocalKS
       iK = parallelKS%localKS(1, iKS)
-      call unpackSPauli(over, kPoints(:,iK), neighlist%iNeighbor, nNeighbor,&
+      call unpackSPauli(over, kPoints(:,iK), neighlist%iNeighbor, nNeighborSK,&
           & denseDesc%iAtomStart, iPair, img2CentCell, iCellVec, cellVec, SSqr)
       do iEig = 1, nEigvecs
         call hemv(cVecTemp, SSqr, eigvecs(:,iEig,iKS))
@@ -1105,7 +1105,7 @@ contains
 
 
   !> Write projected eigenvectors.
-  subroutine writeProjectedEigenvectors(env, regionLabels, eigen, neighborList, nNeighbor,&
+  subroutine writeProjectedEigenvectors(env, regionLabels, eigen, neighborList, nNeighborSK,&
       & cellVec, iCellVec, denseDesc, iPair, img2CentCell, orb, over, kPoint, kWeight, iOrbRegion,&
       & parallelKS, eigvecsReal, workReal, eigvecsCplx, workCplx)
 
@@ -1122,7 +1122,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Number of neighbours for each of the atoms
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Vectors (in units of the lattice constants) to cells of the lattice
     real(dp), intent(in) :: cellVec(:,:)
@@ -1176,30 +1176,30 @@ contains
     if (allocated(eigvecsCplx)) then
       if (denseDesc%t2Component) then
         call writeProjPauliEigvecsBlacs(env, denseDesc, regionLabels, iOrbRegion, eigen,&
-            & eigvecsCplx, orb, parallelKS, kPoint, kWeight, over, neighborList, nNeighbor, iPair,&
-            & img2CentCell, iCellVec, cellVec)
+            & eigvecsCplx, orb, parallelKS, kPoint, kWeight, over, neighborList, nNeighborSK,&
+            & iPair, img2CentCell, iCellVec, cellVec)
       else
-        call writeProjCplxEigvecsBlacs(env, denseDesc, regionLabels, iOrbRegion, eigen&
-            &,eigvecsCplx, parallelKS, kPoint, kWeight, over, neighborList, nNeighbor, iPair,&
+        call writeProjCplxEigvecsBlacs(env, denseDesc, regionLabels, iOrbRegion, eigen,&
+            & eigvecsCplx, parallelKS, kPoint, kWeight, over, neighborList, nNeighborSK, iPair,&
             & img2CentCell, iCellVec, cellVec)
       end if
     else
-      call writeProjRealEigvecsBlacs(env, denseDesc, regionLabels, iOrbRegion, eigen,&
-          & eigvecsReal, parallelKS, over, neighborList, nNeighbor, iPair, img2CentCell)
+      call writeProjRealEigvecsBlacs(env, denseDesc, regionLabels, iOrbRegion, eigen, eigvecsReal,&
+          & parallelKS, over, neighborList, nNeighborSK, iPair, img2CentCell)
     end if
   #:else
     if (allocated(eigvecsCplx)) then
       if (denseDesc%t2Component) then
-        call writeProjPauliEigvecsSerial(regionLabels, eigen, neighborList, nNeighbor, cellVec,&
+        call writeProjPauliEigvecsSerial(regionLabels, eigen, neighborList, nNeighborSK, cellVec,&
             & iCellVec, denseDesc, iPair, img2CentCell, over, kpoint, kWeight, parallelKS,&
             & eigvecsCplx, workCplx, iOrbRegion)
       else
-        call writeProjCplxEigvecsSerial(regionLabels, eigen, neighborList, nNeighbor, cellVec,&
+        call writeProjCplxEigvecsSerial(regionLabels, eigen, neighborList, nNeighborSK, cellVec,&
             & iCellVec, denseDesc, iPair, img2CentCell, over, kpoint, kWeight, parallelKS,&
             & eigvecsCplx, workCplx, iOrbRegion)
       end if
     else
-      call writeProjRealEigvecsSerial(regionLabels, eigen, neighborList, nNeighbor, denseDesc,&
+      call writeProjRealEigvecsSerial(regionLabels, eigen, neighborList, nNeighborSK, denseDesc,&
           & iPair, img2CentCell, over, parallelKS, eigvecsReal, workReal, iOrbRegion)
     end if
   #:endif
@@ -1210,8 +1210,8 @@ contains
 #:if WITH_SCALAPACK
 
   !> Write the real eigvectors into human readible output file (BLACS version).
-  subroutine writeProjRealEigvecsBlacs(env, denseDesc, fileNames, iOrbRegion, eigvals,&
-      & eigvecs, parallelKS, over, neighborList, nNeighbor, iSparseStart, img2CentCell)
+  subroutine writeProjRealEigvecsBlacs(env, denseDesc, fileNames, iOrbRegion, eigvals, eigvecs,&
+      & parallelKS, over, neighborList, nNeighborSK, iSparseStart, img2CentCell)
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -1241,7 +1241,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index array for sparse matrices
     integer, intent(in) :: iSparseStart(:,:)
@@ -1280,7 +1280,7 @@ contains
           end if
           iS = parallelKS%groupKS(2, iKS, iGroup)
           if (iGroup == 0) then
-            call unpackHSRealBlacs(env%blacs, over, neighborList%iNeighbor, nNeighbor,&
+            call unpackHSRealBlacs(env%blacs, over, neighborList%iNeighbor, nNeighborSK,&
                 & iSparseStart, img2CentCell, denseDesc, globalS)
             call pblasfx_psymm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
                 & denseDesc%blacsOrbSqr, globalFrac, denseDesc%blacsOrbSqr)
@@ -1301,7 +1301,7 @@ contains
     else
       ! All processes except the global master process
       do iKS = 1, parallelKS%nLocalKS
-        call unpackHSRealBlacs(env%blacs, over, neighborList%iNeighbor, nNeighbor, iSparseStart,&
+        call unpackHSRealBlacs(env%blacs, over, neighborList%iNeighbor, nNeighborSK, iSparseStart,&
             & img2CentCell, denseDesc, globalS)
         call pblasfx_psymm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS), denseDesc%blacsOrbSqr,&
             & globalFrac, denseDesc%blacsOrbSqr)
@@ -1326,7 +1326,7 @@ contains
 #:else
 
     !> Write the projected eigenstates into text files
-  subroutine writeProjRealEigvecsSerial(fileNames, eigvals, neighlist, nNeighbor, denseDesc,&
+  subroutine writeProjRealEigvecsSerial(fileNames, eigvals, neighlist, nNeighborSK, denseDesc,&
       & iPair, img2CentCell, over, parallelKS, eigvecs, work, iOrbRegion)
 
     !> List with fileNames for each region
@@ -1339,7 +1339,7 @@ contains
     type(TNeighborList), intent(in) :: neighlist
 
     !> Nr. of neighbors for SK-interaction
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Dense matrix descriptor for H and S
     type(TDenseDescr), intent(in) :: denseDesc
@@ -1374,7 +1374,7 @@ contains
     call prepareProjEigvecFiles(fd, fileNames)
 
     allocate(rVecTemp(size(eigvecs, dim=1)))
-    call unpackHS(work, over, neighlist%iNeighbor, nNeighbor, denseDesc%iAtomStart, iPair,&
+    call unpackHS(work, over, neighlist%iNeighbor, nNeighborSK, denseDesc%iAtomStart, iPair,&
         & img2CentCell)
     do iKS = 1, parallelKS%nLocalKS
       iS = parallelKS%localKS(2, iKS)
@@ -1397,8 +1397,8 @@ contains
 #:if WITH_SCALAPACK
 
   !> Write the complex eigvectors into human readible output file (BLACS version).
-  subroutine writeProjCplxEigvecsBlacs(env, denseDesc, fileNames, iOrbRegion, eigvals,&
-      & eigvecs, parallelKS, kPoints, kWeights, over, neighborList, nNeighbor, iSparseStart,&
+  subroutine writeProjCplxEigvecsBlacs(env, denseDesc, fileNames, iOrbRegion, eigvals, eigvecs,&
+      & parallelKS, kPoints, kWeights, over, neighborList, nNeighborSK, iSparseStart,&
       & img2CentCell, iCellVec, cellVec)
 
     !> Environment settings
@@ -1435,7 +1435,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index array for sparse matrices
     integer, intent(in) :: iSparseStart(:,:)
@@ -1484,7 +1484,7 @@ contains
           iS = parallelKS%groupKS(2, iKS, iGroup)
           if (iGroup == 0) then
             call unpackHSCplxBlacs(env%blacs, over, kPoints(:,iK), neighborList%iNeighbor,&
-                & nNeighbor, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, globalS)
+                & nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, globalS)
             call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
                 & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
             globalFrac(:,:) = real(globalSDotC * conjg(eigvecs(:,:,iKS)))
@@ -1505,7 +1505,7 @@ contains
       ! All processes except the global master process
       do iKS = 1, parallelKS%nLocalKS
         iK = parallelKS%localKS(1, iKS)
-        call unpackHSCplxBlacs(env%blacs, over, kPoints(:,iK), neighborList%iNeighbor, nNeighbor,&
+        call unpackHSCplxBlacs(env%blacs, over, kPoints(:,iK), neighborList%iNeighbor, nNeighborSK,&
             & iCellVec, cellVec, iSparseStart, img2CentCell, denseDesc, globalS)
         call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
             & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
@@ -1530,7 +1530,7 @@ contains
 #:else
 
   !> Write the projected complex eigenstates into text files.
-  subroutine writeProjCplxEigvecsSerial(fileNames, eigvals, neighlist, nNeighbor, cellVec,&
+  subroutine writeProjCplxEigvecsSerial(fileNames, eigvals, neighlist, nNeighborSK, cellVec,&
       & iCellVec, denseDesc, iPair, img2CentCell, over, kPoints, kWeights, parallelKS, eigvecs,&
       & work, iOrbRegion)
 
@@ -1544,7 +1544,7 @@ contains
     type(TNeighborList), intent(in) :: neighlist
 
     !> Nr. of neighbors for SK-interaction.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Cell vectors of shifted cells.
     real(dp), intent(in) :: cellVec(:,:)
@@ -1596,7 +1596,7 @@ contains
       iK = parallelKS%localKS(1, iKS)
       iS = parallelKS%localKS(2, iKS)
       call writeProjEigvecHeader(fd, iS, iK, kWeights(iK))
-      call unpackHS(work, over, kPoints(:,iK), neighlist%iNeighbor, nNeighbor, iCellVec,&
+      call unpackHS(work, over, kPoints(:,iK), neighlist%iNeighbor, nNeighborSK, iCellVec,&
           & cellVec, denseDesc%iAtomStart, iPair, img2CentCell)
       do iEig = 1, nOrb
         call hemv(cVecTemp, work, eigvecs(:,iEig,iKS))
@@ -1616,8 +1616,8 @@ contains
 #:if WITH_SCALAPACK
 
   !> Write the complex eigvectors into human readible output file (BLACS version).
-  subroutine writeProjPauliEigvecsBlacs(env, denseDesc, fileNames, iOrbRegion, eigvals,&
-      & eigvecs, orb, parallelKS, kPoints, kWeights, over, neighborList, nNeighbor, iSparseStart,&
+  subroutine writeProjPauliEigvecsBlacs(env, denseDesc, fileNames, iOrbRegion, eigvals, eigvecs,&
+      & orb, parallelKS, kPoints, kWeights, over, neighborList, nNeighborSK, iSparseStart,&
       & img2CentCell, iCellVec, cellVec)
 
     !> Environment settings
@@ -1657,7 +1657,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> Nr. of neighbors for each atom
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index array for sparse matrices
     integer, intent(in) :: iSparseStart(:,:)
@@ -1708,7 +1708,7 @@ contains
           iK = parallelKS%groupKS(1, iKS, iGroup)
           if (iGroup == 0) then
             call unpackSPauliBlacs(env%blacs, over, kPoints(:,iK), neighborList%iNeighbor,&
-                & nNeighbor, iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc,&
+                & nNeighborSK, iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc,&
                 & globalS)
             call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
                 & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
@@ -1733,7 +1733,7 @@ contains
       ! All processes except the global master process
       do iKS = 1, parallelKS%nLocalKS
         iK = parallelKS%localKS(1, iKS)
-        call unpackSPauliBlacs(env%blacs, over, kPoints(:,iK), neighborList%iNeighbor, nNeighbor,&
+        call unpackSPauliBlacs(env%blacs, over, kPoints(:,iK), neighborList%iNeighbor, nNeighborSK,&
             & iCellVec, cellVec, iSparseStart, img2CentCell, orb%mOrb, denseDesc, globalS)
         call pblasfx_phemm(globalS, denseDesc%blacsOrbSqr, eigvecs(:,:,iKS),&
             & denseDesc%blacsOrbSqr, globalSDotC, denseDesc%blacsOrbSqr)
@@ -1761,7 +1761,7 @@ contains
 #:else
 
   !> Write the projected complex eigenstates into text files.
-  subroutine writeProjPauliEigvecsSerial(fileNames, eigvals, neighlist, nNeighbor, cellVec,&
+  subroutine writeProjPauliEigvecsSerial(fileNames, eigvals, neighlist, nNeighborSK, cellVec,&
       & iCellVec, denseDesc, iPair, img2CentCell, over, kPoints, kWeights, parallelKS, eigvecs,&
       & work, iOrbRegion)
 
@@ -1775,7 +1775,7 @@ contains
     type(TNeighborList), intent(in) :: neighlist
 
     !> Nr. of neighbors for SK-interaction.
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Cell vectors of shifted cells.
     real(dp), intent(in) :: cellVec(:,:)
@@ -1830,7 +1830,7 @@ contains
     do iKS = 1, parallelKS%nLocalKS
       iK = parallelKS%localKS(1, iKS)
       call writeProjEigvecHeader(fd, 1, iK, kWeights(iK))
-      call unpackSPauli(over, kPoints(:,iK), neighlist%iNeighbor, nNeighbor,&
+      call unpackSPauli(over, kPoints(:,iK), neighlist%iNeighbor, nNeighborSK,&
           & denseDesc%iAtomStart, iPair, img2CentCell, iCellVec, cellVec, work)
       do iEig = 1, nOrb
         call hemv(cVecTemp, work, eigvecs(:,iEig,iKS))
@@ -2469,7 +2469,7 @@ contains
           do iAt = 1, nAtom
             iSp = species(iAt)
             do iSh = 1, orb%nShell(iSp)
-              write(fd, "(I5, 1X, I3, 1X, I3, 1X, F16.8)") iAt, iSh, orb%angShell(iSh, iSp), &
+              write(fd, "(I5, 1X, I3, 1X, I3, 1X, F16.8)") iAt, iSh, orb%angShell(iSh, iSp),&
                   & sum(qOutput(orb%posShell(iSh,iSp):orb%posShell(iSh+1, iSp) - 1, iAt, iSpin))
             end do
           end do
@@ -2482,8 +2482,8 @@ contains
             do iSh = 1, orb%nShell(iSp)
               ang = orb%angShell(iSh, iSp)
               do kk = 0, 2 * ang
-                write(fd, "(I5, 1X, I3, 1X, I3, 1X, I3, 1X, F16.8)") &
-                    & iAt, iSh, ang, kk - ang, qOutput(orb%posShell(iSh, iSp) + kk, iAt, iSpin)
+                write(fd, "(I5, 1X, I3, 1X, I3, 1X, I3, 1X, F16.8)") iAt, iSh, ang, kk - ang,&
+                    & qOutput(orb%posShell(iSh, iSp) + kk, iAt, iSpin)
               end do
             end do
           end do
@@ -2512,10 +2512,9 @@ contains
         do iAt = 1, nAtom
           iSp = species(iAt)
           do iSh = 1, orb%nShell(iSp)
-            write(fd, "(I5, 1X, I3, 1X, I3, 1X, F14.8, ' :', 3F14.8)") &
-                & iAt, iSh, orb%angShell(iSh, iSp),&
-                & 0.5_dp * sqrt(sum(sum(qOutput(orb%posShell(iSh, iSp)&
-                & :orb%posShell(iSh + 1, iSp) - 1, iAt, 2:4), dim=1)**2)), &
+            write(fd, "(I5, 1X, I3, 1X, I3, 1X, F14.8, ' :', 3F14.8)") iAt, iSh,&
+                & orb%angShell(iSh, iSp), 0.5_dp * sqrt(sum(sum(qOutput(orb%posShell(iSh, iSp)&
+                & :orb%posShell(iSh + 1, iSp) - 1, iAt, 2:4), dim=1)**2)),&
                 & -gfac * 0.25_dp * sum(qOutput(orb%posShell(iSh, iSp)&
                 & :orb%posShell(iSh + 1, iSp) - 1, iAt, 2:4), dim=1)
           end do
@@ -2526,9 +2525,9 @@ contains
         do iAt = 1, nAtom
           iSp = species(iAt)
           do iSh = 1, orb%nShell(iSp)
-            write(fd, "(I5, 1X, I3, 1X, I3, 1X, F14.8, ' :', 3F14.8)") &
-                & iAt, iSh, orb%angShell(iSh, iSp), &
-                & sqrt(sum(orbitalL(1:3, iSh, iAt)**2)), -orbitalL(1:3, iSh, iAt)
+            write(fd, "(I5, 1X, I3, 1X, I3, 1X, F14.8, ' :', 3F14.8)") iAt, iSh,&
+                & orb%angShell(iSh, iSp), sqrt(sum(orbitalL(1:3, iSh, iAt)**2)),&
+                & -orbitalL(1:3, iSh, iAt)
           end do
         end do
 
@@ -2540,16 +2539,14 @@ contains
         do iAt = 1, nAtom
           iSp = species(iAt)
           do iSh = 1, orb%nShell(iSp)
-            write(fd, "(I5, 1X, I3, 1X, I3, 1X, F14.8, ' :', 3F14.8)") &
-                & iAt, iSh, orb%angShell(iSh, iSp),&
-                & sqrt(sum((orbitalL(1:3, iSh, iAt)&
+            write(fd, "(I5, 1X, I3, 1X, I3, 1X, F14.8, ' :', 3F14.8)") iAt, iSh,&
+                & orb%angShell(iSh, iSp), sqrt(sum((orbitalL(1:3, iSh, iAt)&
                 & + sum(0.5_dp * qOutput(orb%posShell(iSh, iSp)&
-                & :orb%posShell(iSh + 1, iSp) - 1, iAt, 2:4), dim=1))**2)), &
-                & -orbitalL(1:3, iSh, iAt) &
+                & :orb%posShell(iSh + 1, iSp) - 1, iAt, 2:4), dim=1))**2)),&
+                & -orbitalL(1:3, iSh, iAt)&
                 & -gfac * 0.25_dp * sum(qOutput(orb%posShell(iSh, iSp)&
                 & :orb%posShell(iSh + 1, iSp) - 1, iAt, 2:4), dim=1)
-            angularMomentum(1:3) = angularMomentum(1:3) &
-                & -orbitalL(1:3, iSh, iAt) &
+            angularMomentum(1:3) = angularMomentum(1:3) -orbitalL(1:3, iSh, iAt)&
                 & -gfac * 0.25_dp * sum(qOutput(orb%posShell(iSh, iSp)&
                 & :orb%posShell(iSh + 1, iSp) - 1, iAt, 2:4), dim=1)
           end do
@@ -2587,8 +2584,8 @@ contains
             do iSh = 1, orb%nShell(iSp)
               ang = orb%angShell(iSh, iSp)
               do kk = 0, 2 * ang
-                write(fd, "(I5, 1X, I3, 1X, I3, 1X, I3, 1X, F16.8)") &
-                    &iAt, iSh, ang, kk - ang, qOutputUpDown(orb%posShell(iSh, iSp) + kk, iAt, iSpin)
+                write(fd, "(I5, 1X, I3, 1X, I3, 1X, I3, 1X, F16.8)") iAt, iSh, ang, kk - ang,&
+                    & qOutputUpDown(orb%posShell(iSh, iSp) + kk, iAt, iSpin)
               end do
             end do
           end do
@@ -2651,8 +2648,8 @@ contains
       write(fd, format2U) 'Energy ext. field', energy%Eext, 'H', energy%Eext * Hartree__eV, 'eV'
     end if
 
-    write(fd, format2U) 'Total Electronic energy', energy%Eelec, 'H', &
-        & energy%Eelec * Hartree__eV, 'eV'
+    write(fd, format2U) 'Total Electronic energy', energy%Eelec, 'H', energy%Eelec * Hartree__eV,&
+        & 'eV'
     write(fd, format2U) 'Repulsive energy', energy%Erep, 'H', energy%Erep * Hartree__eV, 'eV'
 
     if (tDispersion) then
@@ -2846,8 +2843,8 @@ contains
     ! only print excitation energy if 1) its been calculated and 2) its avaialable for a single
     ! state
     if (tLinResp .and. energy%Eexcited /= 0.0_dp) then
-      write(fd, format2U) "Excitation Energy", energy%Eexcited, "H", &
-          & Hartree__eV * energy%Eexcited, "eV"
+      write(fd, format2U) "Excitation Energy", energy%Eexcited, "H", Hartree__eV * energy%Eexcited,&
+          & "eV"
       write(fd, *)
     end if
 
@@ -3231,7 +3228,7 @@ contains
 
 
   !> Writes Hamiltonian and overlap matrices and stops program execution.
-  subroutine writeHSAndStop(env, tWriteHS, tWriteRealHS, tRealHS, over, neighborList, nNeighbor,&
+  subroutine writeHSAndStop(env, tWriteHS, tWriteRealHS, tRealHS, over, neighborList, nNeighborSK,&
       & iAtomStart, iPair, img2CentCell, kPoint, iCellVec, cellVec, ham, iHam)
 
     !> Environment settings
@@ -3253,7 +3250,7 @@ contains
     type(TNeighborList), intent(in) :: neighborList
 
     !> number of neighbours for each central cell atom
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Dense matrix indexing for atomic blocks
     integer, intent(in) :: iAtomStart(:)
@@ -3294,7 +3291,7 @@ contains
 
     ! Write out matrices if necessary and quit.
     call writeHS(env, tWriteHS, tWriteRealHS, tRealHS, hamUpDown, over, neighborList%iNeighbor,&
-        & nNeighbor, iAtomStart, iPair, img2CentCell, kPoint, iCellVec, cellVec, iHam)
+        & nNeighborSK, iAtomStart, iPair, img2CentCell, kPoint, iCellVec, cellVec, iHam)
     write(stdOut, "(A)") "Hamilton/Overlap written, exiting program."
     call env%destruct()
     call destructGlobalEnv()
@@ -3304,7 +3301,7 @@ contains
 
 
   !> Invokes the writing routines for the Hamiltonian and overlap matrices.
-  subroutine writeHS(env, tWriteHS, tWriteRealHS, tRealHS, ham, over, iNeighbor, nNeighbor,&
+  subroutine writeHS(env, tWriteHS, tWriteRealHS, tRealHS, ham, over, iNeighbor, nNeighborSK,&
       & iAtomStart, iPair, img2CentCell, kPoint, iCellVec, cellVec, iHam)
 
     !> Environment settings
@@ -3329,7 +3326,7 @@ contains
     integer, intent(in) :: iNeighbor(0:,:)
 
     !> number of atomic neighbours for each atom
-    integer, intent(in) :: nNeighbor(:)
+    integer, intent(in) :: nNeighborSK(:)
 
     !> Index array for start of atomic block in dense matrices
     integer, intent(in) :: iAtomStart(:)
@@ -3358,33 +3355,31 @@ contains
 
     if (tWriteRealHS) then
       do iS = 1, nSpin
-        call writeSparse("hamreal" // i2c(iS) // ".dat", ham(:,iS), iNeighbor, &
-            &nNeighbor, iAtomStart, iPair, img2CentCell, iCellVec, cellVec)
+        call writeSparse("hamreal" // i2c(iS) // ".dat", ham(:,iS), iNeighbor, nNeighborSK,&
+            & iAtomStart, iPair, img2CentCell, iCellVec, cellVec)
         if (allocated(iHam)) then
-          call writeSparse("hamimag" // i2c(iS) // ".dat", iHam(:,iS),&
-              & iNeighbor, nNeighbor, iAtomStart, iPair, img2CentCell,iCellVec,&
-              & cellVec)
+          call writeSparse("hamimag" // i2c(iS) // ".dat", iHam(:,iS), iNeighbor, nNeighborSK,&
+              & iAtomStart, iPair, img2CentCell, iCellVec, cellVec)
         end if
       end do
-      call writeSparse("overreal.dat", over, iNeighbor, &
-          &nNeighbor, iAtomStart, iPair, img2CentCell, iCellVec, cellVec)
+      call writeSparse("overreal.dat", over, iNeighbor, nNeighborSK, iAtomStart, iPair,&
+          & img2CentCell, iCellVec, cellVec)
     end if
     if (tWriteHS) then
       if (tRealHS) then
         do iS = 1, nSpin
-          call writeSparseAsSquare(env, "hamsqr" // i2c(iS) // ".dat", ham(:,iS), &
-              &iNeighbor, nNeighbor, iAtomStart, iPair, img2CentCell)
+          call writeSparseAsSquare(env, "hamsqr" // i2c(iS) // ".dat", ham(:,iS), iNeighbor,&
+              & nNeighborSK, iAtomStart, iPair, img2CentCell)
         end do
-        call writeSparseAsSquare(env, "oversqr.dat", over, iNeighbor, nNeighbor, &
-            &iAtomStart, iPair, img2CentCell)
+        call writeSparseAsSquare(env, "oversqr.dat", over, iNeighbor, nNeighborSK, iAtomStart,&
+            & iPair, img2CentCell)
       else
         do iS = 1, nSpin
-          call writeSparseAsSquare(env, "hamsqr" // i2c(iS) // ".dat", ham(:,iS), &
-              &kPoint, iNeighbor, nNeighbor, iAtomStart, iPair, img2CentCell, &
-              &iCellVec, cellVec)
+          call writeSparseAsSquare(env, "hamsqr" // i2c(iS) // ".dat", ham(:,iS), kPoint,&
+              & iNeighbor, nNeighborSK, iAtomStart, iPair, img2CentCell, iCellVec, cellVec)
         end do
-        call writeSparseAsSquare(env, "oversqr.dat", over, kPoint, iNeighbor, &
-            &nNeighbor, iAtomStart, iPair, img2CentCell, iCellVec, cellVec)
+        call writeSparseAsSquare(env, "oversqr.dat", over, kPoint, iNeighbor, nNeighborSK,&
+            & iAtomStart, iPair, img2CentCell, iCellVec, cellVec)
       end if
     end if
 
@@ -3823,8 +3818,8 @@ contains
     end if
     write(fd, "(A/)") "Coefficients and Mulliken populations of the atomic orbitals"
     if (t2Component) then
-      write(fd,"(A/)")"   Atom   Orb  up spin coefficients       &
-          & down spin coefficients         charge      x           y           z"
+      write(fd,"(A/)")"   Atom   Orb  up spin coefficients        down spin coefficients        &
+          & charge      x           y           z"
     end if
 
   end subroutine prepareEigvecFileTxt
@@ -4244,8 +4239,8 @@ contains
       else
         ! Scattered points, print locations
         if (allocated(esp%extPotential)) then
-          write(fdEsp,"(A,A)")'#           Location (AA)             Internal (V)       &
-              & External (V)', trim(tmpStr)
+          write(fdEsp,"(A,A)")'#           Location (AA)             Internal (V)        External&
+              & (V)', trim(tmpStr)
           do ii = 1, size(esp%espGrid,dim=2)
             write(fdEsp,"(3E12.4,2E20.12)")esp%espGrid(:,ii) * Bohr__AA,&
                 & -esp%intPotential(ii) * Hartree__eV, -esp%extPotential(ii) * Hartree__eV

--- a/prog/dftb+/prg_dftb/parser.F90
+++ b/prog/dftb+/prg_dftb/parser.F90
@@ -2803,7 +2803,7 @@ contains
       nNeighs(:) = 0
       do iAt1 = 1, geo%nAtom
         iSp1 = geo%species(iAt1)
-        do iNeigh = 1, neighs%nNeighbor(iAt1)
+        do iNeigh = 1, neighs%nNeighborSK(iAt1)
           iAt2f = img2CentCell(neighs%iNeighbor(iNeigh, iAt1))
           iSp2 = geo%species(iAt2f)
           rTmp = rCutoffs(iSp1) + rCutoffs(iSp2)

--- a/prog/dftb+/prg_dftb/parser.F90
+++ b/prog/dftb+/prg_dftb/parser.F90
@@ -2729,7 +2729,7 @@ contains
     real(dp), allocatable :: coords(:,:)
     integer, allocatable :: img2CentCell(:), iCellVec(:)
     integer :: nAllAtom
-    type(TNeighborList) :: neighs
+    type(TNeighbourList) :: neighs
 
     allocate(tmpR2(3, geo%nAtom))
     allocate(input%polar(geo%nAtom))
@@ -2797,14 +2797,14 @@ contains
       allocate(coords(3, nAllAtom))
       allocate(img2CentCell(nAllAtom))
       allocate(iCellVec(nAllAtom))
-      call updateNeighborList(coords, img2CentCell, iCellVec, neighs, &
+      call updateNeighbourList(coords, img2CentCell, iCellVec, neighs, &
           &nAllAtom, geo%coords, mCutoff, rCellVec)
       allocate(nNeighs(geo%nAtom))
       nNeighs(:) = 0
       do iAt1 = 1, geo%nAtom
         iSp1 = geo%species(iAt1)
-        do iNeigh = 1, neighs%nNeighborSK(iAt1)
-          iAt2f = img2CentCell(neighs%iNeighbor(iNeigh, iAt1))
+        do iNeigh = 1, neighs%nNeighbourSK(iAt1)
+          iAt2f = img2CentCell(neighs%iNeighbour(iNeigh, iAt1))
           iSp2 = geo%species(iAt2f)
           rTmp = rCutoffs(iSp1) + rCutoffs(iSp2)
           if (neighs%neighDist2(iNeigh, iAt1) <= rTmp**2) then


### PR DESCRIPTION
Correct cut-offs to generate repulsive and SK nNeighbours. Doesn't seem to have much effect on performance of autotests, which were using mCutoff for both of these (may impact cases with soft atoms in small gamma).