### PR TITLE
Pass in tSpin to detailed.out printing

### DIFF
--- a/prog/dftb+/prg_dftb/main.F90
+++ b/prog/dftb+/prg_dftb/main.F90
@@ -408,13 +408,12 @@ contains
 
         if (tWriteDetailedOut) then
           call openDetailedOut(fdDetailedOut, userOut, tAppendDetailedOut, iGeoStep, iSccIter)
-          call writeDetailedOut1(fdDetailedOut, iDistribFn, nGeoSteps,&
-              & iGeoStep, tMD, tDerivs, tCoordOpt, tLatOpt, iLatGeoStep, iSccIter, energy,&
-              & diffElec, sccErrorQ, indMovedAtom, pCoord0Out, q0, qInput, qOutput, eigen, filling,&
-              & orb, species, tDFTBU, tImHam.or.tSpinOrbit, tPrintMulliken, orbitalL, qBlockOut,&
-              & Ef, Eband, TS, E0, extPressure, cellVol, tAtomicEnergy, tDispersion, tEField,&
-              & tPeriodic, nSpin, tSpinOrbit, tSccCalc, tNegf, invLatVec, kPoint,&
-              & iAtInCentralRegion)
+          call writeDetailedOut1(fdDetailedOut, iDistribFn, nGeoSteps, iGeoStep, tMD, tDerivs,&
+              & tCoordOpt, tLatOpt, iLatGeoStep, iSccIter, energy, diffElec, sccErrorQ,&
+              & indMovedAtom, pCoord0Out, q0, qInput, qOutput, eigen, filling, orb, species,&
+              & tDFTBU, tImHam.or.tSpinOrbit, tPrintMulliken, orbitalL, qBlockOut, Ef, Eband, TS,&
+              & E0, extPressure, cellVol, tAtomicEnergy, tDispersion, tEField, tPeriodic, nSpin,&
+              & tSpin, tSpinOrbit, tSccCalc, tNegf, invLatVec, kPoint, iAtInCentralRegion)
         end if
 
         if (tConverged .or. tStopScc) then

--- a/prog/dftb+/prg_dftb/mainio.F90
+++ b/prog/dftb+/prg_dftb/mainio.F90
@@ -2276,12 +2276,11 @@ contains
 
 
   !> First group of data to go to detailed.out
-  subroutine writeDetailedOut1(fd, iDistribFn, nGeoSteps, iGeoStep,&
-      & tMD, tDerivs, tCoordOpt, tLatOpt, iLatGeoStep, iSccIter, energy, diffElec, sccErrorQ,&
-      & indMovedAtom, coord0Out, q0, qInput, qOutput, eigen, filling, orb, species,&
-      & tDFTBU, tImHam, tPrintMulliken, orbitalL, qBlockOut, Ef, Eband, TS, E0, pressure, cellVol,&
-      & tAtomicEnergy, tDispersion, tEField, tPeriodic, nSpin, tSpinOrbit, tScc, tNegf, &
-      & invLatVec, kPoints, iAtInCentralRegion)
+  subroutine writeDetailedOut1(fd, iDistribFn, nGeoSteps, iGeoStep, tMD, tDerivs, tCoordOpt,&
+      & tLatOpt, iLatGeoStep, iSccIter, energy, diffElec, sccErrorQ, indMovedAtom, coord0Out, q0,&
+      & qInput, qOutput, eigen, filling, orb, species, tDFTBU, tImHam, tPrintMulliken, orbitalL,&
+      & qBlockOut, Ef, Eband, TS, E0, pressure, cellVol, tAtomicEnergy, tDispersion, tEField,&
+      & tPeriodic, nSpin, tSpin, tSpinOrbit, tScc, tNegf, invLatVec, kPoints, iAtInCentralRegion)
 
     !> File ID
     integer, intent(in) :: fd
@@ -2397,6 +2396,9 @@ contains
     !> Number of spin channels
     integer, intent(in) :: nSpin
 
+    !> is this a spin polarized calculation?
+    logical :: tSpin
+
     !> Are spin orbit interactions present
     logical, intent(in) :: tSpinOrbit
 
@@ -2420,7 +2422,6 @@ contains
     integer :: ang
     integer :: nAtom, nKPoint, nSpinHams, nMovedAtom
     integer :: iAt, iSpin, iK, iSp, iSh, iOrb, ii, kk
-    logical :: tSpin
 
     character(lc) :: strTmp
 
@@ -2428,7 +2429,6 @@ contains
     nKPoint = size(eigen, dim=2)
     nSpinHams = size(eigen, dim=3)
     nMovedAtom = size(indMovedAtom)
-    tSpin = (nSpin == 2 .or. nSpin == 4)
 
     qInputUpDown = qInput
     call qm2ud(qInputUpDown)


### PR DESCRIPTION
Avoids zero spin energies being printed for cases with spin-orbit coupling but which are not spin polarized.