### PR TITLE
Fix crash due to multiple concurrent opening of a file

### DIFF
--- a/prog/dftb+/lib_common/globalenv.F90
+++ b/prog/dftb+/lib_common/globalenv.F90
@@ -102,7 +102,7 @@ contains
       stdErr = errorUnit0
     else
       open(newunit=stdOut, file="/dev/null", action="write")
-      open(newunit=stdErr, file="/dev/null", action="write")
+      stdErr = stdOut
     end if
     tIoProc = globalMpiComm%master
   #:else


### PR DESCRIPTION
Multiple opening of '/dev/null' leads to crashes with several compilers. Fix passes all buildbot tests.