### PR TITLE
Restructure main text documents

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,6 +1,6 @@
-******************************
-Compiling and installing DFTB+
-******************************
+*****************************
+Building and installing DFTB+
+*****************************
 
 
 Requirements
@@ -36,7 +36,7 @@ Additionally there are optional requirements for some DFTB+ features:
 * The `MAGMA <http://icl.cs.utk.edu/magma/>`_ library for GPU accelerated
   computation.
 
-* The `PLUMED2 <https://github.com/plumed/plumed2>` library for metadynamics
+* The `PLUMED2 <https://github.com/plumed/plumed2>`_ library for metadynamics
   simulations. If you build DFTB+ with MPI, the linked PLUMED library must be
   also MPI-aware (and must have been built with the same MPI-framework as
   DFTB+).
@@ -52,11 +52,49 @@ results, you will additionally need:
 * The Slater-Koster data used in the tests (see below)
 
 
+Successful builds
+-----------------
+
+DFTB+ is regularly built and tested in following build environments:
+
++---------------+----------------------+-------------+------------------+-----+
+| Architecture  | Compiler             | MPI         | Ext. libraries   |Notes|
++===============+======================+=============+==================+=====+
+| x86_64 /      | GNU Fortran/C 7.5    | OpenMPI 2.1 | OpenBlas 0.3.7,  |     |
+| Linux         |                      |             | ScaLAPACK 2.1    |     |
++---------------+----------------------+-------------+------------------+-----+
+| x86_64 /      | GNU Fortran/C 10.1   | OpenMPI 4.0 | OpenBlas 0.3.10, |     |
+| Linux         |                      |             | ScaLAPACK 2.1    |     |
++---------------+----------------------+-------------+------------------+-----+
+| x86_64 /      | Intel Fortran/C 18.0 | MPICH 3.2   | MKL 18.0         |     |
+| Linux         |                      |             |                  |     |
++---------------+----------------------+-------------+------------------+-----+
+| x86_64 /      | Intel Fortran/C 18.0 | MPICH 3.2   | MKL 18.0         |     |
+| Linux         |                      |             |                  |     |
++---------------+----------------------+-------------+------------------+-----+
+| x86_64 /      | Intel Fortran/C 19.0 | MPICH 3.3   | MKL 19.0         |     |
+| Linux         |                      |             |                  |     |
++---------------+----------------------+-------------+------------------+-----+
+| x86_64 /      | NAG Fortran 7.0      | MPICH 3.3   | OpenBlas 0.3.7   |     |
+| Linux         | GNU C 9.2            |             | ScaLAPACK 2.1    |     |
++---------------+----------------------+-------------+------------------+-----+
+| x86_64 /      | GNU Fortran/C 8      | --          | LAPACK / BLAS    | [1] |
+| OS X          |                      |             |                  |     |
+|               |                      |             |                  |     |
++---------------+----------------------+-------------+------------------+-----+
+
+All builds use ARPACK-NG 3.7, ELSI 2.6.1 and PLUMED 2.5.
+
+Notes:
+
+[1] Only serial version tested.
+
+
 Obtaining the source
 ====================
 
 The source code of the last stable release can be downloaded from the `DFTB+
-homepage <http://www.dftbplus.org>`_.
+homepage <https://www.dftbplus.org/download/dftb-stable/>`_.
 
 Alternatively you can clone the `public git repository
 <https://github.com/dftbplus/dftbplus>`_. The tagged revisions correspond to
@@ -70,7 +108,7 @@ downloaded ::
 
 
 Optional extra components
-~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------
 
 Some optional software components are not distributed with the DFTB+ source
 code. If these are required, but are not already installed on your system, then
@@ -109,14 +147,16 @@ variables in some of the config files.
 **Note for developers:** Please see some further instructions at the end of the
 file.
 
+In order to build DFTB+ carry out the following steps:
+
 * Inspect the `config.cmake` file and customise the global build parameters. (If
   you are unsure, leave the defaults as they are.)
 
