### PR TITLE
Replace use of allocation status by optionals

### DIFF
--- a/prog/dftb+/lib_dftb/dftbplusu.F90
+++ b/prog/dftb+/lib_dftb/dftbplusu.F90
@@ -260,10 +260,7 @@ contains
   !> Calculates the energy contribution for the DFTB+U type functionals
   !>
   !> Note: factor of 0.5 in expressions as using double the Pauli spinors
-  subroutine E_dftbU(egy, qBlock, species, orb, functional, UJ, nUJ, niUJ, iUJ, qiBlock)
-
-    !> energy contribution
-    real(dp), intent(out) :: egy(:)
+  subroutine E_dftbU(qBlock, species, orb, UJ, nUJ, niUJ, iUJ, egy, functional, qiBlock)
 
     !> charge block populations
     real(dp), intent(in) :: qBlock(:,:,:,:)
@@ -273,9 +270,6 @@ contains
 
     !> Angular momentum information about the orbitals.
     type(TOrbitals), intent(in) :: orb
-
-    !> choice of functional, so far FLL, pSIC (1,2)
-    integer, intent(in), optional :: functional
 
     !> list of U-J values for each species
     real(dp), intent(in) :: UJ(:,:)
@@ -288,6 +282,12 @@ contains
 
     !> list of l values in each block for each species
     integer, intent(in) :: iUJ(:,:,:)
+
+    !> energy contribution
+    real(dp), intent(out) :: egy(:)
+
+    !> choice of functional, so far FLL, pSIC (1,2)
+    integer, intent(in), optional :: functional
 
     !> optional skew population for L.S cases
     real(dp), intent(in), optional :: qiBlock(:,:,:,:)
@@ -405,10 +405,7 @@ contains
 
 
   !> Returns the equivalence between the orbitals in the DFTB+U interactions
-  subroutine DFTBplsU_getOrbitalEquiv(equiv, orb, species, nUJ, niUJ, iUJ)
-
-    !> The equivalence vector on return
-    integer, intent(out) :: equiv(:,:,:)
+  subroutine DFTBplsU_getOrbitalEquiv(orb, species, nUJ, niUJ, iUJ, equiv)
 
     !> Information about the orbitals and their angular momenta
     type(TOrbitals), intent(in) :: orb
@@ -424,6 +421,9 @@ contains
 
     !> l-values of U-J for each block
     integer, intent(in) :: iUJ(:,:,:)
+
+    !> The equivalence vector on return
+    integer, intent(out) :: equiv(:,:,:)
 
     integer :: nAtom, iCount, iSpin, nSpin
     integer :: iAt, iSp, ii, jj, kk, iStart, iEnd
@@ -472,10 +472,7 @@ contains
 
 
   !> Returns the index for packing the relevant parts of DFTB+U atomic blocks into a 1D array
-  subroutine DFTBU_blockIndx(iEqBlockDFTBU, count, orb, species, nUJ, niUJ, iUJ)
-
-    !> The mapping array on return
-    integer, intent(out) :: iEqBlockDFTBU(:,:,:,:)
+  subroutine DFTBU_blockIndx(count, orb, species, nUJ, niUJ, iUJ, iEqBlockDFTBU)
 
     !> Number of prior entries in 1D array holding regular charges
     integer, intent(in) :: count
@@ -494,6 +491,9 @@ contains
 
     !> l-values of U-J for each block
     integer, intent(in) :: iUJ(:,:,:)
+
+    !> The mapping array on return
+    integer, intent(out) :: iEqBlockDFTBU(:,:,:,:)
 
     integer :: nAtom, nSpin, iCount
     integer :: iAt, iSp, iSpecies
@@ -628,7 +628,7 @@ contains
     integer, intent(in) :: iUJ(:,:,:)
 
     !> equivalences for atoms
-    integer, intent(in),optional :: orbEquiv(:,:,:)
+    integer, intent(in), optional :: orbEquiv(:,:,:)
 
     !> is skew symmetry required
     logical, optional, intent(in) :: skew

--- a/prog/dftb+/lib_dftb/getenergies.F90
+++ b/prog/dftb+/lib_dftb/getenergies.F90
@@ -110,7 +110,7 @@ contains
     type(TEnergies), intent(inout) :: energy
 
     !> block (dual) atomic populations
-    real(dp), intent(in) :: qBlock(:,:,:,:)
+    real(dp), intent(in), allocatable :: qBlock(:,:,:,:)
 
     !> U-J prefactors in DFTB+U
     real(dp), intent(in) :: UJ(:,:)
@@ -125,7 +125,7 @@ contains
     integer, intent(in) :: niUJ(:,:)
 
     !> Spin orbit constants
-    real(dp), intent(in) :: xi(:,:)
+    real(dp), intent(in), allocatable :: xi(:,:)
 
     !> Atoms over which to sum the total energies
     integer, intent(in) :: iAtInCentralRegion(:)
@@ -156,10 +156,10 @@ contains
     type(TQDepExtPotProxy), intent(inout), optional :: qDepExtPot
 
     !> Corrections terms for on-site elements
-    real(dp), intent(in), optional :: onSiteElements(:,:,:,:)
+    real(dp), intent(in), allocatable :: onSiteElements(:,:,:,:)
 
     !> Imaginary part of block atomic populations
-    real(dp), intent(in), optional :: qiBlock(:,:,:,:)
+    real(dp), intent(in), allocatable :: qiBlock(:,:,:,:)
 
     !> which DFTB+U functional (if used)
     integer, intent(in), optional :: nDftbUFunc
@@ -214,13 +214,13 @@ contains
       energy%eSolv = sum(energy%atomSolv(iAtInCentralRegion))
     end if
 
-    if (present(onSiteElements)) then
+    if (allocated(onSiteElements)) then
       call getEons(qBlock, q0, onSiteElements, species, orb, energy%atomOnSite, qiBlock)
       energy%eOnSite = sum(energy%atomOnSite)
     end if
 
     if (tDftbU) then
-      if (present(qiBlock)) then
+      if (allocated(qiBlock)) then
         call E_DFTBU(qBlock, species, orb, UJ, nUJ, niUJ, iUJ, energy%atomDftbu, nDFTBUfunc, qiBlock)
       else
         call E_DFTBU(qBlock, species, orb, UJ, nUJ, niUJ, iUJ, energy%atomDftbu, nDFTBUfunc)

--- a/prog/dftb+/lib_dftb/getenergies.F90
+++ b/prog/dftb+/lib_dftb/getenergies.F90
@@ -45,9 +45,9 @@ contains
   !> Calculates various energy contribution that can potentially update for the same geometry
   subroutine calcEnergies(qOrb, q0, chargePerShell, species, tExtField, isXlbomd, tDftbU,&
       & tDualSpinOrbit, rhoPrim, H0, orb, neighbourList, nNeighbourSK, img2CentCell, iSparseStart,&
-      & cellVol, extPressure, TS, potential, energy, qBlock, UJ, nUJ, iUJ, niUJ, xi,&
-      & iAtInCentralRegion, tFixEf, Ef, sccCalc, thirdOrd, solvation, rangeSep, reks, qDepExtPot,&
-      & onSiteElements, qiBlock, nDftbUFunc)
+      & cellVol, extPressure, TS, potential, UJ, nUJ, iUJ, niUJ, iAtInCentralRegion, tFixEf, xi,&
+      & onSiteElements, qBlock, qiBlock, energy, Ef, sccCalc, nDftbUFunc, thirdOrd, solvation,&
+      & rangeSep, reks, qDepExtPot)
 
     !> Electrons in each atomic orbital
     real(dp), intent(in) :: qOrb(:,:,:)
@@ -106,12 +106,6 @@ contains
     !> potentials acting
     type(TPotentials), intent(in) :: potential
 
