### PR TITLE
Partial fix for d4 crash

### DIFF
--- a/prog/dftb+/lib_math/lapackroutines.F90
+++ b/prog/dftb+/lib_math/lapackroutines.F90
@@ -639,16 +639,30 @@ contains
     nn = size(aa, dim=1)
     allocate(ipiv(nn))
     call sytrf(aa, ipiv, uplo, info0)
-    if (info0 == 0) then
-      call sytri(aa, ipiv, uplo, info0)
+
+    if (info0 /= 0) then
+      write(error_string, "(A,I10)") "Matrix inversion failed because of &
+          &error in sytrf. Info flag:", info0
+      if (present(info)) then
+        call warning(error_string)
+        info = info0
+        return
+      else
+        call error(error_string)
+      end if
     end if
 
-    if (present(info)) then
-      info = info0
-    elseif (info0 /= 0) then
+    call sytri(aa, ipiv, uplo, info0)
+
+    if (info0 /= 0) then
       write(error_string, "(A,I10)") "Matrix inversion failed because of &
-          &error in sytrf or sytri. Info flag:", info
-      call error(error_string)
+          &error in sytri. Info flag:", info0
+      if (present(info)) then
+        call warning(error_string)
+        info = info0
+      elseif (info0 /= 0) then
+        call error(error_string)
+      end if
     end if
 
   end subroutine symmatinv
@@ -671,17 +685,32 @@ contains
 
     nn = size(aa, dim=1)
     allocate(ipiv(nn))
+
     call hetrf(aa, ipiv, uplo, info0)
-    if (info0 == 0) then
-      call hetri(aa, ipiv, uplo, info0)
+
+    if (info0 /= 0) then
+      write(error_string, "(A,I10)") "Matrix inversion failed because of &
+          &error in hetrf. Info flag:", info0
+      if (present(info)) then
+        call warning(error_string)
+        info = info0
+        return
+      else
+        call error(error_string)
+      end if
     end if
 
-    if (present(info)) then
-      info = info0
-    elseif (info0 /= 0) then
+    call hetri(aa, ipiv, uplo, info0)
+
+    if (info0 /= 0) then
       write(error_string, "(A,I10)") "Matrix inversion failed because of &
-          &error in sytrf or sytri. Info flag:", info
-      call error(error_string)
+          &error in hetri. Info flag:", info0
+      if (present(info)) then
+        call warning(error_string)
+        info = info0
+      elseif (info0 /= 0) then
+        call error(error_string)
+      end if
     end if
 
   end subroutine hermatinv


### PR DESCRIPTION
Error retun in the lapack wrapper was broken, so segfaulted instead
of reporting error on matrix factorization of matrix of equations.
Note, still does not address why DFTD4 was generating a singular
matrix with nag7 compiler.