### PR TITLE
Fix for Analysis/Excited block affected by Options

### DIFF
--- a/prog/dftb+/prg_dftb/parser.F90
+++ b/prog/dftb+/prg_dftb/parser.F90
@@ -110,7 +110,7 @@ contains
     type(inputData), intent(out) :: input
 
     type(fnode), pointer :: hsdTree
-    type(fnode), pointer :: root, tmp, hamNode, child, dummy
+    type(fnode), pointer :: root, tmp, hamNode, analysisNode, child, dummy
     type(TParserflags) :: parserFlags
     logical :: tHSD, missing
 
@@ -170,7 +170,7 @@ contains
 
     call getChild(root, "Dephasing", child, requested=.false.)
     if (associated(child)) then
-      call detailedError(child, "Be patient... Dephasing feature will be available soon!")    
+      call detailedError(child, "Be patient... Dephasing feature will be available soon!")
       !call readDephasing(child, input%slako%orb, input%geom, input%transpar, input%ginfo%tundos)
     end if
 
@@ -193,16 +193,16 @@ contains
   #:endif
 
     ! Analysis of properties
-    call getChildValue(root, "Analysis", dummy, "", child=child, list=.true., &
+    call getChildValue(root, "Analysis", dummy, "", child=analysisNode, list=.true., &
         & allowEmptyValue=.true., dummyValue=.true.)
 
   #:if WITH_TRANSPORT
-    call readAnalysis(child, input%ctrl, input%geom, input%slako%orb, input%transpar, &
+    call readAnalysis(analysisNode, input%ctrl, input%geom, input%slako%orb, input%transpar, &
         & input%ginfo%tundos)
 
     call finalizeNegf(input)
   #:else
-    call readAnalysis(child, input%ctrl, input%geom, input%slako%orb)
+    call readAnalysis(analysisNode, input%ctrl, input%geom, input%slako%orb)
   #:endif
 
     ! excited state options
@@ -218,6 +218,10 @@ contains
     ! Read W values if needed by Hamitonian or excited state calculation
     call readSpinConstants(hamNode, input%geom, input%slako, input%ctrl)
 
+    ! analysis settings that need to know settings from the options block
+    call readLaterAnalysis(analysisNode, input%ctrl)
+
+    ! read parallel calculation settings
     call readParallel(root, input)
 
     ! input data strucutre has been initialised
@@ -3657,10 +3661,6 @@ contains
       end if
 
       call getChildValue(node, "WriteEigenvectors", ctrl%tPrintEigVecs, .false.)
-      if (ctrl%tPrintEigVecs .or. ctrl%lrespini%tPrintEigVecs) then
-        call getChildValue(node, "EigenvectorsAsTxt", ctrl%tPrintEigVecsTxt, &
-            & .false.)
-      end if
 
     #:if WITH_SOCKETS
       tWriteBandDatDef = .not. allocated(ctrl%socketInput)
@@ -3695,6 +3695,23 @@ contains
   #:endif
 
   end subroutine readAnalysis
+
+
+  !> Read in settings that are influenced by those read from Options{} but belong in Analysis{}
+  subroutine readLaterAnalysis(node, ctrl)
+
+    !> Node to parse
+    type(fnode), pointer :: node
+
+    !> Control structure to fill
+    type(control), intent(inout) :: ctrl
+
+    if (ctrl%tPrintEigVecs .or. ctrl%lrespini%tPrintEigVecs) then
+      call getChildValue(node, "EigenvectorsAsTxt", ctrl%tPrintEigVecsTxt, &
+          & .false.)
+    end if
+
+  end subroutine readLaterAnalysis
 
 
   !> Reads W values if required by settings in the Hamiltonian or the excited state


### PR DESCRIPTION
Corrects for
EigenvectorsAsTxt = Yes
not being read if WriteEigenvectors = Yes is only set in the
Casida block.