-    !> energy contributions
-    type(TEnergies), intent(inout) :: energy
-
-    !> block (dual) atomic populations
-    real(dp), intent(in), allocatable :: qBlock(:,:,:,:)
-
     !> U-J prefactors in DFTB+U
     real(dp), intent(in) :: UJ(:,:)
 
@@ -124,14 +118,26 @@ contains
     !> Number of shells in each DFTB+U block
     integer, intent(in) :: niUJ(:,:)
 
-    !> Spin orbit constants
-    real(dp), intent(in), allocatable :: xi(:,:)
-
     !> Atoms over which to sum the total energies
     integer, intent(in) :: iAtInCentralRegion(:)
 
     !> Whether fixed Fermi level(s) should be used. (No charge conservation!)
     logical, intent(in) :: tFixEf
+
+    !> Spin orbit constants
+    real(dp), intent(in), allocatable :: xi(:,:)
+
+    !> Corrections terms for on-site elements
+    real(dp), intent(in), allocatable :: onSiteElements(:,:,:,:)
+
+    !> block (dual) atomic populations
+    real(dp), intent(in), allocatable :: qBlock(:,:,:,:)
+
+    !> Imaginary part of block atomic populations
+    real(dp), intent(in), allocatable :: qiBlock(:,:,:,:)
+
+    !> energy contributions
+    type(TEnergies), intent(inout) :: energy
 
     !> If tFixEf is .true. contains reservoir chemical potential, otherwise the Fermi levels found
     !> from the given number of electrons
@@ -139,6 +145,9 @@ contains
 
     !> SCC module internal variables
     type(TScc), intent(in), optional :: sccCalc
+
+    !> which DFTB+U functional (if used)
+    integer, intent(in), optional :: nDftbUFunc
 
     !> 3rd order settings
     type(TThirdOrder), intent(inout), optional :: thirdOrd
@@ -154,15 +163,6 @@ contains
 
     !> Proxy for querying Q-dependant external potentials
     type(TQDepExtPotProxy), intent(inout), optional :: qDepExtPot
-
-    !> Corrections terms for on-site elements
-    real(dp), intent(in), allocatable :: onSiteElements(:,:,:,:)
-
-    !> Imaginary part of block atomic populations
-    real(dp), intent(in), allocatable :: qiBlock(:,:,:,:)
-
-    !> which DFTB+U functional (if used)
-    integer, intent(in), optional :: nDftbUFunc
 
     integer :: nSpin
     real(dp) :: nEl(2)

--- a/prog/dftb+/lib_dftb/hamiltonian.F90
+++ b/prog/dftb+/lib_dftb/hamiltonian.F90
@@ -203,7 +203,7 @@ contains
 
 
   !> Reset internal potential related quantities
-  subroutine resetInternalPotentials(tDualSpinOrbit, orb, species, potential, xi)
+  subroutine resetInternalPotentials(tDualSpinOrbit, orb, species, xi, potential)
 
     !> Is dual spin orbit being used (block potentials)
     logical, intent(in) :: tDualSpinOrbit
@@ -214,11 +214,11 @@ contains
     !> chemical species
     integer, intent(in) :: species(:)
 
-    !> potentials in the system
-    type(TPotentials), intent(inout) :: potential
-
     !> Spin orbit constants if required
     real(dp), intent(in), allocatable :: xi(:,:)
+
+    !> potentials in the system
+    type(TPotentials), intent(inout) :: potential
 
     @:ASSERT(.not. tDualSpinOrbit .or. allocated(xi))
 
@@ -236,8 +236,8 @@ contains
 
   !> Add potentials comming from point charges.
   subroutine addChargePotentials(env, sccCalc, qInput, q0, chargePerShell, orb, species,&
-      & neighbourList, img2CentCell, potential, electrostatics, tPoisson, tUpload, shiftPerLUp,&
-      & spinW, solvation, thirdOrd)
+      & neighbourList, img2CentCell, electrostatics, tPoisson, tUpload, shiftPerLUp, spinW,&
+      & potential, solvation, thirdOrd)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
@@ -266,9 +266,6 @@ contains
     !> map from image atom to real atoms
     integer, intent(in) :: img2CentCell(:)
 
-    !> Potentials acting
-    type(TPotentials), intent(inout) :: potential
-
     !> electrostatic solver (poisson or gamma-functional)
     integer, intent(in) :: electrostatics
 
@@ -283,6 +280,9 @@ contains
 
     !> spin constants
     real(dp), intent(in), allocatable :: spinW(:,:,:)
+
+    !> Potentials acting
+    type(TPotentials), intent(inout) :: potential
 
     !> Solvation mode
     class(TSolvation), intent(inout), optional :: solvation
@@ -372,14 +372,8 @@ contains
 
 
   !> Add potentials comming from on-site block of the dual density matrix.
-  subroutine addBlockChargePotentials(qBlockIn, qiBlockIn, tDftbU, tImHam, species, orb, nDftbUFunc&
-      &, UJ, nUJ, iUJ, niUJ, potential)
-
-    !> block input charges
-    real(dp), intent(in), allocatable :: qBlockIn(:,:,:,:)
-
-    !> imaginary part
-    real(dp), intent(in), allocatable :: qiBlockIn(:,:,:,:)
+  subroutine addBlockChargePotentials(tDftbU, tImHam, species, orb, nDftbUFunc, UJ, nUJ, iUJ, niUJ,&
+      & qBlockIn, qiBlockIn, potential)
 
     !> is this a +U calculation
     logical, intent(in) :: tDftbU
@@ -407,6 +401,12 @@ contains
 
     !> Number of shells in each DFTB+U block
     integer, intent(in) :: niUJ(:,:)
+
+    !> block input charges
+    real(dp), intent(in), allocatable :: qBlockIn(:,:,:,:)
+
+    !> imaginary part
+    real(dp), intent(in), allocatable :: qiBlockIn(:,:,:,:)
 
     !> potentials acting in system
     type(TPotentials), intent(inout) :: potential

--- a/prog/dftb+/lib_dftb/hamiltonian.F90
+++ b/prog/dftb+/lib_dftb/hamiltonian.F90
@@ -218,9 +218,9 @@ contains
     type(TPotentials), intent(inout) :: potential
 
     !> Spin orbit constants if required
-    real(dp), intent(in), optional :: xi(:,:)
+    real(dp), intent(in), allocatable :: xi(:,:)
 
-    @:ASSERT(.not. tDualSpinOrbit .or. present(xi))
+    @:ASSERT(.not. tDualSpinOrbit .or. allocated(xi))
 
     potential%intAtom(:,:) = 0.0_dp
     potential%intShell(:,:,:) = 0.0_dp
@@ -279,10 +279,10 @@ contains
     logical, intent(in) :: tUpload
 
     !> uploded potential per shell per atom
-    real(dp), intent(in) :: shiftPerLUp(:,:)
+    real(dp), intent(in), allocatable :: shiftPerLUp(:,:)
 
     !> spin constants
-    real(dp), intent(in), optional :: spinW(:,:,:)
+    real(dp), intent(in), allocatable :: spinW(:,:,:)
 
     !> Solvation mode
     class(TSolvation), intent(inout), optional :: solvation
@@ -360,7 +360,7 @@ contains
       potential%intShell(:,:,1) = potential%intShell(:,:,1) + shellPot(:,:,1)
     end if
 
-    if (nSpin /= 1 .and. present(spinW)) then
+    if (nSpin /= 1 .and. allocated(spinW)) then
       call getSpinShift(shellPot, chargePerShell, species, orb, spinW)
       potential%intShell = potential%intShell + shellPot
     end if
@@ -376,10 +376,10 @@ contains
       &, UJ, nUJ, iUJ, niUJ, potential)
 
     !> block input charges
-    real(dp), intent(in) :: qBlockIn(:,:,:,:)
+    real(dp), intent(in), allocatable :: qBlockIn(:,:,:,:)
 
     !> imaginary part
