### PR TITLE
Add/Fix journal abbreviations for manual

### DIFF
--- a/doc/dftb+/manual/titles.bib
+++ b/doc/dftb+/manual/titles.bib
@@ -92,7 +92,7 @@
 @string{jacs = "J{.} Am{.} Chem{.} Soc{.}"}
 @string{jap = "J{.} Appl{.} Phys{.}"}
 @string{jcamd = "J{.} of Computer Aided Molecular Design"}
-@string{jcc = "J{.} Comp{.} Chem{.}"}
+@string{jcc = "J{.} Comput{.} Chem{.}"}
 @string{jce = "J{.} Comp{.} Electron{.}"}
 @string{jcg = "J{.} Crystal Growth"}
 @string{jcics = "J{.} Chem{.} Inf{.} Comp{.} Sci{.}"}
@@ -103,7 +103,7 @@
 @string{jcsft = "J{.} Chem{.} Soc{.} -- Faraday Transactions"}
 @string{jcsft2 = "J{.} Chem{.} Soc{.} -- Faraday Transactions \mbox{II}"}
 @string{jcss = "J{.} Comput{.} Syst{.} Sci{.}"}
-@string{jctc = "J{.} of Chem{.} Theory Comput{.}"}
+@string{jctc = "J{.} Chem{.} Theory Comput{.}"}
 @string{jdp = "J{.} de Physique"}
 @string{jdp1 = "J{.} de Physique {I}"}
 @string{jdp2 = "J{.} de Physique {II}"}
@@ -142,7 +142,8 @@
 @string{jpc = "J{.} Phys{.} C"}
 @string{jpca = "J{.} Phys{.} Chem{.} A"}
 @string{jpcb = "J{.} Phys{.} Chem{.} B"}
-@string{jpcm = "J{.} Phys{.} Cond{.} Matter"}
+@string{jpcl = "J{.} Phys{.} Chem{.} Lett{.}"}
+@string{jpcm = "J{.} Phys{.} Condens{.} Matter"}
 @string{jpcrd = "J{.} Phys{.} Chem{.} Ref{.} Data"}
 @string{jpcs = "J{.} Phys{.} Chem{.} Solids"}
 @string{jpcss = "J{.} Phys{.} C Solid State"}
@@ -157,6 +158,7 @@
 @string{jrnbs = "J{.} of Res{.} of the Nat{.} Bureau of Standards"}
 @string{js = "J{.} of Superconductivity"}
 @string{jsc = "J{.} of Struct{.} Chem{.}"}
+@string{jsiam = "J{.} Soc{.} Ind{.} Appl{.} Math{.}"}
 @string{jssc = "J{.} of Solid State Chem{.}"}
 @string{jvst = "J{.} Vac{.} Sci{.} and Technol{.}"}
 @string{jvsta = "J{.} Vac{.} Sci{.} and Technol{.} A"}
@@ -203,6 +205,7 @@
 @string{pc = "Physica C"}
 @string{pcm = "Phys{.} and Chem{.} of Minerals"}
 @string{pcps = "Proc{.} of the Cambridge Philosophical Soc{.}"}
+@string{pccp = "Phys{.} Chem{.} Chem{.} Phys{.}"}
 @string{pd = "Physica D"}
 @string{pe = "Physica E"}
 @string{picg = "Progress in Crystal Growth and Characterization of Mater{.}"}
@@ -238,6 +241,7 @@
 @string{ptra = "Phil{.} Trans{.} R{.} Soc{.} A"}
 @string{ptrs = "Phil{.} Trans{.} R{.} Soc{.}"}
 @string{pw = "Physics World"}
+@string{qoam = "Q{.} Appl{.} Math{.}"}
 @string{ral = "Rendiconti Accademia dei Lincei"}
 @string{re = "Radiation Effects"}
 @string{reds = "Radiation Effects and Defects in Solids"}
@@ -283,6 +287,8 @@
 @string{tap = "Topics in Appl{.} Phys{.}"}
 @string{tca = "Theoretica Chimica Acta"}
 @string{tcs = "Theor{.} Comput{.} Sci{.}"}
+@string{tcacc = "Theor{.} Chem{.} Acc{.}"}
+@string{tcc = "Top{.} Curr{.} Chem{.}"}
 @string{td = "Tetrahedron"}
 @string{tda = "Tetrahedron Asym{.}"}
 @string{tdl = "Tetrahedron Lett{.}"}
@@ -297,6 +303,7 @@
 @string{u = "Ultramicrosc{.}"}
 @string{ufn = "Uspekhi Fizicheskikh Nauk"}
 @string{w = "Wear"}
+@string{wirescms = "WIREs Comput{.} Mol{.} Sci{.}"}
 @string{yadfiz = "Yad{.} Fiz{.}"}
 @string{zna = "Zeitschrift fur Naturforschung section A"}
 @string{zp = "Z{.} Phys{.}"}


### PR DESCRIPTION
- JCTC, JCC and JPCM were abbreviated incorrectly
- adds WIREs CMS, PCCP, TCAcc, TCC, JPCL, JSIAM and QAM