### PR TITLE
Add additional entries in results.tag

### DIFF
--- a/prog/dftb+/lib_dftbplus/main.F90
+++ b/prog/dftb+/lib_dftbplus/main.F90
@@ -298,9 +298,9 @@ contains
           & lCurrArray)
     end if
     if (tWriteResultsTag) then
-      call writeResultsTag(resultsTag, energy, derivs, chrgForces, electronicSolver, tStress,&
-          & totalStress, pDynMatrix, tPeriodic, cellVol, tMulliken, qOutput, q0, taggedWriter,&
-          & tDefinedFreeE, cm5Cont)
+      call writeResultsTag(resultsTag, energy, derivs, chrgForces, nEl, Ef, eigen, filling,&
+          & electronicSolver, tStress, totalStress, pDynMatrix, tPeriodic, cellVol, tMulliken,&
+          & qOutput, q0, taggedWriter, tDefinedFreeE, cm5Cont)
     end if
     if (tWriteDetailedXML) then
       call writeDetailedXml(runId, speciesName, species0, pCoord0Out, tPeriodic, tHelical, latVec,&

--- a/prog/dftb+/lib_dftbplus/mainio.F90
+++ b/prog/dftb+/lib_dftbplus/mainio.F90
@@ -1782,7 +1782,7 @@ contains
     !> list of region names
     type(TListCharLc), intent(inout) :: fileNames
 
-    !> eigenvalues
+    !> Eigenvalues
     real(dp), intent(in) :: eigvals(:,:,:)
 
     !> Neighbour list.
@@ -2034,9 +2034,9 @@ contains
 
 
   !> Writes out machine readable data
-  subroutine writeResultsTag(fileName, energy, derivs, chrgForces, electronicSolver, tStress,&
-      & totalStress, pDynMatrix, tPeriodic, cellVol, tMulliken, qOutput, q0, taggedWriter,&
-      & tDefinedFreeE, cm5Cont)
+  subroutine writeResultsTag(fileName, energy, derivs, chrgForces, nEl, Ef, eigen, filling,&
+      & electronicSolver, tStress, totalStress, pDynMatrix, tPeriodic, cellVol, tMulliken,&
+      & qOutput, q0, taggedWriter, tDefinedFreeE, cm5Cont)
 
     !> Name of output file
     character(*), intent(in) :: fileName
@@ -2049,6 +2049,18 @@ contains
 
     !> Forces on external charges
     real(dp), allocatable, intent(in) :: chrgForces(:,:)
+
+    !> Number of electrons
+    real(dp), intent(in) :: nEl(:)
+
+    !> Fermi level(s)
+    real(dp), intent(inout) :: Ef(:)
+
+    !> Eigenvalues/single particle states (level, kpoint, spin)
+    real(dp), intent(in) :: eigen(:,:,:)
+
+    !> Filling of the eigenstates
+    real(dp), intent(in) :: filling(:,:,:)
 
     !> Electronic solver information
     type(TElectronicSolver), intent(in) :: electronicSolver
@@ -2095,11 +2107,15 @@ contains
     open(newunit=fd, file=fileName, action="write", status="replace")
 
     call taggedWriter%write(fd, tagLabels%egyTotal, energy%ETotal)
+    call taggedWriter%write(fd, tagLabels%fermiLvl, Ef)
+    call taggedWriter%write(fd, tagLabels%nElec, nEl)
 
     if (electronicSolver%providesEigenvals) then
       call taggedWriter%write(fd, tagLabels%freeEgy, energy%EMermin)
       ! extrapolated zero temperature energy
       call taggedWriter%write(fd, tagLabels%egy0Total, energy%Ezero)
+      call taggedWriter%write(fd, tagLabels%eigvals, eigen)
+      call taggedWriter%write(fd, tagLabels%eigFill, filling)
     end if
 
     if (tDefinedFreeE) then

--- a/prog/dftb+/lib_io/taggedoutput.F90
+++ b/prog/dftb+/lib_io/taggedoutput.F90
@@ -81,6 +81,18 @@ module dftbp_taggedoutput
     !> forces on any external charges present
     character(lenLabel) :: chrgForces = 'forces_ext_charges'
 
+    !> Fermi level(s)
+    character(lenLabel) :: fermiLvl = 'fermi_level'
+
+    !> number of electrons
+    character(lenLabel) :: nElec = 'number_of_electrons'
+
+    !> eigenvalues/single particle states
+    character(lenLabel) :: eigvals = 'eigenvalues'
+
+    !> filling of the eigenstates
+    character(lenLabel) :: eigFill = 'filling'
+
     !> Gibbs free energy for finite pressure periodic systems
     character(lenLabel) :: gibbsFree = 'gibbs_energy'
 


### PR DESCRIPTION
Add additional entries in results.tag files, as requested by [a discussion on the ASE project page](https://gitlab.com/ase/ase/-/issues/542#note_282440001) (closes #372).

- [x] forces on external point charges (were already present)
- [x] eigenvalues
- [x] occupations/filling
- [x] Fermi level(s)
- [ ] magnetic moments on the atoms/total magnetic moment
(not really necessary, as calculable)