### PR TITLE
Fix Python 3 problem in socket tests

### DIFF
--- a/test/prog/dftb+/sockets/H2O/prerun.py
+++ b/test/prog/dftb+/sockets/H2O/prerun.py
@@ -54,17 +54,17 @@ def main():
 
     for iStep in range(NR_STEPS):
         print("Step %i" % iStep)
-        connection.sendall('POSDATA     ')
+        connection.sendall(b'POSDATA     ')
         connection.sendall(latvecs)
 
         connection.sendall(la.inv(latvecs))
         connection.sendall(np.int32(len(coords)))
         connection.sendall(coords)
 
-        connection.sendall('GETFORCE    ')
+        connection.sendall(b'GETFORCE    ')
         # needs work:
         buf = receive_all(connection, 12)
-        if (buf != 'FORCEREADY  '):
+        if (buf != b'FORCEREADY  '):
             raise ValueError('Unexpected value of "GETFORCE": "%s"!' % buf)
 
         # expecting energy and number of atoms

--- a/test/prog/dftb+/sockets/H2O_cluster/prerun.py
+++ b/test/prog/dftb+/sockets/H2O_cluster/prerun.py
@@ -60,7 +60,7 @@ def main():
 
     for iStep in range(NR_STEPS+1):
         print("Step %i" % iStep)
-        connection.sendall('POSDATA     ')
+        connection.sendall(b'POSDATA     ')
         connection.sendall(latvecs)
 
         if tPeriodic:
@@ -70,11 +70,11 @@ def main():
 
         connection.sendall(np.int32(len(coords)))
         connection.sendall(coords)
-        connection.sendall('GETFORCE    ')
+        connection.sendall(b'GETFORCE    ')
 
         # needs work:
         buf = receive_all(connection, 12)
-        if (buf != 'FORCEREADY  '):
+        if (buf != b'FORCEREADY  '):
             raise ValueError('Unexpected value of "GETFORCE": "%s"!' % buf)
 
         # expecting energy and number of atoms

--- a/test/prog/dftb+/sockets/diamond/prerun.py
+++ b/test/prog/dftb+/sockets/diamond/prerun.py
@@ -40,17 +40,17 @@ def main():
     
     for iStep in range(NR_STEPS):
         print("Step %i" % iStep)
-        connection.sendall('POSDATA     ')
+        connection.sendall(b'POSDATA     ')
         connection.sendall(latvecs)
 
         connection.sendall(la.inv(latvecs))
         connection.sendall(np.int32(len(coords)))
         connection.sendall(coords)
 
-        connection.sendall('GETFORCE    ')
+        connection.sendall(b'GETFORCE    ')
         # needs work:
         buf = receive_all(connection, 12)
-        if (buf != 'FORCEREADY  '):
+        if (buf != b'FORCEREADY  '):
             raise ValueError('Unexpected value of "GETFORCE": "%s"!' % buf)
 
         # expecting energy and number of atoms

--- a/test/prog/dftb+/sockets/diamond_exit/prerun.py
+++ b/test/prog/dftb+/sockets/diamond_exit/prerun.py
@@ -40,17 +40,17 @@ def main():
 
     for iStep in range(NR_STEPS):
         print("Step %i" % iStep)
-        connection.sendall('POSDATA     ')
+        connection.sendall(b'POSDATA     ')
         connection.sendall(latvecs)
 
         connection.sendall(la.inv(latvecs))
         connection.sendall(np.int32(len(coords)))
         connection.sendall(coords)
 
-        connection.sendall('GETFORCE    ')
+        connection.sendall(b'GETFORCE    ')
         # needs work:
         buf = receive_all(connection, 12)
-        if (buf != 'FORCEREADY  '):
+        if (buf != b'FORCEREADY  '):
             raise ValueError('Unexpected value of "GETFORCE": "%s"!' % buf)
 
         # expecting energy and number of atoms
@@ -77,7 +77,7 @@ def main():
 
 
     print("Requesting clean shutdown of DFTB+")
-    connection.sendall('EXIT        ')
+    connection.sendall(b'EXIT        ')
 
     time.sleep(2)
     connection.shutdown(socket.SHUT_RDWR)


### PR DESCRIPTION
Solves #180, tests should work now with both python 2 and python 3 being the default interpreter with the name `python`.