### PR TITLE
Fix orbital-resolved projected eigenstates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,8 @@ Changed
 Fixed
 -----
 
+- Orbital-resolved projected eigenstates (shell-resolved were correct)
+
 
 
 18.2

--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -2485,7 +2485,7 @@ contains
               tmpir1 = 0
               ind = 1
               do iAt = 1, nAtomRegion
-                tmpir1(ind) = denseDesc%iAtomStart(iAt) + iOrb - 1
+                tmpir1(ind) = denseDesc%iAtomStart(iAtomRegion(iAt)) + iOrb - 1
                 ind = ind + 1
               end do
               call append(iOrbRegion, tmpir1)


### PR DESCRIPTION
Orbital enumeration was incorrect for orbital-resolved projected
eigenstates. Shell-resolved and unresolved projection were OK, though.