### PR TITLE
DFT-D4: Charge Model Container

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -2780,11 +2780,9 @@ can be adjusted in the input.
   \kw{ChargeSteepness} & r & & 2.0 & \\
   \kw{ChargeScale} & r & & 3.0 & \\
   \kw{CutoffInter} & r & & 64 & \\
-  \kw{CutoffEwald} & r & & 40 & \\
   \kw{CutoffCount} & r & & 40 & \\
   \kw{CutoffThree} & r & & 40 & \\
-  \kw{EwaldParameter} & r & & 0.0 & \\
-  \kw{EwaldTolerance} & r & & 1.0e-9 & \\
+  \kw{ChargeModel} & m & & \is{EEQ} & \\
 \end{ptable}
 
 \begin{description}
@@ -2812,14 +2810,44 @@ can be adjusted in the input.
 \item[\is{CutoffInter}] \modif{\modtype{length}} Cutoff distance when
   calculating two-body interactions.
 
-\item[\is{CutoffEwald}] \modif{\modtype{length}} Cutoff distance when
-  calculating electrostatics interactions under PBC.
-
 \item[\is{CutoffCount}] \modif{\modtype{length}} Cutoff distance when
   calculating coordination numbers.
 
 \item[\is{CutoffThree}] \modif{\modtype{length}} Cutoff distance when
   calculating three-body interactions.
+
+\end{description}
+
+\subsubsection{DftD4 ChargeModel}
+
+This implementation of DFT-D4 supports only the \is{EEQ\cb} method to initialize
+the charge model. For each species four parameters (\kw{Chi}, \kw{Gam}, \kw{Kcn},
+and \kw{Rad}) have to be supplied in a \is{values\cb} method, since the model
+is instanciated inside the \is{DftD4\cb} method, defaults for all elements up to
+86 are supplied automatically.
+
+\begin{ptable}
+  \kw{Chi} & m & & \is{values} & \\
+  \kw{Gam} & m & & \is{values} & \\
+  \kw{Kcn} & m & & \is{values} & \\
+  \kw{Rad} & m & & \is{values} & \\
+  \kw{Cutoff} & r & & 40 & \\
+  \kw{EwaldParameter} & r & & 0.0 & \\
+  \kw{EwaldTolerance} & r & & 1.0e-9 & \\
+\end{ptable}
+
+\begin{description}
+
+\item[\is{Chi}] Electronegativities of all species.
+
+\item[\is{Gam}] Chemical hardnesses of all species.
+
+\item[\is{Kcn}] CN scaling factor of all species.
+
+\item[\is{Rad}] Charge width of all species in Bohr.
+
+\item[\is{CutoffEwald}] \modif{\modtype{length}} Cutoff distance when
+  calculating electrostatics interactions under PBC.
 
 \item[\is{EwaldParameter}] Sets the splitting parameter in the Ewald
   electrostatic summation for periodic calculations. This controls the fraction

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -2822,15 +2822,15 @@ can be adjusted in the input.
 
 This implementation of DFT-D4 supports only the \is{EEQ\cb} method to initialize
 the charge model. For each species four parameters (\kw{Chi}, \kw{Gam}, \kw{Kcn},
-and \kw{Rad}) have to be supplied in a \is{values\cb} method, since the model
-is instanciated inside the \is{DftD4\cb} method, defaults for all elements up to
-86 are supplied automatically.
+and \kw{Rad}) have to be supplied in a \is{Values\cb} method, since the model
+is instanciated inside the \is{DftD4\cb} method, \is{Defaults\cb} for all elements
+up to 86 can be supplied automatically.
 
 \begin{ptable}
-  \kw{Chi} & m & & \is{values} & \\
-  \kw{Gam} & m & & \is{values} & \\
-  \kw{Kcn} & m & & \is{values} & \\
-  \kw{Rad} & m & & \is{values} & \\
+  \kw{Chi} & m & & \is{Defaults} & \\
+  \kw{Gam} & m & & \is{Defaults} & \\
+  \kw{Kcn} & m & & \is{Defaults} & \\
+  \kw{Rad} & m & & \is{Defaults} & \\
   \kw{Cutoff} & r & & 40 & \\
   \kw{EwaldParameter} & r & & 0.0 & \\
   \kw{EwaldTolerance} & r & & 1.0e-9 & \\
