### PR TITLE
Fix wrong print when PCG shows error

### DIFF
--- a/prog/dftb+/lib_reks/rekscpeqn.F90
+++ b/prog/dftb+/lib_reks/rekscpeqn.F90
@@ -564,7 +564,7 @@ module dftbp_rekscpeqn
       ! check singularity for preconditioner
       if (abs(tmpApre(ij)) <= epsilon(1.0_dp)) then
         write(stdOut,'(A,f15.8)') " Current preconditioner value = ", tmpApre(ij)
-        call error("A singularity exists in preconditioner for PCG, set GradientLevel = 2")
+        call error("A singularity exists in preconditioner for PCG, set Preconditioner = No")
       end if
 
       ! preconditioner part for CG

--- a/prog/dftb+/lib_reks/reksgrad.F90
+++ b/prog/dftb+/lib_reks/reksgrad.F90
@@ -3267,7 +3267,7 @@ module dftbp_reksgrad
       ! check singularity for preconditioner
       if (abs(A1ePre(ij,ij)) <= epsilon(1.0_dp)) then
         write(stdOut,'(A,f15.8)') " Current preconditioner value = ", A1ePre(ij,ij)
-        call error("A singularity exists in preconditioner for PCG, set GradientLevel = 2")
+        call error("A singularity exists in preconditioner for PCG, set Preconditioner = No")
       end if
 
       ! preconditioner part for CG


### PR DESCRIPTION
Apply new argument `Preconditioner` rather than old argument `GradientLevel` in print lines.