### PR TITLE
Use prefix var in makefiles

### DIFF
--- a/make.config
+++ b/make.config
@@ -8,9 +8,6 @@ BUILDDIR := $(ROOT)/_build
 # Installation directory
 INSTALLDIR := $(ROOT)/_install
 
-# Directory where packages are installed in the system
-PREFIX := /usr/local
-
 ################################################################################
 # Configuration of optional components
 ################################################################################
@@ -50,24 +47,6 @@ TEST_OMP_THREADS := 1
 # Architecture dependent settings
 ################################################################################
 
-# Whether DFTD3 should be compiled during the build process. If set to 1 (yes),
-# you will have to download the dftd3 library before starting the build using
-# the utils/get_opt_externals tool.
-# (Only active, if WITH_DFTB3 was set to 1 above.)
-COMPILE_DFTD3 := 1
-
-# Set the compile time include and the link time library options for
-# dftd3-lib. Ignored if WITH_DFTD3 has been disabled or COMPILE_DFTD3 enabled.
-DFTD3_INCS := -I$(PREFIX)/include/dftd3-lib
-DFTD3_LIBS := -L$(PREFIX)/lib -ldftd3
-
-# Link time library options for linking ARPACK. Ignored if WITH_ARPACK was
-# disabled.
-ARPACK_LIBS := -larpack
-
-# Whether ARPACK depends on the external LAPACK and BLAS libraries
-ARPACK_NEEDS_LAPACK := 0
-
-# Include further architecture dependent settings from make.arch (make sure to
-# adapt those in make.arch for your system)
+# Include architecture dependent settings from make.arch (make sure to adapt
+# those in make.arch for your system)
 include $(ROOT)/make.arch

--- a/make.config
+++ b/make.config
@@ -23,8 +23,9 @@ WITH_SOCKETS := 1
 WITH_ARPACK := 1
 
 # Whether the DFTD3 library (dispersion) should be linked.
-# NOTE: Due to license incompatibility, distribution of a DFTB+ binary built
-# with this component is not permitted. Use it only for your personal research.
+# NOTE: Due to the license of the DFTD3 library, the linked code must be
+# distributed under the GPLv3 license (as opposed to the LGPLv3 license of the
+# DFTB+ package)
 WITH_DFTD3 := 0
 
 ################################################################################

--- a/make.config
+++ b/make.config
@@ -8,6 +8,9 @@ BUILDDIR := $(ROOT)/_build
 # Installation directory
 INSTALLDIR := $(ROOT)/_install
 
+# Directory where packages are installed in the system
+PREFIX := /usr/local
+
 ################################################################################
 # Configuration of optional components
 ################################################################################
@@ -55,8 +58,8 @@ COMPILE_DFTD3 := 1
 
 # Set the compile time include and the link time library options for
 # dftd3-lib. Ignored if WITH_DFTD3 has been disabled or COMPILE_DFTD3 enabled.
-DFTD3_INCS := -I/usr/local/include/dftd3-lib
-DFTD3_LIBS := -L/usr/local/lib -ldftd3
+DFTD3_INCS := -I$(PREFIX)/include/dftd3-lib
+DFTD3_LIBS := -L$(PREFIX)/lib -ldftd3
 
 # Link time library options for linking ARPACK. Ignored if WITH_ARPACK was
 # disabled.

--- a/sys/make.x86_64-linux-gnu
+++ b/sys/make.x86_64-linux-gnu
@@ -24,7 +24,7 @@ LNOPT = -fopenmp
 # How to link specific libraries
 
 # ScaLAPACK
-SCALAPACKDIR = /usr/lib
+SCALAPACKDIR = $(PREFIX)/lib
 LIB_SCALAPACK = -L$(SCALAPACKDIR) -lscalapack
 
 # LAPACK/BLAS

--- a/sys/make.x86_64-linux-gnu
+++ b/sys/make.x86_64-linux-gnu
@@ -3,6 +3,10 @@
 # gfortran/gcc 5.4 - 7.1
 ############################################################################
 
