### PR TITLE
Add recalcGeometry() call in Gross charges api routines

### DIFF
--- a/prog/dftb+/api/mm/mmapi.F90
+++ b/prog/dftb+/api/mm/mmapi.F90
@@ -375,7 +375,7 @@ contains
 
     call this%checkInit()
 
-    call getGrossCharges(atomCharges)
+    call getGrossCharges(this%env, atomCharges)
 
   end subroutine TDftbPlus_getGrossCharges
 

--- a/prog/dftb+/lib_dftbplus/mainapi.F90
+++ b/prog/dftb+/lib_dftbplus/mainapi.F90
@@ -106,11 +106,15 @@ contains
 
 
   !> get the gross (Mulliken projected) charges for atoms wrt neutral atoms
-  subroutine getGrossCharges(atomCharges)
+  subroutine getGrossCharges(env, atomCharges)
+
+    !> instance
+    type(TEnvironment), intent(inout) :: env
 
     !> resulting charges
     real(dp), intent(out) :: atomCharges(:)
 
+    call recalcGeometry(env)
     atomCharges(:) = sum(q0(:, :, 1) - qOutput(:, :, 1), dim=1)
 
   end subroutine getGrossCharges


### PR DESCRIPTION
This adapts the behavior of DFTB+ to the subroutines for the
extraction of energy, gradients,... and prevents the return
of trivial charges without a calculation carried out via the
ctypes interface.