### PR TITLE
Documentation building action

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,20 @@
+name: docs
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dante-ev/latex-action@v0.2.0
+      with:
+        root_file: manual.tex
+        working_directory: doc/dftb+/manual
+    - uses: actions/upload-artifact@v1
+      if: ${{ github.repository == 'dftbplus/dftbplus' && github.event_name == 'push' }}
+      with:
+        name: dftbplus-manual
+        path: doc/dftb+/manual/manual.pdf

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,10 +3,10 @@ name: docs
 on:
   push:
     paths:
-      - 'doc/manual/**'
+      - 'doc/dftb+/manual/**'
   pull_request:
     paths:
-      - 'doc/manual/**'
+      - 'doc/dftb+/manual/**'
 
 jobs:
   build:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,6 +1,12 @@
 name: docs
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'doc/manual/**'
+  pull_request:
+    paths:
+      - 'doc/manual/**'
 
 jobs:
   build:
@@ -9,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: dante-ev/latex-action@v0.2.0
-      with:
-        root_file: manual.tex
-        working_directory: doc/dftb+/manual
+    - name: "Install dependencies"
+      run: sudo apt install -yq --no-install-recommends texlive-latex-extra texlive-science
+    - name: "Build manual"
+      run: make -C doc/dftb+/manual
     - uses: actions/upload-artifact@v1
       if: ${{ github.repository == 'dftbplus/dftbplus' && github.event_name == 'push' }}
       with:


### PR DESCRIPTION
[![docs](https://github.com/awvwgk/dftbplus/workflows/docs/badge.svg)](https://github.com/awvwgk/dftbplus/actions)

Use GH actions to build the DFTB+ manual. Overall runtime is about ~three~ one minute~s~ ~(two minutes for the docker container)~.

- [x] build of the manual is done only for changes in the `doc/dftb+/manual` directory
- [x] uploads of the pdf only for this repository and push events
- [x] upload manual for push events on master

To discuss
- ~run doxygen and/or ford to generate the documentation from the source?~ not used anyway...

Related to #378