+# Directory where standard packages are installed in the system
+PREFIX := /usr/local
+
+
 ifeq ($(strip $(WITH_MPI)),1)
 ############################################################################
 # MPI settings
@@ -80,7 +84,26 @@ FYPP = $(ROOT)/external/fypp/bin/fypp
 FYPPOPT =
 
 # Library options in general
-LIBOPT = 
+LIBOPT =
+
+# Whether DFTD3 should be compiled during the build process. If set to 1 (yes),
+# you will have to download the dftd3 library before starting the build using
+# the utils/get_opt_externals tool.
+# (Only active, if WITH_DFTB3 was set in make.config.)
+COMPILE_DFTD3 := 1
+
+# Set the compile time include and the link time library options for
+# dftd3-lib. Ignored if WITH_DFTD3 has been disabled or COMPILE_DFTD3 enabled.
+DFTD3_INCS := -I$(PREFIX)/include/dftd3-lib
+DFTD3_LIBS := -L$(PREFIX)/lib -ldftd3
+
+# Link time library options for linking ARPACK. Ignored if WITH_ARPACK was
+# disabled.
+ARPACK_LIBS := -larpack
+
+# Whether ARPACK depends on the external LAPACK and BLAS libraries
+ARPACK_NEEDS_LAPACK := 0
+
 
 ############################################################################
 # Developer settings

--- a/sys/make.x86_64-linux-intel
+++ b/sys/make.x86_64-linux-intel
@@ -3,6 +3,10 @@
 # ifort/icc 17.0
 ############################################################################
 
+# Directory where standard packages are installed in the system
+PREFIX := /usr/local
+
+
 ifeq ($(strip $(WITH_MPI)),1)
 ############################################################################
 # MPI settings
@@ -83,6 +87,25 @@ FYPPOPT =
 
 # Library options in general
 LIBOPT = 
+
+# Whether DFTD3 should be compiled during the build process. If set to 1 (yes),
+# you will have to download the dftd3 library before starting the build using
+# the utils/get_opt_externals tool.
+# (Only active, if WITH_DFTB3 was set in make.config.)
+COMPILE_DFTD3 := 1
+
+# Set the compile time include and the link time library options for
+# dftd3-lib. Ignored if WITH_DFTD3 has been disabled or COMPILE_DFTD3 enabled.
+DFTD3_INCS := -I$(PREFIX)/include/dftd3-lib
+DFTD3_LIBS := -L$(PREFIX)/lib -ldftd3
+
+# Link time library options for linking ARPACK. Ignored if WITH_ARPACK was
+# disabled.
+ARPACK_LIBS := -larpack
+
+# Whether ARPACK depends on the external LAPACK and BLAS libraries
+ARPACK_NEEDS_LAPACK := 0
+
 
 ############################################################################
 # Developer settings

--- a/sys/make.x86_64-linux-nag
+++ b/sys/make.x86_64-linux-nag
@@ -24,7 +24,7 @@ LNOPT = -openmp
 # How to link specific libraries
 
 # ScaLAPACK
-SCALAPACKDIR = /usr/lib
+SCALAPACKDIR = $(PREFIX)/lib
 LIB_SCALAPACK = -L$(SCALAPACKDIR) -lscalapack
 
 # LAPACK/BLAS

--- a/sys/make.x86_64-linux-nag
+++ b/sys/make.x86_64-linux-nag
@@ -3,6 +3,10 @@
 # nagfor 6.1, gcc 4.8
 ############################################################################
 
+# Directory where standard packages are installed in the system
+PREFIX := /usr/local
+
+
 ifeq ($(strip $(WITH_MPI)),1)
 ############################################################################
 # MPI settings
@@ -88,6 +92,25 @@ FYPPOPT = -DINTERNAL_ERFC -DEXP_TRAP
 
 # Library options in general
 LIBOPT = 