-    real(dp), intent(in) :: qiBlockIn(:,:,:,:)
+    real(dp), intent(in), allocatable :: qiBlockIn(:,:,:,:)
 
     !> is this a +U calculation
     logical, intent(in) :: tDftbU

--- a/prog/dftb+/lib_dftb/onscorrection.F90
+++ b/prog/dftb+/lib_dftb/onscorrection.F90
@@ -23,10 +23,7 @@ module dftbp_onsitecorrection
 contains
 
   !> Add the block shift due to onsite matrix element contributions
-  subroutine addOnsShift(qBlock, q0, onsMEs, species, orb, potential, iPotential, qiBlock)
-
-    !> Block charges
-    real(dp), intent(in) :: qBlock(:,:,:,:)
+  subroutine addOnsShift(q0, onsMEs, species, orb, qBlock, qiBlock, potential, iPotential)
 
     !> reference charges
     real(dp), intent(in) :: q0(:,:,:)
@@ -40,14 +37,17 @@ contains
     !> Information about the orbitals in the system
     type(TOrbitals), intent(in) :: orb
 
+    !> Block charges
+    real(dp), intent(in) :: qBlock(:,:,:,:)
+
+    !> Block charges (imaginary part)
+    real(dp), intent(in), allocatable :: qiBlock(:,:,:,:)
+
     !> resulting onsite matrix elements
     real(dp), intent(inout) :: potential(:,:,:,:)
 
     !> resulting onsite matrix elements (imaginary part)
     real(dp), intent(inout), allocatable :: iPotential(:,:,:,:)
-
-    !> Block charges (imaginary part)
-    real(dp), intent(in), allocatable :: qiBlock(:,:,:,:)
 
     integer :: iAt, nAt, iSp, iSpin, nSpin, iSh, iOrb, nOrb
     real(dp), allocatable :: tmpME(:,:,:), tmpBlock(:,:)
@@ -201,7 +201,7 @@ contains
       allocate(iShift(orb%mOrb, orb%mOrb, size(qBlock, dim=3), size(qBlock, dim=4)))
       iShift(:,:,:,:) = 0.0_dp
     end if
-    call addOnsShift(qBlock, q0, onsMEs, species, orb, shift, iShift, qiBlock)
+    call addOnsShift(q0, onsMEs, species, orb, qBlock, qiBlock, shift, iShift)
     Eons(:) = 0.5_dp*sum(sum(sum(shift(:,:,:,:)*qBlock(:,:,:,:),dim=1),dim=1),dim=2)
     if (allocated(qiBlock)) then
       Eons(:) = Eons(:) + 0.5_dp*sum(sum(sum(iShift(:,:,:,:)*qiBlock(:,:,:,:),dim=1),dim=1),dim=2)

--- a/prog/dftb+/lib_dftb/onscorrection.F90
+++ b/prog/dftb+/lib_dftb/onscorrection.F90
@@ -44,10 +44,10 @@ contains
     real(dp), intent(inout) :: potential(:,:,:,:)
 
     !> resulting onsite matrix elements (imaginary part)
-    real(dp), intent(inout) :: iPotential(:,:,:,:)
+    real(dp), intent(inout), allocatable :: iPotential(:,:,:,:)
 
     !> Block charges (imaginary part)
-    real(dp), intent(in), optional :: qiBlock(:,:,:,:)
+    real(dp), intent(in), allocatable :: qiBlock(:,:,:,:)
 
     integer :: iAt, nAt, iSp, iSpin, nSpin, iSh, iOrb, nOrb
     real(dp), allocatable :: tmpME(:,:,:), tmpBlock(:,:)
@@ -98,7 +98,7 @@ contains
 
       end do
 
-      if (present(qiBlock)) then
+      if (allocated(qiBlock)) then
         do iSpin = 1, nSpin
           tmpBlock(:,:) = 0.0_dp
           ! extract the relevant charge parts
@@ -191,19 +191,19 @@ contains
     real(dp), intent(out) :: Eons(:)
 
     !> Block charges imaginary part
-    real(dp), intent(in), optional :: qiBlock(:,:,:,:)
+    real(dp), intent(in), allocatable :: qiBlock(:,:,:,:)
 
     real(dp), allocatable :: shift(:,:,:,:), iShift(:,:,:,:)
 
     allocate(shift(orb%mOrb, orb%mOrb, size(qBlock, dim=3), size(qBlock, dim=4)))
     shift(:,:,:,:) = 0.0_dp
-    if (present(qiBlock)) then
+    if (allocated(qiBlock)) then
       allocate(iShift(orb%mOrb, orb%mOrb, size(qBlock, dim=3), size(qBlock, dim=4)))
       iShift(:,:,:,:) = 0.0_dp
     end if
     call addOnsShift(qBlock, q0, onsMEs, species, orb, shift, iShift, qiBlock)
     Eons(:) = 0.5_dp*sum(sum(sum(shift(:,:,:,:)*qBlock(:,:,:,:),dim=1),dim=1),dim=2)
-    if (present(qiBlock)) then
+    if (allocated(qiBlock)) then
       Eons(:) = Eons(:) + 0.5_dp*sum(sum(sum(iShift(:,:,:,:)*qiBlock(:,:,:,:),dim=1),dim=1),dim=2)
     end if
 

--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -3259,10 +3259,10 @@ contains
 
       allocate(electronDynamics)
 
-      call TElecDynamics_init(electronDynamics, input%ctrl%elecDynInp, species0, speciesName,&
-          & tWriteAutotest, autotestTag, randomThermostat, mass, nAtom, cutOff%skCutoff,&
-          & cutOff%mCutoff, atomEigVal, dispersion, nonSccDeriv, tPeriodic, parallelKS,&
-          & tRealHS, kPoint, kWeight, isRangeSep)
+      call TElecDynamics_init(input%ctrl%elecDynInp, species0, speciesName, tWriteAutotest,&
+          & autotestTag, mass, nAtom, cutOff%skCutoff, cutOff%mCutoff, atomEigVal, nonSccDeriv,&
+          & tPeriodic, parallelKS, tRealHS, kPoint, kWeight, isRangeSep, randomThermostat,&
+          & electronDynamics, dispersion)
 
     end if
 
@@ -3399,7 +3399,7 @@ contains
        if (tDFTBU) then
           allocate(iEqOrbSpin(orb%mOrb, nAtom, nSpin))
           allocate(iEqOrbDFTBU(orb%mOrb, nAtom, nSpin))
-          call DFTBplsU_getOrbitalEquiv(iEqOrbDFTBU,orb, species0, nUJ, niUJ, iUJ)
+          call DFTBplsU_getOrbitalEquiv(orb, species0, nUJ, niUJ, iUJ, iEqOrbDFTBU)
           call OrbitalEquiv_merge(iEqOrbitals, iEqOrbDFTBU, orb, iEqOrbSpin)
           iEqOrbitals(:,:,:) = iEqOrbSpin(:,:,:)
           nIneqOrb = maxval(iEqOrbitals)
@@ -3412,7 +3412,7 @@ contains
           iEqOrbSpin(:,:,:) = 0.0_dp
           allocate(iEqOrbDFTBU(orb%mOrb, nAtom, nSpin))
           iEqOrbDFTBU(:,:,:) = 0.0_dp
-          call Ons_getOrbitalEquiv(iEqOrbDFTBU,orb, species0)
+          call Ons_getOrbitalEquiv(orb, species0, iEqOrbDFTBU)
           call OrbitalEquiv_merge(iEqOrbitals, iEqOrbDFTBU, orb, iEqOrbSpin)
           iEqOrbitals(:,:,:) = iEqOrbSpin(:,:,:)
           nIneqOrb = maxval(iEqOrbitals)
