### PR TITLE
Enable builds with `arpack` on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
       - liblapack-dev
       - libopenmpi-dev
       - libscalapack-openmpi-dev
+      - libarpack2-dev
 
 install:
 - echo "y" | ./utils/get_opt_externals ALL

--- a/utils/test/travis-ci.sh
+++ b/utils/test/travis-ci.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 set -ex
 
+if [ ${WITH_MPI} ]; then
+   WITH_ARPACK=false
+else
+   WITH_ARPACK=true
+fi
+
 cmake_options=(
    "-DWITH_DFTD3=true"
    "-DWITH_TRANSPORT=true"
-   "-DWITH_ARPACK=${WITH_MPI}"
+   "-DWITH_ARPACK=${WITH_ARPACK}"
    "-DWITH_MPI=${WITH_MPI}"
    "-DFYPP_FLAGS='-DTRAVIS'"
    "-DCMAKE_TOOLCHAIN_FILE=../sys/gnu.cmake"

--- a/utils/test/travis-ci.sh
+++ b/utils/test/travis-ci.sh
@@ -4,7 +4,7 @@ set -ex
 cmake_options=(
    "-DWITH_DFTD3=true"
    "-DWITH_TRANSPORT=true"
-   "-DWITH_ARPACK=true"
+   "-DWITH_ARPACK=${WITH_MPI}"
    "-DWITH_MPI=${WITH_MPI}"
    "-DFYPP_FLAGS='-DTRAVIS'"
    "-DCMAKE_TOOLCHAIN_FILE=../sys/gnu.cmake"

--- a/utils/test/travis-ci.sh
+++ b/utils/test/travis-ci.sh
@@ -4,6 +4,7 @@ set -ex
 cmake_options=(
    "-DWITH_DFTD3=true"
    "-DWITH_TRANSPORT=true"
+   "-DWITH_ARPACK=true"
    "-DWITH_MPI=${WITH_MPI}"
    "-DFYPP_FLAGS='-DTRAVIS'"
    "-DCMAKE_TOOLCHAIN_FILE=../sys/gnu.cmake"

--- a/utils/test/travis-ci.sh
+++ b/utils/test/travis-ci.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
-if [ ${WITH_MPI} ]; then
-   WITH_ARPACK=false
-else
+if [ "${WITH_MPI}" == "false" ]; then
    WITH_ARPACK=true
+else
+   WITH_ARPACK=false
 fi
 
 cmake_options=(


### PR DESCRIPTION
This PR enables `arpack` based features in the MPI build on Travis-CI.

#### Timings

No noticeable additional cost in the Travis-CI environment

ARPACK | MPI | Release | Debug
--- | --- | --- | ---
false | false | 7 min | 9 min
true | false | 7 min | 9 min
false | true | 8 min | 10 min

Release build on my fork at: https://travis-ci.com/github/awvwgk/dftbplus/builds/163701087