### PR TITLE
Fix for eigenvector as txt bug

### DIFF
--- a/prog/dftb+/lib_dftbplus/parser.F90
+++ b/prog/dftb+/lib_dftbplus/parser.F90
@@ -3499,6 +3499,9 @@ contains
           & response calculations (requires the ARPACK/ngARPACK library).')
     end if
 
+    ctrl%lrespini%tInit = .false.
+    ctrl%lrespini%tPrintEigVecs = .false.
+
   #:else
 
     if (associated(child)) then


### PR DESCRIPTION
Non-initialised variable used later with non-deterministic results. Addresses #369 