-* Create a build folder (e.g. `_build`) either within the DFTB+ source tree or
+* Create a build folder (e.g. `build`) either within the DFTB+ source tree or
   somewhere else outside of it and change to that folder, e.g.::
 
-    mkdir _build
-    cd _build
+    mkdir build
+    cd build
 
 * From the build folder invoke CMake to configure the build. You have to pass
   the source directory as argument to CMake. Additionally pass your Fortran and
@@ -178,7 +218,7 @@ file.
   should execute a serial build with verbosity turned on instead::
 
     make VERBOSE=1
-  
+
 * Note: The code can be compiled with distributed memory parallelism (MPI), but
   for smaller shared memory machines, you may find that the performance is
   better when using OpenMP parallelism only and an optimised thread aware BLAS
@@ -249,7 +289,7 @@ for linking DFTB+ with C and Fortran programs.
 
 
 Linking the library in non-CMake based builds
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------------
 
 Depending on the choice of external components and whether you want to link
 DFTB+ to a C or a Fortran binary, you may need different compilation flags and
@@ -273,7 +313,7 @@ pkg-config file.
 
 
 Linking the library in CMake based builds
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------
 
 If you use CMake to build your project, you can directly use the CMake
 configuration file installed by DFTB+ into the `lib/cmake/DftbPlus/` folder in
@@ -349,6 +389,6 @@ The customized config file is read by CMake before the compiler detection. If
 your config file contains toolchain dependent options, consider to define the
 ``DFTBPPLUS_TOOLCHAIN`` environment variable and query it in your config file.
 
-See this [CMake customization
-file](https://gist.github.com/aradi/39ab88acfbacc3b2f44d1e41e4da15e7) for a
+See this `CMake customization file
+<https://gist.github.com/aradi/39ab88acfbacc3b2f44d1e41e4da15e7>`_ for a
 template.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -52,10 +52,11 @@ results, you will additionally need:
 * The Slater-Koster data used in the tests (see below)
 
 
-Successful builds
------------------
+Tested builds
+-------------
 
-DFTB+ is regularly built and tested in following build environments:
+DFTB+ is regularly built and tested for both serial and MPI environments on the
+following architectures:
 
 +---------------+----------------------+-------------+------------------+-----+
 | Architecture  | Compiler             | MPI         | Ext. libraries   |Notes|
@@ -83,7 +84,8 @@ DFTB+ is regularly built and tested in following build environments:
 |               |                      |             |                  |     |
 +---------------+----------------------+-------------+------------------+-----+
 
-All builds use ARPACK-NG 3.7, ELSI 2.6.1 and PLUMED 2.5.
+All builds are also tested with the optional ARPACK-NG 3.7, ELSI 2.6.1 and
+PLUMED 2.5 libraries.
 
 Notes:
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -173,8 +173,11 @@ In order to build DFTB+ carry out the following steps:
     env FC=mpifort CC=gcc cmake ..
 
   Based on the detected compilers, the build system will read further settings
-  from a corresponding toolchain file in the `sys/` folder. (The name of the
-  file is shown in the output.)
+  from a corresponding toolchain file in the `sys/` folder. Either from a
+  specific one (e.g. `gnu.cmake`, `intel.cmake`, etc.) or a generic one
+  (`generic.cmake`) if the detected compiler combination does not correspond to
+  any of the specific settings. (The name of the selected toolchain file is
+  shown in the output.)
 
   You may adjust any variables defined in `config.make` or in the toolchain file
   by either modifying the files directly or by overriding the definitions via

--- a/LICENSE
+++ b/LICENSE
@@ -1,32 +1,30 @@
-Note: The license below covers all sofware components of the DFTB+
-package, except external software components located in the
-'external/' directory. Those external software components are not part
-of the DFTB+ project and are only distributed with the DFTB+ source
-for your convenience. Please consult the license file of each external
-software component for its individual copyright information and
-licensing terms.
+DFTB+: general package for performing fast atomistic simulations
+Copyright (C) 2006 - 2020  DFTB+ developers group
 
-|------------------------------------------------------------------------|
-|  DFTB+: general package for performing fast atomistic simulations      |
-|  Copyright (C) 2006 - 2020  DFTB+ developers group                     |
-|                                                                        |
-|  This program is free software: you can redistribute it and/or modify  |
-|  it under the terms of the GNU Lesser General Public License as        |
-|  published by the Free Software Foundation, either version 3 of the    |
-|  License, or (at your option) any later version.                       |
-|                                                                        |
-|  This program is distributed in the hope that it will be useful, but   |
-|  WITHOUT ANY WARRANTY; without even the implied warranty of            |
-|  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     |
-|  Lesser General Public License for more details.                       |
-|                                                                        |
-|  You should have received a copy of the GNU Lesser General Public      |
-|  License along with this program.  If not, see                         |
-|  <http://www.gnu.org/licenses/>.                                       |
-|------------------------------------------------------------------------|
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version.
 
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--------------------------------------------------------------------------------
 
 Documents (e.g. manual) are licensed under the Creative Commons
 Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) license. See
