### PR TITLE
Fixed modes test and hsd parser calls

### DIFF
--- a/prog/modes/initmodes.F90
+++ b/prog/modes/initmodes.F90
@@ -41,22 +41,10 @@ module dftbp_initmodes
   !> parsed output name
   character(len=*), parameter :: hsdParsedInput = "modes_pin.hsd"
 
-  !> xml input file name
-  character(len=*), parameter :: xmlInput = "modes_in.xml"
-
-  !> parsed xml name
-  character(len=*), parameter :: xmlParsedInput = "modes_pin.xml"
-
   !> version of the input document
   integer, parameter :: parserVersion = 3
 
   public :: initProgramVariables
-
-  !! Variables from detailed.xml
-
-
-  !> Unique identifier of the run
-  integer, public :: identity
 
   !> Geometry
   type(TGeometry), public :: geo
@@ -118,7 +106,7 @@ contains
   subroutine initProgramVariables()
 
     type(TOldSKData) :: skData
-    type(fnode), pointer :: input, root, node, tmp
+    type(fnode), pointer :: root, node, tmp, hsdTree
     type(fnode), pointer :: value, child, child2
     type(TListRealR1) :: realBuffer
     type(string) :: buffer, buffer2
@@ -138,7 +126,8 @@ contains
     write(stdout, "(A,/)") repeat("=", 80)
 
     !! Read in input file as HSD
-    call parseHSD(rootTag, hsdInput, root)
+    call parseHSD(rootTag, hsdInput, hsdTree)
+    call getChild(hsdTree, rootTag, root)
 
     write(stdout, "(A)") "Interpreting input file '" // hsdInput // "'"
     write(stdout, "(A)") repeat("-", 80)
@@ -276,12 +265,12 @@ contains
 
     !! Finish parsing, dump parsed and processed input
     if (tWriteHSD) then
-      call dumpHSD(input, hsdParsedInput)
+      call dumpHSD(hsdTree, hsdParsedInput)
       write(stdout, "(A)") "Processed input written as HSD to '" // hsdParsedInput //"'"
     end if
     write(stdout, "(A)") repeat("-", 80)
     write(stdout, *)
-    call destroyNode(input)
+    call destroyNode(hsdTree)
 
     allocate(atomicMasses(nMovedAtom))
     do iAt = 1, nMovedAtom
@@ -298,7 +287,7 @@ contains
   end subroutine initProgramVariables
 
 
-  !> Read in the geometry stored as xml in internal or gen format.
+  !> Read in the geometry stored as gen format.
   subroutine readGeometry(geonode, geo)
 
     !> Node containing the geometry

--- a/prog/modes/modes.F90
+++ b/prog/modes/modes.F90
@@ -29,6 +29,7 @@ program modes
   real(dp), allocatable :: displ(:,:,:)
 
   character(lc) :: lcTmp, lcTmp2
+  integer :: fdUnit
 
   ! Allocate resources
   call initProgramVariables()
@@ -71,13 +72,13 @@ program modes
   write(stdout, *)
 
   call TTaggedWriter_init(taggedWriter)
-  open(12, file="vibrations.tag", form="formatted", status="replace")
-  call taggedWriter%write(12, "frequencies", eigenValues)
+  open(newunit=fdUnit, file="vibrations.tag", form="formatted", status="replace")
+  call taggedWriter%write(fdUnit, "frequencies", eigenValues)
 
   if (tPlotModes) then
-    call taggedWriter%write(12, "saved_modes", modesToPlot)
+    call taggedWriter%write(fdUnit, "saved_modes", modesToPlot)
     write(stdout, *) "Writing eigenmodes to vibrations.tag"
-    call taggedWriter%write(12, "eigenmodes", dynMatrix(:,ModesToPlot))
+    call taggedWriter%write(fdUnit, "eigenmodes", dynMatrix(:,ModesToPlot))
 
     write(stdout, *)'Plotting eigenmodes:'
     write(stdout, *)ModesToPlot(:)
@@ -95,8 +96,8 @@ program modes
       dynMatrix(:,iMode) = dynMatrix(:,iMode) &
           & / sqrt(sum(dynMatrix(:,iMode)**2))
     end do
-    call taggedWriter%write(12, "eigenmodes_scaled", dynMatrix(:,ModesToPlot))
-    close(12)
+    call taggedWriter%write(fdUnit, "eigenmodes_scaled", dynMatrix(:,ModesToPlot))
+    close(fdUnit)
 
     ! Create displacment vectors for every atom in every mode.
     nAtom = geo%nAtom
@@ -118,13 +119,13 @@ program modes
         iMode = ModesToPlot(ii)
         write(lcTmp,"('mode_',I0)")iMode
         write(lcTmp2, "(A,A)") trim(lcTmp), ".xyz"
-        open(123, file=trim(lcTmp2), position="rewind", status="replace")
+        open(newunit=fdUnit, file=trim(lcTmp2), position="rewind", status="replace")
         do kk = 1, nCycles
           do ll = 1, nSteps
