### PR TITLE
Build DFTB+ on OSX

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -1,0 +1,23 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  osx-build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        brew install ninja libomp arpack
+        echo "y" | ./utils/get_opt_externals ALL
+    - name: Configure build files
+      run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DFYPP_FLAGS='-DTRAVIS' -DWITH_TRANSPORT=true -DWITH_DFTD3=true -DWITH_ARPACK=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake
+    - name: Compile project from source
+      run: ninja -C _build
+    - name: Run testsuite
+      run: cd _build && OMP_NUM_THREADS=2 ctest -j 2

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -14,6 +14,7 @@ jobs:
     - name: Install dependencies
       run: |
         brew install ninja libomp arpack
+        pip3 install numpy
         echo "y" | ./utils/get_opt_externals ALL
     - name: Configure build files
       run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DFYPP_FLAGS='-DTRAVIS' -DWITH_TRANSPORT=true -DWITH_DFTD3=true -DWITH_ARPACK=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake


### PR DESCRIPTION
![CI](https://github.com/awvwgk/dftbplus/workflows/CI/badge.svg?branch=osx-build)

Good news for Mac users, we can build and test DFTB+ on OSX now. This GH actions workflow creates a non-MPI build with transport, D3 and ARPACK enabled.

Does not run yet in this repo. Check results at:
https://github.com/awvwgk/dftbplus/actions?query=workflow%3ACI

Fails in the testsuite:

- ~~`test_dptools`~~ resolved