### PR TITLE
Fix for missing ascii contact shift read

### DIFF
--- a/test/prog/dftb+/transport/H-sheet_grp2/dftb_in.hsd
+++ b/test/prog/dftb+/transport/H-sheet_grp2/dftb_in.hsd
@@ -19,6 +19,7 @@ Transport {
       FermiLevel [eV] = -4.4504575
       Potential [eV] = 1.0
     }
+    ReadBinaryContact = No
 }
 
 Hamiltonian = dftb {

--- a/test/prog/dftb+/transport/H-sheet_grp4/dftb_in.hsd
+++ b/test/prog/dftb+/transport/H-sheet_grp4/dftb_in.hsd
@@ -19,6 +19,7 @@ Transport {
       FermiLevel [eV] = -4.4504575
       Potential [eV] = 1.0
     }
+    ReadBinaryContact = No
 }
 
 Hamiltonian = dftb {

--- a/test/prog/dftb+/transport/H-sheet_grp8/dftb_in.hsd
+++ b/test/prog/dftb+/transport/H-sheet_grp8/dftb_in.hsd
@@ -19,6 +19,7 @@ Transport {
       FermiLevel [eV] = -4.4504575
       Potential [eV] = 1.0
     }
+    ReadBinaryContact = No
 }
 
 Hamiltonian = dftb {


### PR DESCRIPTION
Parser version 8 defaults to binary, but examples contained ascii shift files.