### PR TITLE
Remove output that does not mean anything

### DIFF
--- a/prog/dftb+/lib_dftbplus/mainio.F90
+++ b/prog/dftb+/lib_dftbplus/mainio.F90
@@ -2741,8 +2741,9 @@ contains
       if (.not. tNegf) then
         ! set in the input and for multiple contact Ef values not meaningful anyway
         write(fd, format2U) 'Fermi level', Ef(iSpin), "H", Hartree__eV * Ef(iSpin), 'eV'
+        ! not current available from the Green's function solver
+        write(fd, format2U) 'Band energy', Eband(iSpin), "H", Hartree__eV * Eband(iSpin), 'eV'
       end if
-      write(fd, format2U) 'Band energy', Eband(iSpin), "H", Hartree__eV * Eband(iSpin), 'eV'
       if (any(electronicSolver%iSolver == [electronicSolverTypes%qr,&
           & electronicSolverTypes%divideandconquer, electronicSolverTypes%relativelyrobust,&
           & electronicSolverTypes%elpa])) then
@@ -2757,9 +2758,14 @@ contains
               & sum(qInputUpDown(:, iAtInCentralRegion(:), iSpin)),&
               & sum(qOutputUpDown(:, iAtInCentralRegion(:), iSpin))
         else
-          write(fd, "(3A, 2F18.10)") 'Input / Output electrons (', quaternionName(iSpin), '):',&
-              & sum(qInputUpDown(:, iAtInCentralRegion(:), iSpin)),&
-              & sum(qOutputUpDown(:, iAtInCentralRegion(:), iSpin))
+          if (tSCC) then
+            write(fd, "(3A, 2F18.10)") 'Input / Output electrons (', quaternionName(iSpin), '):',&
+                & sum(qInputUpDown(:, iAtInCentralRegion(:), iSpin)),&
+                & sum(qOutputUpDown(:, iAtInCentralRegion(:), iSpin))
+          else
+            write(fd, "(3A, F18.10)") 'Output electrons (', quaternionName(iSpin), '):',&
+                & sum(qOutputUpDown(:, iAtInCentralRegion(:), iSpin))
+          end if
         end if
       end if
       write(fd, *)


### PR DESCRIPTION
For non-SCC there are no input charges, and the NEGF solver doesn't
return a band structure energy. 
Can wait until after release.