### PR TITLE
Preprocessing to catch unallocated variable

### DIFF
--- a/prog/dftb+/prg_dftb/initprogram.F90
+++ b/prog/dftb+/prg_dftb/initprogram.F90
@@ -3738,7 +3738,7 @@ contains
     integer, intent(in) :: iSolver
     logical, intent(in) :: tSpin
     real(dp), intent(in) :: kPoints(:,:)
-    type(TParallelOpts), intent(in) :: parallelOpts
+    type(TParallelOpts), intent(in), allocatable :: parallelOpts
     integer, intent(in) :: nIndepHam
     real(dp), intent(in) :: tempElec
 
@@ -3763,10 +3763,12 @@ contains
     end if
 
     nKPoint = size(kPoints, dim=2)
+  #:if WITH_MPI
     if (tElsiSolver .and. parallelOpts%nGroup /= nIndepHam * nKPoint) then
       call error("This solver requires as many parallel processor groups as there are independent&
           & spin and k-point combinations")
     end if
+  #:endif
 
     if (iSolver == electronicSolverTypes%pexsi .and. tempElec < epsilon(0.0)) then
       call error("This solver requires a finite electron broadening")


### PR DESCRIPTION
PreprocessorOpts isn't allocated unless compiled with MPI, but was being tested in the serial code.