### PR TITLE
Parser bump

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,13 +19,18 @@ Added
 Changed
 -------
 
+- Updated parser version to 6.
+
+- Syntax for H5 and DampedHX corrections for hydrogen bonds unified.
 
 Fixed
 -----
 
 - Compilation when socket interface disabled.
 
-- Stress tensor evaluation for 3rd order DFTB
+- Stress tensor evaluation for 3rd order DFTB.
+
+- Tollerance keyword typo.
 
 18.1 (2018-03-02)
 =================

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -2857,11 +2857,11 @@ maximised. The resulting localised states are output as
 appendix~\ref{sec:dftbp.eigenvec} for \verb|eigenvec.out| and \verb|eigenvec.bin|.
 
 \begin{ptable}
-  \kw{Tollerance} & r &  & 1E-4 & \\
+  \kw{Tolerance} & r &  & 1E-4 & \\
   \kw{MaxIterations} & i &  & 100 & \\
 \end{ptable}
 \begin{description}
-\item[\is{Tollerance}] Cut off for rotations in the localisation process.
+\item[\is{Tolerance}] Cut off for rotations in the localisation process.
 \item[\is{MaxIterations}] Maximum number of total sweeps to perform.
 \end{description}
 
@@ -2871,7 +2871,7 @@ Analysis = {
   Localise = {
     PipekMezey = {
        # These are the default options, which are also set if the bracket is left empty.
-       Tollerance = 1.0E-4
+       Tolerance = 1.0E-4
        MaxIterations = 100
     }  
   }
@@ -2885,12 +2885,12 @@ method which {\em may} have better scaling properties.
 
 \begin{ptable}
   \kw{Dense} & l & & \is{No} & \\
-  \kw{SparseTollerances} & r+ & Dense = No & 1E-1 1E-2 1E-6 1E-12 & \\
+  \kw{SparseTolerances} & r+ & Dense = No & 1E-1 1E-2 1E-6 1E-12 & \\
 \end{ptable}
 \begin{description}
 \item[\is{Dense}] Selects the conventional method (\is{Yes}) using Jacobi sweeps
   over all orbital pairs or (\is{No}) uses the default sparse method.
-\item[\is{SparseTollerances}] The sparse method introduces support regions during
+\item[\is{SparseTolerances}] The sparse method introduces support regions during
   evaluation to increase performance, and these requires a set of tolerances to
   determine the regions to be used (these are listed in decreasing order, i.e.,
   with tighter tolerances as the localisation proceeds).

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -992,9 +992,7 @@ following properties:
   \kw{InitialCharges} & p & SCC = Yes & \cb & \\
   \kw{ElectricField} & p & SCC = Yes & \cb & \pref{sec:dftbp.ElectricField} \\
   \kw{Dispersion} & m & & \cb & \pref{sec:dftbp.Dispersion} \\
-  \kw{DampXH} & l & SCC = Yes & No & \pref{sec:dftbp.DFTB3}\\
-  \kw{DampXHExponent} & r & DampXH = Yes & - & \\
-  \kw{HBondCorrection} & m & SCC = Yes & None \{\} & \pref{sec:dftbp.D3H5}\\
+  \kw{HBondCorrection} & m & SCC = Yes & None \{\} & \pref{sec:dftbp.hbond}\\
   \kw{ThirdOrder} & l & SCC = Yes & No & \\
   \kw{ThirdOrderFull} & l & SCC = Yes & No & \pref{sec:dftbp.DFTB3}\\
   \kw{HubbardDerivs} & p & ThirdOrder(Full) = Yes  & - & \\
@@ -2141,10 +2139,8 @@ description of the methods see the following subsections):
   taken from a Slater-Kirkwood polarisable atomic
   model~\cite{elstner-jcp-114-5149}.
 \item \is{DftD3}: Dispersion is calculated as in the dftd3
-  code~\cite{grimme-jcp-132-154104,grimme-jcp-32-1456-1465}. A modification of
-  the D3 dispersion to be used as a part of the D3H5
-  correction~\cite{rezac-jctc-13-2017} (see section \ref{sec:dftbp.D3H5}) is
-  also available.
+  code~\cite{grimme-jcp-132-154104,grimme-jcp-32-1456-1465}. Modification
+  hydrogen bond interaction strengths (see section \ref{sec:dftbp.hbond}).
 \end{itemize}
 
 \subsubsection{LennardJones}