@@ -3430,7 +3430,7 @@ contains
                 allocate(iEqBlockOnSiteLS(orb%mOrb, orb%mOrb, nAtom, nSpin))
              endif
           end if
-          call Ons_blockIndx(iEqBlockOnSite, iEqBlockOnSiteLS, nIneqOrb, orb)
+          call Ons_blockIndx(nIneqOrb, orb, iEqBlockOnSite, iEqBlockOnSiteLS)
           nMixElements = max(nMixElements, maxval(iEqBlockOnSite))
           if (allocated(iEqBlockOnSiteLS)) then
              nMixElements = max(nMixElements, maxval(iEqBlockOnSiteLS))
@@ -3440,7 +3440,7 @@ contains
           if(.not. allocated(iEqBlockDFTBU))then
              allocate(iEqBlockDFTBU(orb%mOrb, orb%mOrb, nAtom, nSpin))
           endif
-          call DFTBU_blockIndx(iEqBlockDFTBU, nIneqOrb, orb, species0, nUJ, niUJ, iUJ)
+          call DFTBU_blockIndx(nIneqOrb, orb, species0, nUJ, niUJ, iUJ, iEqBlockDFTBU)
           nMixElements = max(nMixElements,maxval(iEqBlockDFTBU)) ! as
           !  iEqBlockDFTBU does not include diagonal elements, so in the case of
           !  a purely s-block DFTB+U calculation, maxval(iEqBlockDFTBU) would
@@ -3449,7 +3449,7 @@ contains
              if(.not. allocated(iEqBlockDFTBULS))then
                 allocate(iEqBlockDFTBULS(orb%mOrb, orb%mOrb, nAtom, nSpin))
              endif
-             call DFTBU_blockIndx(iEqBlockDFTBULS, nMixElements, orb, species0, nUJ, niUJ, iUJ)
+             call DFTBU_blockIndx(nMixElements, orb, species0, nUJ, niUJ, iUJ, iEqBlockDFTBULS)
              nMixElements = max(nMixElements,maxval(iEqBlockDFTBULS))
           end if
        end if

--- a/prog/dftb+/lib_dftbplus/main.F90
+++ b/prog/dftb+/lib_dftbplus/main.F90
@@ -548,7 +548,7 @@ contains
 
         if (allocated(dispersion)) then
           call dispersion%updateOnsiteCharges(qOnsite, orb, referenceN0, species0, tConverged)
-          call calcDispersionEnergy(dispersion, energy%atomDisp, energy%Edisp, iAtInCentralRegion)
+          call calcDispersionEnergy(iAtInCentralRegion, dispersion, energy%atomDisp, energy%Edisp)
           call sumEnergies(energy)
         end if
 
@@ -760,7 +760,7 @@ contains
 
         if (allocated(dispersion)) then
           call dispersion%updateOnsiteCharges(qOnsite, orb, referenceN0, species0, tConverged)
-          call calcDispersionEnergy(dispersion, energy%atomDisp, energy%Edisp, iAtInCentralRegion)
+          call calcDispersionEnergy(iAtInCentralRegion, dispersion, energy%atomDisp, energy%Edisp)
         end if
 
         call sumEnergies(energy)
@@ -791,7 +791,7 @@ contains
       ! non-converged SCC.
       call dispersion%updateOnsiteCharges(qOnsite, orb, referenceN0, species0,&
           & tConverged .or. .not.isSccConvRequired)
-      call calcDispersionEnergy(dispersion, energy%atomDisp, energy%Edisp, iAtInCentralRegion)
+      call calcDispersionEnergy(iAtInCentralRegion, dispersion, energy%atomDisp, energy%Edisp)
       call sumEnergies(energy)
 
 
@@ -808,11 +808,11 @@ contains
           call writeDetailedOut1(fdDetailedOut, iDistribFn, nGeoSteps, iGeoStep, tMD, tDerivs,&
               & tCoordOpt, tLatOpt, iLatGeoStep, iSccIter, energy, diffElec, sccErrorQ,&
               & indMovedAtom, pCoord0Out, q0, qInput, qOutput, eigen, orb, species, tDFTBU,&
-              & tImHam.or.tSpinOrbit, tPrintMulliken, orbitalL, qBlockOut, Ef, Eband, TS, E0,&
-              & extPressure, cellVol, tAtomicEnergy, dispersion, tEField, tPeriodic, nSpin, tSpin,&
-              & tSpinOrbit, tSccCalc, allocated(onSiteElements), tNegf, invLatVec, kPoint,&
-              & iAtInCentralRegion, electronicSolver, allocated(halogenXCorrection), isRangeSep,&
-              & allocated(thirdOrd), allocated(solvation), cm5Cont, qOnsite)
+              & tImHam.or.tSpinOrbit, tPrintMulliken, orbitalL, Ef, Eband, TS, E0, extPressure,&
+              & cellVol, tAtomicEnergy, dispersion, tEField, tPeriodic, nSpin, tSpin, tSpinOrbit,&
+              & tSccCalc, allocated(onSiteElements), tNegf, invLatVec, kPoint, iAtInCentralRegion,&
+              & electronicSolver, allocated(halogenXCorrection), isRangeSep, allocated(thirdOrd),&
+              & allocated(solvation), cm5Cont, qBlockOut, qOnsite)
         end if
       end if
 

--- a/prog/dftb+/lib_dftbplus/main.F90
+++ b/prog/dftb+/lib_dftbplus/main.F90
@@ -988,7 +988,7 @@ contains
       & tLatOptFixAng, tLatOptFixLen, tLatOptIsotropic, constrLatDerivs, derivs, conAtom)
 
     !> Vector to project out forces
-    real(dp), intent(in) :: conVec(:,:)
+    real(dp), intent(in), allocatable :: conVec(:,:)
 
     !> Whether lattice optimisation is on
     logical, intent(in) :: tLatOpt
@@ -1018,9 +1018,9 @@ contains
     real(dp), intent(out) :: constrLatDerivs(:)
 
     !> Atoms being constrained
-    integer, intent(in), optional :: conAtom(:)
+    integer, intent(in), allocatable :: conAtom(:)
 
-    if (present(conAtom)) then
+    if (allocated(conAtom)) then
       call constrainForces(conAtom, conVec, derivs)
     end if
 
@@ -1387,14 +1387,14 @@ contains
     type(TThirdOrder), intent(inout), optional :: thirdOrd
 
     !> Range separation contributions
-    type(TRangeSepFunc), intent(inout), optional :: rangeSep
+    type(TRangeSepFunc), intent(inout), allocatable :: rangeSep
 
     !> Charge model 5
     type(TChargeModel5), intent(inout), optional :: cm5Cont
 
     !> Number of neighbours for each of the atoms for the exchange contributions in the long range
     !> functional
-    integer, intent(inout), optional :: nNeighbourLC(:)
+    integer, intent(inout), allocatable :: nNeighbourLC(:)
 
     !> Status of operation
     integer, intent(out), optional :: stat
@@ -1425,7 +1425,7 @@ contains
     ! count neighbours for repulsive interactions between atoms
     call getNrOfNeighboursForAll(nNeighbourRep, neighbourList, cutoff%repCutOff)
 
-    if (present(nNeighbourLC)) then
+    if (allocated(nNeighbourLC)) then
       ! count neighbours for repulsive interactions between atoms
       call getNrOfNeighboursForAll(nNeighbourLC, neighbourList, cutoff%lcCutOff)
     end if
@@ -1452,7 +1452,7 @@ contains
     if (present(thirdOrd)) then
       call thirdOrd%updateCoords(neighbourList, species)
     end if
-    if (present(rangeSep)) then
+    if (allocated(rangeSep)) then
       call rangeSep%updateCoords(coord0)
     end if
     if (present(cm5Cont)) then
