### PR TITLE
Enable testing of API on CI builds

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -17,10 +17,7 @@ jobs:
         pip3 install numpy
         echo "y" | ./utils/get_opt_externals ALL
     - name: Configure build files
-      run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DFYPP_FLAGS='-DTRAVIS' -DWITH_TRANSPORT=true -DWITH_DFTD3=true -DWITH_ARPACK=true -DWITH_API=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake -DCMAKE_Fortran_COMPILER=$FC -DCMAKE_C_COMPILER=$CC
-      env:
-       - FC=gfortran-7
-       - CC=gcc-7
+      run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DFYPP_FLAGS='-DTRAVIS' -DWITH_TRANSPORT=true -DWITH_DFTD3=true -DWITH_ARPACK=true -DWITH_API=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake -DCMAKE_Fortran_COMPILER=gfortran-7 -DCMAKE_C_COMPILER=gcc-7
     - name: Compile project from source
       run: ninja -C _build
     - name: Run testsuite

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -18,7 +18,9 @@ jobs:
         echo "y" | ./utils/get_opt_externals ALL
     - name: Configure build files
       run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DFYPP_FLAGS='-DTRAVIS' -DWITH_TRANSPORT=true -DWITH_DFTD3=true -DWITH_ARPACK=true -DWITH_API=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake -DCMAKE_Fortran_COMPILER=$FC -DCMAKE_C_COMPILER=$CC
-      env: FC=gfortran-7 CC=gcc-7
+      env:
+       - FC=gfortran-7
+       - CC=gcc-7
     - name: Compile project from source
       run: ninja -C _build
     - name: Run testsuite

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  osx-build-gcc:
+  osx-build:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
@@ -13,33 +13,12 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        brew install ninja arpack gcc@7
+        brew install ninja arpack gcc@8
         pip3 install numpy
         echo "y" | ./utils/get_opt_externals ALL
     - name: Configure build files
-      run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DFYPP_FLAGS='-DTRAVIS' -DWITH_TRANSPORT=true -DWITH_DFTD3=true -DWITH_ARPACK=true -DWITH_API=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake -DCMAKE_Fortran_COMPILER=gfortran-7 -DCMAKE_C_COMPILER=gcc-7
+      run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DFYPP_FLAGS='-DTRAVIS' -DWITH_TRANSPORT=true -DWITH_DFTD3=true -DWITH_ARPACK=true -DWITH_API=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake -DCMAKE_Fortran_COMPILER=gfortran-8 -DCMAKE_C_COMPILER=gcc-8
     - name: Compile project from source
       run: ninja -C _build
     - name: Run testsuite
       run: cd _build && OMP_NUM_THREADS=2 ctest -j 2
-
-  osx-build-clang:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/setup-python@v1
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        brew install ninja arpack
-        pip3 install numpy
-        echo "y" | ./utils/get_opt_externals ALL
-    - name: Configure build files
-      run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DFYPP_FLAGS='-DTRAVIS' -DWITH_TRANSPORT=true -DWITH_DFTD3=true -DWITH_ARPACK=true -DWITH_OMP=false -DWITH_API=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake
-    - name: Compile project from source
-      run: ninja -C _build
-    - name: Run testsuite
-      run: cd _build && ctest -j 2

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  osx-build:
+  osx-build-gcc:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
@@ -13,12 +13,34 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        brew install ninja libomp arpack
+        brew install ninja arpack gcc@7
         pip3 install numpy
         echo "y" | ./utils/get_opt_externals ALL
     - name: Configure build files
-      run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DFYPP_FLAGS='-DTRAVIS' -DWITH_TRANSPORT=true -DWITH_DFTD3=true -DWITH_ARPACK=true -DWITH_API=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake
+      run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DFYPP_FLAGS='-DTRAVIS' -DWITH_TRANSPORT=true -DWITH_DFTD3=true -DWITH_ARPACK=true -DWITH_API=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake -DCMAKE_Fortran_COMPILER=$FC -DCMAKE_C_COMPILER=$CC
+      env: FC=gfortran-7 CC=gcc-7
     - name: Compile project from source
       run: ninja -C _build
     - name: Run testsuite
       run: cd _build && OMP_NUM_THREADS=2 ctest -j 2
+
+  osx-build-clang:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        brew install ninja arpack
+        pip3 install numpy
+        echo "y" | ./utils/get_opt_externals ALL
+    - name: Configure build files
+      run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DFYPP_FLAGS='-DTRAVIS' -DWITH_TRANSPORT=true -DWITH_DFTD3=true -DWITH_ARPACK=true -DWITH_OMP=false -DWITH_API=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake
+    - name: Compile project from source
+      run: ninja -C _build
+    - name: Run testsuite
+      run: cd _build && ctest -j 2

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -17,7 +17,7 @@ jobs:
         pip3 install numpy
         echo "y" | ./utils/get_opt_externals ALL
     - name: Configure build files
-      run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DFYPP_FLAGS='-DTRAVIS' -DWITH_TRANSPORT=true -DWITH_DFTD3=true -DWITH_ARPACK=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake
+      run: cmake -B_build -S. -GNinja -DCMAKE_BUILD_TYPE=Debug -DFYPP_FLAGS='-DTRAVIS' -DWITH_TRANSPORT=true -DWITH_DFTD3=true -DWITH_ARPACK=true -DWITH_API=true -DCMAKE_TOOLCHAIN_FILE=./sys/gnu.cmake
     - name: Compile project from source
       run: ninja -C _build
     - name: Run testsuite

--- a/utils/test/travis-ci.sh
+++ b/utils/test/travis-ci.sh
@@ -12,6 +12,7 @@ cmake_options=(
    "-DWITH_TRANSPORT=true"
    "-DWITH_ARPACK=${WITH_ARPACK}"
    "-DWITH_MPI=${WITH_MPI}"
+   "-DWITH_API=true"
    "-DFYPP_FLAGS='-DTRAVIS'"
    "-DCMAKE_TOOLCHAIN_FILE=../sys/gnu.cmake"
 )


### PR DESCRIPTION
If we have PRs working on the API (#501, #420) we should continuously test them to avoid the most basic failures. This PR enables testing on Linux and OSX for the API.

*OSX build was failing, as clang is unable to link the API testers due to missing OMP symbols.*

libomp (for clang) is installed via homebrew, but the versions don't match (as expected):

```
-- Found OpenMP_C: -Xclang -fopenmp (found version "3.1") 
-- Found OpenMP_Fortran: -fopenmp (found version "4.5")
```

The easy fix would be to disable OMP on OSX builds, but let's not talk about this option. The probably better fix would be to not use clang in the first place, but use GCC. Which will require some hacks because we cannot easily do this with the present cmake toolchain files due to #460.

@dftbplus/administrators any opinion on this?

Interestingly, the GCC7 build on OSX is failing for

```
160 - dftb+_timedep/C6H6-Sym_Arnoldi (Failed)
```

while the clang build is passing.

Decision is to bump the GCC version to 8.