### PR TITLE
Rename Custom to Customised

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -1000,7 +1000,7 @@ following properties:
   \kw{Differentiation} &m&  & FiniteDiff & \pref{sec:dftbp.Differentiation} \\
   \kw{ForceEvaluation} &s& & "Legacy" & \\
   \kw{CustomisedHubbards} & p & SCC = Yes & & \\
-  \kw{CustomOccupations} & p & SCC = Yes & & \\
+  \kw{CustomisedOccupations} & p & SCC = Yes & & \\
   \kw{TruncateSKRange} & p & & & \\
   \hline
 \end{ptable}
@@ -1265,7 +1265,7 @@ following properties:
   }
   \end{verbatim}
 
-\item[\kw{CustomOccupations}] Enables overriding the reference neutral atom
+\item[\kw{CustomisedOccupations}] Enables overriding the reference neutral atom
   electronic occupations of the shells. Note that the atom remains neutral since
   a corresponding ionic counter charge is implicitly added to its core. This
   option can be used, for example, to simulate effective doping by setting a
@@ -1273,7 +1273,7 @@ following properties:
 
   Example:
   \begin{verbatim}
-  CustomOccupations{
+  CustomisedOccupations{
     ReferenceOccupation{
       Atoms={1:30}
       p=2.01

--- a/prog/dftb+/lib_dftbplus/parser.F90
+++ b/prog/dftb+/lib_dftbplus/parser.F90
@@ -5143,7 +5143,7 @@ contains
     character(sc), allocatable :: shellnames(:)
     logical, allocatable :: atomOverriden(:)
 
-    call getChild(root, "CustomOccupations", container, requested=.false.)
+    call getChild(root, "CustomisedOccupations", container, requested=.false.)
     if (.not. associated(container)) then
       return
     end if

--- a/test/prog/dftb+/scc/HH_custom-ref/dftb_in.hsd
+++ b/test/prog/dftb+/scc/HH_custom-ref/dftb_in.hsd
@@ -18,7 +18,7 @@ Hamiltonian = DFTB {
     H-H = "./H1-H1.skf" "./H1-H2.skf" "./H2-H1.skf" "./H2-H2.skf"
   }
 
-  CustomOccupations{
+  CustomisedOccupations{
     ReferenceOccupation{
       Atoms = {1 2} 
       s = 0.5

--- a/test/prog/dftb+/scc/SiH_custom-ref/dftb_in.hsd
+++ b/test/prog/dftb+/scc/SiH_custom-ref/dftb_in.hsd
@@ -26,7 +26,7 @@ Hamiltonian = DFTB {
 
   OldSKInterpolation = Yes
 
-  CustomOccupations{
+  CustomisedOccupations{
     ReferenceOccupation{
       Atoms = {1 3 5 7} 
       p = 2.1 


### PR DESCRIPTION
Occupation keyword renamed to be consistent with Hubbard case.