@@ -1844,11 +1844,11 @@ contains
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Electrochemical potentials (contact, spin)
-    real(dp), intent(in) :: mu(:,:)
+    real(dp), intent(in), allocatable :: mu(:,:)
 
     !> Number of neighbours for each of the atoms for the exchange contributions in the long range
     !> functional
-    integer, intent(in) :: nNeighbourLC(:)
+    integer, intent(in), allocatable :: nNeighbourLC(:)
 
     !> Are dense matrices for H, S, etc. being used
     logical, intent(in) :: tLargeDenseMatrices
@@ -1872,10 +1872,10 @@ contains
     type(TEnergies), intent(inout) :: energy
 
     !> Data for rangeseparated calculation
-    type(TRangeSepFunc), intent(inout) :: rangeSep
+    type(TRangeSepFunc), intent(inout), allocatable :: rangeSep
 
     !> orbital moments of atomic shells
-    real(dp), intent(inout) :: orbitalL(:,:,:)
+    real(dp), intent(inout), allocatable :: orbitalL(:,:,:)
 
     !> imaginary part of density matrix
     real(dp), intent(inout), allocatable :: iRhoPrim(:,:)
@@ -1887,7 +1887,7 @@ contains
     real(dp), intent(inout), allocatable :: SSqrReal(:,:)
 
     !> real eigenvectors on exit
-    real(dp), intent(inout) :: eigvecsReal(:,:,:)
+    real(dp), intent(inout), allocatable :: eigvecsReal(:,:,:)
 
     !> dense complex (k-points) hamiltonian storage
     complex(dp), intent(inout), allocatable :: HSqrCplx(:,:)
@@ -1896,10 +1896,10 @@ contains
     complex(dp), intent(inout), allocatable :: SSqrCplx(:,:)
 
     !> complex eigenvectors on exit
-    complex(dp), intent(inout) :: eigvecsCplx(:,:,:)
+    complex(dp), intent(inout), allocatable :: eigvecsCplx(:,:,:)
 
     !> Dense density matrix
-    real(dp), intent(inout) :: rhoSqrReal(:,:,:)
+    real(dp), intent(inout), allocatable :: rhoSqrReal(:,:,:)
 
     !> Change in density matrix during last SCC iteration
     real(dp), pointer, intent(inout) :: deltaRhoInSqr(:,:,:)
@@ -2074,7 +2074,7 @@ contains
 
     !> Number of neighbours for each of the atoms for the exchange contributions in the long range
     !> functional
-    integer, intent(in) :: nNeighbourLC(:)
+    integer, intent(in), allocatable :: nNeighbourLC(:)
 
     !> imaginary part of hamiltonian
     real(dp), intent(in), allocatable :: iHam(:,:)
@@ -2098,31 +2098,31 @@ contains
     type(TEnergies), intent(inout) :: energy
 
     !> Data for rangeseparated calculation
-    type(TRangeSepFunc), intent(inout) :: rangeSep
+    type(TRangeSepFunc), intent(inout), allocatable :: rangeSep
 
     !> orbital moments of atomic shells
-    real(dp), intent(inout) :: orbitalL(:,:,:)
+    real(dp), intent(inout), allocatable :: orbitalL(:,:,:)
 
     !> dense real hamiltonian storage
-    real(dp), intent(inout) :: HSqrReal(:,:)
+    real(dp), intent(inout), allocatable :: HSqrReal(:,:)
 
     !> dense real overlap storage
-    real(dp), intent(inout) :: SSqrReal(:,:)
+    real(dp), intent(inout), allocatable :: SSqrReal(:,:)
 
     !> real eigenvectors on exit
-    real(dp), intent(inout) :: eigvecsReal(:,:,:)
+    real(dp), intent(inout), allocatable :: eigvecsReal(:,:,:)
 
     !> dense complex (k-points) hamiltonian storage
-    complex(dp), intent(inout) :: HSqrCplx(:,:)
+    complex(dp), intent(inout), allocatable :: HSqrCplx(:,:)
 
     !> dense complex (k-points) overlap storage
-    complex(dp), intent(inout) :: SSqrCplx(:,:)
+    complex(dp), intent(inout), allocatable :: SSqrCplx(:,:)
 
     !> complex eigenvectors on exit
-    complex(dp), intent(inout) :: eigvecsCplx(:,:,:)
+    complex(dp), intent(inout), allocatable :: eigvecsCplx(:,:,:)
 
     !> Dense density matrix
-    real(dp), intent(inout) :: rhoSqrReal(:,:,:)
+    real(dp), intent(inout), allocatable :: rhoSqrReal(:,:,:)
 
     !> Change in density matrix during this SCC step for rangesep
     real(dp), pointer, intent(inout) :: deltaRhoOutSqr(:,:,:)
@@ -2252,7 +2252,7 @@ contains
 
     !> Number of neighbours for each of the atoms for the exchange contributions in the long range
     !> functional
-    integer, intent(in) :: nNeighbourLC(:)
+    integer, intent(in), allocatable :: nNeighbourLC(:)
 
     !> Coordinates of all atoms including images
     real(dp), intent(inout) :: coord(:,:)
@@ -2276,7 +2276,7 @@ contains
     real(dp), intent(out) :: eigen(:,:)
 
     !>Data for rangeseparated calcualtion
-    type(TRangeSepFunc), intent(inout), optional :: rangeSep
+    type(TRangeSepFunc), intent(inout), allocatable :: rangeSep
 
     integer :: iKS, iSpin
 
@@ -2321,7 +2321,7 @@ contains
       ! Add rangeseparated contribution
       ! Assumes deltaRhoInSqr only used by rangeseparation
       ! Should this be used elsewhere, need to pass isRangeSep
