### PR TITLE
Fix value of hbar

### DIFF
--- a/prog/dftb+/lib_common/constants.F90
+++ b/prog/dftb+/lib_common/constants.F90
@@ -60,7 +60,7 @@ module constants
   real(dp), parameter :: J__Hartree = 1.0_dp / Hartree__J
 
   !> hbar in SI units
-  real(dp), parameter :: hbar = 1.054571726e10-34_dp
+  real(dp), parameter :: hbar = 1.054571726e-34_dp
 
   !> electron g factor
   real(dp), parameter :: gfac = 2.00231930436153_dp


### PR DESCRIPTION
Note: Since none of the internal routines use this value,
functionality was not effected by this bug. Only user input in units
needing hbar for conversion was wrong.