### PR TITLE
Enable debug builds on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,6 @@ install:
 script:
 - mkdir _build
 - cd _build
-- cmake -DWITH_DFTD3=true -DWITH_TRANSPORT=true -DWITH_MPI=${WITH_MPI} -DFYPP_FLAGS="-DTRAVIS" -DCMAKE_TOOLCHAIN_FILE=../sys/gnu.cmake ..
-- make -j 2
-- ctest -j 2
+- if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then BUILD_TYPE=Debug; else; BUILD_TYPE=Release; fi
+- cmake -DWITH_DFTD3=true -DWITH_TRANSPORT=true -DWITH_MPI=${WITH_MPI} -DFYPP_FLAGS="-DTRAVIS" -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_TOOLCHAIN_FILE=../sys/gnu.cmake ..
+- make -j 2 && ctest -j 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,4 @@ install:
 - echo "y" | ./utils/get_opt_externals ALL
 
 script:
-- mkdir _build
-- cd _build
-- if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then BUILD_TYPE=Debug; else; BUILD_TYPE=Release; fi
-- cmake -DWITH_DFTD3=true -DWITH_TRANSPORT=true -DWITH_MPI=${WITH_MPI} -DFYPP_FLAGS="-DTRAVIS" -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_TOOLCHAIN_FILE=../sys/gnu.cmake ..
-- make -j 2 && ctest -j 2
+- ./utils/test/travis-ci.sh

--- a/prog/dftb+/lib_poisson/bulkpot.F90
+++ b/prog/dftb+/lib_poisson/bulkpot.F90
@@ -74,7 +74,7 @@ contains
 
    character(*), parameter :: formatStr = '(a, ":", t30, g14.10)'
 
-   write(stdOut,"(I0,1X,I0,1XI0)") SA%a,SA%b,SA%c
+   write(stdOut,"(I0,1X,I0,1X,I0)") SA%a,SA%b,SA%c
    write(stdOut,"(3E20.12)") SA%dla,SA%dlb,SA%dlc
 
    write(stdOut, formatStr) 'size',SA%ibsize

--- a/test/prog/dftb+/tests
+++ b/test/prog/dftb+/tests
@@ -270,8 +270,8 @@ non-scc/Si_384                         #? MPI_PROCS <= 4
 md/DNA                                 #? MPI_PROCS <= 4
 md/DNA_Berendsen2                      #? MPI_PROCS <= 4
 md/ptcda-xlbomd                        #? MPI_PROCS <= 4
-md/SiC64-xlbomdfast-T0                 #? MPI_PROCS <= 4
-md/SiC64-xlbomdfast                    #? MPI_PROCS <= 4
+md/SiC64-xlbomdfast-T0                 #? MPI_PROCS <= 4 and LONG_TEST
+md/SiC64-xlbomdfast                    #? MPI_PROCS <= 4 and LONG_TEST
 
 timedep/C66O10N4H44_OscWindow          #? WITH_ARPACK and MPI_PROCS <= 1
 timedep/C60_OscWindow                  #? WITH_ARPACK and MPI_PROCS <= 1
@@ -291,7 +291,7 @@ poisson/CH4-poisson                    #? MPI_PROCS <= 4
 transport/CNT                          #? WITH_TRANSPORT and MPI_PROCS <= 4
 transport/CNT_GF                       #? WITH_TRANSPORT and MPI_PROCS <= 4 and LONG_TEST
 transport/C-chain_allSteps             #? WITH_TRANSPORT and MPI_PROCS <= 2
-transport/C-chain+U                    #? WITH_TRANSPORT and MPI_PROCS <= 2
+transport/C-chain+U                    #? WITH_TRANSPORT and MPI_PROCS <= 2 and LONG_TEST
 transport/SiH-chain_allSteps           #? WITH_TRANSPORT and MPI_PROCS <= 2 and LONG_TEST
 transport/SiH-chain_bin                #? WITH_TRANSPORT and MPI_PROCS <= 2 and LONG_TEST
 transport/H-chain                      #? WITH_TRANSPORT and MPI_PROCS <= 4
@@ -301,13 +301,13 @@ transport/H-sheet_grp2                 #? WITH_TRANSPORT and MPI_PROCS <= 8 and 
 transport/H-sheet_grp4                 #? WITH_TRANSPORT and MPI_PROCS <= 16 and MPI_PROCS % 4 == 0
 transport/H-sheet_grp8                 #? WITH_TRANSPORT and MPI_PROCS <= 32 and MPI_PROCS % 8 == 0
 transport/H-3conts                     #? WITH_TRANSPORT and MPI_PROCS <= 4
