### PR TITLE
Make release info update at each cmake invokation

### DIFF
--- a/cmake/dftbpUtils.cmake
+++ b/cmake/dftbpUtils.cmake
@@ -104,16 +104,14 @@ endfunction()
 #
 function(dftbp_get_release_name release)
 
-  if(NOT EXISTS ${CMAKE_BINARY_DIR}/RELEASE)
-    if(EXISTS ${CMAKE_SOURCE_DIR}/RELEASE)
-      file(COPY ${CMAKE_SOURCE_DIR}/RELEASE DESTINATION ${CMAKE_BINARY_DIR})
-    else()
-      execute_process(
-	COMMAND ${CMAKE_SOURCE_DIR}/utils/build/update_release ${CMAKE_BINARY_DIR}/RELEASE
-	RESULT_VARIABLE exitcode)
-      if(NOT exitcode EQUAL 0)
-	file(WRITE ${CMAKE_BINARY_DIR}/RELEASE "(UNKNOWN RELEASE)")
-      endif()
+  if(EXISTS ${CMAKE_SOURCE_DIR}/RELEASE)
+    file(COPY ${CMAKE_SOURCE_DIR}/RELEASE DESTINATION ${CMAKE_BINARY_DIR})
+  else()
+    execute_process(
+      COMMAND ${CMAKE_SOURCE_DIR}/utils/build/update_release ${CMAKE_BINARY_DIR}/RELEASE
+      RESULT_VARIABLE exitcode)
+    if(NOT exitcode EQUAL 0)
+      file(WRITE ${CMAKE_BINARY_DIR}/RELEASE "(UNKNOWN RELEASE)")
     endif()
   endif()
   file(READ ${CMAKE_BINARY_DIR}/RELEASE _release)


### PR DESCRIPTION
Partially disables caching of the `RELEASE` file in build-folder. Every cmake invokation should regenerate the `RELEASE` file, while invoking plain make (e.g. when recompiling during develoment) should use the version generated by the last cmake-invokation without any updates.