@@ -2846,7 +2846,7 @@ is instanciated inside the \is{DftD4\cb} method, defaults for all elements up to
 
 \item[\is{Rad}] Charge width of all species in Bohr.
 
-\item[\is{CutoffEwald}] \modif{\modtype{length}} Cutoff distance when
+\item[\is{Cutoff}] \modif{\modtype{length}} Cutoff distance when
   calculating electrostatics interactions under PBC.
 
 \item[\is{EwaldParameter}] Sets the splitting parameter in the Ewald
@@ -2859,6 +2859,29 @@ is instanciated inside the \is{DftD4\cb} method, defaults for all elements up to
   systems.
 
 \end{description}
+
+\begin{verbatim}
+ChargeModel = EEQ {
+  EwaldParameter = 0.25165824
+  EwaldTolerance = 1.0E-9
+  Chi = Values {
+    Ga = 1.15018618
+    As = 1.36313743
+  }
+  Gam = Values {
+    Ga = 8.299615E-2
+    As = 0.19005278
+  }
+  Kcn = Values {
+    Ga = -1.05627E-002
+    As = 7.657769E-002
+  }
+  Rad = Values {
+    Ga = 1.76901636
+    As = 2.41244711
+  }
+}
+\end{verbatim}
 
 \subsection{DFTB3}
 \label{sec:dftbp.DFTB3}

--- a/prog/dftb+/lib_dftb/dftd4param.F90
+++ b/prog/dftb+/lib_dftb/dftd4param.F90
@@ -126,9 +126,6 @@ module dftbp_dftd4param
     !> Cutoff radius for CN counting function.
     real(dp) :: cutoffCount = 40.0_dp
 
-    !> Cutoff radius for real space Ewald summation.
-    real(dp) :: cutoffEwald = 40.0_dp
-
     !> Cutoff radius for three-body interactions.
     real(dp) :: cutoffThree = 40.0_dp
 
@@ -140,15 +137,6 @@ module dftbp_dftd4param
 
     !> Charge scaling steepness for partial charge extrapolation.
     real(dp) :: chargeSteepness = 2.0_dp
-
-    !> If > 0 -> manual setting for alpha
-    real(dp) :: parEwald = 0.0_dp
-
-    !> Ewald tolerance
-    real(dp) :: tolEwald = 0.0_dp
-
-    !> Net charge
-    real(dp) :: nrChrg = 0.0_dp
 
     !> Input for EEQ charge model
     type(TEeqInput) :: eeqInput
@@ -196,14 +184,8 @@ module dftbp_dftd4param
     !> Cutoff radius for CN counting function.
     real(dp) :: cutoffCount
 
-    !> Cutoff radius for real space Ewald summation.
-    real(dp) :: cutoffEwald
-
     !> Cutoff radius for three-body interactions.
     real(dp) :: cutoffThree
-
-    !> Net charge
-    real(dp) :: nrChrg = 0.0_dp
 
     !> Number of distinct species
     integer :: nSpecies
@@ -564,12 +546,9 @@ contains
     calculator%a2 = input%a2
     calculator%alpha = input%alpha
 
-    calculator%nrChrg = input%nrChrg
-
     calculator%cutoffCount = input%cutoffCount
     calculator%cutoffInter = input%cutoffInter
     calculator%cutoffThree = input%cutoffThree
-    calculator%cutoffEwald = input%cutoffEwald
 
     calculator%wf = input%weightingFactor
     calculator%ga = input%chargeScale

--- a/prog/dftb+/lib_dftb/dftd4param.F90
+++ b/prog/dftb+/lib_dftb/dftd4param.F90
@@ -12,6 +12,7 @@ module dftbp_dftd4param
   use dftbp_assert
   use dftbp_accuracy, only : dp
   use dftbp_constants, only : pi, AA__Bohr, symbolToNumber
+  use dftbp_encharges, only : TEeqInput
   use dftbp_dftd4refs
   implicit none
 
@@ -149,6 +150,9 @@ module dftbp_dftd4param
     !> Net charge
     real(dp) :: nrChrg = 0.0_dp
 
+    !> Input for EEQ charge model
+    type(TEeqInput) :: eeqInput
+
   end type TDispDftD4Inp
 
 
@@ -203,18 +207,6 @@ module dftbp_dftd4param
 
     !> Number of distinct species
     integer :: nSpecies