+
+# Whether DFTD3 should be compiled during the build process. If set to 1 (yes),
+# you will have to download the dftd3 library before starting the build using
+# the utils/get_opt_externals tool.
+# (Only active, if WITH_DFTB3 was set in make.config.)
+COMPILE_DFTD3 := 1
+
+# Set the compile time include and the link time library options for
+# dftd3-lib. Ignored if WITH_DFTD3 has been disabled or COMPILE_DFTD3 enabled.
+DFTD3_INCS := -I$(PREFIX)/include/dftd3-lib
+DFTD3_LIBS := -L$(PREFIX)/lib -ldftd3
+
+# Link time library options for linking ARPACK. Ignored if WITH_ARPACK was
+# disabled.
+ARPACK_LIBS := -larpack
+
+# Whether ARPACK depends on the external LAPACK and BLAS libraries
+ARPACK_NEEDS_LAPACK := 0
+
 
 ############################################################################
 # Developer settings

--- a/sys/make.x86_64-linux-pgi
+++ b/sys/make.x86_64-linux-pgi
@@ -3,7 +3,12 @@
 # pgfortran/pgcc 17.10
 ############################################################################
 
+# Directory where standard packages are installed in the system
+PREFIX := /usr/local
+
+# PGI library directory
 PGI_LIBDIR = /opt/pgi/linux86-64/17.10/lib
+
 
 ifeq ($(strip $(WITH_MPI)),1)
 ############################################################################
@@ -81,6 +86,25 @@ FYPPOPT =
 
 # Library options in general
 LIBOPT =
+
+# Whether DFTD3 should be compiled during the build process. If set to 1 (yes),
+# you will have to download the dftd3 library before starting the build using
+# the utils/get_opt_externals tool.
+# (Only active, if WITH_DFTB3 was set in make.config.)
+COMPILE_DFTD3 := 1
+
+# Set the compile time include and the link time library options for
+# dftd3-lib. Ignored if WITH_DFTD3 has been disabled or COMPILE_DFTD3 enabled.
+DFTD3_INCS := -I$(PREFIX)/include/dftd3-lib
+DFTD3_LIBS := -L$(PREFIX)/lib -ldftd3
+
+# Link time library options for linking ARPACK. Ignored if WITH_ARPACK was
+# disabled.
+ARPACK_LIBS := -larpack
+
+# Whether ARPACK depends on the external LAPACK and BLAS libraries
+ARPACK_NEEDS_LAPACK := 0
+
 
 ############################################################################
 # Developer settings

--- a/utils/get_opt_externals
+++ b/utils/get_opt_externals
@@ -22,26 +22,28 @@ Downloads optional external components.
 
 Possible choices for OPTEXT:
 
-  DISTRIB (default) -- download only components which are LGPL-compatible,
-      can be distributed with the DFTB+ source code and do not restrict the
+  UNRESTRICTED (default) -- download only components which are less or equally
+      restrictive than the LGPL license of DFTB+ and do not restrict the
       distribution of the compiled code beyond its LGPL-license.
+
+  RESTRICTED -- download optional components with stricter license as LGPL
+      (typically GPL). The distribution of the compiled code will be restricted
+      beyond the LGPL license and governed by the strictest license of the
+      included optional components (typically GPLv3).
 
   ALL -- download all optional external components.
 
-      NOTE: this will also download components with LGPL-incompatible
-      licenses. Those components can not be distributed with the DFTB+ source
-      code and the distribution of the resulting binary or library is not
-      permitted if those components were part of the build. Using them for
-      personal research is permitted, though.
+      NOTE: this will also download components which may restrict the license of
+      the compiled code beyond the LGPL license.
 
-  slakos -- Parametrisations for testing DFTB+ [license: CC-BY-SA]
+  slakos -- Parametrisations for testing DFTB+ [license: CC-BY-SA, UNRESTRICTED]
 