-<https://creativecommons.org/licenses/by-sa/4.0/> for details on the
-licensing terms.
+<https://creativecommons.org/licenses/by-sa/4.0/> for details on the licensing
+terms.
+
+--------------------------------------------------------------------------------
+
+External software components in the 'external/' directory are not part the of
+the DFTB+ project and are only distributed with the DFTB+ source for your
+convenience. Please consult the license file of each external software component
+for its individual copyright information and licensing terms.
+
+--------------------------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -2,20 +2,136 @@
 DFTB+: general package for performing fast atomistic calculations
 *****************************************************************
 
-DFTB+ is a software package for carrying out fast quantum mechanical
-atomistic calculations based on the Density Functional Tight Binding
-method. The most recent features are described `here
-<https://doi.org/10.1063/1.5143190>`_. It can be either used as a
-standalone program or integrated into other software packages as a
-library.
+|lgpl badge|
 
-The project is hosted on `github <http://github.com/dftbplus/dftbplus>`_.
+DFTB+ is a software package for carrying out fast quantum mechanical atomistic
+calculations based on the Density Functional Tight Binding method. The most
+recent features are described in the `DFTB+ paper (open access)
+<https://doi.org/10.1063/1.5143190>`_.
 
-DFTB+ is released under the GNU Lesser General Public License. Please consult
-the included `LICENSE <LICENSE>`_ file for the detailed licensing conditions.
+|DFTB+ logo|
 
-Information on the compiling, testing and installation of DFTB+ is given in the
-file `INSTALL.rst <INSTALL.rst>`_ in this directory.
+DFTB+ can be either used as a standalone program or integrated into other
+software packages as a library.
 