-
-    !> Electronegativities for EEQ model
-    real(dp), allocatable :: chi(:)
-
-    !> Chemical hardnesses for EEQ model
-    real(dp), allocatable :: gam(:)
-
-    !> Charge widths for EEQ model
-    real(dp), allocatable :: rad(:)
-
-    !> CN scaling for EEQ model
-    real(dp), allocatable :: kcn(:)
 
     !> Atomic expectation values for extrapolation of C6 coefficients
     real(dp), allocatable :: sqrtZr4r2(:)
@@ -557,12 +549,6 @@ contains
 
     nSpecies = size(speciesNames)
     calculator%nSpecies = nSpecies
-
-    ! initialize charge model
-    calculator%chi = getEeqChi(speciesNames)
-    calculator%gam = getEeqGam(speciesNames)
-    calculator%rad = getEeqRad(speciesNames)
-    calculator%kcn = getEeqKcn(speciesNames)
 
     calculator%sqrtZr4r2 = getSqrtZr4r2(speciesNames)
     calculator%covalentRadius = getCovalentRadiusD3(speciesNames)

--- a/prog/dftb+/lib_dftb/dispdftd4.F90
+++ b/prog/dftb+/lib_dftb/dispdftd4.F90
@@ -12,15 +12,14 @@ module dftbp_dispdftd4
   use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
   use dftbp_assert
   use dftbp_accuracy, only : dp
-  use dftbp_dispiface, only : TDispersionIface
   use dftbp_environment, only : TEnvironment
-  use dftbp_periodic, only : TNeighbourList, getNrOfNeighboursForAll, getLatticePoints
-  use dftbp_simplealgebra, only : determinant33, invert33
-  use dftbp_coulomb, only : getMaxGEwald, getOptimalAlphaEwald
+  use dftbp_blasroutines, only : gemv
   use dftbp_constants, only : pi, symbolToNumber
   use dftbp_dftd4param, only : TDftD4Calculator, TDispDftD4Inp, initializeCalculator
-  use dftbp_encharges, only : getEEQcharges, TEeqCont
-  use dftbp_blasroutines, only : gemv
+  use dftbp_dispiface, only : TDispersionIface
+  use dftbp_encharges, only : TEeqCont, init
+  use dftbp_periodic, only : TNeighbourList, getNrOfNeighboursForAll
+  use dftbp_simplealgebra, only : determinant33
   implicit none
   private
 
@@ -119,9 +118,9 @@ contains
     this%tPeriodic = present(latVecs)
 
     if (this%tPeriodic) then
-      call this%eeqCont%initialize(inp%eeqInput, .false., .true., nAtom, latVecs)
+      call init(this%eeqCont, inp%eeqInput, .false., .true., nAtom, latVecs)
     else
-      call this%eeqCont%initialize(inp%eeqInput, .false., .true., nAtom)
+      call init(this%eeqCont, inp%eeqInput, .false., .true., nAtom)
     end if
 
     this%tCoordsUpdated = .false.
@@ -1001,7 +1000,6 @@ contains
     real(dp) :: sigma(3, 3)
     real(dp) :: vol, parEwald0
     real(dp), allocatable :: cn(:), dcndr(:, :, :), dcndL(:, :, :)
-    real(dp), allocatable :: eDummy(:), gDummy(:, :), sDummy(:, :)
 
     if (present(volume)) then
       vol = volume

--- a/prog/dftb+/lib_dftb/dispdftd4.F90
+++ b/prog/dftb+/lib_dftb/dispdftd4.F90
@@ -1034,12 +1034,7 @@ contains
         & calculator%electronegativity, .false., cn, dcndr, dcndL)
     call cutCoordinationNumber(nAtom, cn, dcndr, dcndL, cn_max=8.0_dp)
 