-  dftd3 -- Library for calculating D3 dispersion [license: GPL]
+  dftd3 -- Library for calculating D3 dispersion [license: GPL, RESTRICTED]
 '''
 
-NON_DISTRIB_WARNING = """WARNING:
-    This optional external component is not compatible with the DFTB+ license.
-    Restrictions on distribution of the compiled code may apply.
+RESTRICTED_WARNING = """WARNING:
+    This optional external component has a more restrictive license than the
+    DFTB+ license. Restrictions on distribution of the compiled code may apply.
 """
 
 SCRIPT_DIR = os.path.dirname(sys.argv[0])
@@ -50,6 +52,9 @@ STATUS_FILE = 'status'
 
 STATUS_MISSING = 'missing'
 STATUS_OK = 'ok'
+
+UNRESTRICTED_EXTERNAL = 0
+RESTRICTED_EXTERNAL = 1
 
 
 class ScriptError(Exception):
@@ -65,8 +70,10 @@ def main():
 
     externals = []
     for external in args:
-        if external == 'DISTRIB':
-            externals += EXTERNALS_DISTRIB
+        if external == 'UNRESTRICTED':
+            externals += EXTERNALS_UNRESTRICTED
+        elif external == 'RESTRICTED':
+            externals += EXTERNALS_RESTRICTED
         elif external == 'ALL':
             externals += EXTERNALS
         else:
@@ -76,14 +83,14 @@ def main():
     for external in externals:
         if external in done or external in excluded:
             continue
-        getter, destdir, distrib = GETTERS[external]
+        getter, destdir, restriction = GETTERS[external]
         destdir = os.path.join(EXTERNAL_DIR, destdir)
         if not os.path.isdir(destdir):
             msg = "Directory '{}' does not exist".format(destdir)
             raise ScriptError(msg)
         print('\n*** Getting external:', external, '\n    into', destdir, '\n')
-        if not distrib:
-            print(NON_DISTRIB_WARNING)
+        if restriction == RESTRICTED_EXTERNAL:
+            print(RESTRICTED_WARNING)
         set_status(destdir, STATUS_MISSING)
         getter(destdir)
         set_status(destdir, STATUS_OK)
@@ -101,9 +108,9 @@ def parse_cmdline_args():
         choices=EXTERNALS, default=None, action='append', help=msg)
     opts, args = parser.parse_args()
 
-    argchoices = ['DISTRIB', 'ALL'] + EXTERNALS
+    argchoices = ['UNRESTRICTED', 'RESTRICTED', 'ALL'] + EXTERNALS
     if not args:
-        args = ['DISTRIB']
+        args = ['UNRESTRICTED']
     for arg in args:
         if arg not in argchoices:
             msg = "Invalid optional external '{}'".format(arg)
@@ -228,17 +235,22 @@ def read_input():
 
 
 # Methods to obtain externals.
-# Contains (function, targetfolder, is_distributable) tuples
+# Contains (function, targetfolder, restriction) tuples
 GETTERS = {
-    'slakos': (get_slakos, 'slakos', True),
-    'dftd3': (get_dftd3, 'dftd3', False)
+    'slakos': (get_slakos, 'slakos', UNRESTRICTED_EXTERNAL),
+    'dftd3': (get_dftd3, 'dftd3', RESTRICTED_EXTERNAL)
 }
 
 # All externals
 EXTERNALS = list(GETTERS.keys())
 
 # LGPL-compatible externals without restriction on distribution
-EXTERNALS_DISTRIB = [ext for ext in GETTERS.keys() if GETTERS[ext][2]]
+EXTERNALS_UNRESTRICTED = [ext for ext in GETTERS.keys()
+                          if GETTERS[ext][2] == UNRESTRICTED_EXTERNAL]
+
+# LGPL-compatible externals with restriction on distribution
+EXTERNALS_RESTRICTED = [ext for ext in GETTERS.keys()
+                        if GETTERS[ext][2] == RESTRICTED_EXTERNAL]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Extends the external request by rearranging the makefiles as discussed already earlier. Also, it fixes the wrong license information / notes about optional external components with GPL-license