### PR TITLE
Coordination number container

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -2781,7 +2781,7 @@ can be adjusted in the input.
   \kw{ChargeScale} & r & & 3.0 & \\
   \kw{CutoffInter} & r & & 64 & \\
   \kw{CutoffCount} & r & & 40 & \\
-  \kw{CutoffThree} & r & & 40 & \\
+  \kw{CoordinationNumber} & m & & \is{cov} & \\
   \kw{ChargeModel} & m & & \is{EEQ} & \\
 \end{ptable}
 
@@ -2810,9 +2810,6 @@ can be adjusted in the input.
 \item[\is{CutoffInter}] \modif{\modtype{length}} Cutoff distance when
   calculating two-body interactions.
 
-\item[\is{CutoffCount}] \modif{\modtype{length}} Cutoff distance when
-  calculating coordination numbers.
-
 \item[\is{CutoffThree}] \modif{\modtype{length}} Cutoff distance when
   calculating three-body interactions.
 
@@ -2834,6 +2831,7 @@ up to 86 can be supplied automatically.
   \kw{Cutoff} & r & & 40 & \\
   \kw{EwaldParameter} & r & & 0.0 & \\
   \kw{EwaldTolerance} & r & & 1.0e-9 & \\
+  \kw{CoordinationNumber} & m & & \is{erf} & \\
 \end{ptable}
 
 \begin{description}
@@ -2880,6 +2878,46 @@ ChargeModel = EEQ {
     Ga = 1.76901636
     As = 2.41244711
   }
+}
+\end{verbatim}
+
+\subsubsection{DftD4 CoordinationNumber}
+
+The \kw{CoordinationNumber} determines how the local coordination environment
+for its parent method is calculated. Currently four different counting functions
+are available: \is{erf\cb}, \is{cov\cb}, \is{gfn\cb}, and \is{exp\cb}.
+\is{erf\cb} is the default coordination number for the EEQ charge model,
+while \is{cov\cb} is the default coordination number for DFTD4.
+
+\begin{ptable}
+  \kw{Electronegativities} & m & & \is{PaulingEN} & \\
+  \kw{Radii} & m & & \is{CovalentRadiiD3} & \\
+  \kw{Cutoff} & r & & 40 & \\
+  \kw{CutCN} & r & & 0 / 8 & \\
+\end{ptable}
+
+\begin{description}
+
+\item[\is{Radii}] Covalent radii of all species in Bohr.
+  Default values taken are the DFTD3 covalent radii.
+
+\item[\is{Electronegativities}] Electronegativities of all species.
+  Default values taken are Pauling ENs.
+
+\item[\is{Cutoff}] \modif{\modtype{length}} Cutoff distance when
+  evaluating counting function.
+
+\item[\is{CutCN}] Maximum value for coordination number, coordination numbers
+  higher than this value will be smoothly cut away. Deactivated for values
+  smaller or equal to zero. Default depends on parent method.
+
+\end{description}
+
+\begin{verbatim}
+CoordinationNumber = Cov {
+  CutCN = 0
+  Electronegativities = PaulingEN {}
+  Radii = CovalentRadiiD3 {}
 }
 \end{verbatim}
 

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -2780,9 +2780,9 @@ can be adjusted in the input.
   \kw{ChargeSteepness} & r & & 2.0 & \\
   \kw{ChargeScale} & r & & 3.0 & \\
   \kw{CutoffInter} & r & & 64 & \\
-  \kw{CutoffCount} & r & & 40 & \\
-  \kw{CoordinationNumber} & m & & \is{cov} & \\
-  \kw{ChargeModel} & m & & \is{EEQ} & \\
+  \kw{CutoffThree} & r & & 40 & \\
+  \kw{CoordinationNumber} & m & & \is{Cov} & \pref{dftbp.CoordinationNumber} \\
+  \kw{ChargeModel} & m & & \is{EEQ} & \pref{dftbp.ChargeModel} \\
 \end{ptable}
 
 \begin{description}
@@ -2816,12 +2816,14 @@ can be adjusted in the input.
 \end{description}
 
 \subsubsection{DftD4 ChargeModel}
+\label{sec:dftbp.ChargeModel}
 
 This implementation of DFT-D4 supports only the \is{EEQ\cb} method to initialize
-the charge model. For each species four parameters (\kw{Chi}, \kw{Gam}, \kw{Kcn},
-and \kw{Rad}) have to be supplied in a \is{Values\cb} method, since the model
+the charge model with an electronegativity equilibration~(EEQ) model.\cite{rappe1991}
+For each species four parameters (\kw{Chi}, \kw{Gam}, \kw{Kcn}, and \kw{Rad})
+have to be supplied in a \is{Values\cb} method, since the model
 is instanciated inside the \is{DftD4\cb} method, \is{Defaults\cb} for all elements
-up to 86 can be supplied automatically.
+up to 86 can be supplied automatically.\cite{caldeweyher-jcp-150-154122}
 
 \begin{ptable}
   \kw{Chi} & m & & \is{Defaults} & \\
@@ -2832,6 +2834,7 @@ up to 86 can be supplied automatically.
   \kw{EwaldParameter} & r & & 0.0 & \\
   \kw{EwaldTolerance} & r & & 1.0e-9 & \\
   \kw{CoordinationNumber} & m & & \is{erf} & \\
+  \kw{CoordinationNumber} & m & & \is{Erf} & \pref{dftbp.CoordinationNumber} \\
 \end{ptable}
 
 \begin{description}
@@ -2882,12 +2885,13 @@ ChargeModel = EEQ {
 \end{verbatim}
 
 \subsubsection{DftD4 CoordinationNumber}
+\label{sec:dftbp.CoordinationNumber}
 
 The \kw{CoordinationNumber} determines how the local coordination environment
 for its parent method is calculated. Currently four different counting functions
-are available: \is{erf\cb}, \is{cov\cb}, \is{gfn\cb}, and \is{exp\cb}.
-\is{erf\cb} is the default coordination number for the EEQ charge model,
-while \is{cov\cb} is the default coordination number for DFTD4.
+are available: \is{Erf\cb}, \is{Cov\cb}, \is{Gfn\cb}, and \is{Exp\cb}.
+\is{Erf\cb} is the default coordination number for the EEQ charge model,
+while \is{Cov\cb} is the default coordination number for DFTD4.
 
 \begin{ptable}
   \kw{Electronegativities} & m & & \is{PaulingEN} & \\
@@ -2899,7 +2903,7 @@ while \is{cov\cb} is the default coordination number for DFTD4.
 \begin{description}
 
 \item[\is{Radii}] Covalent radii of all species in Bohr.
-  Default values taken are the DFTD3 covalent radii.
+  Default values taken are the DFTD3 covalent radii.\cite{grimme-jcp-132-154104}
 
 \item[\is{Electronegativities}] Electronegativities of all species.
   Default values taken are Pauling ENs.

--- a/doc/dftb+/manual/manual.bib
+++ b/doc/dftb+/manual/manual.bib
@@ -655,3 +655,12 @@ author = {Stephan Lany and Alex Zunger},
 title = {Accurate prediction of defect properties in density functional supercell calculations},
 journal = {Modelling and Simulation in Materials Science and Engineering}
 }
