### PR TITLE
 Refactor initprogram

### DIFF
--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -3351,7 +3351,7 @@ contains
     real(dp), allocatable, intent(inout) :: qiBlockOut(:, :, :, :)
 
     !> Tolerance in difference between total charge and sum of initial charges
-    real(dp), parameter :: delta_charge_tol = 1.e-4_dp
+    real(dp), parameter :: deltaChargeTol = 1.e-4_dp
 
     integer :: iAt,iSp,iSh,ii,jj,i,j, iStart,iStop,iEnd,iS
     real(dp) :: rTmp

--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -1600,7 +1600,7 @@ contains
     ! Orbital equivalency relations 
     call setEquivalencyRelations(species0, sccCalc, orb, onSiteElements, iEqOrbitals, &
          & iEqBlockDFTBU, iEqBlockOnSite, iEqBlockDFTBULS, iEqBlockOnSiteLS, nIneqOrb, nMixElements)
- 
+
     ! Initialize mixer
     ! (at the moment, the mixer does not need to know about the size of the
     ! vector to mix.)
@@ -3177,13 +3177,14 @@ contains
   
   !> Create equivalency relations
   ! Data available from module: nUJ, niUJ, iUJ, nAtom, nSpin, nOrb and logicals 
+  ! Note, this routine should not be called
   subroutine setEquivalencyRelations(species0, sccCalc, orb, onSiteElements, iEqOrbitals, &
        & iEqBlockDFTBU, iEqBlockOnSite, iEqBlockDFTBULS, iEqBlockOnSiteLS, nIneqOrb, nMixElements)
     
     !> Type of the atoms (nAtom)
     integer,  intent(in) :: species0(:)
     !> SCC module internal variables
-    type(TScc), intent(in) :: sccCalc
+    type(TScc), allocatable, intent(in) :: sccCalc
     !> data type for atomic orbital information
     type(TOrbitals), intent(in) :: orb
     !> Correction to energy from on-site matrix elements
@@ -3212,11 +3213,12 @@ contains
     integer, allocatable :: iEqOrbDFTBU(:,:,:)
     
 
-    if (tSccCalc) then
+    if (tSccCalc) then 
        if(.not. allocated(iEqOrbitals)) then
           allocate(iEqOrbitals(orb%mOrb, nAtom, nSpin))
        endif
        allocate(iEqOrbSCC(orb%mOrb, nAtom, nSpin))
+       @:ASSERT(allocated(sccCalc))
        call sccCalc%getOrbitalEquiv(orb, species0, iEqOrbSCC)
        if (nSpin == 1) then
           iEqOrbitals(:,:,:) = iEqOrbSCC(:,:,:)
@@ -3288,7 +3290,7 @@ contains
           end if
        end if
 
-    !Non-SCC
+    !Non-SCC 
     else
        nIneqOrb = nOrb
        nMixElements = 0

--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -3417,26 +3417,18 @@ contains
        end if
     endif
 
-    !Input charges packed into unique equivalence elements
-    if (.not. allocated(reks)) then
+    !Input charges packed into unique equivalence elements 
     #:for NAME in [('qDiffRed'),('qInpRed'),('qOutRed')]
        if (.not. allocated(${NAME}$)) then
           allocate(${NAME}$(nMixElements))
        end if
        ${NAME}$(:) = 0.0_dp
     #:endfor
-    endif
        
-    ! Only qInpRed is used in REKS, hence RETURN
-    if(allocated(reks)) then
-       if (.not. allocated(qInpRed)) then
-          allocate(qInpRed(nMixElements))
-       endif
-       qInpRed = 0.0_dp
-
-       return
-    endif
-
+ 
+    !TODO(Alex) Could definitely split the code here
+    if(allocated(reks)) return
+    
 
     ! Charges not read from file
     notChrgRead: if (.not. tReadChrg) then

--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -3427,7 +3427,7 @@ contains
     ! Only qInpRed is used in REKS, hence RETURN
     if(allocated(reks)) then
        if (.not. allocated(qInpRed)) then
-          allocate(qInpRed)
+          allocate(qInpRed(nMixElements))
        endif
        qInpRed = 0.0_dp
 

--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -3314,7 +3314,7 @@ contains
     !> Number of electrons
     real(dp), intent(in) :: nEl(:)
     !> Orbital equivalence relations
-    integer, intent(in) :: iEqOrbitals(:,:,:)
+    integer, intent(in), allocatable :: iEqOrbitals(:,:,:)
     !> nr. of inequivalent orbitals
     integer, intent(in) :: nIneqOrb
     !> nr. of elements to go through the mixer

