### PR TITLE
Separate SCC and second order electrostatic

### DIFF
--- a/prog/dftb+/lib_dftb/scc.F90
+++ b/prog/dftb+/lib_dftb/scc.F90
@@ -207,7 +207,7 @@ module dftbp_scc
     !> Updates the SCC module, if the charges have been changed
     procedure :: updateCharges
 
-    !> TODO
+    !> Set external charge field
     procedure :: setExternalCharges
 
     !> Update potential shifts
@@ -255,7 +255,7 @@ module dftbp_scc
   end type TScc
 
 
-  !> TODO
+  !> Initialize SCC container from input data
   interface initialize
     module procedure Scc_initialize
   end interface initialize
@@ -264,7 +264,7 @@ module dftbp_scc
 contains
 
 
-  !> TODO
+  !> Initialize SCC container from input data
   subroutine Scc_initialize(this, env, inp)
 
     !> Resulting instance
@@ -564,19 +564,19 @@ contains
   end subroutine updateShifts
 
 
-  !> TODO
+  !> set external charge field
   subroutine setExternalCharges(this, chargeCoords, chargeQs, blurWidths)
 
-    !> TODO
+    !> Instance
     class(TScc), intent(inout) :: this
 
-    !> TODO
+    !> Coordinates of external charges
     real(dp), intent(in) :: chargeCoords(:,:)
 
-    !> TODO
+    !> Magnitude of external charges
     real(dp), intent(in) :: chargeQs(:)
 
-    !> TODO
+    !> Spatial extension of external charge distribution
     real(dp), intent(in), optional :: blurWidths(:)
 
     if (.not. allocated(this%extCharge)) then

--- a/prog/dftb+/lib_dftb/scc.F90
+++ b/prog/dftb+/lib_dftb/scc.F90
@@ -16,8 +16,7 @@ module dftbp_scc
   use dftbp_chargeconstr
   use dftbp_commontypes
   use dftbp_constants
-  use dftbp_coulomb, only : TCoulombCont, TCoulombInput, init, &
-      & sumInvR, addInvRPrime, invRStress, addInvRPrimeXlbomd
+  use dftbp_coulomb, only : TCoulombCont, TCoulombInput, init, sumInvR
   use dftbp_dynneighlist
   use dftbp_environment
   use dftbp_fileid

--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -1460,8 +1460,8 @@ contains
         sccInp%thirdOrderOn = input%ctrl%thirdOrderOn
       end if
 
-      sccInp%ewaldAlpha = input%ctrl%ewaldAlpha
-      sccInp%tolEwald = input%ctrl%tolEwald
+      sccInp%coulombInput%ewaldAlpha = input%ctrl%ewaldAlpha
+      sccInp%coulombInput%tolEwald = input%ctrl%tolEwald
       call initialize(sccCalc, env, sccInp)
       deallocate(sccInp)
 


### PR DESCRIPTION
**WIP**: do not merge!

My take on abstracting the evaluation of the second order electrostatic / coulombic interactions from the SCC. Aim of this PR is to reuse the second order electrostatic for all implemented and future boundary conditions within a different context than the DFTB SCC.

Possible applications are the extended tight binding (xTB) SCC (see #319), the electronegativity equilibration model (EEQ) model in DFT-D4 (see #384) and the generalized Born (GB) implicit solvation model (see #387), which are right now either *blocked* by the current infrastructure or *reimplement* the second order electrostatic by themselves.

fixes #320