-            write(123,*)nAtom
-            write(123,*)'Eigenmode',iMode,eigenValues(iMode)*Hartree__cm,'cm-1'
+            write(fdUnit,*)nAtom
+            write(fdUnit,*)'Eigenmode',iMode,eigenValues(iMode)*Hartree__cm,'cm-1'
             do iAt = 1, nAtom
-              write(123,'(A3,T4,3F10.6)') &
+              write(fdUnit,'(A3,T4,3F10.6)') &
                   & geo%speciesNames(geo%species(iAt)), &
                   & (geo%coords(:,iAt)&
                   & + cos(2.0_dp * pi * real(ll) / real(nSteps))&
@@ -132,18 +133,18 @@ program modes
             end do
           end do
         end do
-        close(123)
+        close(fdUnit)
       end do
     else
-      open(123, file="modes.xyz", position="rewind", status="replace")
+      open(newunit=fdUnit, file="modes.xyz", position="rewind", status="replace")
       do ii = 1, nModesToPlot
         iMode = ModesToPlot(ii)
-        write(123,*)nAtom
-        write(123,*)'Eigenmode',iMode,eigenValues(iMode)*Hartree__cm,'cm-1'
+        write(fdUnit,*)nAtom
+        write(fdUnit,*)'Eigenmode',iMode,eigenValues(iMode)*Hartree__cm,'cm-1'
         if (tXmakeMol) then
           ! need to account for its non-standard xyz vector format:
           do iAt = 1, nAtom
-            write(123,'(A3,T4,3F10.6,A,3F10.6)') &
+            write(fdUnit,'(A3,T4,3F10.6,A,3F10.6)') &
                 & geo%speciesNames(geo%species(iAt)), &
                 & geo%coords(:,iAt)* Bohr__AA, ' atom_vector ',&
                 & displ(:,iAt,ii)
@@ -151,14 +152,14 @@ program modes
         else
           ! genuine xyz format
           do iAt = 1, nAtom
-            write(123,'(A3,T4,6F10.6)') &
+            write(fdUnit,'(A3,T4,6F10.6)') &
                 & geo%speciesNames(geo%species(iAt)), &
                 & geo%coords(:,iAt)* Bohr__AA, &
                 & displ(:,iAt,ii)
           end do
         end if
       end do
-      close(123)
+      close(fdUnit)
     end if
 
   end if

--- a/prog/setupgeom/parser_setup.F90
+++ b/prog/setupgeom/parser_setup.F90
@@ -106,7 +106,8 @@ contains
     write(stdOut, "(/, A, /)") "***  Parsing and initializing"
 
     ! Read in the input
-    call parseHSD(rootTag, hsdInputName, root)
+    call parseHSD(rootTag, hsdInputName, hsdTree)
+    call getChild(hsdTree, rootTag, root)
 
     write(stdout, '(A,1X,I0,/)') 'Parser version:', parserVersion
     write(stdout, "(A)") "Interpreting input file '" // hsdInputName // "'"

--- a/prog/waveplot/initwaveplot.F90
+++ b/prog/waveplot/initwaveplot.F90
@@ -200,7 +200,7 @@ contains
   !> Initialise program variables
   subroutine initProgramVariables()
 
-    type(fnode), pointer :: input, root, tmp, detailed
+    type(fnode), pointer :: root, tmp, detailed, hsdTree
     type(string) :: strBuffer
     integer :: inputVersion
     integer :: ii
@@ -212,7 +212,9 @@ contains
     write(stdout, "(A,/)") repeat("=", 80)
 
     !! Read in input file as HSD
-    call parseHSD(rootTag, hsdInput, root)
+    call parseHSD(rootTag, hsdInput, hsdTree)
+    call getChild(hsdTree, rootTag, root)
+
     write(stdout, "(A)") "Interpreting input file '" // hsdInput // "'"
 
     !! Check if input version is the one, which we can handle
@@ -247,12 +249,12 @@ contains
     call warnUnprocessedNodes(root, .true.)
 
     !! Finish parsing, dump parsed and processed input
-    call dumpHSD(input, hsdParsedInput)
+    call dumpHSD(hsdTree, hsdParsedInput)
     write(stdout, "(A)") "Processed input written as HSD to '" // hsdParsedInput &
         &//"'"
     write(stdout, "(A)") repeat("-", 80)
     write(stdout, *)
-    call destroyNode(input)
+    call destroyNode(hsdTree)
 
     !! Create grid vectors, shift them if necessary
     do ii = 1, 3

--- a/test/prog/modes/bin/autotest2
+++ b/test/prog/modes/bin/autotest2
@@ -39,7 +39,7 @@ TAGDIFF_MATCH_OK="OK"
 TAGDIFF_MATCH_INCOMPLETE="Not found in new"
 
 #APP_STDIN=input
-APP_INPUT=dftb_in.hsd
+APP_INPUT=modes_in.hsd
 APP_STDOUT=output
 APP_STDERR=stderror.log
 APP_TAGDATA=vibrations.tag


### PR DESCRIPTION
Fixes modes test to actually run, as input script missing.
Fixes HSD head nodes and dumping in codes with xml removal
from 386312df where parseHSDInput was called without setting
the top of the tree afterward.

Also changed to use newunit for the files in modes.