### PR TITLE
Fix for Ef exceeding top eigenvalue

### DIFF
--- a/prog/dftb+/lib_dftb/etemp.F90
+++ b/prog/dftb+/lib_dftb/etemp.F90
@@ -543,6 +543,11 @@ contains
       nElec = nElec + kWeight(iKpt)
       ind = ind + 1
     end do
+
+    ! just in case the system has all levels filled, but eventually this means Ef has to be above
+    ! last eigenvalue:
+    ind = min(size(eigenvals), ind)
+
     iLev = tmpIndx(ind)
     jOrb = mod(iLev - 1, size1) + 1
     jKpt = mod((iLev - 1) / size1, size2) + 1


### PR DESCRIPTION
Mid-gap check would then exhaust size of arrays. This for example
occurs for atoms where all shells are full in reference
configurations (e.g. can trip it off with artificial example of
MaxAngularMomentum = {Si = "s"} bulk Si.