### PR TITLE
Make All Dispersion Interfaces MPI-aware

### DIFF
--- a/prog/dftb+/lib_dftb/dispdftd3.F90
+++ b/prog/dftb+/lib_dftb/dispdftd3.F90
@@ -13,6 +13,7 @@ module dftbp_dispdftd3
   use dftbp_accuracy
   use dftbp_dispiface
   use dftbp_dftd3
+  use dftbp_environment, only : TEnvironment
   use dftbp_periodic, only : TNeighbourList, getNrOfNeighboursForAll
   use dftbp_simplealgebra, only : determinant33
   use dftbp_constants
@@ -158,10 +159,13 @@ contains
 
 
   !> Notifies the objects about changed coordinates.
-  subroutine updateCoords(this, neigh, img2CentCell, coords, species0)
+  subroutine updateCoords(this, env, neigh, img2CentCell, coords, species0)
 
     !> Instance of DFTD3 data
     class(DispDftD3), intent(inout) :: this
+
+    !> Computational environment settings
+    type(TEnvironment), intent(in) :: env
 
     !> Updated neighbour list.
     type(TNeighbourList), intent(in) :: neigh

--- a/prog/dftb+/lib_dftb/dispdftd4.F90
+++ b/prog/dftb+/lib_dftb/dispdftd4.F90
@@ -13,6 +13,7 @@ module dftbp_dispdftd4
   use dftbp_assert
   use dftbp_accuracy, only : dp
   use dftbp_dispiface, only : DispersionIface
+  use dftbp_environment, only : TEnvironment
   use dftbp_periodic, only : TNeighbourList, getNrOfNeighboursForAll, getLatticePoints
   use dftbp_simplealgebra, only : determinant33, invert33
   use dftbp_coulomb, only : getMaxGEwald, getOptimalAlphaEwald
@@ -165,13 +166,16 @@ contains
 
 
   !> Notifies the objects about changed coordinates.
-  subroutine updateCoords(this, neigh, img2CentCell, coords, species0)
+  subroutine updateCoords(this, env, neigh, img2CentCell, coords, species0)
 
     !> Instance of DFTD4 data
     class(DispDftD4), intent(inout) :: this
 
     !> Updated neighbour list.
     type(TNeighbourList), intent(in) :: neigh
+
+    !> Computational environment settings
+    type(TEnvironment), intent(in) :: env
 
     !> Updated mapping to central cell.
     integer, intent(in) :: img2CentCell(:)

--- a/prog/dftb+/lib_dftb/dispiface.F90
+++ b/prog/dftb+/lib_dftb/dispiface.F90
@@ -8,6 +8,7 @@
 !> Common interface for all dispersion modules.
 module dftbp_dispiface
   use dftbp_accuracy, only : dp
+  use dftbp_environment, only : TEnvironment
   use dftbp_periodic, only : TNeighbourList
   implicit none
   private
@@ -41,11 +42,14 @@ module dftbp_dispiface
   abstract interface
 
     !> Update internal stored coordinate
-    subroutine updateCoordsIface(this, neigh, img2CentCell, coords, species0)
-      import :: DispersionIface, TNeighbourList, dp
+    subroutine updateCoordsIface(this, env, neigh, img2CentCell, coords, species0)
+      import :: DispersionIface, TEnvironment, TNeighbourList, dp
 
       !> data structure
       class(DispersionIface), intent(inout) :: this
+
+      !> Computational environment settings
+      type(TEnvironment), intent(in) :: env
 
       !> list of neighbours to atoms
       type(TNeighbourList), intent(in) :: neigh

--- a/prog/dftb+/lib_dftb/dispslaterkirkw.F90
+++ b/prog/dftb+/lib_dftb/dispslaterkirkw.F90
@@ -30,6 +30,7 @@ module dftbp_dispslaterkirkw
   use dftbp_constants, only : pi
   use dftbp_dispiface
   use dftbp_dispcommon
+  use dftbp_environment, only : TEnvironment
   use dftbp_message
   implicit none
   private
@@ -217,10 +218,13 @@ end subroutine DispSlaKirk_init
 
 
 !> Notifies the objects about changed coordinates.
-subroutine updateCoords(this, neigh, img2CentCell, coords, species0)
+subroutine updateCoords(this, env, neigh, img2CentCell, coords, species0)
 
   !> The data object for dispersion
   class(DispSlaKirk), intent(inout) :: this
+
+  !> Computational environment settings
+  type(TEnvironment), intent(in) :: env
 
   !> Updated neighbour list.
   type(TNeighbourList), intent(in) :: neigh

--- a/prog/dftb+/lib_dftb/dispuff.F90
+++ b/prog/dftb+/lib_dftb/dispuff.F90
@@ -24,6 +24,7 @@ module dftbp_dispuff
   use dftbp_constants, only: pi
   use dftbp_dispiface
   use dftbp_dispcommon
+  use dftbp_environment, only : TEnvironment
   implicit none
   private
 
@@ -188,13 +189,16 @@ contains
   end subroutine DispUff_init
 
   !> Notifies the objects about changed coordinates.
-  subroutine updateCoords(this, neigh, img2CentCell, coords, species0)
+  subroutine updateCoords(this, env, neigh, img2CentCell, coords, species0)
 
     !> Instance of dispersion to update
     class(DispUff), intent(inout) :: this
 
     !> Updated neighbour list.
     type(TNeighbourList), intent(in) :: neigh
+
+    !> Computational environment settings
+    type(TEnvironment), intent(in) :: env
 
     !> Updated mapping to central cell.
     integer, intent(in) :: img2CentCell(:)

--- a/prog/dftb+/lib_dftbplus/main.F90
+++ b/prog/dftb+/lib_dftbplus/main.F90
@@ -1208,7 +1208,7 @@ contains
     end if
 
     if (allocated(dispersion)) then
-      call dispersion%updateCoords(neighbourList, img2CentCell, coord, species0)
+      call dispersion%updateCoords(env, neighbourList, img2CentCell, coord, species0)
     end if
     if (allocated(thirdOrd)) then
       call thirdOrd%updateCoords(neighbourList, species)


### PR DESCRIPTION
This PR passes the calculation environment to the dispersion interface and allows to use MPI parallelisation in the respective dispersion correction. Even with this PR no dispersion correction currently uses MPI (will be done separately).

fixes #383