### PR TITLE
Update for Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,11 @@ addons:
       - libscalapack-openmpi-dev
 
 install:
-- git submodule update --init --recursive
 - echo "y" | ./utils/get_opt_externals ALL
 
 script:
 - mkdir _build
 - cd _build
-- cmake -DWITH_DFTD3=true -DWITH_MPI=${WITH_MPI} -DCMAKE_TOOLCHAIN_FILE=../sys/gnu.cmake ..
+- cmake -DWITH_DFTD3=true -DWITH_TRANSPORT=true -DWITH_MPI=${WITH_MPI} -DFYPP_FLAGS="-DTRAVIS" -DCMAKE_TOOLCHAIN_FILE=../sys/gnu.cmake ..
 - make -j 2
 - ctest -j 2

--- a/test/prog/dftb+/tests
+++ b/test/prog/dftb+/tests
@@ -3,6 +3,7 @@
 #! $(TEST_MPI_PROCS) and OMP_THREADS to $(TEST_OMP_THREADS).
 
 #:include 'common.fypp'
+#:set LONG_TEST = not defined('TRAVIS')
 
 non-scc/Si_384_GPU                     #? WITH_GPU and not WITH_MPI
 scc/SiC_512_GPU                        #? WITH_GPU and not WITH_MPI
@@ -249,10 +250,10 @@ timedep/C66O10N4H44_OscWindow          #? WITH_ARPACK and MPI_PROCS <= 1
 timedep/C60_OscWindow                  #? WITH_ARPACK and MPI_PROCS <= 1
 timedep/C60_EandOsc                    #? WITH_ARPACK and MPI_PROCS <= 1
 
-non-scc/Si_216                         #? MPI_PROCS <= 4
-md/ptcda-xlbomd-ldep                   #? MPI_PROCS <= 4
-geoopt/Vsi+O_lbfgs                     #? MPI_PROCS <= 4
-geoopt/Vsi+O                           #? MPI_PROCS <= 4
+non-scc/Si_216                         #? MPI_PROCS <= 4 and LONG_TEST
+md/ptcda-xlbomd-ldep                   #? MPI_PROCS <= 4 and LONG_TEST
+geoopt/Vsi+O_lbfgs                     #? MPI_PROCS <= 4 and LONG_TEST
+geoopt/Vsi+O                           #? MPI_PROCS <= 4 and LONG_TEST
 scc/SiC64+V_dynforce_groups            #? (MPI_PROCS <= 8 and MPI_PROCS % 4 == 0) or not WITH_MPI
 scc/SiC64+V_dynforce                   #? (MPI_PROCS <= 4 and MPI_PROCS % 2 == 0) or not WITH_MPI
 
@@ -260,9 +261,9 @@ transport/CH4                          #? WITH_TRANSPORT and MPI_PROCS <= 4
 transport/GaAs                         #? WITH_TRANSPORT and MPI_PROCS <= 4
 transport/CH4-poisson                  #? WITH_TRANSPORT and MPI_PROCS <= 4
 transport/CNT                          #? WITH_TRANSPORT and MPI_PROCS <= 4
-transport/CNT_GF                       #? WITH_TRANSPORT and MPI_PROCS <= 4
+transport/CNT_GF                       #? WITH_TRANSPORT and MPI_PROCS <= 4 and LONG_TEST
 transport/C-chain_allSteps             #? WITH_TRANSPORT and MPI_PROCS <= 2
-transport/SiH-chain_allSteps           #? WITH_TRANSPORT and MPI_PROCS <= 2
+transport/SiH-chain_allSteps           #? WITH_TRANSPORT and MPI_PROCS <= 2 and LONG_TEST
 transport/H-chain                      #? WITH_TRANSPORT and MPI_PROCS <= 4
 transport/H-sheet                      #? WITH_TRANSPORT and MPI_PROCS <= 4
 transport/H-sheet_grp2                 #? WITH_TRANSPORT and MPI_PROCS <= 8 and MPI_PROCS % 2 == 0
@@ -272,10 +273,10 @@ transport/H-3conts                     #? WITH_TRANSPORT and MPI_PROCS <= 4
 transport/SiH-chain                    #? WITH_TRANSPORT and MPI_PROCS <= 4
 transport/SiH-chain-cont               #? WITH_TRANSPORT and MPI_PROCS <= 4
 transport/SiH-cont-poiss               #? WITH_TRANSPORT and MPI_PROCS <= 4
-transport/graphene_x                   #? WITH_TRANSPORT and MPI_PROCS <= 4
-transport/graphene3T                   #? WITH_TRANSPORT and MPI_PROCS <= 4
+transport/graphene_x                   #? WITH_TRANSPORT and MPI_PROCS <= 4 and LONG_TEST
+transport/graphene3T                   #? WITH_TRANSPORT and MPI_PROCS <= 4 and LONG_TEST
 transport/Au-chain                     #? WITH_TRANSPORT and MPI_PROCS <= 4
 transport/SiH-chain_semiInf            #? WITH_TRANSPORT and MPI_PROCS <= 2
-transport/local-curr                   #? WITH_TRANSPORT and MPI_PROCS <= 4
+transport/local-curr                   #? WITH_TRANSPORT and MPI_PROCS <= 4 and LONG_TEST
 transport/polyacetylene_semiInf        #? WITH_TRANSPORT and MPI_PROCS <= 4
 transport/H-sheet_end                  #? WITH_TRANSPORT and MPI_PROCS <= 4


### PR DESCRIPTION
[![Build Status](https://travis-ci.com/awvwgk/dftbplus.svg?branch=travis-ci)](https://travis-ci.com/awvwgk/dftbplus)

- every test taking longer than a minute has to be guard with `LONG_TEST` and is disabled for Travis-CI
- enable compilation `WITH_TRANSPORT`
- remove redundant initialization of submodules

I looked up the Travis-CI specs, we have 2 cores on our virtual machine for building. With the new setup we overall save one minute and test most of the transport features.

Logs and timings are here: https://travis-ci.com/awvwgk/dftbplus/builds/151042525