### PR TITLE
nEl0 fix

### DIFF
--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -1647,10 +1647,7 @@ contains
       end if  
     end if
 
-    nEl0 = 0.0_dp
-    do ii = 1, nAtom
-      nEl0 = nEl0 + sum(q0(1:orb%nOrbAtom(ii),ii,1)) 
-    end do
+    nEl0 = sum(q0(:,:,1))
     nEl(:) = 0.0_dp
     if (nSpin == 1 .or. nSpin == 4) then
       nEl(1) = nEl0 - input%ctrl%nrChrg

--- a/prog/dftb+/lib_timedep/linrespgrad.F90
+++ b/prog/dftb+/lib_timedep/linrespgrad.F90
@@ -601,7 +601,7 @@ contains
       end if
 
       ! redefine if needed (generalize it for spin-polarized and fractional occupancy)
-      nocc = int(rnel) / 2
+      nocc = nint(rnel) / 2
       nocc_r = nOcc
       nvir_r = nOrb - nOcc
 


### PR DESCRIPTION
Addresses the 4 core bug. It was due to underflow in an accumulating sum using a loop, instead of the safer sum() intrinsic (underflow effects in last two figures for loop and only the last for sum()).
First commit fixes the bug, second makes the place where it manifested more robust.
Fix tested for intel18.0 and gnu7.3 compilers.