--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -3208,7 +3208,6 @@ contains
     integer, allocatable :: iEqOrbSCC(:,:,:), iEqOrbSpin(:,:,:)
     !> Orbital equivalency for orbital potentials
     integer, allocatable :: iEqOrbDFTBU(:,:,:)
-    
 
     if (tSccCalc) then 
        if(.not. allocated(iEqOrbitals)) then
@@ -3360,17 +3359,18 @@ contains
     ! Charge arrays may have already been initialised
     @:ASSERT(size(species0) == nAtom)
 
-    if ((.not. allocated(qInput)) .and. (.not.allocated(reks))) then
-       allocate(qInput(orb%mOrb, nAtom, nSpin))
+    if (.not.allocated(reks)) then
+       if (.not. allocated(qInput)) then
+          allocate(qInput(orb%mOrb, nAtom, nSpin))
+       endif
+       qInput(:,:,:) = 0.0_dp
     endif
     
     if (.not. allocated(qOutput)) then
        allocate(qOutput(orb%mOrb, nAtom, nSpin))
     endif
-    
-    qInput(:,:,:) = 0.0_dp
     qOutput(:,:,:) = 0.0_dp
-
+    
     if (tMixBlockCharges) then
        if ((.not. allocated(qBlockIn)) .and. (.not. allocated(reks))) then
           allocate(qBlockIn(orb%mOrb, orb%mOrb, nAtom, nSpin))
@@ -3387,7 +3387,7 @@ contains
           qiBlockIn(:,:,:,:) = 0.0_dp
        end if
     end if
-    
+
     if (tImHam) then
        if(.not. allocated(qiBlockOut))then
           allocate(qiBlockOut(orb%mOrb, orb%mOrb, nAtom, nSpin))
@@ -3396,7 +3396,6 @@ contains
     end if
     
     if( .not. tSccCalc) return
-
 
     ! Charges read from file
     if (tReadChrg) then
@@ -3428,7 +3427,6 @@ contains
  
     !TODO(Alex) Could definitely split the code here
     if(allocated(reks)) return
-    
 
     ! Charges not read from file
     notChrgRead: if (.not. tReadChrg) then

--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -3350,6 +3350,9 @@ contains
     !> Imaginary part of output Mulliken block charges
     real(dp), allocatable, intent(inout) :: qiBlockOut(:, :, :, :)
 
+    !> Tolerance in difference between total charge and sum of initial charges
+    real(dp), parameter :: delta_charge_tol = 1.e-4_dp
+
     integer :: iAt,iSp,iSh,ii,jj,i,j, iStart,iStop,iEnd,iS
     real(dp) :: rTmp
     character(lc) :: message 
@@ -3439,8 +3442,7 @@ contains
     notChrgRead: if (.not. tReadChrg) then
 
       if (allocated(initialCharges)) then
-         !TODO(Alex) Address use of magic number
-        if (abs(sum(initialCharges) - nrChrg) > 1e-4_dp) then
+        if (abs(sum(initialCharges) - nrChrg) > deltaChargeTol) then
           write(message, "(A,G13.6,A,G13.6,A,A)") "Sum of initial charges does not match&
               & specified total charge. (", sum(initialCharges), " vs. ", nrChrg, ") ",&
               & "Your initial charge distribution will be rescaled."

--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -551,7 +551,7 @@ module dftbp_initprogram
   !> Spin polarisation  
   real(dp) :: nrSpinPol
   
-  !> Is the check-sum for charges read externally be used?                                                     
+  !> Is the check-sum for charges read externally to be used?
   logical :: tSkipChrgChecksum
 
   !> reference neutral atomic occupations
@@ -1125,9 +1125,6 @@ contains
 
     !> First guess for nr. of neighbours.
     integer, parameter :: nInitNeighbour = 40
-
-    !> Is the check-sum for charges read externally be used?
-    logical :: tSkipChrgChecksum
 
     !> Spin loop index
     integer :: iSpin
@@ -3396,6 +3393,7 @@ contains
     end if
     
     if( .not. tSccCalc) return
+
 
     ! Charges read from file
     if (tReadChrg) then


### PR DESCRIPTION
This PR refactors initprogram by moving:   
* equivalency relations 
* charge initialisation and setting
* N-electrons setting

to separate subroutines within the initprogram module, where they can subsequently be used by the DFTB+ API.  