### PR TITLE
Trapping for modified forces without eigenvectors

### DIFF
--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -1729,6 +1729,10 @@ contains
           & kWeight(parallelKS%localKS(1, 1)), input%ctrl%tWriteHS)
     end if
 
+    if (forceType /= forceTypes%orig .and. .not. electronicSolver%providesEigenvals) then
+      call error("Alternative force evaluation methods are not supported by this electronic&
+          & solver.")
+    end if
 
   #:if WITH_TRANSPORT
     ! whether tunneling is computed

--- a/prog/dftb+/lib_dftbplus/main.F90
+++ b/prog/dftb+/lib_dftbplus/main.F90
@@ -4179,6 +4179,11 @@ contains
 
     case (electronicSolverTypes%GF)
 
+      if (forceType /= forceTypes%orig) then
+        call error("Alternative force evaluation methods are not supported by this electronic&
+            & solver.")
+      end if
+
     #:if WITH_TRANSPORT
       if (electronicSolver%iSolver == electronicSolverTypes%GF) then
         call calcEdensity_green(iSCC, env%mpi%globalComm, parallelKS%localKS, ham, over,&
@@ -4189,7 +4194,7 @@ contains
 
     case (electronicSolverTypes%onlyTransport)
 
-      call error("OnlyTransport solver cannot calculate the energy weighted density matrix")
+      call error("The OnlyTransport solver cannot calculate the energy weighted density matrix")
 
     case (electronicSolverTypes%qr, electronicSolverTypes%divideandconquer,&
         & electronicSolverTypes%relativelyrobust, electronicSolverTypes%elpa)
@@ -4199,6 +4204,11 @@ contains
           & tRealHS, ham, over, parallelKS, ERhoPrim, HSqrReal, SSqrReal, HSqrCplx, SSqrCplx)
 
     case (electronicSolverTypes%omm, electronicSolverTypes%pexsi, electronicSolverTypes%ntpoly)
+
+      if (forceType /= forceTypes%orig) then
+        call error("Alternative force evaluation methods are not supported by this electronic&
+            & solver.")
+      end if
 
       call electronicSolver%elsi%getEDensity(env, denseDesc, nSpin, kPoint, kWeight, neighbourList,&
           & nNeighbourSK, orb, iSparseStart, img2CentCell, iCellVec, cellVec, tRealHS, parallelKS,&

--- a/test/prog/dftb+/solvers/SiC64+V_PEXSI/dftb_in.hsd
+++ b/test/prog/dftb+/solvers/SiC64+V_PEXSI/dftb_in.hsd
@@ -90,7 +90,6 @@ Hamiltonian = DFTB {
     C-C = "./C-C.skf"
   }
       
-  ForceEvaluation = 'dynamics'
   KPointsAndWeights = SupercellFolding {
     1 0 0
     0 1 0


### PR DESCRIPTION
The dynamics force correction methods require eigenvectors to
calculate the density matrix (not sure why that is re-built
there), so should be disabled for non-eigen solver modes of the
code.