### PR TITLE
Rename eigensolver to solver

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -979,7 +979,7 @@ following properties:
   \kw{ShellResolvedSpin} &l& ShellResolvedSCC = No & No & \\
   \kw{SpinOrbit} &m& SpinPolarisation $\neq$ Colinear\{\}~ & \cb &
   \pref{sec:dftbp.SpinOrbit} \\
-  \kw{Eigensolver} &m& & RelativelyRobust\cb  & \pref{sec:dftbp.Eigensolver} \\
+  \kw{Solver} &m& & RelativelyRobust\cb  & \pref{sec:dftbp.Solver} \\
   \kw{Filling} &m&  & Fermi\cb & \pref{sec:dftbp.Filling} \\
   \kw{SlaterKosterFiles} &p|m&  & - & \pref{sec:dftbp.SlaterKosterFiles} \\
   \kw{OldSKInterpolation} & l & & No & \\
@@ -1135,8 +1135,8 @@ following properties:
 \item[\is{SpinOrbit}] Specifies if the system includes Russel-Saunders
   coupling. See p.~\pref{sec:dftbp.SpinOrbit}
 
-\item[\is{Eigensolver}] Specifies which eigensolver to use for
-  diagonalising the Hamiltonian. See p.~\pref{sec:dftbp.Eigensolver}.
+\item[\is{Solver}] Specifies which solver (eigensolver, Green's function, etc.)
+  to use with the hamiltonian. See p.~\pref{sec:dftbp.Solver}.
 
 \item[\is{Filling}] Method for occupying the one electron levels with
   electrons. See p.~\pref{sec:dftbp.Filling}.
@@ -1746,11 +1746,11 @@ the single particle density matrix. The default value of this option is
 \is{Yes}, also giving extra information regarding atomic orbital moments in the
 detailed output.
 
-\subsection{Eigensolver}
-\label{sec:dftbp.Eigensolver}
+\subsection{Solver}
+\label{sec:dftbp.Solver}
 
-Currently the following LAPACK~3.0~\cite{lapack3} eigensolver methods
-are always available:
+Currently the following LAPACK~3.0~\cite{lapack3} eigensolver methods are always
+available:
 \begin{itemize}
 \item \iscb{QR}\\ (QR decomposition based solver)
 \item \iscb{DivideAndConquer}\\ (this requires about twice the memory of the
@@ -1762,10 +1762,11 @@ None of them needs any parameters or properties specified.
 
 Example:\invparskip
 \begin{verbatim}
-  Eigensolver = DivideAndConquer {}
+  Solver = DivideAndConquer {}
 \end{verbatim}
 
-For ScaLAPACK enabled compilation, all three solvers are also available.
+For ScaLAPACK enabled compilation, all three solvers are also available for MPI
+parallel use.
 
 If {\dftbp} is compiled with the ELSI library also included~\cite{YU2018267},
 the additional \kw{ELPA}, \kw{OMM}, \kw{PEXSI} and \kw{NTPoly} solvers also
@@ -1779,12 +1780,12 @@ variable.)
 
 \subsubsection{ELPA}
 
-This is avalable with either single or two stage solution methods (the second of
-these is claimed to be more efficiently parallel for large problems).
+This is available with either single or two stage solution methods (the second
+of these should be more efficiently parallel for large problems).
 
 Example:\invparskip
 \begin{verbatim}
-  Eigensolver = ELPA {
+  Solver = ELPA {
     Mode = 2
   }
 \end{verbatim}

--- a/prog/dftb+/lib_dftbplus/oldcompat.F90
+++ b/prog/dftb+/lib_dftbplus/oldcompat.F90
@@ -407,6 +407,13 @@ contains
     end if
     call handleD3Defaults(root)
 
+    call getDescendant(root, "Hamiltonian/DFTB/Eigensolver", ch1)
+    if (associated(ch1)) then
+      call detailedWarning(ch1, "Keyword renamed to 'Solver'.")
+      call setNodeName(ch1, "Solver")
+    end if
+
+
   end subroutine convert_6_7
 
 

--- a/prog/dftb+/lib_dftbplus/parser.F90
+++ b/prog/dftb+/lib_dftbplus/parser.F90
@@ -1752,7 +1752,7 @@ contains
     end if
 
     ! Electronic solver
-    call getChildValue(node, "Eigensolver", value1, "RelativelyRobust")
+    call getChildValue(node, "Solver", value1, "RelativelyRobust")
     call getNodeName(value1, buffer)
 
     select case(char(buffer))


### PR DESCRIPTION
As several non-ES methods are now available. Change as per email discussion on 29th May.