### PR TITLE
Change to default port selection behaviour

### DIFF
--- a/test/prog/dftb+/sockets/diamond_exit/prerun.py
+++ b/test/prog/dftb+/sockets/diamond_exit/prerun.py
@@ -12,7 +12,7 @@ NR_STEPS = 1
 
 def connect():
     serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    serversocket.bind(('localhost', 21013))
+    serversocket.bind(('localhost', 0))
     serversocket.listen(1)
     port = serversocket.getsockname()[1]
     # write file for dftb_in.hsd to include:


### PR DESCRIPTION
Hopefully stops occasional crashes for the diamond_exit test, as
may be due to port collision if running multiple copies of the same
test simultaneously.