### PR TITLE
Lammps integration

### DIFF
--- a/prog/dftb+/api/mm/capi.F90
+++ b/prog/dftb+/api/mm/capi.F90
@@ -263,6 +263,21 @@ contains
 
   end subroutine c_DftbPlus_getEnergy
 
+  subroutine c_DftbPlus_getEnergyParts(handler, merminEnergy, repulsiveEnergy, electronicEnergy) bind(C, name='dftbp_get_energyparts')
+
+    !> handler for the calculation
+    type(c_DftbPlus), intent(inout) :: handler
+
+    !> resulting energy
+    real(c_double), intent(out) :: merminEnergy
+    real(c_double), intent(out) :: repulsiveEnergy
+    real(c_double), intent(out) :: electronicEnergy    
+
+    type(TDftbPlusC), pointer :: instance
+
+    call c_f_pointer(handler%instance, instance)
+    call instance%getEnergyParts(merminEnergy,repulsiveEnergy,electronicEnergy)
+  end subroutine c_DftbPlus_getEnergyParts
 
   !> Obtain the gradients wrt DFTB atom positions
   subroutine c_DftbPlus_getGradients(handler, gradients) bind(C, name='dftbp_get_gradients')
@@ -301,7 +316,23 @@ contains
 
   end subroutine c_DftbPlus_getStressTensor
 
+  subroutine c_DftbPlus_getVirial(handler, virial) &
+       bind(C, name='dftbp_get_virial')
 
+    !> handler for the calculation
+    type(c_DftbPlus), intent(inout) :: handler
+
+    !> virial, row major format
+    real(c_double), intent(out) :: virial(3, 3)
+
+    type(TDftbPlusC), pointer :: instance
+
+    call c_f_pointer(handler%instance, instance)
+    
+    call instance%getVirial(virial(:,:))
+
+  end subroutine c_DftbPlus_getVirial
+  
   !> Obtain gross (Mulliken) charges for atoms wrt to neutral references
   subroutine c_DftbPlus_getGrossCharges(handler, atomCharges)&
       & bind(C, name='dftbp_get_gross_charges')

--- a/prog/dftb+/api/mm/dftbplus.h
+++ b/prog/dftb+/api/mm/dftbplus.h
@@ -195,7 +195,7 @@ int dftbp_get_nr_atoms(DftbPlus *instance);
  * \param[out] mermin_energy  Mermin free energy of the current geometry. Unit: Bohr.
  */
 void dftbp_get_energy(DftbPlus *instance, double *mermin_energy);
-
+void dftbp_get_energyparts(DftbPlus *instance, double *mermin_energy,double *repulsive_energy,double *electronic_energy);
 
 /**
  * Queries the gradients of the current geometry.
@@ -215,6 +215,15 @@ void dftbp_get_gradients(DftbPlus *instance, double *gradients);
  * \param[out] stresstensor Stress Tensor for the periodic box. Shape [3, 3]. Unit: Pascals.
  */
 void dftbp_get_stress_tensor(DftbPlus *instance, double *stresstensor);
+
+ /**
+ * Queries the virial tensor of the current geometry.
+ *
+ * \param[inout] instance Handler of the DFTB+ instance.
+ *
+ * \param[out] totalStress Stress Shape [3, 3]. Unit: Hartree/Bohr^2.
+ */
+void dftbp_get_virial(DftbPlus *instance, double *virial);
 
 
 /**

--- a/prog/dftb+/api/mm/mmapi.F90
+++ b/prog/dftb+/api/mm/mmapi.F90
@@ -67,10 +67,14 @@ module dftbp_mmapi
     procedure :: setQDepExtPotGen => TDftbPlus_setQDepExtPotGen
     !> obtain the DFTB+ energy
     procedure :: getEnergy => TDftbPlus_getEnergy
+    !> obtain the DFTB+ energy parts repulisve and electronic    
+    procedure :: getEnergyParts => TDftbPlus_getEnergyParts       
     !> obtain the DFTB+ gradients
     procedure :: getGradients => TDftbPlus_getGradients
     !> obtain the DFTB+ stress tensor
     procedure :: getStressTensor => TDftbPlus_getStressTensor
+    !> obtain the DFTB+ Virial tensor
+    procedure :: getVirial => TDftbPlus_getVirial    
     !> obtain the gradients of the external charges
     procedure :: getExtChargeGradients => TDftbPlus_getExtChargeGradients
     !> get the gross (Mulliken) DFTB+ charges

--- a/prog/dftb+/lib_dftbplus/mainapi.F90
+++ b/prog/dftb+/lib_dftbplus/mainapi.F90
@@ -128,6 +128,11 @@ contains
     !> resulting gradients wrt atom positions
     real(dp), intent(out) :: virial(:,:)
 
+    if (.not. tStress) then
+      call error("Virial not available, you must initialise your calculator with&
+          & this property enabled.")
+    end if
+
     call recalcGeometry(env)
     virial(:,:) = totalStress*CellVol
 


### PR DESCRIPTION
Dear administrator,

I am developing a code for lammps to use dftb+. 

In order to better use, I added some functions in the api. 

One is to get repulsive and electronic energy separately. 

The other is to get virial term to use in lammps. 

Pleas let me know if there is further modification is needed. 

Thank you.

Best,

GS