### PR TITLE
Proper sizing for nAtoms

### DIFF
--- a/prog/dftb+/lib_timedep/dynamics.F90
+++ b/prog/dftb+/lib_timedep/dynamics.F90
@@ -492,6 +492,8 @@ contains
         this%movedMass(:,:) = spread(mass, 1, 3)
         allocate(this%derivator, source=nonSccDeriv)
         this%indMovedAtom = [(iAtom, iAtom = 1, nAtom)]
+      else
+        this%nMovedAtom = 0
       end if
       allocate(this%movedVelo(3, nAtom))
       this%movedVelo(:,:) = 0.0_dp


### PR DESCRIPTION
Fixes allocation from an undefined variable in electron dynamics routine for cases without dynamics/forces