+
+@article{rappe1991,
+   author={Rapp{\'e}, Anthony K. and Goddard III, William A.},
+   title={Charge Equilibration for Molecular Dynamics Simulation},
+   journal=jcp,
+   volume={95},
+   year={1991},
+   pages={3358-3363}
+}

--- a/prog/dftb+/lib_dftb/CMakeLists.txt
+++ b/prog/dftb+/lib_dftb/CMakeLists.txt
@@ -3,6 +3,7 @@ set(curdir "lib_dftb")
 set(sources-fpp
   ${curdir}/chargeconstr.F90
   ${curdir}/charges.F90
+  ${curdir}/coordinationnumber.F90
   ${curdir}/coulomb.F90
   ${curdir}/densitymatrix.F90
   ${curdir}/dftbplusu.F90

--- a/prog/dftb+/lib_dftb/CMakeLists.txt
+++ b/prog/dftb+/lib_dftb/CMakeLists.txt
@@ -3,7 +3,7 @@ set(curdir "lib_dftb")
 set(sources-fpp
   ${curdir}/chargeconstr.F90
   ${curdir}/charges.F90
-  ${curdir}/coordinationnumber.F90
+  ${curdir}/coordnumber.F90
   ${curdir}/coulomb.F90
   ${curdir}/densitymatrix.F90
   ${curdir}/dftbplusu.F90

--- a/prog/dftb+/lib_dftb/coordinationnumber.F90
+++ b/prog/dftb+/lib_dftb/coordinationnumber.F90
@@ -1,0 +1,844 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2020  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+#:include 'common.fypp'
+
+!> Coordination number implementation
+module dftbp_coordinationnumber
+  use dftbp_accuracy, only : dp
+  use dftbp_blasroutines, only : gemv
+  use dftbp_constants, only : pi, AA__Bohr, symbolToNumber
+  use dftbp_message, only : error
+  use dftbp_periodic, only : TNeighbourList, getNrOfNeighboursForAll
+  use dftbp_simplealgebra, only : determinant33
+  implicit none
+  private
+
+  public :: TCNCont, TCNInput, cnType, init
+  public :: getElectronegativity, getCovalentRadius
+
+
+  !> Get electronegativity for a species
+  interface getElectronegativity
+    module procedure :: getElectronegativitySymbol
+    module procedure :: getElectronegativityNumber
+  end interface getElectronegativity
+
+
+  !> Get atomic radius for a species
+  interface getCovalentRadius
+    module procedure :: getCovalentRadiusSymbol
+    module procedure :: getCovalentRadiusNumber
+  end interface getCovalentRadius
+
+
+  !> Covalent radii (taken from Pyykko and Atsumi, Chem. Eur. J. 15, 2009,
+  !> 188-197), values for metals decreased by 10%.
+  real(dp), parameter :: CovalentRadii(1:118) = [ &
+    & 0.32_dp,0.46_dp, & ! H,He
+    & 1.20_dp,0.94_dp,0.77_dp,0.75_dp,0.71_dp,0.63_dp,0.64_dp,0.67_dp, & ! Li-Ne
+    & 1.40_dp,1.25_dp,1.13_dp,1.04_dp,1.10_dp,1.02_dp,0.99_dp,0.96_dp, & ! Na-Ar
+    & 1.76_dp,1.54_dp, & ! K,Ca
+    &                 1.33_dp,1.22_dp,1.21_dp,1.10_dp,1.07_dp, & ! Sc-
+    &                 1.04_dp,1.00_dp,0.99_dp,1.01_dp,1.09_dp, & ! -Zn
+    &                 1.12_dp,1.09_dp,1.15_dp,1.10_dp,1.14_dp,1.17_dp, & ! Ga-Kr
+    & 1.89_dp,1.67_dp, & ! Rb,Sr
+    &                 1.47_dp,1.39_dp,1.32_dp,1.24_dp,1.15_dp, & ! Y-
+    &                 1.13_dp,1.13_dp,1.08_dp,1.15_dp,1.23_dp, & ! -Cd
+    &                 1.28_dp,1.26_dp,1.26_dp,1.23_dp,1.32_dp,1.31_dp, & ! In-Xe
+    & 2.09_dp,1.76_dp, & ! Cs,Ba
+    &         1.62_dp,1.47_dp,1.58_dp,1.57_dp,1.56_dp,1.55_dp,1.51_dp, & ! La-Eu
+    &         1.52_dp,1.51_dp,1.50_dp,1.49_dp,1.49_dp,1.48_dp,1.53_dp, & ! Gd-Yb
+    &                 1.46_dp,1.37_dp,1.31_dp,1.23_dp,1.18_dp, & ! Lu-
+    &                 1.16_dp,1.11_dp,1.12_dp,1.13_dp,1.32_dp, & ! -Hg
+    &                 1.30_dp,1.30_dp,1.36_dp,1.31_dp,1.38_dp,1.42_dp, & ! Tl-Rn
+    & 2.01_dp,1.81_dp, & ! Fr,Ra
+    &         1.67_dp,1.58_dp,1.52_dp,1.53_dp,1.54_dp,1.55_dp,1.49_dp, & ! Ac-Am
+    &         1.49_dp,1.51_dp,1.51_dp,1.48_dp,1.50_dp,1.56_dp,1.58_dp, & ! Cm-No
+    &                 1.45_dp,1.41_dp,1.34_dp,1.29_dp,1.27_dp, & ! Lr-
+    &                 1.21_dp,1.16_dp,1.15_dp,1.09_dp,1.22_dp, & ! -Cn
+    &                 1.36_dp,1.43_dp,1.46_dp,1.58_dp,1.48_dp,1.57_dp] & ! Nh-Og
+    & * AA__Bohr * 4.0_dp / 3.0_dp
+
+
+  !> Pauling electronegativities, used for the covalent coordination number.
+  real(dp), parameter :: paulingEN(1:118) = [ &
+    & 2.20_dp,3.00_dp, & ! H,He
+    & 0.98_dp,1.57_dp,2.04_dp,2.55_dp,3.04_dp,3.44_dp,3.98_dp,4.50_dp, & ! Li-Ne
+    & 0.93_dp,1.31_dp,1.61_dp,1.90_dp,2.19_dp,2.58_dp,3.16_dp,3.50_dp, & ! Na-Ar
+    & 0.82_dp,1.00_dp, & ! K,Ca
+    &                 1.36_dp,1.54_dp,1.63_dp,1.66_dp,1.55_dp, & ! Sc-
+    &                 1.83_dp,1.88_dp,1.91_dp,1.90_dp,1.65_dp, & ! -Zn
+    &                 1.81_dp,2.01_dp,2.18_dp,2.55_dp,2.96_dp,3.00_dp, & ! Ga-Kr
+    & 0.82_dp,0.95_dp, & ! Rb,Sr
+    &                 1.22_dp,1.33_dp,1.60_dp,2.16_dp,1.90_dp, & ! Y-
+    &                 2.20_dp,2.28_dp,2.20_dp,1.93_dp,1.69_dp, & ! -Cd
+    &                 1.78_dp,1.96_dp,2.05_dp,2.10_dp,2.66_dp,2.60_dp, & ! In-Xe
+    & 0.79_dp,0.89_dp, & ! Cs,Ba
+    &         1.10_dp,1.12_dp,1.13_dp,1.14_dp,1.15_dp,1.17_dp,1.18_dp, & ! La-Eu
+    &         1.20_dp,1.21_dp,1.22_dp,1.23_dp,1.24_dp,1.25_dp,1.26_dp, & ! Gd-Yb
+    &                 1.27_dp,1.30_dp,1.50_dp,2.36_dp,1.90_dp, & ! Lu-
+    &                 2.20_dp,2.20_dp,2.28_dp,2.54_dp,2.00_dp, & ! -Hg
+    &                 1.62_dp,2.33_dp,2.02_dp,2.00_dp,2.20_dp,2.20_dp, & ! Tl-Rn
+    ! only dummies below
+    & 1.50_dp,1.50_dp, & ! Fr,Ra
+    &         1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp, & ! Ac-Am
+    &         1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp, & ! Cm-No
+    &                 1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp, & ! Rf-
+    &                 1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp, & ! Rf-Cn
+    &                 1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp ] ! Nh-Og
+
+
+  !> Possible counting functions for calculating coordination numbers
+  type :: TCNCountEnum
+
+    !> Counting function not specified
+    integer :: invalid = 0
+
+    !> Original DFT-D3 coordination number
+    integer :: exp = 1
+
+    !> Faster decaying error function CN, better for dense systems
+    integer :: erf = 2
+
+    !> Error function CN with covalency correction
+    integer :: cov = 3
+
+    !> Particular long-ranged version of the DFT-D3 coordination number
+    integer :: gfn = 4
+
+  end type TCNCountEnum
+
+  !> Enumerator for different coordination number types
+  type(TCNCountEnum), parameter :: cnType = TCNCountEnum()
+
+
+  !> Input to generate coordination number container
+  type :: TCNInput
+
+    !> Coordination number type
+    integer :: cnType
+
+    !> Real space cutoff
+    real(dp) :: rCutoff
+
+    !> Upper bound for coordination number
+    real(dp) :: maxCN
+
+    !> Covalent radii
+    real(dp), allocatable :: covRad(:)
+
+    !> Electronegativity
+    real(dp), allocatable :: en(:)
+
+  end type TCNInput
+
+
+  !> Coordination number container
+  type :: TCNCont
+
+    !> number of atoms
+    integer :: nAtom = 0
+
+    !> lattice vectors if periodic
+    real(dp) :: latVecs(3, 3) = 0.0_dp
+
+    !> is this periodic
+    logical :: tPeriodic
+
+    !> are the coordinates current?
+    logical :: tCoordsUpdated = .false.
+
+    !> Use covalency correction from EN
+    logical :: tENScale
+
+    !> Real space cutoff
+    real(dp) :: rCutoff = 0.0_dp
+
+    !> Steepness of the counting function
+    real(dp) :: kcn
+
+    !> Cut coordination number
+    logical :: tCutCN
+
+    !> Upper bound for coordination number
+    real(dp) :: maxCN
+
+    !> Covalent radii
+    real(dp), allocatable :: covRad(:)
+
+    !> Electronegativity
+    real(dp), allocatable :: en(:)
+
+    !> Coordination number
+    real(dp), allocatable :: cn(:)
+
+    !> Derivative of coordination numbers w.r.t. coordinates
+    real(dp), allocatable :: dcndr(:, :, :)
+
+    !> Derivative of coordination numbers w.r.t. strain deformations
+    real(dp), allocatable :: dcndL(:, :, :)
+
+    !> Counting function for CN
+    procedure(countFunction), nopass, pointer :: countFunc => null()
+
+    !> Derivative of counting function w.r.t. distance
+    procedure(countFunction), nopass, pointer :: countDeriv => null()
+
+  contains
+
+    !> update internal copy of coordinates
+    procedure :: updateCoords
+
+    !> update internal copy of lattice vectors
+    procedure :: updateLatVecs
+
+    !> get real space cutoff
+    procedure :: getRCutoff
+
+    !> get force contributions
+    procedure :: addGradients
+
+    !> get stress tensor contributions
+    procedure :: addStress
+
+  end type TCNCont
+
+
+  abstract interface
+  !> Abstract interface for the counting function (and its derivative)
+  pure function countFunction(k, r, r0)
+    import :: dp
+
+    !> Constant for counting function
+    real(dp), intent(in) :: k
+
+    !> Actual distance
+    real(dp), intent(in) :: r
+
+    !> Critical distance
+    real(dp), intent(in) :: r0
+
+    !> Value of the counting function in the range of [0,1]
+    real(dp) :: countFunction
+  end function countFunction
+  end interface
+
+  !> Initialize container from geometry
+  interface init
+    module procedure :: initialize
+  end interface init
+
+
+contains
+
+
+  !> Initialize coordination number container
+  subroutine initialize(self, input, nAtom, latVecs)
+
+    !> Initialised instance at return
+    type(TCNCont), intent(out) :: self
+
+    !> Nr. of atoms in the system
+    integer, intent(in) :: nAtom
+
+    !> Input for container
+    type(TCNInput), intent(in) :: input
+
+    !> Lattice vectors, if the system is periodic
+    real(dp), intent(in), optional :: latVecs(:,:)
+
+    @:ASSERT(allocated(input%covRad))
+    @:ASSERT(allocated(input%en))
+
+    self%tPeriodic = present(latVecs)
+    if (self%tPeriodic) then
+      call self%updateLatVecs(LatVecs)
+    end if
+    self%nAtom = nAtom
+
+    allocate(self%cn(nAtom))
+    allocate(self%dcndr(3, nAtom, nAtom))
+    allocate(self%dcndL(3, 3, nAtom))
+
+    self%rCutoff = input%rCutoff
+
+    select case(input%cnType)
+    case default
+      call error("Fatal programming error in dftbp_coordinationnumber!")
+    case(cnType%erf)
+      self%countFunc => erfCount
+      self%countDeriv => derfCount
+      self%kcn = 7.5_dp
+      self%tENScale = .false.
+    case(cnType%exp)
+      self%countFunc => expCount
+      self%countDeriv => dexpCount
+      self%kcn = 16.0_dp
+      self%tENScale = .false.
+    case(cnType%cov)
+      self%countFunc => erfCount
+      self%countDeriv => derfCount
+      self%kcn = 7.5_dp
+      self%tENScale = .true.
+    case(cnType%gfn)
+      self%countFunc => gfnCount
+      self%countDeriv => dgfnCount
+      self%kcn = 10.0_dp
+      self%tENScale = .false.
+    end select
+
+    self%tCutCN = input%maxCN > 0.0_dp
+    self%maxCN = input%maxCN
+
+    allocate(self%covRad(size(input%covRad)))
+    allocate(self%en(size(input%en)))
+    self%covRad(:) = input%covRad
+    self%en(:) = input%en
+
+    self%tCoordsUpdated = .false.
+
+  end subroutine initialize
+
+
+  !> Update internal stored coordinates
+  subroutine updateCoords(self, neighList, img2CentCell, coords, species0)
+
+    !> data structure
+    class(TCNCont), intent(inout) :: self
+
+    !> list of neighbours to atoms
+    type(TNeighbourList), intent(in) :: neighList
+
+    !> image to central cell atom index
+    integer, intent(in) :: img2CentCell(:)
+
+    !> atomic coordinates
+    real(dp), intent(in) :: coords(:,:)
+
+    !> central cell chemical species
+    integer, intent(in) :: species0(:)
+
+    integer, allocatable :: nNeigh(:)
+
+    allocate(nNeigh(self%nAtom))
+    call getNrOfNeighboursForAll(nNeigh, neighList, self%rCutoff)
+    call getCoordinationNumber(self%nAtom, coords, species0, nNeigh, &
+        & neighList%iNeighbour, neighList%neighDist2, img2CentCell, &
+        & self%covRad, self%en, self%tENScale, self%kcn, self%countFunc, &
+        & self%countDeriv, self%cn, self%dcndr, self%dcndL)
+
+    if (self%tCutCN) then
+      call cutCoordinationNumber(self%nAtom, self%cn, self%dcndr, self%dcndL, &
+          & self%maxCN)
+    end if
+
+    self%tCoordsUpdated = .true.
+
+  end subroutine updateCoords
+
+
+  !> update internal copy of lattice vectors
+  subroutine updateLatVecs(self, latVecs)
+
+    !> data structure
+    class(TCNCont), intent(inout) :: self
+
+    !> lattice vectors
+    real(dp), intent(in) :: latVecs(:,:)
+
+    @:ASSERT(self%tPeriodic)
+    @:ASSERT(all(shape(latvecs) == shape(self%latvecs)))
+
+    self%latVecs(:,:) = latVecs
+
+    self%tCoordsUpdated = .false.
+
+  end subroutine updateLatVecs
+
+
+  !> get force contributions
+  subroutine addGradients(self, dEdcn, gradients)
+
+    !> data structure
+    class(TCNCont), intent(inout) :: self
+
+    !> Derivative w.r.t. CM5 correction
+    real(dp), intent(in) :: dEdcn(:)
+
+    !> gradient contributions for each atom
+    real(dp), intent(inout) :: gradients(:,:)
+
+    @:ASSERT(self%tCoordsUpdated)
+    @:ASSERT(all(shape(stress) == [3, self%nAtom]))
+
+    call gemv(gradients, self%dcndr, dEdcn, beta=1.0_dp)
+
+  end subroutine addGradients
+
+
+  !> get stress tensor contributions
+  subroutine addStress(self, dEdcn, stress)
+
+    !> data structure
+    class(TCNCont), intent(inout) :: self
+
+    !> Derivative w.r.t. CM5 correction
+    real(dp), intent(in) :: dEdcn(:)
+
+    !> Stress tensor contributions (not volume scaled)
+    real(dp), intent(inout) :: stress(:,:)
+
+    @:ASSERT(self%tCoordsUpdated)
+    @:ASSERT(all(shape(stress) == [3, 3]))
+
+    call gemv(stress, self%dcndL, dEdcn, beta=1.0_dp)
+
+  end subroutine addStress
+
+
+  !> Distance cut off for coordination number
+  function getRCutoff(self) result(cutoff)
+
+    !> data structure
+    class(TCNCont), intent(inout) :: self
+
+    !> resulting cutoff
+    real(dp) :: cutoff
+
+    cutoff = self%rCutoff
+
+  end function getRCutoff
+
+
+  !> Actual implementation of the coordination number calculation
+  subroutine getCoordinationNumber(nAtom, coords, species, nNeighbour, iNeighbour,&
+      & neighDist2, img2CentCell, covalentRadius, electronegativity, tENscale, &
+      & kcn, countFunc, countDeriv, cn, dcndr, dcndL)
+
+    !> Nr. of atoms (without periodic images)
+    integer, intent(in) :: nAtom
+
+    !> Coordinates of the atoms (including images)
+    real(dp), intent(in) :: coords(:, :)
+
+    !> Species of every atom.
+    integer, intent(in) :: species(:)
+
+    !> Nr. of neighbours for each atom
+    integer, intent(in) :: nNeighbour(:)
+
+    !> Neighbourlist.
+    integer, intent(in) :: iNeighbour(0:, :)
+
+    !> Square distances of the neighbours.
+    real(dp), intent(in) :: neighDist2(0:, :)
+
+    !> Mapping into the central cell.
+    integer, intent(in) :: img2CentCell(:)
+
+    !> Use covalent coordination number by weighting with EN difference.
+    logical, intent(in) :: tENscale
+
+    !> Covalent Radii for counting function
+    real(dp), intent(in) :: covalentRadius(:)
+
+    !> Electronegativities for covalancy scaling
+    real(dp), intent(in) :: electronegativity(:)
+
+    !> Steepness of the counting function for the fractional coordination number.
+    real(dp), intent(in) :: kcn
+
+    !> Counting function for CN
+    procedure(countFunction) :: countFunc
+
+    !> Derivative of counting function w.r.t. distance
+    procedure(countFunction) :: countDeriv
+
+    !> Error function coordination number.
+    real(dp), intent(out) :: cn(:)
+
+    !> Derivative of the CN with respect to the Cartesian coordinates.
+    real(dp), intent(out) :: dcndr(:, :, :)
+
+    !> Derivative of the CN with respect to strain deformations.
+    real(dp), intent(out) :: dcndL(:, :, :)
+
+    !> EN scaling parameter
+    real(dp), parameter :: k4 = 4.10451_dp
+    real(dp), parameter :: k5 = 19.08857_dp
+    real(dp), parameter :: k6 = 2*11.28174_dp**2
+
+    integer :: iAt1, iSp1, iAt2, iAt2f, iSp2, iNeigh
+    real(dp) :: r2, r1, rc, vec(3), countf, countd(3), stress(3, 3), dEN
+
+    cn(:) = 0.0_dp
+    dcndr(:, :, :) = 0.0_dp
+    dcndL(:, :, :) = 0.0_dp
+
+    !$omp parallel do default(none) schedule(runtime) &
+    !$omp reduction(+:cn, dcndr, dcndL) &
+    !$omp shared(nAtom, species, nNeighbour, iNeighbour, coords, img2CentCell) &
+    !$omp shared(neighDist2, covalentRadius, tENScale, electronegativity, kcn) &
+    !$omp private(iAt1, iSp1, iAt2, vec, iAt2f, iSp2, r2, r1, rc, dEN, countf) &
+    !$omp private(countd, stress)
+    do iAt1 = 1, nAtom
+      iSp1 = species(iAt1)
+      do iNeigh = 1, nNeighbour(iAt1)
+        iAt2 = iNeighbour(iNeigh, iAt1)
+        vec(:) = coords(:, iAt1) - coords(:, iAt2)
+        iAt2f = img2CentCell(iAt2)
+        iSp2 = species(iAt2f)
+        r2 = neighDist2(iNeigh, iAt1)
+        r1 = sqrt(r2)
+
+        rc = covalentRadius(iSp1) + covalentRadius(iSp2)
+
+        if (tENScale) then
+          dEN = abs(electronegativity(iSp1) - electronegativity(iSp2))
+          dEN = k4 * exp(-(dEN + k5)**2 / k6)
+        else
+          dEN = 1.0_dp
+        end if
+
+        countf = dEN * countFunc(kcn, r1, rc)
+        countd = dEN * countDeriv(kcn, r1, rc) * vec / r1
+
+        cn(iAt1) = cn(iAt1) + countf
+        if (iAt1 /= iAt2f) then
+          cn(iAt2f) = cn(iAt2f) + countf
+        end if
+
+        dcndr(:, iAt1, iAt1) = dcndr(:, iAt1, iAt1) + countd
+        dcndr(:, iAt2f, iAt2f) = dcndr(:, iAt2f, iAt2f) - countd
+        dcndr(:, iAt1, iAt2f) = dcndr(:, iAt1, iAt2f) + countd
+        dcndr(:, iAt2f, iAt1) = dcndr(:, iAt2f, iAt1) - countd
+
+        stress = spread(countd, 1, 3) * spread(vec, 2, 3)
+
+        dcndL(:, :, iAt1) = dcndL(:, :, iAt1) - stress
+        if (iAt1 /= iAt2f) then
+          dcndL(:, :, iAt2f) = dcndL(:, :, iAt2f) - stress
+        end if
+
+      end do
+    end do
+    !$omp end parallel do
+  end subroutine getCoordinationNumber
+
+
+  !> Error function counting function for coordination number contributions.
+  pure function erfCount(k, r, r0) result(count)
+
+    !> Steepness of the counting function.
+    real(dp), intent(in) :: k
+
+    !> Current distance.
+    real(dp), intent(in) :: r
+
+    !> Cutoff radius.
+    real(dp), intent(in) :: r0
+
+    real(dp) :: count
+
+    count = 0.5_dp * (1.0_dp + erf(-k*(r-r0)/r0))
+
+  end function erfCount
+
+
+  !> Derivative of the counting function w.r.t. the distance.
+  pure function derfCount(k, r, r0) result(count)
+
+    !> Steepness of the counting function.
+    real(dp), intent(in) :: k
+
+    !> Current distance.
+    real(dp), intent(in) :: r
+
+    !> Cutoff radius.
+    real(dp), intent(in) :: r0
+
+    real(dp), parameter :: sqrtpi = sqrt(pi)
+
+    real(dp) :: count
+
+    count = -k/sqrtpi/r0*exp(-k**2*(r-r0)**2/r0**2)
+
+  end function derfCount
+
+
+  !> Exponential counting function for coordination number contributions.
+  pure function expCount(k, r, r0) result(count)
+
+    !> Steepness of the counting function.
+    real(dp), intent(in) :: k
+
+    !> Current distance.
+    real(dp), intent(in) :: r
+
+    !> Cutoff radius.
+    real(dp), intent(in) :: r0
+
+    real(dp) :: count
+
+    count =1.0_dp/(1.0_dp+exp(-k*(r0/r-1.0_dp)))
+
+  end function expCount
+
+
+  !> Derivative of the counting function w.r.t. the distance.
+  pure function dexpCount(k, r, r0) result(count)
+
+    !> Steepness of the counting function.
+    real(dp), intent(in) :: k
+
+    !> Current distance.
+    real(dp), intent(in) :: r
+
+    !> Cutoff radius.
+    real(dp), intent(in) :: r0
+
+    real(dp) :: count
+    real(dp) :: expterm
+
+    expterm = exp(-k*(r0/r-1._dp))
+
+    count = (-k*r0*expterm)/(r**2*((expterm+1._dp)**2))
+
+  end function dexpCount
+
+
+  !> Exponential counting function for coordination number contributions.
+  pure function gfnCount(k, r, r0) result(count)
+
+    !> Steepness of the counting function.
+    real(dp), intent(in) :: k
+
+    !> Current distance.
+    real(dp), intent(in) :: r
+
+    !> Cutoff radius.
+    real(dp), intent(in) :: r0
+
+    real(dp) :: count
+
+    count = expCount(k, r, r0) * expCount(2*k, r, r0+2)
+
+  end function gfnCount
+
+
+  !> Derivative of the counting function w.r.t. the distance.
+  pure function dgfnCount(k, r, r0) result(count)
+
+    !> Steepness of the counting function.
+    real(dp), intent(in) :: k
+
+    !> Current distance.
+    real(dp), intent(in) :: r
+
+    !> Cutoff radius.
+    real(dp), intent(in) :: r0
+
+    real(dp) :: count
+
+    count = dexpCount(k, r, r0) * expCount(2*k, r, r0+2) &
+        &  + expCount(k, r, r0) * dexpCount(2*k, r, r0+2)
+
+  end function dgfnCount
+
+
+  !> Cutoff function for large coordination numbers
+  pure subroutine cutCoordinationNumber(nAtom, cn, dcndr, dcndL, maxCN)
+
+   !> number of atoms
+    integer, intent(in) :: nAtom
+
+    !> on input coordination number, on output modified CN
+    real(dp), intent(inout) :: cn(:)
+
+    !> on input derivative of CN w.r.t. cartesian coordinates,
+    !> on output derivative of modified CN
+    real(dp), intent(inout), optional :: dcndr(:, :, :)
+
+    !> on input derivative of CN w.r.t. strain deformation,
+    !> on output derivative of modified CN
+    real(dp), intent(inout), optional :: dcndL(:, :, :)
+
+    !> maximum CN (not strictly obeyed)
+    real(dp), intent(in), optional :: maxCN
+
+    real(dp) :: cnmax
+    integer :: iAt
+
+    if (present(maxCN)) then
+      cnmax = maxCN
+    else
+      cnmax = 4.5_dp
+    end if
+
+    if (cnmax <= 0.0_dp) return
+
+    if (present(dcndL)) then
+      do iAt = 1, nAtom
+        dcndL(:, :, iAt) = dcndL(:, :, iAt) * dCutCN(cn(iAt), cnmax)
+      end do
+    end if
+
+    if (present(dcndr)) then
+      do iAt = 1, nAtom
+        dcndr(:, :, iAt) = dcndr(:, :, iAt) * dCutCN(cn(iAt), cnmax)
+      end do
+    end if
+
+    do iAt = 1, nAtom
+      cn(iAt) = cutCN(cn(iAt), cnmax)
+    end do
+
+  end subroutine cutCoordinationNumber
+
+
+  !> Cutting function for the coordination number.
+  elemental function cutCN(cn, cut) result(cnp)
+
+    !> Current coordination number.
+    real(dp), intent(in) :: cn
+
+    !> Cutoff for the CN, this is not the maximum value.
+    real(dp), intent(in) :: cut
+
+    !> Cuting function vlaue
+    real(dp) :: cnp
+
+    cnp = log(1.0_dp + exp(cut)) - log(1.0_dp + exp(cut - cn))
+
+  end function cutCN
+
+
+  !> Derivative of the cutting function w.r.t. coordination number
+  elemental function dCutCN(cn, cut) result(dcnpdcn)
+
+    !> Current coordination number.
+    real(dp), intent(in) :: cn
+
+    !> Cutoff for the CN, this is not the maximum value.
+    real(dp), intent(in) :: cut
+
+    !> Derivative of the cutting function
+    real(dp) :: dcnpdcn
+
+    dcnpdcn = exp(cut)/(exp(cut) + exp(cn))
+
+  end function dCutCn
+
+
+  !> Populate covalent radius field from speciesNames
+  subroutine covRadFromSpecies(self, speciesNames)
+
+    !> Instance of the CN input data
+    class(TCNInput), intent(inout) :: self
+
+    !> Element symbols for all species
+    character(len=*), intent(in) :: speciesNames(:)
+
+    integer :: iSp
+
+    @:ASSERT(.not.allocated(self%covRad))
+
+    allocate(self%covRad(size(speciesNames)))
+    do iSp = 1, size(speciesNames)
+      self%covRad(iSp) = getCovalentRadius(speciesNames(iSp))
+    end do
+
+  end subroutine covRadFromSpecies
+
+
+  !> Get covalent radius for species with a given symbol
+  elemental function getCovalentRadiusSymbol(symbol) result(radius)
+
+    !> Element symbol
+    character(len=*), intent(in) :: symbol
+
+    !> atomic radius
+    real(dp) :: radius
+
+    radius = getCovalentRadius(symbolToNumber(symbol))
+
+  end function getCovalentRadiusSymbol
+
+
+  !> Get covalent radius for species with a given atomic number
+  elemental function getCovalentRadiusNumber(number) result(radius)
+
+    !> Atomic number
+    integer, intent(in) :: number
+
+    !> atomic radius
+    real(dp) :: radius
+
+    if (number > 0 .and. number <= size(CovalentRadii, dim=1)) then
+      radius = CovalentRadii(number)
+    else
+      radius = -1.0_dp
+    end if
+
+  end function getCovalentRadiusNumber
+
+
+  !> Populate electronegativity field from speciesNames
+  subroutine enFromSpecies(self, speciesNames)
+
+    !> Instance of the CN input data
+    class(TCNInput), intent(inout) :: self
+
+    !> Element symbols for all species
+    character(len=*), intent(in) :: speciesNames(:)
+
+    integer :: iSp
+
+    @:ASSERT(.not.allocated(self%en))
+
+    allocate(self%en(size(speciesNames)))
+    do iSp = 1, size(speciesNames)
+      self%en(iSp) = getElectronegativity(speciesNames(iSp))
+    end do
+
+  end subroutine enFromSpecies
+
+
+  !> Get electronegativity for species with a given symbol
+  elemental function getElectronegativitySymbol(symbol) result(en)
+
+    !> Element symbol
+    character(len=*), intent(in) :: symbol
+
+    !> atomic EN
+    real(dp) :: en
+
+    en = getElectronegativity(symbolToNumber(symbol))
+
+  end function getElectronegativitySymbol
+
+
+  !> Get electronegativity for species with a given atomic number
+  elemental function getElectronegativityNumber(number) result(en)
+
+    !> Atomic number
+    integer, intent(in) :: number
+
+    !> atomic EN
+    real(dp) :: en
+
+    if (number > 0 .and. number <= size(paulingEN, dim=1)) then
+      en = paulingEN(number)
+    else
+      en = -1.0_dp
+    end if
+
+  end function getElectronegativityNumber
+
+
+end module dftbp_coordinationnumber

--- a/prog/dftb+/lib_dftb/dftd4param.F90
+++ b/prog/dftb+/lib_dftb/dftd4param.F90
@@ -13,7 +13,7 @@ module dftbp_dftd4param
   use dftbp_accuracy, only : dp
   use dftbp_constants, only : pi, AA__Bohr, symbolToNumber
   use dftbp_encharges, only : TEeqInput
-  use dftbp_coordinationnumber, only : TCNCont, TCNInput, cnType
+  use dftbp_coordnumber, only : TCNCont, TCNInput, cnType
   use dftbp_dftd4refs
   implicit none
 

--- a/prog/dftb+/lib_dftb/dftd4param.F90
+++ b/prog/dftb+/lib_dftb/dftd4param.F90
@@ -13,13 +13,13 @@ module dftbp_dftd4param
   use dftbp_accuracy, only : dp
   use dftbp_constants, only : pi, AA__Bohr, symbolToNumber
   use dftbp_encharges, only : TEeqInput
+  use dftbp_coordinationnumber, only : TCNCont, TCNInput, cnType
   use dftbp_dftd4refs
   implicit none
 
   public :: TDftD4Calculator, TDispDftD4Inp, initializeCalculator
   public :: getEeqChi, getEeqGam, getEeqKcn, getEeqRad
   public :: getChemicalHardness, getEffectiveNuclearCharge, getSqrtZr4r2
-  public :: getCovalentRadiusD3, getPaulingEN
   private
 
   !> Element-specific electronegativity for the electronegativity equilibration charges used in
@@ -62,18 +62,6 @@ module dftbp_dftd4param
     module procedure :: getEffectiveNuclearChargeSymbol
     module procedure :: getEffectiveNuclearChargeNumber
   end interface getEffectiveNuclearCharge
-
-  !> Covalent radii used for coordination number.
-  interface getCovalentRadiusD3
-    module procedure :: getCovalentRadiusD3Symbol
-    module procedure :: getCovalentRadiusD3Number
-  end interface getCovalentRadiusD3
-
-  !> Pauling electronegativities, used for the covalent coordination number.
-  interface getPaulingEN
-    module procedure :: getPaulingENSymbol
-    module procedure :: getPaulingENNumber
-  end interface getPaulingEN
 
   !> PBE0/def2-QZVP atomic <r⁴>/<r²> expectation values.
   interface getSqrtZr4r2
@@ -123,9 +111,6 @@ module dftbp_dftd4param
     !> Cutoff radius for dispersion interactions.
     real(dp) :: cutoffInter = 64.0_dp
 
-    !> Cutoff radius for CN counting function.
-    real(dp) :: cutoffCount = 40.0_dp
-
     !> Cutoff radius for three-body interactions.
     real(dp) :: cutoffThree = 40.0_dp
 
@@ -140,6 +125,9 @@ module dftbp_dftd4param
 
     !> Input for EEQ charge model
     type(TEeqInput) :: eeqInput
+
+    !> Coordination number specific input
+    type(TCNInput) :: cnInput
 
   end type TDispDftD4Inp
 
@@ -181,9 +169,6 @@ module dftbp_dftd4param
     !> Cutoff radius for dispersion interactions.
     real(dp) :: cutoffInter
 
-    !> Cutoff radius for CN counting function.
-    real(dp) :: cutoffCount
-
     !> Cutoff radius for three-body interactions.
     real(dp) :: cutoffThree
 
@@ -192,12 +177,6 @@ module dftbp_dftd4param
 
     !> Atomic expectation values for extrapolation of C6 coefficients
     real(dp), allocatable :: sqrtZr4r2(:)
-
-    !> Electronegativities for covalent CN
-    real(dp), allocatable :: electronegativity(:)
-
-    !> Covalent radius for coordination number
-    real(dp), allocatable :: covalentRadius(:)
 
     !> Chemical hardnesses for charge scaling function
     real(dp), allocatable :: chemicalHardness(:)
@@ -355,61 +334,6 @@ module dftbp_dftd4param
     &   9,10,11,30,31,32,33,34,35,36,37,38,39,40,41,42,43,  & ! Fr-Lr
     &  12,13,14,15,16,17,18,19,20,21,22,23,24,25,26] ! Rf-Og
 
-  !> Covalent radii (taken from Pyykko and Atsumi, Chem. Eur. J. 15, 2009, 188-197), values for
-  !> metals decreased by 10%.
-  real(dp), parameter :: CovalentRadiusD3(maxElementD4) = [ &
-    & 0.32_dp,0.46_dp, & ! H,He
-    & 1.20_dp,0.94_dp,0.77_dp,0.75_dp,0.71_dp,0.63_dp,0.64_dp,0.67_dp, & ! Li-Ne
-    & 1.40_dp,1.25_dp,1.13_dp,1.04_dp,1.10_dp,1.02_dp,0.99_dp,0.96_dp, & ! Na-Ar
-    & 1.76_dp,1.54_dp, & ! K,Ca
-    &                 1.33_dp,1.22_dp,1.21_dp,1.10_dp,1.07_dp, & ! Sc-
-    &                 1.04_dp,1.00_dp,0.99_dp,1.01_dp,1.09_dp, & ! -Zn
-    &                 1.12_dp,1.09_dp,1.15_dp,1.10_dp,1.14_dp,1.17_dp, & ! Ga-Kr
-    & 1.89_dp,1.67_dp, & ! Rb,Sr
-    &                 1.47_dp,1.39_dp,1.32_dp,1.24_dp,1.15_dp, & ! Y-
-    &                 1.13_dp,1.13_dp,1.08_dp,1.15_dp,1.23_dp, & ! -Cd
-    &                 1.28_dp,1.26_dp,1.26_dp,1.23_dp,1.32_dp,1.31_dp, & ! In-Xe
-    & 2.09_dp,1.76_dp, & ! Cs,Ba
-    &         1.62_dp,1.47_dp,1.58_dp,1.57_dp,1.56_dp,1.55_dp,1.51_dp, & ! La-Eu
-    &         1.52_dp,1.51_dp,1.50_dp,1.49_dp,1.49_dp,1.48_dp,1.53_dp, & ! Gd-Yb
-    &                 1.46_dp,1.37_dp,1.31_dp,1.23_dp,1.18_dp, & ! Lu-
-    &                 1.16_dp,1.11_dp,1.12_dp,1.13_dp,1.32_dp, & ! -Hg
-    &                 1.30_dp,1.30_dp,1.36_dp,1.31_dp,1.38_dp,1.42_dp, & ! Tl-Rn
-    & 2.01_dp,1.81_dp, & ! Fr,Ra
-    &         1.67_dp,1.58_dp,1.52_dp,1.53_dp,1.54_dp,1.55_dp,1.49_dp, & ! Ac-Am
-    &         1.49_dp,1.51_dp,1.51_dp,1.48_dp,1.50_dp,1.56_dp,1.58_dp, & ! Cm-No
-    &                 1.45_dp,1.41_dp,1.34_dp,1.29_dp,1.27_dp, & ! Lr-
-    &                 1.21_dp,1.16_dp,1.15_dp,1.09_dp,1.22_dp, & ! -Cn
-    &                 1.36_dp,1.43_dp,1.46_dp,1.58_dp,1.48_dp,1.57_dp] & ! Nh-Og
-    & * AA__Bohr * 4.0_dp / 3.0_dp
-
-  !> Pauling electronegativities, used for the covalent coordination number.
-  real(dp), parameter :: paulingEN(maxElementD4) = [ &
-    & 2.20_dp,3.00_dp, & ! H,He
-    & 0.98_dp,1.57_dp,2.04_dp,2.55_dp,3.04_dp,3.44_dp,3.98_dp,4.50_dp, & ! Li-Ne
-    & 0.93_dp,1.31_dp,1.61_dp,1.90_dp,2.19_dp,2.58_dp,3.16_dp,3.50_dp, & ! Na-Ar
-    & 0.82_dp,1.00_dp, & ! K,Ca
-    &                 1.36_dp,1.54_dp,1.63_dp,1.66_dp,1.55_dp, & ! Sc-
-    &                 1.83_dp,1.88_dp,1.91_dp,1.90_dp,1.65_dp, & ! -Zn
-    &                 1.81_dp,2.01_dp,2.18_dp,2.55_dp,2.96_dp,3.00_dp, & ! Ga-Kr
-    & 0.82_dp,0.95_dp, & ! Rb,Sr
-    &                 1.22_dp,1.33_dp,1.60_dp,2.16_dp,1.90_dp, & ! Y-
-    &                 2.20_dp,2.28_dp,2.20_dp,1.93_dp,1.69_dp, & ! -Cd
-    &                 1.78_dp,1.96_dp,2.05_dp,2.10_dp,2.66_dp,2.60_dp, & ! In-Xe
-    & 0.79_dp,0.89_dp, & ! Cs,Ba
-    &         1.10_dp,1.12_dp,1.13_dp,1.14_dp,1.15_dp,1.17_dp,1.18_dp, & ! La-Eu
-    &         1.20_dp,1.21_dp,1.22_dp,1.23_dp,1.24_dp,1.25_dp,1.26_dp, & ! Gd-Yb
-    &                 1.27_dp,1.30_dp,1.50_dp,2.36_dp,1.90_dp, & ! Lu-
-    &                 2.20_dp,2.20_dp,2.28_dp,2.54_dp,2.00_dp, & ! -Hg
-    &                 1.62_dp,2.33_dp,2.02_dp,2.00_dp,2.20_dp,2.20_dp, & ! Tl-Rn
-    ! only dummies below
-    & 1.50_dp,1.50_dp, & ! Fr,Ra
-    &         1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp, & ! Ac-Am
-    &         1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp, & ! Cm-No
-    &                 1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp, & ! Rf-
-    &                 1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp, & ! Rf-Cn
-    &                 1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp,1.50_dp ] ! Nh-Og
-
 
   !> PBE0/def2-QZVP atomic <r⁴>/<r²> expectation values.
   real(dp), parameter :: r4r2(maxElementD4) = [ &
@@ -533,8 +457,6 @@ contains
     calculator%nSpecies = nSpecies
 
     calculator%sqrtZr4r2 = getSqrtZr4r2(speciesNames)
-    calculator%covalentRadius = getCovalentRadiusD3(speciesNames)
-    calculator%electronegativity = getPaulingEN(speciesNames)
     calculator%ChemicalHardness = getChemicalHardness(speciesNames)
     calculator%EffectiveNuclearCharge = getEffectiveNuclearCharge(speciesNames)
 
@@ -546,7 +468,6 @@ contains
     calculator%a2 = input%a2
     calculator%alpha = input%alpha
 
-    calculator%cutoffCount = input%cutoffCount
     calculator%cutoffInter = input%cutoffInter
     calculator%cutoffThree = input%cutoffThree
 
@@ -810,70 +731,6 @@ contains
     end if
 
   end function getEffectiveNuclearChargeNumber
-
-
-  !> Get covalent radius for species with a given symbol
-  elemental function getCovalentRadiusD3Symbol(symbol) result(rad)
-
-    !> Element symbol
-    character(len=*), intent(in) :: symbol
-
-    !> Covalent radius
-    real(dp) :: rad
-
-    rad = getCovalentRadiusD3(symbolToNumber(symbol))
-
-  end function getCovalentRadiusD3Symbol
-
-
-  !> Get covalent radius for species with a given atomic number
-  elemental function getCovalentRadiusD3Number(number) result(rad)
-
-    !> Atomic number
-    integer, intent(in) :: number
-
-    !> Covalent radius
-    real(dp) :: rad
-
-    if (number > 0 .and. number <= size(covalentRadiusD3, dim=1)) then
-      rad = covalentRadiusD3(number)
-    else
-      rad = -1.0_dp
-    end if
-
-  end function getCovalentRadiusD3Number
-
-
-  !> Get electronegativity for species with a given symbol
-  elemental function getPaulingENSymbol(symbol) result(en)
-
-    !> Element symbol
-    character(len=*), intent(in) :: symbol
-
-    !> Electronegativity
-    real(dp) :: en
-
-    en = getPaulingEN(symbolToNumber(symbol))
-
-  end function getPaulingENSymbol
-
-
-  !> Get electronegativity for species with a given atomic number
-  elemental function getPaulingENNumber(number) result(en)
-
-    !> Atomic number
-    integer, intent(in) :: number
-
-    !> Electronegativity
-    real(dp) :: en
-
-    if (number > 0 .and. number <= size(paulingEN, dim=1)) then
-      en = paulingEN(number)
-    else
-      en = -1.0_dp
-    end if
-
-  end function getPaulingENNumber
 
 
   !> Get atomic expectation value for species with a given symbol

--- a/prog/dftb+/lib_dftb/dispdftd4.F90
+++ b/prog/dftb+/lib_dftb/dispdftd4.F90
@@ -15,7 +15,7 @@ module dftbp_dispdftd4
   use dftbp_environment, only : TEnvironment
   use dftbp_blasroutines, only : gemv
   use dftbp_constants, only : pi, symbolToNumber
-  use dftbp_coordinationnumber, only : TCNCont, init
+  use dftbp_coordnumber, only : TCNCont, init
   use dftbp_dftd4param, only : TDftD4Calculator, TDispDftD4Inp, initializeCalculator
   use dftbp_dispiface, only : TDispersionIface
   use dftbp_encharges, only : TEeqCont, init

--- a/prog/dftb+/lib_dftb/dispdftd4.F90
+++ b/prog/dftb+/lib_dftb/dispdftd4.F90
@@ -15,6 +15,7 @@ module dftbp_dispdftd4
   use dftbp_environment, only : TEnvironment
   use dftbp_blasroutines, only : gemv
   use dftbp_constants, only : pi, symbolToNumber
+  use dftbp_coordinationnumber, only : TCNCont, init
   use dftbp_dftd4param, only : TDftD4Calculator, TDispDftD4Inp, initializeCalculator
   use dftbp_dispiface, only : TDispersionIface
   use dftbp_encharges, only : TEeqCont, init
@@ -59,6 +60,9 @@ module dftbp_dispdftd4
 
     !> EEQ model
     type(TEeqCont) :: eeqCont
+
+    !> Coordination number
+    type(TCNCont) :: cnCont
 
   contains
 
@@ -119,8 +123,10 @@ contains
 
     if (this%tPeriodic) then
       call init(this%eeqCont, inp%eeqInput, .false., .true., nAtom, latVecs)
+      call init(this%cnCont, inp%cnInput, nAtom, latVecs)
     else
       call init(this%eeqCont, inp%eeqInput, .false., .true., nAtom)
+      call init(this%cnCont, inp%cnInput, nAtom)
     end if
 
     this%tCoordsUpdated = .false.
@@ -165,11 +171,11 @@ contains
 
     if (this%tPeriodic) then
       call dispersionEnergy(this%calculator, this%nAtom, coords, species0, neigh, img2CentCell,&
-          & this%eeqCont, this%energies, this%gradients, stress=this%stress, volume=this%vol,&
-          & parEwald=this%eeqCont%parEwald)
+          & this%eeqCont, this%cnCont, this%energies, this%gradients, &
+          & stress=this%stress, volume=this%vol, parEwald=this%eeqCont%parEwald)
     else
       call dispersionEnergy(this%calculator, this%nAtom, coords, species0, neigh, img2CentCell,&
-          & this%eeqCont, this%energies, this%gradients)
+          & this%eeqCont, this%cnCont, this%energies, this%gradients)
     end if
 
     this%tCoordsUpdated = .true.
@@ -195,6 +201,7 @@ contains
     this%vol = abs(determinant33(latVecs))
 
     call this%eeqCont%updateLatVecs(latVecs)
+    call this%cnCont%updateLatVecs(LatVecs)
 
     this%tCoordsUpdated = .false.
 
@@ -264,167 +271,10 @@ contains
     !> Resulting cutoff
     real(dp) :: cutoff
 
-    cutoff = max(this%calculator%cutoffInter, this%calculator%cutoffCount,&
+    cutoff = max(this%calculator%cutoffInter, this%cnCont%getRCutoff(),&
         & this%eeqCont%getRCutoff(), this%calculator%cutoffThree)
 
   end function getRCutoff
-
-
-  !> Error function based fractional coordination number.
-  subroutine getCoordinationNumber(nAtom, coords, species, nNeighbour, iNeighbour, neighDist2,&
-      & img2CentCell, covalentRadius, electronegativity, tENscale, cn, dcndr, dcndL)
-
-    !> Nr. of atoms (without periodic images)
-    integer, intent(in) :: nAtom
-
-    !> Coordinates of the atoms (including images)
-    real(dp), intent(in) :: coords(:, :)
-
-    !> Species of every atom.
-    integer, intent(in) :: species(:)
-
-    !> Nr. of neighbours for each atom
-    integer, intent(in) :: nNeighbour(:)
-
-    !> Neighbourlist.
-    integer, intent(in) :: iNeighbour(0:, :)
-
-    !> Square distances of the neighbours.
-    real(dp), intent(in) :: neighDist2(0:, :)
-
-    !> Mapping into the central cell.
-    integer, intent(in) :: img2CentCell(:)
-
-    !> Use covalent coordination number by weighting with EN difference.
-    logical, intent(in) :: tENscale
-
-    !> Covalent Radii for counting function
-    real(dp), intent(in) :: covalentRadius(:)
-
-    !> Electronegativities for covalancy scaling
-    real(dp), intent(in) :: electronegativity(:)
-
-    !> Error function coordination number.
-    real(dp), intent(out) :: cn(:)
-
-    !> Derivative of the CN with respect to the Cartesian coordinates.
-    real(dp), intent(out) :: dcndr(:, :, :)
-
-    !> Derivative of the CN with respect to strain deformations.
-    real(dp), intent(out) :: dcndL(:, :, :)
-
-    !> Steepness of the counting function for the fractional coordination number.
-    real(dp), parameter :: kcn = 7.5_dp
-    !> EN scaling parameter
-    real(dp), parameter :: k4 = 4.10451_dp
-    real(dp), parameter :: k5 = 19.08857_dp
-    real(dp), parameter :: k6 = 2*11.28174_dp**2
-
-    integer :: iAt1, iSp1, iAt2, iAt2f, iSp2, iNeigh
-    real(dp) :: r2, r1, rc, vec(3), countf, countd(3), stress(3, 3), dEN
-
-    cn(:) = 0.0_dp
-    dcndr(:, :, :) = 0.0_dp
-    dcndL(:, :, :) = 0.0_dp
-
-    !$OMP PARALLEL DEFAULT(NONE) REDUCTION(+:cn, dcndr, dcndL) &
-    !$OMP SHARED(nAtom, species, nNeighbour, iNeighbour, coords, img2CentCell) &
-    !$OMP SHARED(neighDist2, covalentRadius, tENScale, electronegativity) &
-    !$OMP PRIVATE(iAt1, iSp1, iAt2, vec, iAt2f, iSp2, r2, r1, rc, dEN, countf) &
-    !$OMP PRIVATE(countd, stress)
-    !$OMP DO SCHEDULE(RUNTIME)
-    do iAt1 = 1, nAtom
-      iSp1 = species(iAt1)
-      do iNeigh = 1, nNeighbour(iAt1)
-        iAt2 = iNeighbour(iNeigh, iAt1)
-        vec(:) = coords(:, iAt1) - coords(:, iAt2)
-        iAt2f = img2CentCell(iAt2)
-        iSp2 = species(iAt2f)
-        r2 = neighDist2(iNeigh, iAt1)
-        r1 = sqrt(r2)
-
-        rc = covalentRadius(iSp1) + covalentRadius(iSp2)
-
-        if (tENScale) then
-          dEN = abs(electronegativity(iSp1) - electronegativity(iSp2))
-          dEN = k4 * exp(-(dEN + k5)**2 / k6)
-        else
-          dEN = 1.0_dp
-        end if
-
-        countf = dEN * erfCount(kcn, r1, rc)
-        countd = dEN * derfCount(kcn, r1, rc) * vec / r1
-
-        cn(iAt1) = cn(iAt1) + countf
-        if (iAt1 /= iAt2f) then
-          cn(iAt2f) = cn(iAt2f) + countf
-        end if
-
-        dcndr(:, iAt1, iAt1) = dcndr(:, iAt1, iAt1) + countd
-        dcndr(:, iAt2f, iAt2f) = dcndr(:, iAt2f, iAt2f) - countd
-        dcndr(:, iAt1, iAt2f) = dcndr(:, iAt1, iAt2f) + countd
-        dcndr(:, iAt2f, iAt1) = dcndr(:, iAt2f, iAt1) - countd
-
-        stress = spread(countd, 1, 3) * spread(vec, 2, 3)
-
-        dcndL(:, :, iAt1) = dcndL(:, :, iAt1) - stress
-        if (iAt1 /= iAt2f) then
-          dcndL(:, :, iAt2f) = dcndL(:, :, iAt2f) - stress
-        end if
-
-      end do
-    end do
-    !$OMP END DO
-    !$OMP END PARALLEL
-  end subroutine getCoordinationNumber
-
-
-  !> cutoff function for large coordination numbers
-  subroutine cutCoordinationNumber(nAtom, cn, dcndr, dcndL, cn_max)
-
-    !> number of atoms
-    integer, intent(in) :: nAtom
-
-    !> on input coordination number, on output modified CN
-    real(dp), intent(inout) :: cn(:)
-
-    !> on input derivative of CN w.r.t. cartesian coordinates,
-    !> on output derivative of modified CN
-    real(dp), intent(inout), optional :: dcndr(:, :, :)
-
-    !> on input derivative of CN w.r.t. strain deformation,
-    !> on output derivative of modified CN
-    real(dp), intent(inout), optional :: dcndL(:, :, :)
-
-    !> maximum CN (not strictly obeyed)
-    real(dp), intent(in), optional :: cn_max
-
-    real(dp) :: cnmax
-    integer :: iAt
-
-    if (present(cn_max)) then
-      cnmax = cn_max
-    else
-      cnmax = 4.5_dp
-    end if
-
-    if (cnmax <= 0.0_dp) return
-
-    if (present(dcndL)) then
-      do iAt = 1, nAtom
-        dcndL(:, :, iAt) = dcndL(:, :, iAt) * dCutCN(cn(iAt), cnmax)
-      end do
-    end if
-
-    if (present(dcndr)) then
-      do iAt = 1, nAtom
-        dcndr(:, :, iAt) = dcndr(:, :, iAt) * dCutCN(cn(iAt), cnmax)
-      end do
-    end if
-
-    cn(:) = cutCN(cn, cnmax)
-
-  end subroutine cutCoordinationNumber
 
 
   !> Calculate the weights of the reference systems and scale them according
@@ -956,8 +806,8 @@ contains
 
 
   !> Driver for the calculation of DFT-D4 dispersion related properties.
-  subroutine dispersionEnergy(calculator, nAtom, coords, species, neigh, img2CentCell, eeqCont,&
-      & energies, gradients, stress, volume, parEwald)
+  subroutine dispersionEnergy(calculator, nAtom, coords, species, neigh, img2CentCell, &
+      & eeqCont, cnCont, energies, gradients, stress, volume, parEwald)
 
     !> DFT-D dispersion model.
     type(TDftD4Calculator), intent(in) :: calculator
@@ -980,6 +830,9 @@ contains
     !> EEQ model
     type(TEeqCont), intent(inout) :: eeqCont
 
+    !> Coordination number
+    type(TCNCont), intent(inout) :: cnCont
+
     !> Parameter for Ewald summation.
     real(dp), intent(in), optional :: parEwald
 
@@ -995,11 +848,8 @@ contains
     !> Volume, if system is periodic
     real(dp), intent(in), optional :: volume
 
-    integer, allocatable :: nNeigh(:)
-
     real(dp) :: sigma(3, 3)
     real(dp) :: vol, parEwald0
-    real(dp), allocatable :: cn(:), dcndr(:, :, :), dcndL(:, :, :)
 
     if (present(volume)) then
       vol = volume
@@ -1017,108 +867,19 @@ contains
     gradients(:, :) = 0.0_dp
     sigma(:, :) = 0.0_dp
 
-    allocate(cn(nAtom), dcndr(3, nAtom, nAtom), dcndL(3, 3, nAtom))
-    cn(:) = 0.0_dp
-    dcndr(:, :, :) = 0.0_dp
-    dcndL(:, :, :) = 0.0_dp
+    call eeqCont%updateCoords(neigh, img2CentCell, coords, species)
 
-    allocate(nNeigh(nAtom))
-    nNeigh(:) = 0
+    call cnCont%updateCoords(neigh, img2CentCell, coords, species)
 
-    call getNrOfNeighboursForAll(nNeigh, neigh, calculator%cutoffCount)
-
-    call getCoordinationNumber(nAtom, coords, species, nNeigh, neigh%iNeighbour,&
-        & neigh%neighDist2, img2CentCell, calculator%covalentRadius,&
-        & calculator%electronegativity, .false., cn, dcndr, dcndL)
-    call cutCoordinationNumber(nAtom, cn, dcndr, dcndL, cn_max=8.0_dp)
-
-    call eeqCont%updateCoords(neigh, img2CentCell, coords, species, cn, dcndr, dcndL)
-
-    call getCoordinationNumber(nAtom, coords, species, nNeigh, neigh%iNeighbour, neigh%neighDist2,&
-        & img2CentCell, calculator%covalentRadius, calculator%electronegativity, .true., cn, dcndr,&
-        & dcndL)
-
-    call dispersionGradient(calculator, nAtom, coords, species, neigh, img2CentCell, cn, dcndr,&
-        & dcndL, eeqCont%charges, eeqCont%dqdr, eeqCont%dqdL, energies, gradients, sigma)
+    call dispersionGradient(calculator, nAtom, coords, species, neigh, img2CentCell, &
+        & cnCont%cn, cnCont%dcndr, cnCont%dcndL, eeqCont%charges, eeqCont%dqdr, eeqCont%dqdL, &
+        & energies, gradients, sigma)
 
     if (present(stress)) then
       stress(:, :) = sigma / volume
     end if
 
   end subroutine dispersionEnergy
-
-
-  !> Error function counting function for coordination number contributions.
-  pure elemental function erfCount(k, r, r0) result(count)
-
-    !> Steepness of the counting function.
-    real(dp), intent(in) :: k
-
-    !> Current distance.
-    real(dp), intent(in) :: r
-
-    !> Cutoff radius.
-    real(dp), intent(in) :: r0
-
-    real(dp) :: count
-
-    count = 0.5_dp * (1.0_dp + erf(-k*(r-r0)/r0))
-
-  end function erfCount
-
-
-  !> Derivative of the counting function w.r.t. the distance.
-  pure elemental function derfCount(k, r, r0) result(count)
-
-    !> Steepness of the counting function.
-    real(dp), intent(in) :: k
-
-    !> Current distance.
-    real(dp), intent(in) :: r
-
-    !> Cutoff radius.
-    real(dp), intent(in) :: r0
-
-    real(dp), parameter :: sqrtpi = sqrt(pi)
-    real(dp) :: count
-
-    count = -k/sqrtpi/r0*exp(-k**2*(r-r0)**2/r0**2)
-
-  end function derfCount
-
-
-  !> Cutting function for the coordination number.
-  elemental function cutCN(cn, cut) result(cnp)
-
-    !> Current coordination number.
-    real(dp), intent(in) :: cn
-
-    !> Cutoff for the CN, this is not the maximum value.
-    real(dp), intent(in) :: cut
-
-    !> Cuting function vlaue
-    real(dp) :: cnp
-
-    cnp = log(1.0_dp + exp(cut)) - log(1.0_dp + exp(cut - cn))
-
-  end function cutCN
-
-
-  !> Derivative of the cutting function w.r.t. coordination number
-  elemental function dCutCN(cn, cut) result(dcnpdcn)
-
-    !> Current coordination number.
-    real(dp), intent(in) :: cn
-
-    !> Cutoff for the CN, this is not the maximum value.
-    real(dp), intent(in) :: cut
-
-    !> Derivative of the cutting function
-    real(dp) :: dcnpdcn
-
-    dcnpdcn = exp(cut) / (exp(cut) + exp(cn))
-
-  end function dCutCn
 
 
   !> charge scaling function

--- a/prog/dftb+/lib_dftb/encharges.F90
+++ b/prog/dftb+/lib_dftb/encharges.F90
@@ -18,7 +18,7 @@ module dftbp_encharges
   use dftbp_errorfunction, only : erfwrap
   use dftbp_coulomb, only : ewaldReal, ewaldReciprocal, derivStressEwaldRec, &
       & getMaxGEwald, getOptimalAlphaEwald
-  use dftbp_coordinationnumber, only : TCNCont, TCNInput, init
+  use dftbp_coordnumber, only : TCNCont, TCNInput, init
   use dftbp_blasroutines, only : hemv, gemv, gemm
   use dftbp_lapackroutines, only : symmatinv
   use dftbp_periodic, only : TNeighbourList, getNrOfNeighboursForAll, getLatticePoints

--- a/prog/dftb+/lib_dftb/encharges.F90
+++ b/prog/dftb+/lib_dftb/encharges.F90
@@ -18,6 +18,7 @@ module dftbp_encharges
   use dftbp_errorfunction, only : erfwrap
   use dftbp_coulomb, only : ewaldReal, ewaldReciprocal, derivStressEwaldRec, &
       & getMaxGEwald, getOptimalAlphaEwald
+  use dftbp_coordinationnumber, only : TCNCont, TCNInput, init
   use dftbp_blasroutines, only : hemv, gemv, gemm
   use dftbp_lapackroutines, only : symmatinv
   use dftbp_periodic, only : TNeighbourList, getNrOfNeighboursForAll, getLatticePoints
@@ -65,6 +66,9 @@ module dftbp_encharges
     !> Cutoff for real-space summation under PBCs
     real(dp) :: cutoff
 
+    !> Input for coordination number
+    type(TCNInput) :: cnInput
+
   end type TEeqInput
 
 
@@ -104,6 +108,9 @@ module dftbp_encharges
     !> Contains the points included in the reciprocal sum.
     !> The set should not include the origin or inversion related points.
     real(dp), allocatable :: recPoint(:, :)
+
+    !> Coordination number container
+    type(TCNCont) :: cnCont
 
     !> are the coordinates current?
     logical :: tCoordsUpdated
@@ -197,6 +204,12 @@ contains
 
     this%tPeriodic = present(latVecs)
 
+    if (this%tPeriodic) then
+      call init(this%cnCont, input%cnInput, nAtom, latVecs)
+    else
+      call init(this%cnCont, input%cnInput, nAtom)
+    end if
+
     this%param = input%TEeqParam
     this%cutoff = input%cutoff
     this%nrChrg = input%nrChrg
@@ -229,8 +242,7 @@ contains
 
 
   !> Notifies the objects about changed coordinates.
-  subroutine updateCoords(this, neigh, img2CentCell, coords, species, &
-      & cn, dcndr, dcndL)
+  subroutine updateCoords(this, neigh, img2CentCell, coords, species)
 
     !> Instance of EEQ container
     class(TEeqCont), intent(inout) :: this
@@ -247,9 +259,9 @@ contains
     !> Species of the atoms in the unit cell.
     integer, intent(in) :: species(:)
 
-    real(dp), intent(in) :: cn(:), dcndr(:, :, :), dcndL(:, :, :)
-
     integer, allocatable :: nNeigh(:)
+
+    call this%cnCont%updateCoords(neigh, img2CentCell, coords, species)
 
     allocate(nNeigh(this%nAtom))
     call getNrOfNeighboursForAll(nNeigh, neigh, this%cutoff)
@@ -257,7 +269,8 @@ contains
     call getEEQCharges(this%nAtom, coords, species, this%nrChrg, nNeigh, &
         & neigh%iNeighbour, neigh%neighDist2, img2CentCell, this%recPoint, this%parEwald, &
         & this%vol, this%param%chi, this%param%kcn, this%param%gam, this%param%rad, &
-        & cn, dcndr, dcndL, this%energies, this%gradients, this%stress, &
+        & this%cnCont%cn, this%cnCont%dcndr, this%cnCont%dcndL, &
+        & this%energies, this%gradients, this%stress, &
         & this%charges, this%dqdr, this%dqdL)
 
     this%tCoordsUpdated = .true.
@@ -292,6 +305,8 @@ contains
     call getLatticePoints(this%recPoint, recVecs, latVecs/(2.0_dp*pi), maxGEwald,&
         & onlyInside=.true., reduceByInversion=.true., withoutOrigin=.true.)
     this%recPoint(:, :) = matmul(recVecs, this%recPoint)
+
+    call this%cnCont%updateLatVecs(LatVecs)
 
     this%tCoordsUpdated = .false.
 
@@ -443,7 +458,7 @@ contains
     !> Resulting cutoff
     real(dp) :: cutoff
 
-    cutoff = this%cutoff
+    cutoff = max(this%cutoff, this%cnCont%getRCutoff())
 
   end function getRCutoff
 

--- a/prog/dftb+/lib_dftbplus/parser.F90
+++ b/prog/dftb+/lib_dftbplus/parser.F90
@@ -26,7 +26,7 @@ module dftbp_parser
   use dftbp_inputconversion
   use dftbp_lapackroutines, only : matinv
   use dftbp_periodic
-  use dftbp_coordinationnumber
+  use dftbp_coordnumber
   use dftbp_dispersions
   use dftbp_dftd4param, only : getEeqChi, getEeqGam, getEeqKcn, getEeqRad
   use dftbp_encharges, only : TEeqInput
@@ -3828,13 +3828,13 @@ contains
     call getChildValue(node, "a1", input%a1)
     call getChildValue(node, "a2", input%a2)
     call getChildValue(node, "alpha", input%alpha, default=16.0_dp)
-    call getChildValue(node, "weightingFactor", input%weightingFactor, default=6.0_dp)
-    call getChildValue(node, "chargeSteepness", input%chargeSteepness, default=2.0_dp)
-    call getChildValue(node, "chargeScale", input%chargeScale, default=3.0_dp)
-    call getChildValue(node, "cutoffInter", input%cutoffInter, default=64.0_dp, modifier=buffer,&
+    call getChildValue(node, "WeightingFactor", input%weightingFactor, default=6.0_dp)
+    call getChildValue(node, "ChargeSteepness", input%chargeSteepness, default=2.0_dp)
+    call getChildValue(node, "ChargeScale", input%chargeScale, default=3.0_dp)
+    call getChildValue(node, "CutoffInter", input%cutoffInter, default=64.0_dp, modifier=buffer,&
         & child=child)
     call convertByMul(char(buffer), lengthUnits, child, input%cutoffInter)
-    call getChildValue(node, "cutoffThree", input%cutoffThree, default=40.0_dp, modifier=buffer,&
+    call getChildValue(node, "CutoffThree", input%cutoffThree, default=40.0_dp, modifier=buffer,&
         & child=child)
     call convertByMul(char(buffer), lengthUnits, child, input%cutoffThree)
 
@@ -3855,7 +3855,7 @@ contains
       call readEeqModel(value1, input%eeqInput, geo, nrChrg, d4Chi, d4Gam, d4Kcn, d4Rad)
     end select
 
-    call readCoordinationNumber(node, input%cnInput, geo, "cov", 0.0_dp)
+    call readCoordinationNumber(node, input%cnInput, geo, "Cov", 0.0_dp)
 
   end subroutine readDispDFTD4
 
@@ -3899,7 +3899,7 @@ contains
     allocate(input%kcn(geo%nSpecies))
     allocate(input%rad(geo%nSpecies))
 
-    call getChildValue(node, "chi", value1, "defaults", child=child)
+    call getChildValue(node, "Chi", value1, "Defaults", child=child)
     call getNodeName(value1, buffer)
     select case(char(buffer))
     case default
@@ -3916,7 +3916,7 @@ contains
       end do
     end select
 
-    call getChildValue(node, "gam", value1, "defaults", child=child)
+    call getChildValue(node, "Gam", value1, "Defaults", child=child)
     call getNodeName(value1, buffer)
     select case(char(buffer))
     case default
@@ -3933,7 +3933,7 @@ contains
       end do
     end select
 
-    call getChildValue(node, "kcn", value1, "defaults", child=child)
+    call getChildValue(node, "Kcn", value1, "Defaults", child=child)
     call getNodeName(value1, buffer)
     select case(char(buffer))
     case default
@@ -3950,7 +3950,7 @@ contains
       end do
     end select
 
-    call getChildValue(node, "rad", value1, "defaults", child=child)
+    call getChildValue(node, "Rad", value1, "Defaults", child=child)
     call getNodeName(value1, buffer)
     select case(char(buffer))
     case default
@@ -3967,14 +3967,14 @@ contains
       end do
     end select
 
-    call getChildValue(node, "cutoff", input%cutoff, default=40.0_dp, modifier=buffer,&
+    call getChildValue(node, "Cutoff", input%cutoff, default=40.0_dp, modifier=buffer,&
         & child=child)
     call convertByMul(char(buffer), lengthUnits, child, input%cutoff)
 
     call getChildValue(node, "EwaldParameter", input%parEwald, 0.0_dp)
     call getChildValue(node, "EwaldTolerance", input%tolEwald, 1.0e-9_dp)
 
-    call readCoordinationNumber(node, input%cnInput, geo, "erf", 8.0_dp)
+    call readCoordinationNumber(node, input%cnInput, geo, "Erf", 8.0_dp)
 
   end subroutine readEeqModel
 
@@ -4008,22 +4008,26 @@ contains
     select case(char(buffer))
     case default
       call detailedError(child, "Invalid coordination number type specified")
-  #:for cnType in ("exp", "erf", "cov", "gfn")
-    case("${cnType}$")
-      input%cnType = cnType%${cnType}$
-  #:endfor
+    case("exp")
+      input%cnType = cnType%exp
+    case("erf")
+      input%cnType = cnType%erf
+    case("cov")
+      input%cnType = cnType%cov
+    case("gfn")
+      input%cnType = cnType%gfn
     end select
 
     call getChildValue(value1, "CutCN", input%maxCN, cutDefault, &
         & child=child2)
 
-    call getChildValue(value1, "cutoff", input%rCutoff, 40.0_dp, &
+    call getChildValue(value1, "Cutoff", input%rCutoff, 40.0_dp, &
         & modifier=modifier, child=field)
     call convertByMul(char(modifier), lengthUnits, field, input%rCutoff)
 
     allocate(input%en(geo%nSpecies))
     if (input%cnType == cnType%cov) then
-      call getChildValue(value1, "electronegativities", value2, "PaulingEN", child=child2)
+      call getChildValue(value1, "Electronegativities", value2, "PaulingEN", child=child2)
       call getNodeName(value2, buffer)
       select case(char(buffer))
       case default
@@ -4050,7 +4054,7 @@ contains
     end if
 
     allocate(input%covRad(geo%nSpecies))
-    call getChildValue(value1, "radii", value2, "CovalentRadiiD3", child=child2)
+    call getChildValue(value1, "Radii", value2, "CovalentRadiiD3", child=child2)
     call getNodeName(value2, buffer)
     select case(char(buffer))
     case default

--- a/prog/dftb+/lib_dftbplus/parser.F90
+++ b/prog/dftb+/lib_dftbplus/parser.F90
@@ -26,6 +26,7 @@ module dftbp_parser
   use dftbp_inputconversion
   use dftbp_lapackroutines, only : matinv
   use dftbp_periodic
+  use dftbp_coordinationnumber
   use dftbp_dispersions
   use dftbp_dftd4param, only : getEeqChi, getEeqGam, getEeqKcn, getEeqRad
   use dftbp_encharges, only : TEeqInput
@@ -3833,9 +3834,6 @@ contains
     call getChildValue(node, "cutoffInter", input%cutoffInter, default=64.0_dp, modifier=buffer,&
         & child=child)
     call convertByMul(char(buffer), lengthUnits, child, input%cutoffInter)
-    call getChildValue(node, "cutoffCount", input%cutoffCount, default=40.0_dp, modifier=buffer,&
-        & child=child)
-    call convertByMul(char(buffer), lengthUnits, child, input%cutoffCount)
     call getChildValue(node, "cutoffThree", input%cutoffThree, default=40.0_dp, modifier=buffer,&
         & child=child)
     call convertByMul(char(buffer), lengthUnits, child, input%cutoffThree)
@@ -3856,6 +3854,8 @@ contains
       d4Rad(:) = getEeqRad(geo%speciesNames)
       call readEeqModel(value1, input%eeqInput, geo, nrChrg, d4Chi, d4Gam, d4Kcn, d4Rad)
     end select
+
+    call readCoordinationNumber(node, input%cnInput, geo, "cov", 0.0_dp)
 
   end subroutine readDispDFTD4
 
@@ -3974,7 +3974,106 @@ contains
     call getChildValue(node, "EwaldParameter", input%parEwald, 0.0_dp)
     call getChildValue(node, "EwaldTolerance", input%tolEwald, 1.0e-9_dp)
 
+    call readCoordinationNumber(node, input%cnInput, geo, "erf", 8.0_dp)
+
   end subroutine readEeqModel
+
+
+  !> Read in coordination number settings
+  subroutine readCoordinationNumber(node, input, geo, cnDefault, cutDefault)
+
+    !> Node to get the information from
+    type(fnode), pointer :: node
+
+    !> Control structure to be filled
+    type(TCNInput), intent(inout) :: input
+
+    !> Geometry structure to be filled
+    type(TGeometry), intent(in) :: geo
+
+    !> Default value for the coordination number type
+    character(len=*), intent(in) :: cnDefault
+
+    !> Default value for the maximum CN used for cutting (0 turns it off)
+    real(dp), intent(in) :: cutDefault
+
+    type(fnode), pointer :: value1, value2, child, child2, field
+    type(string) :: buffer, modifier
+    real(dp), allocatable :: kENDefault(:), kRadDefault(:)
+    integer :: iSp
+
+    call getChildValue(node, "CoordinationNumber", value1, cnDefault, child=child)
+    call getNodeName(value1, buffer)
+
+    select case(char(buffer))
+    case default
+      call detailedError(child, "Invalid coordination number type specified")
+  #:for cnType in ("exp", "erf", "cov", "gfn")
+    case("${cnType}$")
+      input%cnType = cnType%${cnType}$
+  #:endfor
+    end select
+
+    call getChildValue(value1, "CutCN", input%maxCN, cutDefault, &
+        & child=child2)
+
+    call getChildValue(value1, "cutoff", input%rCutoff, 40.0_dp, &
+        & modifier=modifier, child=field)
+    call convertByMul(char(modifier), lengthUnits, field, input%rCutoff)
+
+    allocate(input%en(geo%nSpecies))
+    if (input%cnType == cnType%cov) then
+      call getChildValue(value1, "electronegativities", value2, "PaulingEN", child=child2)
+      call getNodeName(value2, buffer)
+      select case(char(buffer))
+      case default
+        call detailedError(child2, "Unknown method '"//char(buffer)//"' to generate electronegativities")
+      case("paulingen")
+        allocate(kENDefault(geo%nSpecies))
+        kENDefault(:) = getElectronegativity(geo%speciesNames)
+        do iSp = 1, geo%nSpecies
+          call getChildValue(value2, geo%speciesNames(iSp), input%en(iSp), &
+              & kENDefault(iSp), child=child2)
+        end do
+        deallocate(kENDefault)
+      case("values")
+        do iSp = 1, geo%nSpecies
+          call getChildValue(value2, geo%speciesNames(iSp), input%en(iSp), child=child2)
+        end do
+      end select
+      if (any(input%en <= 0.0_dp)) then
+        call detailedError(value1, "Electronegativities are not defined for all species")
+      end if
+    else
+      ! array is not used, but should still be populated with dummies
+      input%en(:) = 0.0_dp
+    end if
+
+    allocate(input%covRad(geo%nSpecies))
+    call getChildValue(value1, "radii", value2, "CovalentRadiiD3", child=child2)
+    call getNodeName(value2, buffer)
+    select case(char(buffer))
+    case default
+      call detailedError(child2, "Unknown method '"//char(buffer)//"' to generate radii")
+    case("covalentradiid3")
+      allocate(kRadDefault(geo%nSpecies))
+      kRadDefault(:) = getCovalentRadius(geo%speciesNames)
+      do iSp = 1, geo%nSpecies
+        call getChildValue(value2, geo%speciesNames(iSp), input%covRad(iSp), &
+            & kRadDefault(iSp), child=child2)
+      end do
+      deallocate(kRadDefault)
+    case("values")
+      do iSp = 1, geo%nSpecies
+        call getChildValue(value2, geo%speciesNames(iSp), input%covRad(iSp), child=child2)
+      end do
+    end select
+
+    if (any(input%covRad <= 0.0_dp)) then
+      call detailedError(value1, "Covalent radii are not defined for all species")
+    end if
+
+  end subroutine readCoordinationNumber
 
 
   !> reads in value of temperature for MD with sanity checking of the input

--- a/test/prog/dftb+/dispersion/2H2O_dftd4/dftb_in.hsd
+++ b/test/prog/dftb+/dispersion/2H2O_dftd4/dftb_in.hsd
@@ -40,11 +40,11 @@ Hamiltonian = DFTB {
     s9 = 1.0
     s8 = 0.61
     CutoffInter = 60
-    CoordinationNumber = cov {
+    CoordinationNumber = Cov {
        Cutoff = 34
     }
     ChargeModel = EEQ {
-       CoordinationNumber = erf {
+       CoordinationNumber = Erf {
           Cutoff = 34
        }
     }

--- a/test/prog/dftb+/dispersion/2H2O_dftd4/dftb_in.hsd
+++ b/test/prog/dftb+/dispersion/2H2O_dftd4/dftb_in.hsd
@@ -40,7 +40,14 @@ Hamiltonian = DFTB {
     s9 = 1.0
     s8 = 0.61
     CutoffInter = 60
-    CutoffCount = 34
+    CoordinationNumber = cov {
+       Cutoff = 34
+    }
+    ChargeModel = EEQ {
+       CoordinationNumber = erf {
+          Cutoff = 34
+       }
+    }
   }
 }
 

--- a/test/prog/dftb+/dispersion/GaAs_dftd4/dftb_in.hsd
+++ b/test/prog/dftb+/dispersion/GaAs_dftd4/dftb_in.hsd
@@ -29,12 +29,12 @@ Hamiltonian = DFTB {
     s6 = 1.0
     s8 = 0.61
     CutoffInter = 60
-    CoordinationNumber = cov {
+    CoordinationNumber = Cov {
        Cutoff = 34
     }
     ChargeModel = EEQ {
        EwaldParameter = 0.25165824
-       CoordinationNumber = erf {
+       CoordinationNumber = Erf {
           Cutoff = 34
        }
     }

--- a/test/prog/dftb+/dispersion/GaAs_dftd4/dftb_in.hsd
+++ b/test/prog/dftb+/dispersion/GaAs_dftd4/dftb_in.hsd
@@ -29,9 +29,14 @@ Hamiltonian = DFTB {
     s6 = 1.0
     s8 = 0.61
     CutoffInter = 60
-    CutoffCount = 34 
+    CoordinationNumber = cov {
+       Cutoff = 34
+    }
     ChargeModel = EEQ {
        EwaldParameter = 0.25165824
+       CoordinationNumber = erf {
+          Cutoff = 34
+       }
     }
   }
 }

--- a/test/prog/dftb+/dispersion/diamond_dftd4/dftb_in.hsd
+++ b/test/prog/dftb+/dispersion/diamond_dftd4/dftb_in.hsd
@@ -49,7 +49,14 @@ Hamiltonian = DFTB {
     s6 = 1.0
     s8 = 0.61
     CutoffInter = 60
-    CutoffCount = 34 
+    CoordinationNumber = cov {
+       Cutoff = 34
+    }
+    ChargeModel = EEQ {
+       CoordinationNumber = erf {
+          Cutoff = 34
+       }
+    }
   }
 }
 

--- a/test/prog/dftb+/dispersion/diamond_dftd4/dftb_in.hsd
+++ b/test/prog/dftb+/dispersion/diamond_dftd4/dftb_in.hsd
@@ -49,11 +49,11 @@ Hamiltonian = DFTB {
     s6 = 1.0
     s8 = 0.61
     CutoffInter = 60
-    CoordinationNumber = cov {
+    CoordinationNumber = Cov {
        Cutoff = 34
     }
     ChargeModel = EEQ {
-       CoordinationNumber = erf {
+       CoordinationNumber = Erf {
           Cutoff = 34
        }
     }


### PR DESCRIPTION
This PR generalizes the calculation of the coordination number

#### New Features

- [x] Coordination number container in four flavours
  - error function CN used in EEQ model and later GFN0-xTB
  - exponential CN (originial DFT-D3) for GFN1-xTB and DFT-D3
  - covalent CN used in DFT-D4
  - smooth exponential CN used in GFN2-xTB
- [x] reusable input for CN container
- [x] adjusted test inputs and manual entry

#### New Input

Coordination numbers can be generated by

```cson
CoordinationNumber = cov { # or exp/erf/gfn
  CutCN = 0  # for no cutting
  Electronegativities = PaulingEN {}  # only for cov-CN
  Radii = CovalentRadiiD3 {}
}
```

This PR is required for the xTB implementation.