### PR TITLE
Build DFTB+ on OSX

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -11,7 +11,8 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        brew install gcc cmake ninja
+        brew install ninja libomp open-mpi
+        echo "y" | ./utils/get_opt_externals ALL
     - name: Configure the project
       run: |
         cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -18,4 +18,4 @@ jobs:
         cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake
     - name: Build from source
       run: |
-        ninja -C _build_gcc
+        ninja -C _build

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -14,7 +14,7 @@ jobs:
         brew install gcc cmake ninja
     - name: Configure the project
       run: |
-        cmake -S. -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake
+        cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake
     - name: Build from source
       run: |
         ninja -C _build_gcc

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -6,6 +6,8 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
     - uses: actions/setup-python@v1
       with:
         python-version: '3.x'

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -1,0 +1,20 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  osx-build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        brew install gcc cmake ninja
+    - name: Configure the project
+      run: |
+        cmake -S. -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake
+    - name: Build from source
+      run: |
+        ninja -C _build_gcc

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -11,11 +11,11 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        brew install ninja libomp open-mpi
+        brew install ninja libomp arpack
         echo "y" | ./utils/get_opt_externals ALL
-    - name: Configure the project
-      run: |
-        cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake
-    - name: Build from source
-      run: |
-        ninja -C _build
+    - name: Configure build files
+      run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DWITH_DFTD3=true -DWITH_ARPACK=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake
+    - name: Compile project from source
+      run: ninja -C _build
+    - name: Run testsuite
+      run: cd _build && OMP_NUM_THREADS=2 ctest -j 2

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -14,7 +14,7 @@ jobs:
         brew install ninja libomp arpack
         echo "y" | ./utils/get_opt_externals ALL
     - name: Configure build files
-      run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DWITH_DFTD3=true -DWITH_ARPACK=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake
+      run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DFYPP_FLAGS='-DTRAVIS' -DWITH_TRANSPORT=true -DWITH_DFTD3=true -DWITH_ARPACK=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake
     - name: Compile project from source
       run: ninja -C _build
     - name: Run testsuite


### PR DESCRIPTION
Good news for Mac users, we can build and test DFTB+ on OSX now. This GH actions workflow creates a non-MPI build with DFTD3 and ARPACK enabled.

Does not run yet in this repo. Check results at:
https://github.com/awvwgk/dftbplus/actions?query=workflow%3ACI

Fails in the testsuite:

- `test_dptools`