-    call getNrOfNeighboursForAll(nNeigh, neigh, eeqCont%cutoff)
-
-    call getEEQCharges(nAtom, coords, species, eeqCont%nrChrg, nNeigh, neigh%iNeighbour,&
-        & neigh%neighDist2, img2CentCell, eeqCont%recPoint, parEwald0, vol, eeqCont%param%chi, eeqCont%param%kcn,&
-        & eeqCont%param%gam, eeqCont%param%rad, cn, dcndr, dcndL, eDummy, gDummy, sDummy, &
-        & eeqCont%charges, eeqCont%dqdr, eeqCont%dqdL)
+    call eeqCont%updateCoords(neigh, img2CentCell, coords, species, cn, dcndr, dcndL)
 
     call getCoordinationNumber(nAtom, coords, species, nNeigh, neigh%iNeighbour, neigh%neighDist2,&
         & img2CentCell, calculator%covalentRadius, calculator%electronegativity, .true., cn, dcndr,&

--- a/prog/dftb+/lib_dftbplus/parser.F90
+++ b/prog/dftb+/lib_dftbplus/parser.F90
@@ -27,6 +27,7 @@ module dftbp_parser
   use dftbp_lapackroutines, only : matinv
   use dftbp_periodic
   use dftbp_dispersions
+  use dftbp_dftd4param, only : getEeqChi, getEeqGam, getEeqKcn, getEeqRad
   use dftbp_encharges, only : TEeqInput
   use dftbp_simplealgebra, only: cross3, determinant33
   use dftbp_slakocont
@@ -3802,8 +3803,6 @@ contains
   !> tend to be expensive especially in the tight-binding context, s9 = 0.0_dp
   !> will disable the calculation.
   subroutine readDispDFTD4(node, geo, input, nrChrg)
-    !> Do not pollute the global namespace of the parser -> import locally
-    use dftbp_dftd4param, only : getEeqChi, getEeqGam, getEeqKcn, getEeqRad
 
     !> Node to process.
     type(fnode), pointer :: node
@@ -3848,13 +3847,13 @@ contains
       call detailedError(value1, "Unknown method '"//char(buffer)//"' for ChargeModel")
     case ("eeq")
       allocate(d4Chi(geo%nSpecies))
-      d4Chi = getEeqChi(geo%speciesNames)
+      d4Chi(:) = getEeqChi(geo%speciesNames)
       allocate(d4Gam(geo%nSpecies))
-      d4Gam = getEeqGam(geo%speciesNames)
+      d4Gam(:) = getEeqGam(geo%speciesNames)
       allocate(d4Kcn(geo%nSpecies))
-      d4Kcn = getEeqKcn(geo%speciesNames)
+      d4Kcn(:) = getEeqKcn(geo%speciesNames)
       allocate(d4Rad(geo%nSpecies))
-      d4Rad = getEeqRad(geo%speciesNames)
+      d4Rad(:) = getEeqRad(geo%speciesNames)
       call readEeqModel(value1, input%eeqInput, geo, nrChrg, d4Chi, d4Gam, d4Kcn, d4Rad)
     end select
 
@@ -3878,16 +3877,16 @@ contains
     real(dp), intent(in) :: nrChrg
 
     !> Electronegativities default values
-    real(dp), intent(in), optional :: kChiDefault(:)
+    real(dp), intent(in) :: kChiDefault(:)
 
     !> Chemical hardnesses default values
-    real(dp), intent(in), optional :: kGamDefault(:)
+    real(dp), intent(in) :: kGamDefault(:)
 
     !> CN scaling default values
-    real(dp), intent(in), optional :: kKcnDefault(:)
+    real(dp), intent(in) :: kKcnDefault(:)
 
     !> Charge widths default values
-    real(dp), intent(in), optional :: kRadDefault(:)
+    real(dp), intent(in) :: kRadDefault(:)
 
     type(fnode), pointer :: value1, child
     type(string) :: buffer
@@ -3906,9 +3905,6 @@ contains
     case default
       call detailedError(child, "Unknown method '"//char(buffer)//"' for chi")
     case ("defaults")
-      if (.not.present(kChiDefault)) then
-        call detailedError(child, "Parent method did not supply defaults")
-      end if
       do iSp1 = 1, geo%nSpecies
         call getChildValue(value1, geo%speciesNames(iSp1), input%chi(iSp1), &
             & kChiDefault(iSp1), child=child)
@@ -3926,9 +3922,6 @@ contains
     case default
       call detailedError(child, "Unknown method '"//char(buffer)//"' for gam")
     case ("defaults")
-      if (.not.present(kGamDefault)) then
-        call detailedError(child, "Parent method did not supply defaults")
-      end if
       do iSp1 = 1, geo%nSpecies
         call getChildValue(value1, geo%speciesNames(iSp1), input%gam(iSp1), &
             & kGamDefault(iSp1), child=child)
@@ -3946,9 +3939,6 @@ contains
     case default
       call detailedError(child, "Unknown method '"//char(buffer)//"' for kcn")
     case ("defaults")
-      if (.not.present(kKcnDefault)) then
-        call detailedError(child, "Parent method did not supply defaults")
-      end if
       do iSp1 = 1, geo%nSpecies
         call getChildValue(value1, geo%speciesNames(iSp1), input%kcn(iSp1), &
             & kKcnDefault(iSp1), child=child)
@@ -3966,9 +3956,6 @@ contains
     case default
       call detailedError(child, "Unknown method '"//char(buffer)//"' for rad")
     case ("defaults")
-      if (.not.present(kRadDefault)) then
-        call detailedError(child, "Parent method did not supply defaults")
-      end if
       do iSp1 = 1, geo%nSpecies
         call getChildValue(value1, geo%speciesNames(iSp1), input%rad(iSp1), &
             & kRadDefault(iSp1), child=child)

--- a/prog/dftb+/lib_dftbplus/parser.F90
+++ b/prog/dftb+/lib_dftbplus/parser.F90
@@ -27,6 +27,7 @@ module dftbp_parser
   use dftbp_lapackroutines, only : matinv
   use dftbp_periodic
   use dftbp_dispersions
+  use dftbp_encharges, only : TEeqInput
   use dftbp_simplealgebra, only: cross3, determinant33
   use dftbp_slakocont
   use dftbp_slakoeqgrid
@@ -3552,7 +3553,7 @@ contains
   #:endif
     case ("dftd4")
       allocate(input%dftd4)
-      call readDispDFTD4(dispModel, input%dftd4, nrChrg)
+      call readDispDFTD4(dispModel, geo, input%dftd4, nrChrg)
     case default
       call detailedError(node, "Invalid dispersion model name.")
     end select
@@ -3800,10 +3801,15 @@ contains
   !> Here we additionally require a s9, since the non-addititive contributions
   !> tend to be expensive especially in the tight-binding context, s9 = 0.0_dp
   !> will disable the calculation.
-  subroutine readDispDFTD4(node, input, nrChrg)
+  subroutine readDispDFTD4(node, geo, input, nrChrg)
+    !> Do not pollute the global namespace of the parser -> import locally
+    use dftbp_dftd4param, only : getEeqChi, getEeqGam, getEeqKcn, getEeqRad
 
     !> Node to process.
     type(fnode), pointer :: node
+
+    !> Geometry of the system
+    type(TGeometry), intent(in) :: geo
 
     !> Filled input structure on exit.
     type(TDispDftD4Inp), intent(out) :: input
@@ -3811,8 +3817,9 @@ contains
     !> Net charge of the system.
     real(dp), intent(in) :: nrChrg
 
-    type(fnode), pointer :: child, childval
+    type(fnode), pointer :: value1, child, childval
     type(string) :: buffer
+    real(dp), allocatable :: d4Chi(:), d4Gam(:), d4Kcn(:), d4Rad(:)
 
     input%nrChrg = nrChrg
 
@@ -3842,7 +3849,149 @@ contains
     call getChildValue(node, "EwaldParameter", input%parEwald, 0.0_dp)
     call getChildValue(node, "EwaldTolerance", input%tolEwald, 1.0e-9_dp)
 
+    call getChildValue(node, "ChargeModel", value1, "EEQ", child=child)
+    call getNodeName(value1, buffer)
+    select case(char(buffer))
+    case default
+      call detailedError(value1, "Unknown method '"//char(buffer)//"' for ChargeModel")
+    case ("eeq")
+      allocate(d4Chi(geo%nSpecies))
+      d4Chi = getEeqChi(geo%speciesNames)
+      allocate(d4Gam(geo%nSpecies))
+      d4Gam = getEeqGam(geo%speciesNames)
+      allocate(d4Kcn(geo%nSpecies))
+      d4Kcn = getEeqKcn(geo%speciesNames)
+      allocate(d4Rad(geo%nSpecies))
+      d4Rad = getEeqRad(geo%speciesNames)
+      call readEeqModel(value1, input%eeqInput, geo, nrChrg, d4Chi, d4Gam, d4Kcn, d4Rad)
+    end select
+
   end subroutine readDispDFTD4
+
+
+  !> Read settings regarding the EEQ charge model
+  subroutine readEeqModel(node, input, geo, nrChrg, kChiDefault, kGamDefault, &
+      & kKcnDefault, kRadDefault)
+
+    !> Node to process.
+    type(fnode), pointer :: node
+
+    !> Geometry of the system
+    type(TGeometry), intent(in) :: geo
+
+    !> Filled input structure on exit.
+    type(TEeqInput), intent(out) :: input
+
+    !> Net charge of the system.
+    real(dp), intent(in) :: nrChrg
+
+    !> Electronegativities default values
+    real(dp), intent(in), optional :: kChiDefault(:)
+
+    !> Chemical hardnesses default values
+    real(dp), intent(in), optional :: kGamDefault(:)
+
+    !> CN scaling default values
+    real(dp), intent(in), optional :: kKcnDefault(:)
+
+    !> Charge widths default values
+    real(dp), intent(in), optional :: kRadDefault(:)
+
+    type(fnode), pointer :: value1, child
+    type(string) :: buffer
+    integer :: iSp1
+
+    input%nrChrg = nrChrg
+
+    allocate(input%chi(geo%nSpecies))
+    allocate(input%gam(geo%nSpecies))
+    allocate(input%kcn(geo%nSpecies))
+    allocate(input%rad(geo%nSpecies))
+
+    call getChildValue(node, "chi", value1, "values", child=child)
+    call getNodeName(value1, buffer)
+    select case(char(buffer))
+    case default
+      call detailedError(child, "Unknown method '"//char(buffer)//"' for chi")
+    case ("values")
+      if (present(kChiDefault)) then
+        do iSp1 = 1, geo%nSpecies
+          call getChildValue(value1, geo%speciesNames(iSp1), input%chi(iSp1), &
+              & kChiDefault(iSp1), child=child)
+        end do
+      else
+        do iSp1 = 1, geo%nSpecies
+          call getChildValue(value1, geo%speciesNames(iSp1), input%chi(iSp1), &
+              & child=child)
+        end do
+      end if
+    end select
+
+    call getChildValue(node, "gam", value1, "values", child=child)
+    call getNodeName(value1, buffer)
+    select case(char(buffer))
+    case default
+      call detailedError(child, "Unknown method '"//char(buffer)//"' for gam")
+    case ("values")
+      if (present(kGamDefault)) then
+        do iSp1 = 1, geo%nSpecies
+          call getChildValue(value1, geo%speciesNames(iSp1), input%gam(iSp1), &
+              & kGamDefault(iSp1), child=child)
+        end do
+      else
+        do iSp1 = 1, geo%nSpecies
+          call getChildValue(value1, geo%speciesNames(iSp1), input%gam(iSp1), &
+              & child=child)
+        end do
+      end if
+    end select
+
+    call getChildValue(node, "kcn", value1, "values", child=child)
+    call getNodeName(value1, buffer)
+    select case(char(buffer))
+    case default
+      call detailedError(child, "Unknown method '"//char(buffer)//"' for kcn")
+    case ("values")
+      if (present(kKcnDefault)) then
+        do iSp1 = 1, geo%nSpecies
+          call getChildValue(value1, geo%speciesNames(iSp1), input%kcn(iSp1), &
+              & kKcnDefault(iSp1), child=child)
+        end do
+      else
+        do iSp1 = 1, geo%nSpecies
+          call getChildValue(value1, geo%speciesNames(iSp1), input%kcn(iSp1), &
+              & child=child)
+        end do
+      end if
+    end select
+
+    call getChildValue(node, "rad", value1, "values", child=child)
+    call getNodeName(value1, buffer)
+    select case(char(buffer))
+    case default
+      call detailedError(child, "Unknown method '"//char(buffer)//"' for rad")
+    case ("values")
+      if (present(kRadDefault)) then
+        do iSp1 = 1, geo%nSpecies
+          call getChildValue(value1, geo%speciesNames(iSp1), input%rad(iSp1), &
+              & kRadDefault(iSp1), child=child)
+        end do
+      else
+        do iSp1 = 1, geo%nSpecies
+          call getChildValue(value1, geo%speciesNames(iSp1), input%rad(iSp1), &
+              & child=child)
+        end do
+      end if
+    end select
+
+    call getChildValue(node, "cutoff", input%cutoff, default=40.0_dp, modifier=buffer,&
+        & child=child)
+    call convertByMul(char(buffer), lengthUnits, child, input%cutoff)
+
+    call getChildValue(node, "EwaldParameter", input%parEwald, 0.0_dp)
+    call getChildValue(node, "EwaldTolerance", input%tolEwald, 1.0e-9_dp)
+
+  end subroutine readEeqModel
 
 
   !> reads in value of temperature for MD with sanity checking of the input

--- a/prog/dftb+/lib_dftbplus/parser.F90
+++ b/prog/dftb+/lib_dftbplus/parser.F90
@@ -3900,80 +3900,84 @@ contains
     allocate(input%kcn(geo%nSpecies))
     allocate(input%rad(geo%nSpecies))
 
-    call getChildValue(node, "chi", value1, "values", child=child)
+    call getChildValue(node, "chi", value1, "defaults", child=child)
     call getNodeName(value1, buffer)
     select case(char(buffer))
     case default
       call detailedError(child, "Unknown method '"//char(buffer)//"' for chi")
-    case ("values")
-      if (present(kChiDefault)) then
-        do iSp1 = 1, geo%nSpecies
-          call getChildValue(value1, geo%speciesNames(iSp1), input%chi(iSp1), &
-              & kChiDefault(iSp1), child=child)
-        end do
-      else
-        do iSp1 = 1, geo%nSpecies
-          call getChildValue(value1, geo%speciesNames(iSp1), input%chi(iSp1), &
-              & child=child)
-        end do
+    case ("defaults")
+      if (.not.present(kChiDefault)) then
+        call detailedError(child, "Parent method did not supply defaults")
       end if
+      do iSp1 = 1, geo%nSpecies
+        call getChildValue(value1, geo%speciesNames(iSp1), input%chi(iSp1), &
+            & kChiDefault(iSp1), child=child)
+      end do
+    case ("values")
+      do iSp1 = 1, geo%nSpecies
+        call getChildValue(value1, geo%speciesNames(iSp1), input%chi(iSp1), &
+            & child=child)
+      end do
     end select
 
-    call getChildValue(node, "gam", value1, "values", child=child)
+    call getChildValue(node, "gam", value1, "defaults", child=child)
     call getNodeName(value1, buffer)
     select case(char(buffer))
     case default
       call detailedError(child, "Unknown method '"//char(buffer)//"' for gam")
-    case ("values")
-      if (present(kGamDefault)) then
-        do iSp1 = 1, geo%nSpecies
-          call getChildValue(value1, geo%speciesNames(iSp1), input%gam(iSp1), &
-              & kGamDefault(iSp1), child=child)
-        end do
-      else
-        do iSp1 = 1, geo%nSpecies
-          call getChildValue(value1, geo%speciesNames(iSp1), input%gam(iSp1), &
-              & child=child)
-        end do
+    case ("defaults")
+      if (.not.present(kGamDefault)) then
+        call detailedError(child, "Parent method did not supply defaults")
       end if
+      do iSp1 = 1, geo%nSpecies
+        call getChildValue(value1, geo%speciesNames(iSp1), input%gam(iSp1), &
+            & kGamDefault(iSp1), child=child)
+      end do
+    case ("values")
+      do iSp1 = 1, geo%nSpecies
+        call getChildValue(value1, geo%speciesNames(iSp1), input%gam(iSp1), &
+            & child=child)
+      end do
     end select
 
-    call getChildValue(node, "kcn", value1, "values", child=child)
+    call getChildValue(node, "kcn", value1, "defaults", child=child)
     call getNodeName(value1, buffer)
     select case(char(buffer))
     case default
       call detailedError(child, "Unknown method '"//char(buffer)//"' for kcn")
-    case ("values")
-      if (present(kKcnDefault)) then
-        do iSp1 = 1, geo%nSpecies
-          call getChildValue(value1, geo%speciesNames(iSp1), input%kcn(iSp1), &
-              & kKcnDefault(iSp1), child=child)
-        end do
-      else
-        do iSp1 = 1, geo%nSpecies
-          call getChildValue(value1, geo%speciesNames(iSp1), input%kcn(iSp1), &
-              & child=child)
-        end do
+    case ("defaults")
+      if (.not.present(kKcnDefault)) then
+        call detailedError(child, "Parent method did not supply defaults")
       end if
+      do iSp1 = 1, geo%nSpecies
+        call getChildValue(value1, geo%speciesNames(iSp1), input%kcn(iSp1), &
+            & kKcnDefault(iSp1), child=child)
+      end do
+    case ("values")
+      do iSp1 = 1, geo%nSpecies
+        call getChildValue(value1, geo%speciesNames(iSp1), input%kcn(iSp1), &
+            & child=child)
+      end do
     end select
 
-    call getChildValue(node, "rad", value1, "values", child=child)
+    call getChildValue(node, "rad", value1, "defaults", child=child)
     call getNodeName(value1, buffer)
     select case(char(buffer))
     case default
       call detailedError(child, "Unknown method '"//char(buffer)//"' for rad")
-    case ("values")
-      if (present(kRadDefault)) then
-        do iSp1 = 1, geo%nSpecies
-          call getChildValue(value1, geo%speciesNames(iSp1), input%rad(iSp1), &
-              & kRadDefault(iSp1), child=child)
-        end do
-      else
-        do iSp1 = 1, geo%nSpecies
-          call getChildValue(value1, geo%speciesNames(iSp1), input%rad(iSp1), &
-              & child=child)
-        end do
+    case ("defaults")
+      if (.not.present(kRadDefault)) then
+        call detailedError(child, "Parent method did not supply defaults")
       end if
+      do iSp1 = 1, geo%nSpecies
+        call getChildValue(value1, geo%speciesNames(iSp1), input%rad(iSp1), &
+            & kRadDefault(iSp1), child=child)
+      end do
+    case ("values")
+      do iSp1 = 1, geo%nSpecies
+        call getChildValue(value1, geo%speciesNames(iSp1), input%rad(iSp1), &
+            & child=child)
+      end do
     end select
 
     call getChildValue(node, "cutoff", input%cutoff, default=40.0_dp, modifier=buffer,&

--- a/prog/dftb+/lib_dftbplus/parser.F90
+++ b/prog/dftb+/lib_dftbplus/parser.F90
@@ -3821,8 +3821,6 @@ contains
     type(string) :: buffer
     real(dp), allocatable :: d4Chi(:), d4Gam(:), d4Kcn(:), d4Rad(:)
 
-    input%nrChrg = nrChrg
-
     call getChildValue(node, "s6", input%s6, default=1.0_dp)
     call getChildValue(node, "s8", input%s8)
     call getChildValue(node, "s9", input%s9)
@@ -3839,15 +3837,9 @@ contains
     call getChildValue(node, "cutoffCount", input%cutoffCount, default=40.0_dp, modifier=buffer,&
         & child=child)
     call convertByMul(char(buffer), lengthUnits, child, input%cutoffCount)
-    call getChildValue(node, "cutoffEwald", input%cutoffEwald, default=40.0_dp, modifier=buffer,&
-        & child=child)
-    call convertByMul(char(buffer), lengthUnits, child, input%cutoffEwald)
     call getChildValue(node, "cutoffThree", input%cutoffThree, default=40.0_dp, modifier=buffer,&
         & child=child)
     call convertByMul(char(buffer), lengthUnits, child, input%cutoffThree)
-
-    call getChildValue(node, "EwaldParameter", input%parEwald, 0.0_dp)
-    call getChildValue(node, "EwaldTolerance", input%tolEwald, 1.0e-9_dp)
 
     call getChildValue(node, "ChargeModel", value1, "EEQ", child=child)
     call getNodeName(value1, buffer)

--- a/test/prog/dftb+/dispersion/GaAs_dftd4/dftb_in.hsd
+++ b/test/prog/dftb+/dispersion/GaAs_dftd4/dftb_in.hsd
@@ -28,9 +28,11 @@ Hamiltonian = DFTB {
     s9 = 1.0
     s6 = 1.0
     s8 = 0.61
-    EwaldParameter = 0.25165824
     CutoffInter = 60
     CutoffCount = 34 
+    ChargeModel = EEQ {
+       EwaldParameter = 0.25165824
+    }
   }
 }
 


### PR DESCRIPTION
This PR abstracts the charge model implementation from the DFT-D4 implementation.

- [x] wrap EEQ calculation in a container
- [x] remove all Ewald specific data from DFT-D4 calculator
- [x] add dedicated input for the charge model used in DFT-D4
  - [x] support EEQ model and allow modification of species parameters
- [x] don't use internals of the EEQ container in DFT-D4
- [x] update the manual and the test inputs

#### New Input

EEQ charge model can be supplied with customized parameters. The `Defaults` method depends on the parametrisation supplied by the parent (here DFTD4), which can be explicitly overwritten in the method. The `Values` method can be used to supply all parameters explicitly.

```cson
Dispersion = DFTD4 {
  ChargeModel = EEQ {
    Chi = Defaults {}
    Gam = Defaults {}
    Kcn = Defaults {}
    Rad = Defaults {}
  }
}
```