### PR TITLE
Tweak on the mid-gap insulator case

### DIFF
--- a/prog/dftb+/lib_dftb/etemp.F90
+++ b/prog/dftb+/lib_dftb/etemp.F90
@@ -120,10 +120,10 @@ contains
     end if
 
     ! For integer number of electrons, try middle gap for Ef
-    if (nElectrons - floor(nElectrons) < epsilon(1.0_dp)) then
+    if (abs(nElectrons - nint(nElectrons)) <= elecTol) then
       Ef = middleGap(eigenvals, kWeight, nElectrons)
       nElec = electronCount(Ef, eigenvals, kT, distrib, kWeight)
-      if (abs(nElectrons - nElec) <= elecTol) then
+      if (abs(nElectrons - nElec) <= elecTolMax) then
         call electronFill(Ebs, filling, TS, E0, Ef, eigenvals, kT, distrib, kWeight)
         return
       end if


### PR DESCRIPTION
Tolerance was too tight for numerical errors with lots of k-points.