@@ -2419,7 +2415,7 @@ parameters are taken to be the same as in the dftd3 code.
 
 \item[\is{HHRepulsion}] Required when calculating the
   DFTB3-D3H5~\cite{rezac-jctc-13-2017} modification to D3 dispersion (see
-  section~\ref{sec:dftbp.D3H5} for details and parameter values). This keyword
+  section~\ref{sec:dftbp.hbond} for details and parameter values). This keyword
   enables an additional short range repulsion term in all hydrogen--hydrogen
   pairs~\cite{rezac-jctc-8-2012} which prevents them from approaching too
   closely together.
@@ -2431,26 +2427,11 @@ parameters are taken to be the same as in the dftd3 code.
 
 If you would like to use what is called ``DFTB3'' in some publication(s)
 \cite{gauss-jctc-7-931}, this group of options include the relevant
-modifications to the SCC Hamiltonian and energy. \emph{To enable the DFTB3 model
-  you will need to set \is{{ThirdOrderFull} = Yes}, \is{DampXH = Yes} and set
-  the exponents in \is{DampXHExponent} }.
+modifications to the SCC Hamiltonian and energy. \emph{To enable the DFTB3
+  model} you will need to set \is{{ThirdOrderFull} = Yes} and damp H--X the
+interactions (see Section \ref{sec:dftbp.hbond}).
 
 \begin{description}
-
-\item[\is{DampXH}] If set to \is{Yes} the short range contribution to the SCC
-  interaction between atoms $A$ and $B$ is damped by the factor
-  \begin{equation*}
-    e^{-\left(\frac{U_{Al} + U_{Bl}}{2}\right)^\zeta r_{AB}^2}
-  \end{equation*}
-  provided that at least one of the two atoms is hydrogen
-  \cite{gauss-jctc-7-931,yang-JPCA-111-10861}. ($U_{Al}$ and $U_{Bl}$ are the
-  Hubbard Us of the two atoms for the $l$-shell, $r_{AB}$ is the distance
-  between the atoms.) An atom is considered to be a hydrogen-like atom, if its
-  mass (stored in the appropriate homonuclear SK-file) is less than 3.5 amu. The
-  parameter $\zeta$ can be set with the keyword \is{DampXHExponent}.
-
-\item[\is{DampXHExponent}] Sets the parameter $\zeta$ for the short range
-  damping. (See keyword \is{DampXH} above.)
 
 \item[\is{ThirdOrder}] If set to \is{Yes} the \textit{on-site} 3rd order
   correction \cite{yang-JPCA-111-10861} is switched on. This corrects the
@@ -2483,27 +2464,51 @@ Hamiltonian = DFTB {
 \end{verbatim}
 \end{description}
 
-\subsection{DFTB3-D3H5}
-\label{sec:dftbp.D3H5}
-\index{DFTB3-D3H5}
+\subsection{Hydrogen bond corrections}
+\label{sec:dftbp.hbond}
+
+There are currently two available methods to correct hydrogen bond interactions
+in the \is{HBondCorrection} environment:
+
+\subsubsection{Damping}
+\index{sec:Damp X-H}
+
+The \is{Damping} method modifies the short range contribution to the SCC
+interaction between atoms $A$ and $B$ with the damping factor
+\begin{equation*}
+  e^{-\left(\frac{U_{Al} + U_{Bl}}{2}\right)^\zeta r_{AB}^2}
+\end{equation*}
+provided that at least one of the two atoms is
+hydrogen~\cite{gauss-jctc-7-931,yang-JPCA-111-10861}. ($U_{Al}$ and $U_{Bl}$ are
+the Hubbard U values of the two atoms for the $l$-shell, $r_{AB}$ is the
+distance between the atoms.) An atom is considered to be a hydrogen-like atom,
+if its mass (stored in the appropriate homonuclear SK-file) is less than 3.5
+amu.  The \is{Exponent} keyword in this environment sets the parameter $\zeta$
+for the short range damping:
+\begin{verbatim}
+HBondCorrection = Damping {
+  Exponent = 4.05
+}
+\end{verbatim}
+Table 2 of reference~\cite{gauss-jctc-7-931} gives suggested values of the
+exponent for different DFTB2 and DFTB3 models applied to light atoms bonded to
+hydrogen.
+
+\subsubsection{DFTB3-D3H5}
+\index{sec:DFTB3-D3H5}
 
 DFTB3-D3H5~\cite{rezac-jctc-13-2017} is a variant of DFTB3 with additional
 corrections for non-covalent interactions (dispersion and hydrogen bonds).  It
 consists of a third-order DFTB calculation using the 3OB parameter set, but
-where the gamma-function damping (\is{DampXH}) is replaced by the H5 correction
-and an additional D3 dispersion correction in included. This method also
-includes a repulsive term which is added to prevent unphysically close approach
-of pairs of hydrogen atoms~\cite{rezac-jctc-8-2012}.
+where the gamma-function damping (\is{Damping} method above) is replaced by the
+H5 correction and an additional D3 dispersion correction in included. This
+method also includes a repulsive term which is added to prevent unphysically
+close approach of pairs of hydrogen atoms~\cite{rezac-jctc-8-2012}.
 
-\begin{description}
-\item[\is{HBondCorrection}] Setting this keyword to \iscb{H5} activates the
-  correction for hydrogen bonds~\cite{rezac-jctc-13-2017}. \is{H5} is currently
-  the only option accepted for \is{HBondCorrection}.
-\end{description}
-
-If no additional parameters are provided in the input, suitable values for
-H-\{O,N,S\} systems are used (the correction was developed for the DFTB3/3OB
-model and parameters).
+Setting the \is{HBondCorrection} environment to \iscb{H5} activates this
+correction for hydrogen bonds~\cite{rezac-jctc-13-2017}. If no additional
+parameters are provided in the input, suitable values for H-\{O,N,S\} systems
+are used (the correction was developed for the DFTB3/3OB model and parameters).
 \begin{verbatim}
 HBondCorrection = H5 {}
 \end{verbatim}
@@ -2513,8 +2518,8 @@ involving the terminal nitrogen of an azide group, and the published results in
 Ref.~\cite{rezac-jctc-13-2017} were obtained with the H5 correction switched off
 for these specific atoms. To reproduce this behavior in a system containing
 nitrogen in several environments, a new atom type with a different name but the
-same DFTB parameters can be used for for the specific N atoms to which the
-correction should not be applied.
+same DFTB parameters can be used for specific N atoms to which the correction
+should not be applied.
 
 If you want to specify the parameters manually, \is{H5} accepts following
 options, corresponding to terms in Ref.~\cite{rezac-jctc-13-2017}:
@@ -2545,13 +2550,13 @@ options, corresponding to terms in Ref.~\cite{rezac-jctc-13-2017}:
     \exp\left(-\frac{\left(r_{X\text{H}} - r_0\right)^2}{2w^2}\right)\right)
     \text.
   \end{equation*}