-      if (present(rangeSep)) then
+      if (allocated(rangeSep)) then
         call denseMulliken(deltaRhoInSqr, SSqrReal, denseDesc%iAtomStart, qOutput)
         call rangeSep%addLRHamiltonian(env, deltaRhoInSqr(:,:,iSpin), over,&
             & neighbourList%iNeighbour,  nNeighbourLC, denseDesc%iAtomStart, iSparseStart,&
@@ -2879,7 +2879,7 @@ contains
     integer, intent(in) :: species(:)
 
     !> spin orbit constants
-    real(dp), intent(in) :: xi(:,:)
+    real(dp), intent(in), allocatable :: xi(:,:)
 
     !> K-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
@@ -2894,13 +2894,13 @@ contains
     type(TEnergies), intent(inout) :: energy
 
     !> Angular momentum of atomic shells
-    real(dp), intent(inout) :: orbitalL(:,:,:)
+    real(dp), intent(inout), allocatable :: orbitalL(:,:,:)
 
     !> sparse stored density matrix
     real(dp), intent(out) :: rhoPrim(:,:)
 
     !> imaginary part of density matrix  if required
-    real(dp), intent(inout), optional :: iRhoPrim(:,:)
+    real(dp), intent(inout), allocatable :: iRhoPrim(:,:)
 
 
     real(dp), allocatable :: rVecTemp(:), orbitalLPart(:,:,:)
@@ -2909,10 +2909,10 @@ contains
     logical :: tImHam
 
     nAtom = size(orb%nOrbAtom)
-    tImHam = present(iRhoPrim)
+    tImHam = allocated(iRhoPrim)
 
     rhoPrim(:,:) = 0.0_dp
-    if (present(iRhoPrim)) then
+    if (allocated(iRhoPrim)) then
       iRhoPrim(:,:) = 0.0_dp
     end if
     work(:,:) = 0.0_dp
@@ -2983,7 +2983,7 @@ contains
     call env%globalTimer%startTimer(globalTimers%denseToSparse)
     ! Add up and distribute contributions from each group
     call mpifx_allreduceip(env%mpi%globalComm, rhoPrim, MPI_SUM)
-    if (present(iRhoPrim)) then
+    if (allocated(iRhoPrim)) then
       call mpifx_allreduceip(env%mpi%globalComm, iRhoPrim, MPI_SUM)
     end if
     call mpifx_allreduceip(env%mpi%globalComm, energy%atomLS, MPI_SUM)
@@ -3134,7 +3134,7 @@ contains
     integer, intent(in) :: iSparseStart(:,:)
 
     !> imaginary part of density matrix
-    real(dp), intent(in) :: iRhoPrim(:,:)
+    real(dp), intent(in), allocatable :: iRhoPrim(:,:)
 
     !> orbital charges
     real(dp), intent(out) :: qOrb(:,:,:)
@@ -3417,10 +3417,10 @@ contains
     real(dp), intent(inout) :: deltaRhoDiff(:)
 
     !> Dual output charges
-    real(dp), intent(inout) :: qBlockOut(:,:,:,:)
+    real(dp), intent(inout), allocatable :: qBlockOut(:,:,:,:)
 
     !> Square dense overlap storage
-    real(dp), allocatable, intent(inout) :: SSqrReal(:,:)
+    real(dp), intent(inout), allocatable :: SSqrReal(:,:)
 
     !> SCC error
     real(dp), intent(out) :: sccErrorQ
@@ -3508,13 +3508,13 @@ contains
     real(dp), intent(in) :: qOrb(:,:,:)
 
     !> equivalences for block charges
-    integer, intent(in) :: iEqBlockDftbu(:,:,:,:)
+    integer, intent(in), allocatable :: iEqBlockDftbu(:,:,:,:)
 
     !> Equivalences for spin orbit if needed
-    integer, intent(in) :: iEqBlockDftbuLS(:,:,:,:)
+    integer, intent(in), allocatable :: iEqBlockDftbuLS(:,:,:,:)
 
     !> Equivalences for onsite block corrections if needed for imaginary part
-    integer, intent(in) :: iEqBlockOnSiteLS(:,:,:,:)
+    integer, intent(in), allocatable :: iEqBlockOnSiteLS(:,:,:,:)
 
     !> Reduction of atomic populations
     real(dp), intent(out) :: qRed(:)
@@ -4356,7 +4356,7 @@ contains
     integer, intent(in) :: iSCC
 
     !> Electrochemical potentials per contact and spin
-    real(dp), intent(in) :: mu(:,:)
+    real(dp), intent(in), allocatable :: mu(:,:)
 
     !> Storage for dense hamiltonian matrix
     real(dp), intent(inout), allocatable :: HSqrReal(:,:,:)
@@ -5148,7 +5148,7 @@ contains
     real(dp), intent(out) :: derivs(:,:)
 
     !> imaginary part of density matrix
-    real(dp), intent(in), optional :: iRhoPrim(:,:)
+    real(dp), intent(in), allocatable :: iRhoPrim(:,:)
 
     !> Is 3rd order SCC being used
     type(TThirdOrder), intent(inout), optional :: thirdOrd
@@ -5166,7 +5166,7 @@ contains
     class(TDispersionIface), intent(inout), optional :: dispersion
 
     !> Data from rangeseparated calculations
-    type(TRangeSepFunc), intent(inout), optional :: rangeSep
+    type(TRangeSepFunc), intent(inout), allocatable :: rangeSep
 
     !> SCC module internal variables
     type(TScc), intent(in), optional :: sccCalc
@@ -5183,7 +5183,7 @@ contains
 
 
     tSccCalc = present(sccCalc)
-    tImHam = present(iRhoPrim)
+    tImHam = allocated(iRhoPrim)
     tExtChrg = present(chrgForces)
     nAtom = size(derivs, dim=2)
 
@@ -5282,7 +5282,7 @@ contains
       call halogenXCorrection%addGradients(derivs, coord, species, neighbourList, img2CentCell)
     end if
 
-    if (present(rangeSep)) then
+    if (allocated(rangeSep)) then
       if (tHelical) then
         call unpackHelicalHS(SSqrReal, over, neighbourList%iNeighbour, nNeighbourSK,&
             & denseDesc%iAtomStart, iSparseStart, img2CentCell, orb, species, coord)
@@ -5487,7 +5487,7 @@ contains
     type(TThirdOrder), intent(inout), optional :: thirdOrd
 
     !> imaginary part of the density matrix (if present)
-    real(dp), intent(in), optional :: iRhoPrim(:,:)
+    real(dp), intent(in), allocatable :: iRhoPrim(:,:)
 
     !> Solvation model
     class(TSolvation), intent(inout), optional :: solvation
@@ -5501,7 +5501,7 @@ contains
     real(dp) :: tmpStress(3, 3)
     logical :: tImHam
 
-    tImHam = present(iRhoPrim)
+    tImHam = allocated(iRhoPrim)
 
     if (present(sccCalc)) then
       if (tImHam) then
@@ -5611,10 +5611,10 @@ contains
   subroutine constrainForces(conAtom, conVec, derivs)
 
     !> atoms being constrained
-    integer, intent(in) :: conAtom(:)
+    integer, intent(in), allocatable :: conAtom(:)
 
     !> vector to project out forces
-    real(dp), intent(in) :: conVec(:,:)
+    real(dp), intent(in), allocatable :: conVec(:,:)
 
     !> on input energy derivatives, on exit resulting projected derivatives
     real(dp), intent(inout) :: derivs(:,:)
@@ -6041,7 +6041,7 @@ contains
     real(dp), intent(out) :: localisation
 
     !> Storage for dense hamiltonian matrix
-    real(dp), intent(inout), optional :: eigvecsReal(:,:,:)
+    real(dp), intent(inout), allocatable :: eigvecsReal(:,:,:)
 
     integer :: nFilledLev, nAtom, nSpin
     integer :: iSpin, iKS, iK
@@ -6053,7 +6053,7 @@ contains
       call warning("Fractional occupations allocated for electron localisation")
     end if
 
-    if (present(eigvecsReal)) then
+    if (allocated(eigvecsReal)) then
       if (tHelical) then
         call unpackHelicalHS(SSqrReal,over,neighbourList%iNeighbour, nNeighbourSK,&
             & denseDesc%iAtomStart, iSparseStart, img2CentCell, orb, species, coord)
@@ -6478,7 +6478,7 @@ contains
     real(dp), intent(in) :: over(:)
 
     !> spin constants
-    real(dp), intent(in) :: spinW(:,:,:)
+    real(dp), intent(in), allocatable :: spinW(:,:,:)
 
     !> unit cell volume
     real(dp), intent(in) :: cellVol
@@ -6511,19 +6511,19 @@ contains
     logical, intent(in) :: tUpload
 
     !> uploded potential per shell per atom
-    real(dp), intent(in) :: shiftPerLUp(:,:)
+    real(dp), intent(in), allocatable :: shiftPerLUp(:,:)
 
     !> Data for rangeseparated calculation
     type(TRangeSepFunc), allocatable, intent(inout) :: rangeSep
 
     !> Nr. of neighbours for each atom in the long-range functional.
-    integer, intent(in) :: nNeighbourLC(:)
+    integer, intent(in), allocatable :: nNeighbourLC(:)
 
     !> Is dual spin orbit being used (block potentials)
     logical, intent(in) :: tDualSpinOrbit
 
     !> Spin orbit constants if required
-    real(dp), intent(in) :: xi(:,:)
+    real(dp), intent(in), allocatable :: xi(:,:)
 
     !> is an external electric field present
     logical, intent(in) :: tExtField

--- a/prog/dftb+/lib_dftbplus/mainio.F90
+++ b/prog/dftb+/lib_dftbplus/mainio.F90
@@ -167,21 +167,21 @@ contains
     logical, intent(in) :: tPrintEigvecsTxt
 
     !> Real eigenvectors (will be overwritten)
-    real(dp), intent(inout), allocatable :: eigvecsReal(:,:,:)
+    real(dp), intent(inout), optional :: eigvecsReal(:,:,:)
 
     !> Storage for dense real overlap matrix
-    real(dp), intent(inout), allocatable :: SSqrReal(:,:)
+    real(dp), intent(inout), optional :: SSqrReal(:,:)
 
     !> Complex eigenvectors (will be overwritten)
-    complex(dp), intent(inout), allocatable :: eigvecsCplx(:,:,:)
+    complex(dp), intent(inout), optional :: eigvecsCplx(:,:,:)
 
     !> Storage for dense complex overlap matrix
-    complex(dp), intent(inout), allocatable :: SSqrCplx(:,:)
+    complex(dp), intent(inout), optional :: SSqrCplx(:,:)
 
-    @:ASSERT(allocated(eigvecsReal) .neqv. allocated(eigvecsCplx))
-    @:ASSERT(allocated(SSqrReal) .neqv. allocated(SSqrCplx))
+    @:ASSERT(present(eigvecsReal) .neqv. present(eigvecsCplx))
+    @:ASSERT(present(SSqrReal) .neqv. present(SSqrCplx))
 
-    if (allocated(eigvecsCplx)) then
+    if (present(eigvecsCplx)) then
       call writeCplxEigvecs(env, runId, neighbourList, nNeighbourSK, cellVec, iCellVec, denseDesc,&
           & iPair, img2CentCell, species, speciesName, orb, kPoint, over, parallelKS,&
           & tPrintEigvecsTxt, eigvecsCplx, SSqrCplx)
@@ -2209,7 +2209,7 @@ contains
     real(dp), intent(in) :: filling(:,:,:)
 
     !> Occupation numbers for natural orbitals
-    real(dp), allocatable, target, intent(in) :: occNatural(:)
+    real(dp), target, intent(in), optional :: occNatural(:)
 
     type(xmlf_t) :: xf
     real(dp), allocatable :: bufferRealR2(:,:)
@@ -2254,7 +2254,7 @@ contains
       call xml_EndElement(xf, "spin" // i2c(ii))
     end do
     call xml_EndElement(xf, "occupations")
-    if (allocated(occNatural)) then
+    if (present(occNatural)) then
       call xml_NewElement(xf, "excitedoccupations")
       call xml_NewElement(xf, "spin" // i2c(1))
       !pOccNatural(1:size(occNatural), 1:1) => occNatural
@@ -2354,10 +2354,10 @@ contains
   !> First group of data to go to detailed.out
   subroutine writeDetailedOut1(fd, iDistribFn, nGeoSteps, iGeoStep, tMD, tDerivs, tCoordOpt,&
       & tLatOpt, iLatGeoStep, iSccIter, energy, diffElec, sccErrorQ, indMovedAtom, coord0Out, q0,&
-      & qInput, qOutput, eigen, orb, species, tDFTBU, tImHam, tPrintMulliken, orbitalL, qBlockOut,&
-      & Ef, Eband, TS, E0, pressure, cellVol, tAtomicEnergy, dispersion, tEField, tPeriodic,&
-      & nSpin, tSpin, tSpinOrbit, tScc, tOnSite, tNegf,  invLatVec, kPoints, iAtInCentralRegion,&
-      & electronicSolver, tHalogenX, tRangeSep, t3rd, tSolv, cm5Cont, qOnsite)
+      & qInput, qOutput, eigen, orb, species, tDFTBU, tImHam, tPrintMulliken, orbitalL, Ef, Eband,&
+      & TS, E0, pressure, cellVol, tAtomicEnergy, dispersion, tEField, tPeriodic, nSpin, tSpin,&
+      & tSpinOrbit, tScc, tOnSite, tNegf, invLatVec, kPoints, iAtInCentralRegion,&
+      & electronicSolver, tHalogenX, tRangeSep, t3rd, tSolv, cm5Cont, qBlockOut, qOnsite)
 
     !> File ID
     integer, intent(in) :: fd
@@ -2432,10 +2432,7 @@ contains
     logical, intent(in) :: tPrintMulliken
 
     !> Orbital angular momentum (if available)
-    real(dp), allocatable, intent(in) :: orbitalL(:,:,:)
-
-    !> Output block (dual) Mulliken charges
-    real(dp), allocatable, intent(in) :: qBlockOut(:,:,:,:)
+    real(dp), intent(in) :: orbitalL(:,:,:)
 
     !> Fermi level
     real(dp), intent(in) :: Ef(:)
@@ -2470,9 +2467,6 @@ contains
     !> Number of spin channels
     integer, intent(in) :: nSpin
 
-    !> is this a spin polarized calculation?
-    logical :: tSpin
-
     !> Are spin orbit interactions present
     logical, intent(in) :: tSpinOrbit
 
@@ -2500,9 +2494,6 @@ contains
     !> Is there a halogen bond correction present?
     logical, intent(in) :: tHalogenX
 
-    !> Onsite mulliken population per atom
-    real(dp), allocatable, intent(in) :: qOnsite(:)
-
     !> Is this a range separation calculation?
     logical, intent(in) :: tRangeSep
 
@@ -2513,7 +2504,16 @@ contains
     logical, intent(in) :: tSolv
 
     !> Charge model 5 for correcting atomic gross charges
-    type(TChargeModel5), allocatable, intent(in) :: cm5Cont
+    type(TChargeModel5), intent(in), optional :: cm5Cont
+
+    !> Output block (dual) Mulliken charges
+    real(dp), intent(in), optional :: qBlockOut(:,:,:,:)
+
+    !> Onsite mulliken population per atom
+    real(dp), intent(in), optional :: qOnsite(:)
+
+    !> is this a spin polarized calculation?
+    logical :: tSpin
 
     real(dp), allocatable :: qInputUpDown(:,:,:), qOutputUpDown(:,:,:), qBlockOutUpDown(:,:,:,:)
     real(dp) :: angularMomentum(3)
@@ -2532,7 +2532,7 @@ contains
     call qm2ud(qInputUpDown)
     qOutputUpDown = qOutput
     call qm2ud(qOutputUpDown)
-    if (allocated(qBlockOut)) then
+    if (present(qBlockOut)) then
       qBlockOutUpDown = qBlockOut
       call qm2ud(qBlockOutUpDown)
     end if
@@ -2610,7 +2610,7 @@ contains
       end do
       write(fd, *)
 
-      if (allocated(qOnsite)) then
+      if (present(qOnsite)) then
         write(fd, "(/,A)") " Atomic net (on-site) populations and hybridisation ratios"
         write(fd, "(A5, 1X, A16, A16)")" Atom", " Population", "Hybrid."
         do ii = 1, size(iAtInCentralRegion)
@@ -2621,7 +2621,7 @@ contains
         write(fd, *)
       end if
 
-      if (allocated(cm5Cont)) then
+      if (present(cm5Cont)) then
          write(fd, "(A)") " CM5 corrected atomic gross charges (e)"
          write(fd, "(A5, 1X, A16)")" Atom", " Charge"
          do ii = 1, size(iAtInCentralRegion)

--- a/prog/dftb+/lib_dftbplus/mainio.F90
+++ b/prog/dftb+/lib_dftbplus/mainio.F90
@@ -2432,7 +2432,7 @@ contains
     logical, intent(in) :: tPrintMulliken
 
     !> Orbital angular momentum (if available)
-    real(dp), intent(in) :: orbitalL(:,:,:)
+    real(dp), intent(in), allocatable :: orbitalL(:,:,:)
 
     !> Fermi level
     real(dp), intent(in) :: Ef(:)

--- a/prog/dftb+/lib_elecsolvers/elsisolver.F90
+++ b/prog/dftb+/lib_elecsolvers/elsisolver.F90
@@ -897,7 +897,7 @@ contains
     type(TEnergies), intent(inout) :: energy
 
     !> orbital moments of atomic shells
-    real(dp), intent(inout) :: orbitalL(:,:,:)
+    real(dp), intent(inout), allocatable :: orbitalL(:,:,:)
 
     !> dense real hamiltonian storage
     real(dp), intent(inout), allocatable :: HSqrReal(:,:)
@@ -1566,7 +1566,7 @@ contains
     real(dp), intent(inout) :: rhoPrim(:,:)
 
     !> orbital moments of atomic shells
-    real(dp), intent(inout) :: orbitalL(:,:,:)
+    real(dp), intent(inout), allocatable :: orbitalL(:,:,:)
 
     !> imaginary part of density matrix
     real(dp), intent(inout) :: iRhoPrim(:,:)

--- a/prog/dftb+/lib_timedep/dynamics.F90
+++ b/prog/dftb+/lib_timedep/dynamics.F90
@@ -1221,7 +1221,7 @@ contains
     real(dp), intent(inout) :: chargePerShell(:,:,:)
 
     !> spin constants
-    real(dp), intent(in) :: spinW(:,:,:)
+    real(dp), intent(in), allocatable :: spinW(:,:,:)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
@@ -1230,7 +1230,7 @@ contains
     logical, intent(in) :: tDualSpinOrbit
 
     !> Spin orbit constants if required
-    real(dp), intent(in) :: xi(:,:)
+    real(dp), intent(in), allocatable :: xi(:,:)
 
     !> 3rd order settings
     type(TThirdOrder), intent(inout), allocatable :: thirdOrd

--- a/prog/dftb+/lib_timedep/dynamics.F90
+++ b/prog/dftb+/lib_timedep/dynamics.F90
@@ -1302,12 +1302,12 @@ contains
     tImHam = .false. ! for the moment
 
     call resetExternalPotentials(refExtPot, potential)
-    call resetInternalPotentials(tDualSpinOrbit, orb, speciesAll, potential, xi)
+    call resetInternalPotentials(tDualSpinOrbit, orb, speciesAll, xi, potential)
 
     call getChargePerShell(qq, orb, speciesAll, chargePerShell)
     call addChargePotentials(env, this%sccCalc, qq, q0, chargePerShell, orb, speciesAll,&
-        & neighbourList, img2CentCell, potential, elstatTypes%gammaFunc, .false., .false., dummy,&
-        & spinW, solvation, thirdOrd)
+        & neighbourList, img2CentCell, elstatTypes%gammaFunc, .false., .false., dummy, spinW,&
+        & potential, solvation, thirdOrd)
 
     if ((size(UJ) /= 0) .or. present(onSiteElements)) then
       ! convert to qm representation
@@ -1315,12 +1315,12 @@ contains
     end if
 
     if (size(UJ) /= 0) then
-      call addBlockChargePotentials(qBlock, qiBlock, tDftbU, .false., speciesAll, orb, nDftbUFunc,&
-          & UJ, nUJ, iUJ, niUJ, potential)
+      call addBlockChargePotentials(tDftbU, .false., speciesAll, orb, nDftbUFunc, UJ, nUJ, iUJ,&
+          & niUJ, qBlock, qiBlock, potential)
     end if
     if (present(onSiteElements)) then
-      call addOnsShift(qBlock, q0, onSiteElements, speciesAll, orb, potential%intBlock,&
-          & potential%iOrbitalBlock, qiBlock)
+      call addOnsShift(q0, onSiteElements, speciesAll, orb, qBlock, qiBlock,&
+          & potential%intBlock, potential%iOrbitalBlock)
     end if
 
     ! Add time dependent field if necessary
@@ -1753,10 +1753,9 @@ contains
     TS = 0.0_dp
     call calcEnergies(qq, q0, chargePerShell, this%speciesAll, this%tLaser, .false., tDFTBU,&
         & tDualSpinOrbit, rhoPrim, ham0, orb, neighbourList, nNeighbourSK, img2CentCell,&
-        & iSparseStart, 0.0_dp, 0.0_dp, TS, potential, energy, qBlock, UJ, nUJ, iUJ, niUJ, xi,&
-        & iAtInCentralRegion, tFixEf, Ef, this%sccCalc, thirdOrd, solvation, rangeSep, reks,&
-        & qDepExtPot, onSiteElements, qiBlock, nDftbUFunc)
-    call sumEnergies(energy)
+        & iSparseStart, 0.0_dp, 0.0_dp, TS, potential, UJ, nUJ, iUJ, niUJ, iAtInCentralRegion,&
+        & tFixEf, xi, onSiteElements, qBlock, qiBlock, energy, Ef, this%sccCalc, nDftbUFunc,&
+        & thirdOrd, solvation, rangeSep, reks, qDepExtPot)
     ! calcEnergies then sumEnergies returns the total energy Etotal including repulsive and
     ! dispersions energies
 