-transport/SiH-chain                    #? WITH_TRANSPORT and MPI_PROCS <= 4
+transport/SiH-chain                    #? WITH_TRANSPORT and MPI_PROCS <= 4 and LONG_TEST
 transport/SiH-chain-cont               #? WITH_TRANSPORT and MPI_PROCS <= 4
 transport/SiH-cont-poiss               #? WITH_TRANSPORT and MPI_PROCS <= 4
 transport/graphene_x                   #? WITH_TRANSPORT and MPI_PROCS <= 4 and LONG_TEST
 transport/graphene3T                   #? WITH_TRANSPORT and MPI_PROCS <= 4 and LONG_TEST
 transport/Au-chain                     #? WITH_TRANSPORT and MPI_PROCS <= 4
-transport/SiH-chain_semiInf            #? WITH_TRANSPORT and MPI_PROCS <= 2
+transport/SiH-chain_semiInf            #? WITH_TRANSPORT and MPI_PROCS <= 2 and LONG_TEST
 transport/local-curr                   #? WITH_TRANSPORT and MPI_PROCS <= 4 and LONG_TEST
 transport/polyacetylene_semiInf        #? WITH_TRANSPORT and MPI_PROCS <= 4
 transport/H-sheet_end                  #? WITH_TRANSPORT and MPI_PROCS <= 4

--- a/utils/test/travis-ci.sh
+++ b/utils/test/travis-ci.sh
@@ -12,7 +12,7 @@ cmake_options=(
 mkdir -p _build
 pushd _build
 
-if ["$TRAVIS_PULL_REQUEST" != "false" ]; then
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
    cmake -DCMAKE_BUILD_TYPE=Debug "${cmake_options[@]}" ..
 else
    cmake -DCMAKE_BUILD_TYPE=Release "${cmake_options[@]}" ..

--- a/utils/test/travis-ci.sh
+++ b/utils/test/travis-ci.sh
@@ -12,7 +12,7 @@ cmake_options=(
 mkdir -p _build
 pushd _build
 
-if ["TRAVIS_PULL_REQUEST" != "false" ]; then
+if ["$TRAVIS_PULL_REQUEST" != "false" ]; then
    cmake -DCMAKE_BUILD_TYPE=Debug "${cmake_options[@]}" ..
 else
    cmake -DCMAKE_BUILD_TYPE=Release "${cmake_options[@]}" ..

--- a/utils/test/travis-ci.sh
+++ b/utils/test/travis-ci.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+set -ex
+
+cmake_options=(
+   "-DWITH_DFTD3=true"
+   "-DWITH_TRANSPORT=true"
+   "-DWITH_MPI=${WITH_MPI}"
+   "-DFYPP_FLAGS='-DTRAVIS'"
+   "-DCMAKE_TOOLCHAIN_FILE=../sys/gnu.cmake"
+)
+
+mkdir -p _build
+pushd _build
+
+if ["TRAVIS_PULL_REQUEST" != "false" ]; then
+   cmake -DCMAKE_BUILD_TYPE=Debug "${cmake_options[@]}" ..
+else
+   cmake -DCMAKE_BUILD_TYPE=Release "${cmake_options[@]}" ..
+fi
+
+make -j 2
+ctest -j 2

--- a/utils/test/travis-ci.sh
+++ b/utils/test/travis-ci.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -ex
 
 cmake_options=(


### PR DESCRIPTION
This setup will perform builds in debug mode on PRs and in release mode on branches.
See https://docs.travis-ci.com/user/pull-requests/ for details.

The branch build for this PR: https://travis-ci.com/github/awvwgk/dftbplus/builds/162396959

#### Timings

MPI | Release | Debug
--- | --- | ---
true | ~9 min | ~ ~~12~~ 10 min
false | ~8 min |  ~ ~~11~~ 8 min

Might require to mark more tests as `LONG_TEST`: 
- `dftb+_md/SiC64-xlbomdfast-T0`
- `dftb+_md/SiC64-xlbomdfast`
- `dftb+_transport/CH4-poisson`
- `dftb+_transport/C-chain+U`
- `dftb+_transport/SiH-chain`
- `dftb+_transport/SiH-chain_semiInf`

#### Conflicts

Does not work with #458 unless we bump the GCC version for Travis-CI, which then does not work with the current toolchain file.