-If you wish to contribute to the project, please check the `CONTRIBUTING.rst
-<CONTRIBUTING.rst>`_ file for guide lines.
+
+Installation
+============
+
+
+Downloading the binary distribution
+-----------------------------------
+
+Binary (threaded) distribution of the latest stable release can be found on the
+`stable release page <http://www.dftbplus.org/download/dftb-stable/>`_.
+
+
+Building from source
+--------------------
+
+**Note:** This section describes the building with default settings (offering
+only a subset of all possible features in DFTB+). For more detailed information
+on the build customization and the build process, consult the `detailed building
+instructions <INSTALL.rst>`_.
+
+Download the source code from the `stable release page
+<http://www.dftbplus.org/download/dftb-stable/>`_.
+
+You need CMake (>= 3.5.0) to build DFTB+. Create a build folder
+(e.g. ``build``) in the source folder and start the configuration from
+there. Pass your compilers as environment variables (``FC`` and ``CC``) and
+the location where the code should be installed (``-DCMAKE_INSTALL_PREFIX``)::
+
+  mkdir build
+  cd build
+  env FC=gfortran CC=gcc cmake -DCMAKE_INSTALL_PREFIX=$HOME/opt/dftb+ ..
+
+If the configuration was successful, start the build with ::
+
+  make -j
+
+After successful build, you should test the code. First download the SK-files
+needed for the test ::
+
+  cd ..
+  ./utils/get_opt_externals slakos
+  cd build
+
+and then run the tests with ::
+
+  ctest -j
+
+If the tests were successful, install the package with ::
+
+  make install
+
+For further details see the `detailed building instructions <INSTALL.rst>`_.
+
+
+Parameterisations
+=================
+
+In order to carry out calculations with DFTB+, you need according
+parameterisations (a.k.a. Slater-Koster files). You can download them from
+`dftb.org <https://dftb.org>`_.
+
+
+Documentation
+=============
+
+Consult following resources for documentation:
+
+* `Step-by-step instructions with selected examples (DFTB+ Recipes)
+  <http://dftbplus-recipes.readthedocs.io/>`_
+
+* `Reference manual describing all features (DFTB+ Manual)
+  <http://www.dftbplus.org/fileadmin/DFTBPLUS/public/dftbplus/latest/manual.pdf>`_
+
+
+Citing
+======
+
+When publishing results obtained with DFTB+, please cite following works:
+
+* `DFTB+, a software package for efficient approximate density functional theory
+  based atomistic simulations; J. Chem. Phys. 152, 124101 (2020)
+  <https://doi.org/10.1063/1.5143190>`_
+
+* Reference publications of the Slater-Koster parameterization sets you
+  used. (See `dftb.org <https://dftb.org>`_ for the references.)
+
+* Methodological papers relevant to your calculations (e.g. excited states,
+  electron-transport, third order DFTB etc.). Those references can be found in
+  the `DFTB+ manual
+  <http://www.dftbplus.org/fileadmin/DFTBPLUS/public/dftbplus/latest/manual.pdf>`_.
+
+
+Contributing
+============
+
+Welcome in the DFTB+ developer community!
+
+The project is `hosted on github <http://github.com/dftbplus/dftbplus>`_.
+Please check `CONTRIBUTING.rst <CONTRIBUTING.rst>`_ and the `DFTB+ developers
+guide <https://dftbplus-develguide.readthedocs.io/>`_ for guide lines.
+
+We are looking forward to your pull request!
+
+
+License
+=======
+
+DFTB+ is released under the GNU Lesser General Public License. See the included
+`LICENSE <LICENSE>`_ file for the detailed licensing conditions.
+
+
+
+.. |DFTB+ logo| image:: https://www.dftbplus.org/fileadmin/DFTBPLUS/images/DFTB-Plus-Icon_06_f_150x150.png
+    :alt: DFTB+ website
+    :scale: 100%
+    :target: https://dftbplus.org/
+
+.. |lgpl badge| image:: http://www.dftbplus.org/fileadmin/DFTBPLUS/images/license-GNU-LGPLv3-blue.svg
+    :alt: LGPL v3.0
+    :scale: 100%
+    :target: https://opensource.org/licenses/LGPL-3.0

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ DFTB+: general package for performing fast atomistic calculations
 
 DFTB+ is a software package for carrying out fast quantum mechanical atomistic
 calculations based on the Density Functional Tight Binding method. The most
-recent features are described in the `DFTB+ paper (open access)
+recent features are described in the (open access) `DFTB+ paper
 <https://doi.org/10.1063/1.5143190>`_.
 
 |DFTB+ logo|
@@ -109,9 +109,10 @@ When publishing results obtained with DFTB+, please cite following works:
 Contributing
 ============
 
-Welcome in the DFTB+ developer community!
+New features, bug fixes, documentation, tutorial examples and code testing is
+welcome in the DFTB+ developer community!
 
-The project is `hosted on github <http://github.com/dftbplus/dftbplus>`_.
+The project is `hosted on github <http://github.com/dftbplus/>`_.
 Please check `CONTRIBUTING.rst <CONTRIBUTING.rst>`_ and the `DFTB+ developers
 guide <https://dftbplus-develguide.readthedocs.io/>`_ for guide lines.
 


### PR DESCRIPTION
Make readme more informative, add table of successful builds to install instructions, change license formatting.