### PR TITLE
Bump libnegf and remove sparskit in cmake

### DIFF
--- a/external/libnegf/CMakeLists.txt
+++ b/external/libnegf/CMakeLists.txt
@@ -2,7 +2,7 @@ set(INSTALL_EXPORT_NAME dftbplus-targets)
 set(MPIFX_INCLUDE_DIR "${CMAKE_BINARY_DIR}/external/mpifx/origin/lib/include" CACHE STRING
   "Where to find the MPIFX include directory")
 add_subdirectory(origin)
-set(EXPORTED_COMPILED_LIBRARIES ${EXPORTED_COMPILED_LIBRARIES} negf sparskit PARENT_SCOPE)
+set(EXPORTED_COMPILED_LIBRARIES ${EXPORTED_COMPILED_LIBRARIES} negf PARENT_SCOPE)
 if(WITH_MPI)
   add_dependencies(negf mpifx)
 endif()

--- a/prog/dftb+/CMakeLists.txt
+++ b/prog/dftb+/CMakeLists.txt
@@ -77,7 +77,7 @@ if(WITH_DFTD3)
 endif()
 
 if(WITH_TRANSPORT)
-  target_link_libraries(dftbplus PUBLIC negf sparskit mudpack)
+  target_link_libraries(dftbplus PUBLIC negf mudpack)
 endif()
 
 if(WITH_ELSI)


### PR DESCRIPTION
sparskit is not compiled as stand-alone library anymore and rather embedded in libnegf. Because of this, we would like to bump version. DFTB+ cmake is modified accordingly.

Other changes in libnegf are not relevant as they are restricted to features not yet used in DFTB+