### PR TITLE
Tests for suitability of k-points in transport

### DIFF
--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -2490,6 +2490,22 @@ contains
     else
       allocate(iAtInCentralRegion(transpar%idxdevice(2)))
     end if
+
+    if (transpar%tPeriodic1D) then
+      if ( any(abs(kPoint(2:3, :)) > 0.0_dp) ) then
+        call error("For transport in wire-like cases, only k-points in the first index should be&
+            & non-zero")
+      end if
+    end if
+
+    if (transpar%taskUpload .and. transpar%ncont > 0) then
+      do ii = 1, transpar%ncont
+        if (any(abs(kPoint(abs(transpar%contacts(ii)%dir), :)) > 0.0_dp)) then
+          call error("The k-points along transport direction(s) should zero in that direction")
+        end if
+      end do
+    end if
+
   #:else
     allocate(iAtInCentralRegion(nAtom))
   #:endif

--- a/test/prog/dftb+/transport/H-sheet/dftb_in.hsd
+++ b/test/prog/dftb+/transport/H-sheet/dftb_in.hsd
@@ -43,7 +43,7 @@ hamiltonian = dftb {
    1 0 0
    0 16 0 
    0 0 1 
-   0.50 0.50 0.50
+   0.0 0.50 0.0
   }
   #!KPointsAndWeights = {
   #  0.0000 0.0 0.0 1.0


### PR DESCRIPTION
Checks for
a) 1D cases having only non-zero k-points along the 1st index, as this is always the transport direction for sampling in these cases(?) and sampling for contact GF construction.
b) In transport, checks k-points parallel to contact directions are at zero.

Possibly a question as to whether to test if k-points are all the same value in relevant directions instead of zero (gamma) in that direction(s). Does a shift matter here?