### PR TITLE
Set compilation to the basic common functionality

### DIFF
--- a/make.config
+++ b/make.config
@@ -16,11 +16,11 @@ INSTALLDIR := $(ROOT)/_install
 WITH_MPI := 0
 
 # Whether the socket library (external control) should be linked.
-WITH_SOCKETS := 1
+WITH_SOCKETS := 0
 
 # Whether the ARPACK library (needed by TD-DFTB) should be linked with DFTB+
 # Only affects serial build (MPI-version is built without ARPACK/TD-DFTB).
-WITH_ARPACK := 1
+WITH_ARPACK := 0
 
 # Whether transport via libNEGF should be included.
 # Only affects parallel build (serial version is built without libNEGF/transport)


### PR DESCRIPTION
Majority of the userbase aren't apparently needing sockets/arpack/transport by default.