--- a/prog/dftb+/lib_timedep/linresp.F90
+++ b/prog/dftb+/lib_timedep/linresp.F90
@@ -384,7 +384,7 @@ contains
 
     !> the natural orbitals of the excited state transition density matrix or the total density
     !> matrix in the excited state
-    real(dp), intent(inout), allocatable :: naturalOrbs(:,:,:)
+    real(dp), intent(inout), optional :: naturalOrbs(:,:,:)
 
     !> energy of particular excited state
     real(dp), intent(out) :: excenergy

--- a/prog/dftb+/lib_timedep/linresp.F90
+++ b/prog/dftb+/lib_timedep/linresp.F90
@@ -313,8 +313,8 @@ contains
   !> Wrapper to call linear response calculations of excitations and forces in excited states
   subroutine LinResp_addGradients(tSpin, this, iAtomStart, eigVec, eigVal, SSqrReal, filling,&
       & coords0, sccCalc, dqAt, species0, iNeighbour, img2CentCell, orb, skHamCont, skOverCont,&
-      & tWriteTagged, fdTagged, taggedWriter, derivator, rhoSqr, allExcEnergies, naturalOrbs,&
-      & excEnergy, excgradient, occNatural)
+      & tWriteTagged, fdTagged, derivator, rhoSqr, taggedWriter, allExcEnergies, excEnergy,&
+      & excgradient, occNatural, naturalOrbs)
 
     !> is this a spin-polarized calculation
     logical, intent(in) :: tSpin
