### PR TITLE
Replace matrix inversion in Broyden mixer

### DIFF
--- a/prog/dftb+/lib_math/lapackroutines.F90
+++ b/prog/dftb+/lib_math/lapackroutines.F90
@@ -99,8 +99,20 @@ module dftbp_lapackroutines
   end interface gesvd
 
 
+  !> Solves a system of linear equations
+  !>  A * X = B  or  A**T * X = B
+  !> with a general N-by-N matrix A using the LU factorization computed by getrf.
+  interface getrs
+    module procedure :: getrs_dble
+    module procedure :: getrs1_dble
+    module procedure :: getrs_real
+    module procedure :: getrs1_real
+  end interface getrs
+
+
   public :: gesv, getri, getrf, sytri, sytrf, matinv, symmatinv, sytrs, larnv
   public :: hermatinv, hetri, hetrf, gesvd
+  public :: getrs
 
 contains
 
@@ -1495,5 +1507,148 @@ contains
     deallocate(work)
 
   end subroutine zgesvd_dblecplx
+
+
+  !> Solves a system of linear equations with multiple right hand sides
+  subroutine getrs_dble(amat, ipiv, bmat, trans, iError)
+
+    !> Matrix of the linear system
+    real(rdp), intent(in) :: amat(:, :)
+
+    !> Pivot indices, row i of the matrix was interchanged with row ipiv(i).
+    integer, intent(in) :: ipiv(:)
+
+    !> Matrix of the right hand side vectors
+    real(rdp), intent(inout) :: bmat(:, :)
+
+    !> Optional transpose (defaults to 'n')
+    character(len=1), intent(in), optional :: trans
+
+    !> Error flag, zero on successful exit
+    integer, intent(out), optional :: iError
+
+    character(len=1) :: atr
+    integer :: info, nn, nrhs, lda, ldb
+
+    @:ASSERT(size(amat, 1) == size(amat, dim=2))
+    @:ASSERT(size(amat, 1) == size(bmat, dim=1))
+    if(present(trans)) then
+      @:ASSERT(any(trans == ['n', 'N', 't', 'T', 'c', 'C']))
+      atr = trans
+    else
+      atr = 'n'
+    endif
+    lda = max(1, size(amat, 1))
+    ldb = max(1, size(bmat, 1))
+    nn = size(amat, 2)
+    nrhs = size(bmat, 2)
+    call dgetrs(atr, nn, nrhs, amat, lda, ipiv, bmat, ldb, info)
+    if(present(iError)) then
+      iError = info
+    else
+      if (info /= 0) then
+        call error("Failed to solve linear system by diagonal pivoting")
+      end if
+    endif
+
+  end subroutine getrs_dble
+
+
+  !> Solves a system of linear equations with one right hand sides
+  subroutine getrs1_dble(amat, ipiv, bvec, trans, iError)
+
+    !> Matrix of the linear system
+    real(rdp), intent(in) :: amat(:, :)
+
+    !> Pivot indices, row i of the matrix was interchanged with row ipiv(i).
+    integer, intent(in) :: ipiv(:)
+
+    !> Right hand side vector
+    real(rdp), intent(inout), target :: bvec(:)
+
+    !> optional transpose (defaults to 'n')
+    character(len=1), intent(in), optional :: trans
+
+    !> Error flag, zero on successful exit
+    integer, intent(out), optional :: iError
+
+    real(rdp), pointer :: bptr(:, :)
+
+    bptr(1:size(bvec, 1), 1:1) => bvec(1:size(bvec, 1))
+    call getrs(amat, ipiv, bptr, trans, iError)
+
+  end subroutine getrs1_dble
+
+
+  !> Solves a system of linear equations with multiple right hand sides
+  subroutine getrs_real(amat, ipiv, bmat, trans, iError)
+
+    !> Matrix of the linear system
+    real(rsp), intent(in) :: amat(:, :)
+
+    !> Pivot indices, row i of the matrix was interchanged with row ipiv(i).
+    integer, intent(in) :: ipiv(:)
+
+    !> Matrix of the right hand side vectors
+    real(rsp), intent(inout) :: bmat(:, :)
+
+    !> Optional transpose (defaults to 'n')
+    character(len=1), intent(in), optional :: trans
+
+    !> Error flag, zero on successful exit
+    integer, intent(out), optional :: iError
+
+    character(len=1) :: atr
+    integer :: info, nn, nrhs, lda, ldb
+
+    @:ASSERT(size(amat, 1) == size(amat, dim=2))
+    @:ASSERT(size(amat, 1) == size(bmat, dim=1))
+    if(present(trans)) then
+      @:ASSERT(any(trans == ['n', 'N', 't', 'T', 'c', 'C']))
+      atr = trans
+    else
+      atr = 'n'
+    endif
+    lda = max(1, size(amat, 1))
+    ldb = max(1, size(bmat, 1))
+    nn = size(amat, 2)
+    nrhs = size(bmat, 2)
+    call sgetrs(atr, nn, nrhs, amat, lda, ipiv, bmat, ldb, info)
+    if(present(iError)) then
+      iError = info
+    else
+      if (info /= 0) then
+        call error("Failed to solve linear system by diagonal pivoting")
+      end if
+    endif
+
+  end subroutine getrs_real
+
+
+  !> Solves a system of linear equations with one right hand sides
+  subroutine getrs1_real(amat, ipiv, bvec, trans, iError)
+
+    !> Matrix of the linear system
+    real(rsp), intent(in) :: amat(:, :)
+
+    !> Pivot indices, row i of the matrix was interchanged with row ipiv(i).
+    integer, intent(in) :: ipiv(:)
+
+    !> Right hand side vector
+    real(rsp), intent(inout), target :: bvec(:)
+
+    !> Optional transpose (defaults to 'n')
+    character(len=1), intent(in), optional :: trans
+
+    !> Error flag, zero on successful exit
+    integer, intent(out), optional :: iError
+
+    real(rsp), pointer :: bptr(:, :)
+
+    bptr(1:size(bvec, 1), 1:1) => bvec(1:size(bvec, 1))
+    call getrs(amat, ipiv, bptr, trans, iError)
+
+  end subroutine getrs1_real
+
 
 end module dftbp_lapackroutines


### PR DESCRIPTION
Found this superfluous matrix inversion in the Broyden mixer, when working on an iterative solver for linear equations, which should probably not use a mixer defeating the purpose of the solver by needlessly inverting matrices.

Unfortunately, this cannot use the default `gesv` wrapper for `getrf` and `getrs`, because the matrix must be transposed before solving which is not available in the `gesv` interface on the LAPACK side. Also I had to remove and replace the already present wrapper for `getrs` (not used anywhere), because it was also doing the factorisation using `getrf`, which it is not supposed to do.

We should probably think about implementing `gesv` ourselves instead of using the LAPACK interface.