### PR TITLE
Trap for SCC iter < 1 at initialisation

### DIFF
--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -1156,6 +1156,9 @@ contains
     else
       maxSccIter = 1
     end if
+    if (maxSccIter < 1) then
+      call error("SCC iterations must be larger than 0")
+    end if
 
     tWriteHS = input%ctrl%tWriteHS
     tWriteRealHS = input%ctrl%tWriteRealHS


### PR DESCRIPTION
The 0 case causes various weird problems for the code (no
calculation or electrons and file not opening for parts of
detailed.out).