@@ -370,21 +370,17 @@ contains
     !> file descriptor for tagged data
     integer, intent(in) :: fdTagged
 
-    !> Tagged writer
-    type(TTaggedWriter), intent(inout) :: taggedWriter
-
     !> method for calculating derivatives of S and H0 matrices
     class(TNonSccDiff), intent(in) :: derivator
 
     !> ground state density matrix (square matrix plus spin index)
     real(dp), intent(in) :: rhoSqr(:,:,:)
 
+    !> Tagged writer
+    type(TTaggedWriter), intent(inout) :: taggedWriter
+
     !> energes of all solved states
     real(dp), intent(inout), allocatable :: allExcEnergies(:)
-
-    !> the natural orbitals of the excited state transition density matrix or the total density
-    !> matrix in the excited state
-    real(dp), intent(inout), optional :: naturalOrbs(:,:,:)
 
     !> energy of particular excited state
     real(dp), intent(out) :: excenergy
@@ -394,6 +390,10 @@ contains
 
     !> occupations of the natural orbitals from the density matrix
     real(dp), intent(inout), optional :: occNatural(:)
+
+    !> the natural orbitals of the excited state transition density matrix or the total density
+    !> matrix in the excited state
+    real(dp), intent(inout), optional :: naturalOrbs(:,:,:)
 
     real(dp), allocatable :: shiftPerAtom(:), shiftPerL(:,:)
 


### PR DESCRIPTION
The use of the allocation status to check for presence of variables has been kept as a workaround to maintain compatibility with some older compilers; until this point. Since this is probably a thing of the past and the corresponding buggy compilers no longer have to be supported, a change to the consistent use of optional arguments is possible.