### PR TITLE
Makes gnu.cmake internally consistent

### DIFF
--- a/sys/gnu.cmake
+++ b/sys/gnu.cmake
@@ -42,7 +42,7 @@ set(CMAKE_C_FLAGS_RELEASE "-O2 -funroll-all-loops" CACHE STRING "Specific C flag
 if(WITH_MPI)
   set(LAPACK_LIBRARIES "lapack;blas" CACHE STRING "LAPACK and BLAS libraries to link")
 else()
-  set(LAPACK_LIBRARIES "openblas" CACHE STRING "LAPACK and BLAS libraries to link")
+  set(LAPACK_LIBRARIES "lapack;blas" CACHE STRING "LAPACK and BLAS libraries to link")
 endif()
 set(LAPACK_LIBRARY_DIRS "" CACHE STRING
   "Directories where LAPACK and BLAS libraries can be found")


### PR DESCRIPTION
Different lapack/blas combinations were used for serial/parallel (one missing a lapack).