-  You have to specify one value for each of the chemical species you would like
-  to correct (see the example below). Explicitly setting a negative value
+  You will have to specify one value for each of the chemical species you would
+  like to correct (see the example below). Explicitly setting a negative value
   (e.g. \is{-1.0}) for a given atom type switches off the correction for
   hydrogen bonds involving that type of atom. In the special cases of N, O or S,
-  if do not specify a value (and do not disable the contribution by using
+  if you do not specify a value (and do not disable the contribution by using
   \is{-1.0}), the default value from the reference paper will be
-  used~\cite{rezac-jctc-13-2017}. For any other ommitted atom types, the code
+  used~\cite{rezac-jctc-13-2017}. For any other omitted atom types, the code
   defaults to a choice of \is{-1.0} (no correction).
 \end{description}
 

--- a/prog/dftb+/prg_dftb/oldcompat.F90
+++ b/prog/dftb+/prg_dftb/oldcompat.F90
@@ -53,6 +53,9 @@ contains
       case (4)
         call convert_4_5(root)
         version = 5
+      case (5)
+        call convert_5_6(root)
+        version = 6
       end select
     end do
 
@@ -331,5 +334,27 @@ contains
     end if
 
   end subroutine convert_4_5
+
+  !> Converts input from version 5 to 6. (Version 6 introduced in May. 2018)
+  subroutine convert_5_6(root)
+
+    !> Root tag of the HSD-tree
+    type(fnode), pointer :: root
+
+    type(fnode), pointer :: ch1
+
+    call getDescendant(root, "Analysis/Localise/PipekMezey/Tollerance", ch1)
+    if (associated(ch1)) then
+      call detailedWarning(ch1, "Keyword converted to 'Tolerance'.")
+      call setNodeName(ch1, "Tolerance")
+    end if
+
+    call getDescendant(root, "Analysis/Localise/PipekMezey/SparseTollerances", ch1)
+    if (associated(ch1)) then
+      call detailedWarning(ch1, "Keyword converted to 'SparseTollerances'.")
+      call setNodeName(ch1, "SparseTolerances")
+    end if
+
+  end subroutine convert_5_6
 
 end module oldcompat

--- a/prog/dftb+/prg_dftb/oldcompat.F90
+++ b/prog/dftb+/prg_dftb/oldcompat.F90
@@ -367,7 +367,7 @@ contains
       call getChildValue(par, "DampXH", tVal)
       call getDescendant(root, "Hamiltonian/DFTB/DampXHExponent", ch2)
       if (tVal .neqv. associated(ch2)) then
-        call error("Incompatible combinaton of ")
+        call error("Incompatible combinaton of DampXH and DampXHExponent")
       end if
       if (associated(ch2)) then
         call getChildValue(par, "DampXHExponent", rTmp)
@@ -381,8 +381,7 @@ contains
       ! clean out any HBondCorrection entry
       call getDescendant(root, "Hamiltonian/DFTB/HBondCorrection", ch2, parent=par)
       if (associated(ch2)) then
-         dummy => removeChild(par,ch2)
-        call destroyNode(ch2)
+        call detailedError(ch2, "HBondCorrection already present.")
       end if
 
       call getDescendant(root, "Hamiltonian/DFTB", ch2, parent=par)

--- a/prog/dftb+/prg_dftb/oldcompat.F90
+++ b/prog/dftb+/prg_dftb/oldcompat.F90
@@ -327,6 +327,11 @@ contains
           & differentiation")
     end if
 
+    call getDescendant(root, "Hamiltonian/DFTB/SpinConstants", ch1, parent=par)
+    if (associated(ch1)) then
+      call setChildValue(ch1, "ShellResolvedSpin", .true.)
+    end if
+
   end subroutine convert_4_5
 
   !> Converts input from version 5 to 6. (Version 6 introduced in May. 2018)
@@ -338,7 +343,7 @@ contains
     type(fnode), pointer :: ch1, ch2, ch3, ch4, par, par2, dummy
     logical :: tVal, tVal2
     real(dp) :: rTmp
-    
+
     call getDescendant(root, "Analysis/Localise/PipekMezey/Tollerance", ch1)
     if (associated(ch1)) then
       call detailedWarning(ch1, "Keyword converted to 'Tolerance'.")
@@ -366,7 +371,7 @@ contains
       end if
       if (associated(ch2)) then
         call getChildValue(par, "DampXHExponent", rTmp)
-      end if      
+      end if
       call detailedWarning(ch1, "Keyword DampXH moved to HBondCorrection block")
       dummy => removeChild(par,ch1)
       call destroyNode(ch1)
@@ -379,7 +384,7 @@ contains
          dummy => removeChild(par,ch2)
         call destroyNode(ch2)
       end if
-      
+
       call getDescendant(root, "Hamiltonian/DFTB", ch2, parent=par)
       if (associated(ch2)) then
         call setChild(ch2, "HBondCorrection", ch3)
@@ -388,7 +393,7 @@ contains
         call detailedWarning(ch3, "Adding Damping to HBondCorrection")
       end if
     end if
-    
+
   end subroutine convert_5_6
 
 end module oldcompat

--- a/prog/dftb+/prg_dftb/oldcompat.F90
+++ b/prog/dftb+/prg_dftb/oldcompat.F90
@@ -356,12 +356,6 @@ contains
       call setNodeName(ch1, "SparseTolerances")
     end if
 
-    call getDescendant(root, "Analysis/Localise/PipekMezey/Tollerance", ch1)
-    if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword converted to 'Tolerance'.")
-      call setNodeName(ch1, "Tolerance")
-    end if
-
     call getDescendant(root, "Hamiltonian/DFTB/DampXH", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(par, "DampXH", tVal)
@@ -385,12 +379,10 @@ contains
       end if
 
       call getDescendant(root, "Hamiltonian/DFTB", ch2, parent=par)
-      if (associated(ch2)) then
-        call setChild(ch2, "HBondCorrection", ch3)
-        call setChild(ch3, "Damping", ch4)
-        call setChildValue(ch4, "Exponent", rTmp)
-        call detailedWarning(ch3, "Adding Damping to HBondCorrection")
-      end if
+      call setChild(ch2, "HBondCorrection", ch3)
+      call setChild(ch3, "Damping", ch4)
+      call setChildValue(ch4, "Exponent", rTmp)
+      call detailedWarning(ch3, "Adding Damping to HBondCorrection")
     end if
 
   end subroutine convert_5_6

--- a/prog/dftb+/prg_dftb/oldcompat.F90
+++ b/prog/dftb+/prg_dftb/oldcompat.F90
@@ -327,12 +327,6 @@ contains
           & differentiation")
     end if
 
-    call getDescendant(root, "Hamiltonian/DFTB/SpinConstants", ch1, &
-        & parent=par)
-    if (associated(ch1)) then
-      call setChildValue(ch1, "ShellResolvedSpin", .true.)
-    end if
-
   end subroutine convert_4_5
 
   !> Converts input from version 5 to 6. (Version 6 introduced in May. 2018)
@@ -341,8 +335,10 @@ contains
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
 
-    type(fnode), pointer :: ch1
-
+    type(fnode), pointer :: ch1, ch2, ch3, ch4, par, par2, dummy
+    logical :: tVal, tVal2
+    real(dp) :: rTmp
+    
     call getDescendant(root, "Analysis/Localise/PipekMezey/Tollerance", ch1)
     if (associated(ch1)) then
       call detailedWarning(ch1, "Keyword converted to 'Tolerance'.")
@@ -355,6 +351,44 @@ contains
       call setNodeName(ch1, "SparseTolerances")
     end if
 
+    call getDescendant(root, "Analysis/Localise/PipekMezey/Tollerance", ch1)
+    if (associated(ch1)) then
+      call detailedWarning(ch1, "Keyword converted to 'Tolerance'.")
+      call setNodeName(ch1, "Tolerance")
+    end if
+
+    call getDescendant(root, "Hamiltonian/DFTB/DampXH", ch1, parent=par)
+    if (associated(ch1)) then
+      call getChildValue(par, "DampXH", tVal)
+      call getDescendant(root, "Hamiltonian/DFTB/DampXHExponent", ch2)
+      if (tVal .neqv. associated(ch2)) then
+        call error("Incompatible combinaton of ")
+      end if
+      if (associated(ch2)) then
+        call getChildValue(par, "DampXHExponent", rTmp)
+      end if      
+      call detailedWarning(ch1, "Keyword DampXH moved to HBondCorrection block")
+      dummy => removeChild(par,ch1)
+      call destroyNode(ch1)
+      dummy => removeChild(par,ch2)
+      call destroyNode(ch2)
+
+      ! clean out any HBondCorrection entry
+      call getDescendant(root, "Hamiltonian/DFTB/HBondCorrection", ch2, parent=par)
+      if (associated(ch2)) then
+         dummy => removeChild(par,ch2)
+        call destroyNode(ch2)
+      end if
+      
+      call getDescendant(root, "Hamiltonian/DFTB", ch2, parent=par)
+      if (associated(ch2)) then
+        call setChild(ch2, "HBondCorrection", ch3)
+        call setChild(ch3, "Damping", ch4)
+        call setChildValue(ch4, "Exponent", rTmp)
+        call detailedWarning(ch3, "Adding Damping to HBondCorrection")
+      end if
+    end if
+    
   end subroutine convert_5_6
 
 end module oldcompat

--- a/prog/dftb+/prg_dftb/parser.F90
+++ b/prog/dftb+/prg_dftb/parser.F90
@@ -65,7 +65,7 @@ module parser
 
 
   !> Version of the current parser
-  integer, parameter :: parserVersion = 5
+  integer, parameter :: parserVersion = 6
 
 
   !> Version of the oldest parser for which compatibility is still maintained
@@ -3281,13 +3281,13 @@ contains
       if (associated(child2)) then
         allocate(ctrl%pipekMezeyInp)
         associate(inp => ctrl%pipekMezeyInp)
-          call getChildValue(child2, "Tollerance", inp%tolerance, 1.0E-4_dp)
           call getChildValue(child2, "MaxIterations", inp%maxIter, 100)
+          tPipekDense = .true.
           if (.not. geo%tPeriodic) then
             call getChildValue(child2, "Dense", tPipekDense, .false.)
             if (.not. tPipekDense) then
               call init(lr1)
-              call getChild(child2, "SparseTollerances", child=child3, requested=.false.)
+              call getChild(child2, "SparseTolerances", child=child3, requested=.false.)
               if (associated(child3)) then
                 call getChildValue(child3, "", 1, lr1)
                 if (len(lr1) < 1) then
@@ -3298,10 +3298,13 @@ contains
               else
                 allocate(inp%sparseTols(4))
                 inp%sparseTols = [0.1_dp, 0.01_dp, 1.0E-6_dp, 1.0E-12_dp]
-                call setChildValue(child2, "Tollerances", inp%sparseTols)
+                call setChildValue(child2, "SparseTolerances", inp%sparseTols)
               end if
               call destruct(lr1)
             end if
+          end if
+          if (tPipekDense) then
+            call getChildValue(child2, "Tolerance", inp%tolerance, 1.0E-4_dp)
           end if
         end associate
       else


### PR DESCRIPTION
Change to parser 6, fixing 'tollerance' in the Pipek-Mezey localization and unifying syntax for the two hydrogen bond correction schemes currently available.

Ready to merge (unless we want to also add setting a default value for the H-X damping correction exponent at this parser revision).