### PR TITLE
DFT-D4: Use species instead of atomic numbers

### DIFF
--- a/prog/dftb+/lib_common/constants.F90
+++ b/prog/dftb+/lib_common/constants.F90
@@ -146,5 +146,67 @@ module dftbp_constants
   !> Imaginary unit
   complex(dp), parameter :: imag = (0.0_dp,1.0_dp)
 
+  !> Symbols of the periodic system of elements, up to 118
+  character(len=2), private, parameter :: pse(1:118) = [&
+      & 'h ','he',&
+      & 'li','be','b ','c ','n ','o ','f ','ne',&
+      & 'na','mg','al','si','p ','s ','cl','ar',&
+      & 'k ','ca',&
+      & 'sc','ti','v ','cr','mn','fe','co','ni','cu','zn',&
+      &           'ga','ge','as','se','br','kr',&
+      & 'rb','sr',&
+      & 'y ','zr','nb','mo','tc','ru','rh','pd','ag','cd',&
+      &           'in','sn','sb','te','i ','xe',&
+      & 'cs','ba','la',&
+      & 'ce','pr','nd','pm','sm','eu','gd','tb','dy','ho','er','tm','yb',&
+      & 'lu','hf','ta','w ','re','os','ir','pt','au','hg',&
+      &           'tl','pb','bi','po','at','rn',&
+      & 'fr','ra','ac',&
+      & 'th','pa','u ','np','pu','am','cm','bk','cf','es','fm','md','no',&
+      & 'lr','rf','db','sg','bh','hs','mt','ds','rg','cn',&
+      &           'nh','fl','mc','lv','ts','og' ]
+
+contains
+
+
+  !> get atomic number from element symbol.
+  elemental function symbolToNumber(symbol) result(number)
+
+    !> Element symbol
+    character(len=*), intent(in) :: symbol
+
+    !> Atomic number
+    integer :: number
+
+    integer, parameter :: offset = iachar('a') - iachar('A')
+
+    character(len=2) :: lcSymbol
+    integer :: i, j, k, l
+
+    number = 0
+    lcSymbol = '  '
+
+    k = 0
+    do j = 1, len_trim(symbol)
+      if (k > 2) exit
+      l = iachar(symbol(j:j))
+      if (k >= 1 .and. l == iachar(' ')) exit
+      if (k >= 1 .and. l == 9) exit
+      if (l >= iachar('A') .and. l <= iachar('Z')) l = l + offset
+      if (l >= iachar('a') .and. l <= iachar('z')) then
+        k = k+1
+        lcSymbol(k:k) = achar(l)
+      end if
+    end do
+
+    do i = 1, size(pse)
+      if (lcSymbol == pse(i)) then
+        number = i
+        exit
+      end if
+    end do
+
+  end function symbolToNumber
+
 
 end module dftbp_constants

--- a/prog/dftb+/lib_dftb/dftd4param.F90
+++ b/prog/dftb+/lib_dftb/dftd4param.F90
@@ -10,7 +10,7 @@
 !> Necessary parameters to perform DFT-D4 calculations.
 module dftbp_dftd4param
   use dftbp_assert
-  use dftbp_accuracy
+  use dftbp_accuracy, only : dp
   use dftbp_constants, only : pi, AA__Bohr, symbolToNumber
   use dftbp_dftd4refs
   implicit none

--- a/prog/dftb+/lib_dftb/dftd4param.F90
+++ b/prog/dftb+/lib_dftb/dftd4param.F90
@@ -234,9 +234,6 @@ module dftbp_dftd4param
     !> Number of reference systems per species
     integer, allocatable :: numberOfReferences(:)
 
-    !> Internal atom count FIXME
-    integer, allocatable :: atoms(:)
-
     !> Number of weighting functions per reference system and species
     integer, allocatable :: countNumber(:, :)
 
@@ -592,10 +589,9 @@ contains
     calculator%ga = input%chargeScale
     calculator%gc = input%chargeSteepness
 
