### PR TITLE
Build DFTB+ on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+os: linux
+dist: bionic
+
+language: python
+python: 3.7
+
+
+env:
+ - WITH_MPI=false
+ - WITH_MPI=true
+
+addons:
+   apt:
+      packages:
+      - cmake
+      - gfortran
+      - libblas-dev
+      - liblapack-dev
+      - libopenmpi-dev
+      - libscalapack-openmpi-dev
+
+install:
+- git submodule update --init --recursive
+- echo "y" | ./utils/get_opt_externals ALL
+
+script:
+- mkdir _build
+- cd _build
+- cmake -DWITH_DFTD3=true -DWITH_MPI=${WITH_MPI} -DCMAKE_TOOLCHAIN_FILE=../sys/gnu.cmake ..
+- make -j 2
+- ctest -j 2


### PR DESCRIPTION
[![Build Status](https://travis-ci.com/awvwgk/dftbplus.svg?branch=travis-ci-build)](https://travis-ci.com/awvwgk/dftbplus)

In case there is interest to build DFTB+ for every PR and commit on Travis-CI I setup a build on Ubuntu Bionic using GCC7 (with and without MPI). The build and the test suite take around 10 minutes on the CI server.

Things to discuss:

- Should DFTB+ also be build on OSX or Windows?
- Should different versions of GCC be tested?
  Does not work with current tool-chain file
- Should mpich as MPI provider be tested?
- Which optional features of DFTB+ should be included?
  from the build file: ELSI/PEXSI, ARPACK, transport, DFT-D3 (done), socket integration, API
- Should different compiler vendors be tested?
  Intel can be used on Travis-CI, but requires some work to setup
- Should another service be preferred?