### PR TITLE
Change Intel mpi compiler to mpifort

### DIFF
--- a/sys/make.x86_64-linux-intel
+++ b/sys/make.x86_64-linux-intel
@@ -9,7 +9,7 @@ ifeq ($(strip $(WITH_MPI)),1)
 ############################################################################
 
 # Compilers
-FXX = mpif90
+FXX = mpifort
 CC = icc
 
 # Compiler options

--- a/sys/make.x86_64-linux-intel
+++ b/sys/make.x86_64-linux-intel
@@ -8,7 +8,8 @@ ifeq ($(strip $(WITH_MPI)),1)
 # MPI settings
 ############################################################################
 
-# Compilers
+# Compilers, note that mpif90 or mpiifort may be more suitable depending on
+# your system configuration
 FXX = mpifort
 CC = icc
 


### PR DESCRIPTION
Due to the 2017 change in the Intel tools wrapper naming
convention.

See for [example](http://www.hpc.cineca.it/center_news/important-use-intel-mpi-wrappers-mpif90-mpicc-mpicxx).