-    allocate(calculator%numberOfReferences(nSpecies), calculator%atoms(nSpecies), &
+    allocate(calculator%numberOfReferences(nSpecies), &
         & calculator%countNumber(maxReferences, nSpecies))
     calculator%numberOfReferences(:) = 0
-    calculator%atoms(:) = 0
     calculator%countNumber(:, :) = 0
     allocate(calculator%referenceCN(maxReferences, nSpecies), &
         & calculator%referenceCharge(maxReferences, nSpecies), &

--- a/prog/dftb+/lib_dftb/dispdftd4.F90
+++ b/prog/dftb+/lib_dftb/dispdftd4.F90
@@ -16,7 +16,7 @@ module dftbp_dispdftd4
   use dftbp_periodic, only: TNeighbourList, getNrOfNeighboursForAll, getLatticePoints
   use dftbp_simplealgebra, only: determinant33, invert33
   use dftbp_coulomb, only: getMaxGEwald, getOptimalAlphaEwald
-  use dftbp_constants, only: pi
+  use dftbp_constants, only: pi, symbolToNumber
   use dftbp_dftd4param, only: DftD4Calculator, DispDftD4Inp, initializeCalculator
   use dftbp_encharges, only: getEEQcharges
   use dftbp_blasroutines, only : gemv
@@ -160,7 +160,7 @@ contains
 
     allocate(this%izp(nAtom))
     do iAt1 = 1, nAtom
-      call symbolToNumber(this%izp(iAt1), speciesNames(species0(iAt1)))
+      this%izp(iAt1) = symbolToNumber(speciesNames(species0(iAt1)))
     end do
 
     allocate(this%energies(nAtom))
@@ -1275,65 +1275,6 @@ contains
     end if
 
   end function tripleScale
-
-
-  !> get atomic number from element symbol.
-  elemental subroutine symbolToNumber(number, symbol)
-
-    !> Element symbol
-    character(len=*), intent(in) :: symbol
-
-    !> Atomic number
-    integer, intent(out) :: number
-
-    character(len=2), parameter :: pse(118) = [&
-      & 'h ','he',&
-      & 'li','be','b ','c ','n ','o ','f ','ne',&
-      & 'na','mg','al','si','p ','s ','cl','ar',&
-      & 'k ','ca',&
-      & 'sc','ti','v ','cr','mn','fe','co','ni','cu','zn',&
-      &           'ga','ge','as','se','br','kr',&
-      & 'rb','sr',&
-      & 'y ','zr','nb','mo','tc','ru','rh','pd','ag','cd',&
-      &           'in','sn','sb','te','i ','xe',&
-      & 'cs','ba','la',&
-      & 'ce','pr','nd','pm','sm','eu','gd','tb','dy','ho','er','tm','yb',&
-      & 'lu','hf','ta','w ','re','os','ir','pt','au','hg',&
-      &           'tl','pb','bi','po','at','rn',&
-      & 'fr','ra','ac',&
-      & 'th','pa','u ','np','pu','am','cm','bk','cf','es','fm','md','no',&
-      & 'lr','rf','db','sg','bh','hs','mt','ds','rg','cn',&
-      &           'nh','fl','mc','lv','ts','og' ]
-
-    integer, parameter :: offset = iachar('a') - iachar('A')
-
-    character(len=2) :: lc_symbol
-    integer :: i, j, k, l
-
-    number = 0
-    lc_symbol = '  '
-
-    k = 0
-    do j = 1, len_trim(symbol)
-      if (k > 2) exit
-      l = iachar(symbol(j:j))
-      if (k >= 1 .and. l == iachar(' ')) exit
-      if (k >= 1 .and. l == 9) exit
-      if (l >= iachar('A') .and. l <= iachar('Z')) l = l + offset
-      if (l >= iachar('a') .and. l <= iachar('z')) then
-        k = k+1
-        lc_symbol(k:k) = achar(l)
-      end if
-    end do
-
-    do i = 1, size(pse)
-      if (lc_symbol == pse(i)) then
-        number = i
-        exit
-      end if
-    end do
-
-  end subroutine symbolToNumber
 
 
 end module dftbp_dispdftd4

--- a/prog/dftb+/lib_dftb/dispdftd4.F90
+++ b/prog/dftb+/lib_dftb/dispdftd4.F90
@@ -167,7 +167,7 @@ contains
     allocate(this%gradients(3, nAtom))
 
     allocate(this%calculator)
-    call initializeCalculator(this%calculator, inp, this%nAtom, this%izp)
+    call initializeCalculator(this%calculator, inp, this%nAtom, speciesNames, this%izp)
 
   end subroutine DispDftD4_init
 
@@ -193,11 +193,11 @@ contains
     @:ASSERT(allocated(this%calculator))
 
     if (this%tPeriodic) then
-      call dispersionEnergy(this%calculator, this%nAtom, coords, this%izp, neigh, img2CentCell,&
+      call dispersionEnergy(this%calculator, this%nAtom, coords, species0, this%izp, neigh, img2CentCell,&
           & this%recPoint, this%energies, this%gradients, stress=this%stress, volume=this%vol,&
           & parEwald=this%parEwald)
     else
-      call dispersionEnergy(this%calculator, this%nAtom, coords, this%izp, neigh, img2CentCell,&
+      call dispersionEnergy(this%calculator, this%nAtom, coords, species0, this%izp, neigh, img2CentCell,&
           & this%recPoint, this%energies, this%gradients)
     end if
 
@@ -994,7 +994,7 @@ contains
 
 
   !> Driver for the calculation of DFT-D4 dispersion related properties.
-  subroutine dispersionEnergy(calculator, nAtom, coords, species, neigh, img2CentCell, recPoint,&
+  subroutine dispersionEnergy(calculator, nAtom, coords, species, izp, neigh, img2CentCell, recPoint,&
       & energies, gradients, stress, volume, parEwald)
 
     !> DFT-D dispersion model.
@@ -1008,6 +1008,9 @@ contains
 
     !> Species of every atom.
     integer, intent(in) :: species(:)
+
+    !> Atomic numbers of every atom.
+    integer, intent(in) :: izp(:)
 
     !> Updated neighbour list.
     type(TNeighbourList), intent(in) :: neigh
@@ -1067,7 +1070,7 @@ contains
 
     call getNrOfNeighboursForAll(nNeigh, neigh, calculator%cutoffCount)
 
-    call getCoordinationNumber(nAtom, coords, species, nNeigh, neigh%iNeighbour,&
+    call getCoordinationNumber(nAtom, coords, izp, nNeigh, neigh%iNeighbour,&
         & neigh%neighDist2, img2CentCell, calculator%covalentRadius,&
         & calculator%electronegativity, .false., cn, dcndr, dcndL)
     call cutCoordinationNumber(nAtom, cn, dcndr, dcndL, cn_max=8.0_dp)
@@ -1080,11 +1083,11 @@ contains
         & neigh%neighDist2, img2CentCell, recPoint, parEwald0, vol, calculator%chi, calculator%kcn,&
         & calculator%gam, calculator%rad, cn, dcndr, dcndL, qAtom=q, dqdr=dqdr, dqdL=dqdL)
 
-    call getCoordinationNumber(nAtom, coords, species, nNeigh, neigh%iNeighbour, neigh%neighDist2,&
+    call getCoordinationNumber(nAtom, coords, izp, nNeigh, neigh%iNeighbour, neigh%neighDist2,&
         & img2CentCell, calculator%covalentRadius, calculator%electronegativity, .true., cn, dcndr,&
         & dcndL)
 
-    call dispersionGradient(calculator, nAtom, coords, species, neigh, img2CentCell, cn, dcndr,&
+    call dispersionGradient(calculator, nAtom, coords, izp, neigh, img2CentCell, cn, dcndr,&
         & dcndL, q, dqdr, dqdL, energies, gradients, sigma)
 
     if (present(stress)) then

--- a/prog/dftb+/lib_dftb/dispdftd4.F90
+++ b/prog/dftb+/lib_dftb/dispdftd4.F90
@@ -11,7 +11,7 @@
 module dftbp_dispdftd4
   use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
   use dftbp_assert
-  use dftbp_accuracy
+  use dftbp_accuracy, only : dp
   use dftbp_dispiface, only : DispersionIface
   use dftbp_periodic, only : TNeighbourList, getNrOfNeighboursForAll, getLatticePoints
   use dftbp_simplealgebra, only : determinant33, invert33

--- a/prog/dftb+/lib_dftb/encharges.F90
+++ b/prog/dftb+/lib_dftb/encharges.F90
@@ -14,7 +14,7 @@
 !
 module dftbp_encharges
   use dftbp_assert
-  use dftbp_accuracy
+  use dftbp_accuracy, only : dp
   use dftbp_constants, only : pi
   use dftbp_errorfunction, only : erfwrap
   use dftbp_coulomb, only : ewaldReal, ewaldReciprocal, derivStressEwaldRec

--- a/prog/dftb+/lib_dftb/encharges.F90
+++ b/prog/dftb+/lib_dftb/encharges.F90
@@ -15,8 +15,8 @@
 module dftbp_encharges
   use dftbp_assert
   use dftbp_accuracy
-  use dftbp_constants, only: pi
-  use dftbp_errorfunction, only: erfwrap
+  use dftbp_constants, only : pi
+  use dftbp_errorfunction, only : erfwrap
   use dftbp_coulomb, only : ewaldReal, ewaldReciprocal, derivStressEwaldRec
   use dftbp_blasroutines, only : hemv, gemv, gemm
   use dftbp_lapackroutines, only : symmatinv


### PR DESCRIPTION
- [x] Fix-up the usage of atomic numbers in the DFT-D4 implementation
- [x] Style fixes for `use, only :`, more comments and more whitespace

closes #379