### PR TITLE
Clean up of erf/erfc pre-F2008 fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ dftbp_ensure_out_of_source_build()
 dftbp_load_build_settings()
 
 project(dftbplus VERSION ${DFTBPLUS_VERSION} LANGUAGES Fortran C)
+
+# By default, use intrinsic Fortran 2008 erf/erfc
+set(INTERNAL_ERFC CACHE BOOL 0)
+
 dftbp_load_toolchain_settings()
 dftbp_setup_global_compiler_flags()
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
@@ -116,7 +120,6 @@ endif()
 dftbp_create_library_targets("${OTHER_LIBRARIES}" "${OTHER_LIBRARY_DIRS}")
 list(APPEND EXPORTED_EXTERNAL_LIBRARIES ${OTHER_LIBRARIES})
 list(APPEND EXPORTED_EXTERNAL_LIBRARY_DIRS ${OTHER_LIBRARY_DIRS})
-
 
 #
 # Preprocessor details

--- a/cmake/dftbpUtils.cmake
+++ b/cmake/dftbpUtils.cmake
@@ -56,6 +56,10 @@ function (dftbp_add_fypp_defines fyppflags)
     list(APPEND _fyppflags -DDEBUG=0)
   endif()
 
+  if(INTERNAL_ERFC)
+    list(APPEND _fyppflags -DINTERNAL_ERFC=1)
+  endif()
+
   if(WITH_OMP)
     list(APPEND _fyppflags -DWITH_OMP)
   endif()

--- a/prog/dftb+/lib_math/erfcalc.F90
+++ b/prog/dftb+/lib_math/erfcalc.F90
@@ -5,6 +5,8 @@
 !  See the LICENSE file for terms of usage and distribution.                                       !
 !--------------------------------------------------------------------------------------------------!
 
+#:include 'common.fypp'
+
 !> Implementing the special functions erf(x), erfc(x) and exp(x*x) * erfc(x).
 !>
 !> The special functions erf(x), erfc(x) and exp(x * x) * erfc(x) are
@@ -21,8 +23,9 @@ module dftbp_erfcalc
   implicit none
   private
 
-  public :: erf, erfc, erfcx
+#:if INTERNAL_ERFC
 
+  public :: erf, erfc
 
   !> Evaluate erf()
   interface erfcalc_calc
@@ -59,73 +62,60 @@ contains
 
   end function erfc
 
-
-  !> Calculates the value of the function exp(x**2) * erfc(x)
-  function erfcx(x)
-
-    !> Function argument.
-    real(wp), intent(in) :: x
-
-    !> exp(x**2) * erfc(x)
-    real(wp) :: erfcx
-
-    call erfcalc_calc(x, erfcx, 2)
-
-  end function erfcx
-
+#:for VC, LABEL in [('sp', 'single'), ('dp', 'double')]
 
   !> Calculates the appropriate function in double precision.
-  subroutine erfcalc_calcdouble(arg, res, jint)
+  subroutine erfcalc_calc${LABEL}$(arg, res, jint)
 
     !> Where to evaluate the function (x).
-    real(dp), intent(in) :: arg
+    real(${VC}$), intent(in) :: arg
 
     !> Result.
-    real(dp), intent(out) :: res
+    real(${VC}$), intent(out) :: res
 
     !> Function type: 1 - erf(x), 2 - erfc(x), 3 - exp(x**2)*erfc(x).
     integer, intent(in) :: jint
 
-    real(dp), parameter :: xsmall = 1.11E-16_dp
-    real(dp), parameter :: xbig = 26.543_dp
-    real(dp), parameter :: xhuge = 6.71E7_dp
-    real(dp), parameter :: xmax = 2.53E307_dp
+    real(${VC}$), parameter :: xsmall = 1.11E-16_${VC}$
+    real(${VC}$), parameter :: xbig = 26.543_${VC}$
+    real(${VC}$), parameter :: xhuge = 6.71E7_${VC}$
+    real(${VC}$), parameter :: xmax = 2.53E307_${VC}$
 
-    real(dp), parameter :: four = 4.0_dp
-    real(dp), parameter :: one = 1.0_dp
-    real(dp), parameter :: zero = 0.0_dp
-    real(dp), parameter :: sqrpi = 5.6418958354775628695E-1_dp
-    real(dp), parameter :: thresh = 0.46875E0_dp
-    real(dp), parameter :: sixteen = 16.0_dp
-    real(dp), parameter :: aa(5) = [&
-        & 3.16112374387056560E00_dp, 1.13864154151050156E02_dp,&
-        & 3.77485237685302021E02_dp, 3.20937758913846947E03_dp,&
-        & 1.85777706184603153E-1_dp ]
-    real(dp), parameter :: bb(4) = [&
-        & 2.36012909523441209E01_dp, 2.44024637934444173E02_dp,&
-        & 1.28261652607737228E03_dp, 2.84423683343917062E03_dp ]
-    real(dp), parameter :: cc(9) = [&
-        & 5.64188496988670089E-1_dp, 8.88314979438837594E00_dp,&
-        & 6.61191906371416295E01_dp, 2.98635138197400131E02_dp,&
-        & 8.81952221241769090E02_dp, 1.71204761263407058E03_dp,&
-        & 2.05107837782607147E03_dp, 1.23033935479799725E03_dp,&
-        & 2.15311535474403846E-8_dp ]
-    real(dp), parameter :: dd(8) = [&
-        & 1.57449261107098347E01_dp, 1.17693950891312499E02_dp,&
-        & 5.37181101862009858E02_dp, 1.62138957456669019E03_dp,&
-        & 3.29079923573345963E03_dp, 4.36261909014324716E03_dp,&
-        & 3.43936767414372164E03_dp, 1.23033935480374942E03_dp ]
-    real(dp), parameter :: pp(6) = [&
-        & 3.05326634961232344E-1_dp, 3.60344899949804439E-1_dp,&
-        & 1.25781726111229246E-1_dp, 1.60837851487422766E-2_dp,&
-        & 6.58749161529837803E-4_dp, 1.63153871373020978E-2_dp ]
-    real(dp), parameter :: qq(5) = [&
-        & 2.56852019228982242E00_dp, 1.87295284992346047E00_dp,&
-        & 5.27905102951428412E-1_dp, 6.05183413124413191E-2_dp,&
-        & 2.33520497626869185E-3_dp ]
+    real(${VC}$), parameter :: four = 4.0_${VC}$
+    real(${VC}$), parameter :: one = 1.0_${VC}$
+    real(${VC}$), parameter :: zero = 0.0_${VC}$
+    real(${VC}$), parameter :: sqrpi = 5.6418958354775628695E-1_${VC}$
+    real(${VC}$), parameter :: thresh = 0.46875E0_${VC}$
+    real(${VC}$), parameter :: sixteen = 16.0_${VC}$
+    real(${VC}$), parameter :: aa(5) = [&
+        & 3.16112374387056560E00_${VC}$, 1.13864154151050156E02_${VC}$,&
+        & 3.77485237685302021E02_${VC}$, 3.20937758913846947E03_${VC}$,&
+        & 1.85777706184603153E-1_${VC}$ ]
+    real(${VC}$), parameter :: bb(4) = [&
+        & 2.36012909523441209E01_${VC}$, 2.44024637934444173E02_${VC}$,&
+        & 1.28261652607737228E03_${VC}$, 2.84423683343917062E03_${VC}$ ]
+    real(${VC}$), parameter :: cc(9) = [&
+        & 5.64188496988670089E-1_${VC}$, 8.88314979438837594E00_${VC}$,&
+        & 6.61191906371416295E01_${VC}$, 2.98635138197400131E02_${VC}$,&
+        & 8.81952221241769090E02_${VC}$, 1.71204761263407058E03_${VC}$,&
+        & 2.05107837782607147E03_${VC}$, 1.23033935479799725E03_${VC}$,&
+        & 2.15311535474403846E-8_${VC}$ ]
+    real(${VC}$), parameter :: dd(8) = [&
+        & 1.57449261107098347E01_${VC}$, 1.17693950891312499E02_${VC}$,&
+        & 5.37181101862009858E02_${VC}$, 1.62138957456669019E03_${VC}$,&
+        & 3.29079923573345963E03_${VC}$, 4.36261909014324716E03_${VC}$,&
+        & 3.43936767414372164E03_${VC}$, 1.23033935480374942E03_${VC}$ ]
+    real(${VC}$), parameter :: pp(6) = [&
+        & 3.05326634961232344E-1_${VC}$, 3.60344899949804439E-1_${VC}$,&
+        & 1.25781726111229246E-1_${VC}$, 1.60837851487422766E-2_${VC}$,&
+        & 6.58749161529837803E-4_${VC}$, 1.63153871373020978E-2_${VC}$ ]
+    real(${VC}$), parameter :: qq(5) = [&
+        & 2.56852019228982242E00_${VC}$, 1.87295284992346047E00_${VC}$,&
+        & 5.27905102951428412E-1_${VC}$, 6.05183413124413191E-2_${VC}$,&
+        & 2.33520497626869185E-3_${VC}$ ]
 
     integer :: ii
-    real(dp) :: del, xx, xden, xnum, yy, ysq
+    real(${VC}$) :: del, xx, xden, xnum, yy, ysq
 
     xx = arg
     yy = abs(xx)
@@ -170,12 +160,12 @@ contains
       res = zero
       if (yy >= xbig) then
         if ((jint /= 2) .or. (yy >= xmax)) then
-          call fixnegf_dp(res, ysq, del, yy, jint, xx)
+          call fixnegf_${VC}$(res, ysq, del, yy, jint, xx)
           return
         end if
         if (yy >= xhuge) then
           res = sqrpi / yy
-          call fixnegf_dp(res, ysq, del, yy, jint, xx)
+          call fixnegf_${VC}$(res, ysq, del, yy, jint, xx)
           return
         end if
       end if
@@ -194,25 +184,26 @@ contains
         res = exp(-ysq*ysq) * exp(-del) * res
       end if
     end if
-    call fixnegf_dp(res, ysq, del, yy, jint, xx)
+    call fixnegf_${VC}$(res, ysq, del, yy, jint, xx)
 
-  end subroutine erfcalc_calcdouble
+  end subroutine erfcalc_calc${LABEL}$
+
 
   !> fix up for negative argument, erf, etc.
-  subroutine fixnegf_dp(res, ysq, del, yy, jint, xx)
-    real(dp), intent(inout) :: res
-    real(dp), intent(inout) :: ysq
-    real(dp), intent(inout) :: del
-    real(dp), intent(inout) :: yy
+  subroutine fixnegf_${VC}$(res, ysq, del, yy, jint, xx)
+    real(${VC}$), intent(inout) :: res
+    real(${VC}$), intent(inout) :: ysq
+    real(${VC}$), intent(inout) :: del
+    real(${VC}$), intent(inout) :: yy
     integer, intent(in) :: jint
-    real(dp), intent(in) :: xx
+    real(${VC}$), intent(in) :: xx
 
-    real(dp), parameter :: zero = 0.0_dp
-    real(dp), parameter :: half = 0.5_dp
-    real(dp), parameter :: two = 2.0_dp
-    real(dp), parameter :: sixteen = 16.0_dp
-    real(dp), parameter :: xneg = -26.628_dp
-    real(dp), parameter :: xinf = 1.79E308_dp
+    real(${VC}$), parameter :: zero = 0.0_${VC}$
+    real(${VC}$), parameter :: half = 0.5_${VC}$
+    real(${VC}$), parameter :: two = 2.0_${VC}$
+    real(${VC}$), parameter :: sixteen = 16.0_${VC}$
+    real(${VC}$), parameter :: xneg = -26.628_${VC}$
+    real(${VC}$), parameter :: xinf = 1.79E308_${VC}$
 
     if (jint == 0) then
       res = (half - res) + half
@@ -232,165 +223,10 @@ contains
       end if
     end if
 
-  end subroutine fixnegf_dp
+  end subroutine fixnegf_${VC}$
 
-  !> Calculates the appropriate function in single precision.
-  subroutine erfcalc_calcsingle(arg, res, jint)
+#:endfor
 
-    !> Where to evaluate the function (x).
-    real(sp), intent(in) :: arg
-
-    !> Result.
-    real(sp), intent(out) :: res
-
-    !> Function type: 1 - erf(x), 2 - erfc(x), 3 - exp(x**2)*erfc(x).
-    integer, intent(in) :: jint
-
-    real(sp), parameter :: xsmall = 5.96E-8_sp
-    real(sp), parameter :: xbig = 9.194E0_sp
-    real(sp), parameter :: xhuge = 2.90E3_sp
-    real(sp), parameter :: xmax = 4.79E37_dp
-
-    real(sp), parameter :: four = 4.0_sp
-    real(sp), parameter :: one = 1.0_sp
-    real(sp), parameter :: zero = 0.0_sp
-    real(sp), parameter :: sqrpi = 5.6418958354775628695E-1_sp
-    real(sp), parameter :: thresh = 0.46875E0_sp
-    real(sp), parameter :: sixteen = 16.0_sp
-    real(sp), parameter :: aa(5) = [&
-        & 3.16112374387056560E00_sp, 1.13864154151050156E02_sp,&
-        & 3.77485237685302021E02_sp, 3.20937758913846947E03_sp,&
-        & 1.85777706184603153E-1_sp ]
-    real(sp), parameter :: bb(4) = [&
-        & 2.36012909523441209E01_sp, 2.44024637934444173E02_sp,&
-        & 1.28261652607737228E03_sp, 2.84423683343917062E03_sp ]
-    real(sp), parameter :: cc(9) = [&
-        & 5.64188496988670089E-1_sp, 8.88314979438837594E00_sp,&
-        & 6.61191906371416295E01_sp, 2.98635138197400131E02_sp,&
-        & 8.81952221241769090E02_sp, 1.71204761263407058E03_sp,&
-        & 2.05107837782607147E03_sp, 1.23033935479799725E03_sp,&
-        & 2.15311535474403846E-8_sp ]
-    real(sp), parameter :: dd(8) = [&
-        & 1.57449261107098347E01_sp, 1.17693950891312499E02_sp,&
-        & 5.37181101862009858E02_sp, 1.62138957456669019E03_sp,&
-        & 3.29079923573345963E03_sp, 4.36261909014324716E03_sp,&
-        & 3.43936767414372164E03_sp, 1.23033935480374942E03_sp ]
-    real(sp), parameter :: pp(6) = [&
-        & 3.05326634961232344E-1_sp, 3.60344899949804439E-1_sp,&
-        & 1.25781726111229246E-1_sp, 1.60837851487422766E-2_sp,&
-        & 6.58749161529837803E-4_sp, 1.63153871373020978E-2_sp ]
-    real(sp), parameter :: qq(5) = [&
-        & 2.56852019228982242E00_sp, 1.87295284992346047E00_sp,&
-        & 5.27905102951428412E-1_sp, 6.05183413124413191E-2_sp,&
-        & 2.33520497626869185E-3_sp ]
-
-    integer :: ii
-    real(sp) :: del, xx, xden, xnum, yy, ysq
-
-    xx = arg
-    yy = abs(xx)
-
-    if (yy <= thresh) then
-      !------------------------------------------------------------------
-      !  evaluate  erf  for  |x| <= 0.46875
-      !------------------------------------------------------------------
-      ysq = zero
-      if (yy > xsmall) ysq = yy * yy
-      xnum = aa(5)*ysq
-      xden = ysq
-      do ii = 1, 3
-        xnum = (xnum + aa(ii)) * ysq
-        xden = (xden + bb(ii)) * ysq
-      end do
-      res = xx * (xnum + aa(4)) / (xden + bb(4))
-      if (jint /= 0) res = one - res
-      if (jint == 2) res = exp(ysq) * res
-      return
-
-    elseif (yy <= four) then
-      !------------------------------------------------------------------
-      !  evaluate  erfc  for 0.46875 <= |x| <= 4.0
-      !------------------------------------------------------------------
-      xnum = cc(9) * yy
-      xden = yy
-      do ii = 1, 7
-        xnum = (xnum + cc(ii)) * yy
-        xden = (xden + dd(ii)) * yy
-      end do
-      res = (xnum + cc(8)) / (xden + dd(8))
-      if (jint /= 2) then
-        ysq = aint(yy * sixteen) / sixteen
-        del = (yy - ysq) * (yy + ysq)
-        res = exp(-ysq * ysq) * exp(-del) * res
-      end if
-    else
-      !------------------------------------------------------------------
-      !  evaluate  erfc  for |x| > 4.0
-      !------------------------------------------------------------------
-      res = zero
-      if (yy >= xbig) then
-        if ((jint /= 2) .or. (yy >= xmax)) then
-          call fixnegf_sp(res, ysq, del, yy, jint, xx)
-          return
-        end if
-        if (yy >= xhuge) then
-          res = sqrpi / yy
-          call fixnegf_sp(res, ysq, del, yy, jint, xx)
-          return
-        end if
-      end if
-      ysq = one / (yy * yy)
-      xnum = pp(6)*ysq
-      xden = ysq
-      do ii = 1, 4
-        xnum = (xnum + pp(ii)) * ysq
-        xden = (xden + qq(ii)) * ysq
-      end do
-      res = ysq *(xnum + pp(5)) / (xden + qq(5))
-      res = (sqrpi -  res) / yy
-      if (jint /= 2) then
-        ysq = aint(yy * sixteen) / sixteen
-        del = (yy - ysq) * (yy + ysq)
-        res = exp(-ysq*ysq) * exp(-del) * res
-      end if
-    end if
-    call fixnegf_sp(res, ysq, del, yy, jint, xx)
-
-  end subroutine erfcalc_calcsingle
-
-  !> fix up for negative argument, erf, etc.
-  subroutine fixnegf_sp(res, ysq, del, yy, jint, xx)
-    real(sp), intent(inout) :: res
-    real(sp), intent(inout) :: ysq
-    real(sp), intent(inout) :: del
-    real(sp), intent(inout) :: yy
-    integer, intent(in) :: jint
-    real(sp), intent(in) :: xx
-
-    real(sp), parameter :: zero = 0.0_sp
-    real(sp), parameter :: half = 0.5_sp
-    real(sp), parameter :: two = 2.0_sp
-    real(sp), parameter :: sixteen = 16.0_sp
-    real(sp), parameter :: xneg = -9.382E0_sp
-    real(sp), parameter :: xinf = 3.40E+38_sp
-
-    if (jint == 0) then
-      res = (half - res) + half
-      if (xx < zero) res = -res
-    else if (jint == 1) then
-      if (xx < zero) res = two - res
-    else
-      if (xx < zero) then
-        if (xx < xneg) then
-          res = xinf
-        else
-          ysq = aint(xx * sixteen) / sixteen
-          del = (xx - ysq) * (xx + ysq)
-          yy = exp(ysq * ysq) * exp(del)
-          res = (yy + yy) - res
-        end if
-      end if
-    end if
-  end subroutine fixnegf_sp
+#:endif
 
 end module dftbp_erfcalc

--- a/prog/dftb+/lib_math/erfcalc.F90
+++ b/prog/dftb+/lib_math/erfcalc.F90
@@ -36,7 +36,7 @@ contains
 
 
   !> Calculates the value of the error function.
-  function erf(x)
+  elemental function erf(x)
 
     !> Function argument.
     real(wp), intent(in) :: x
@@ -44,13 +44,13 @@ contains
     !> erf(x)
     real(wp) :: erf
 
-    call erfcalc_calc(x, erf, 0)
+    erf = erfcalc_calc(x, 0)
 
   end function erf
 
 
   !> Calculates the value of the complementary error function.
-  function erfc(x)
+  elemental function erfc(x)
 
     !> Function argument.
     real(wp), intent(in) :: x
@@ -58,28 +58,34 @@ contains
     !> erfc(x)
     real(wp) :: erfc
 
-    call erfcalc_calc(x, erfc, 1)
+    erfc = erfcalc_calc(x, 1)
 
   end function erfc
 
 #:for VC, LABEL in [('sp', 'single'), ('dp', 'double')]
 
   !> Calculates the appropriate function in double precision.
-  subroutine erfcalc_calc${LABEL}$(arg, res, jint)
+  elemental function erfcalc_calc${LABEL}$(arg, jint) result(res)
 
     !> Where to evaluate the function (x).
     real(${VC}$), intent(in) :: arg
 
-    !> Result.
-    real(${VC}$), intent(out) :: res
-
-    !> Function type: 1 - erf(x), 2 - erfc(x), 3 - exp(x**2)*erfc(x).
+    !> Function type: 1 - erf(x), 2 - erfc(x)
     integer, intent(in) :: jint
+
+    !> Result
+    real(${VC}$) :: res
 
     real(${VC}$), parameter :: xsmall = 1.11E-16_${VC}$
     real(${VC}$), parameter :: xbig = 26.543_${VC}$
     real(${VC}$), parameter :: xhuge = 6.71E7_${VC}$
-    real(${VC}$), parameter :: xmax = 2.53E307_${VC}$
+
+    ! see https://www.netlib.org/specfun/erf :
+  #:if VC == 'sp'
+    real(sp), parameter :: xmax = 4.79E37_sp
+  #:else
+    real(dp), parameter :: xmax = 2.53E307_dp
+  #:endif
 
     real(${VC}$), parameter :: four = 4.0_${VC}$
     real(${VC}$), parameter :: one = 1.0_${VC}$
@@ -186,11 +192,11 @@ contains
     end if
     call fixnegf_${VC}$(res, ysq, del, yy, jint, xx)
 
-  end subroutine erfcalc_calc${LABEL}$
+  end function erfcalc_calc${LABEL}$
 
 
   !> fix up for negative argument, erf, etc.
-  subroutine fixnegf_${VC}$(res, ysq, del, yy, jint, xx)
+  pure subroutine fixnegf_${VC}$(res, ysq, del, yy, jint, xx)
     real(${VC}$), intent(inout) :: res
     real(${VC}$), intent(inout) :: ysq
     real(${VC}$), intent(inout) :: del

--- a/prog/dftb+/lib_math/errorfunction.F90
+++ b/prog/dftb+/lib_math/errorfunction.F90
@@ -14,14 +14,12 @@
 !> a) no special definitions: the intrinsic error function is used (officially first available in
 !>    the Fortran 2008 standard, but most F95/2003 compilers already implements this).
 !>
-!> b) EXTERNALERFC is defined: single precision and double precision external routines are expected
-!>    (erf(x), erfc(x), derf(x), derfc(x)).
+!> b) INTERNAL_ERFC is defined: erf(x) and erfc(x) are internally calculated by the code.
 !>
-!> c) INTERNALERFC is defined: erf(x) and erfc(x) are internally calculated by the code.
 module dftbp_errorfunction
   use dftbp_accuracy
 #:if INTERNAL_ERFC
-  use dftbp_erfcalc, only: erf, erfc
+  use dftbp_erfcalc, only : erf, erfc
 #:endif
   implicit none
   private

--- a/prog/dftb+/lib_math/errorfunction.F90
+++ b/prog/dftb+/lib_math/errorfunction.F90
@@ -30,7 +30,7 @@ contains
 
 
   !> Calculates the value of the error function.
-  function erfwrap(xx) result(res)
+  elemental function erfwrap(xx) result(res)
 
     !> Function argument.
     real(dp), intent(in) :: xx
@@ -44,7 +44,7 @@ contains
 
 
   !> Calculates the value of the complementary error function.
-  function erfcwrap(xx) result(res)
+  elemental function erfcwrap(xx) result(res)
 
     !> Function argument.
     real(dp), intent(in) :: xx


### PR DESCRIPTION
Uses pre-processor to avoid precision duplication (also fixing an implicit type conversion in the single precision routine as a byproduct). Also processes the internal routine providing the erf/erfc functions to avoid collision with the intrinsic name when the variable is not defined.
Finally, removes mention of (un-used) intrinsic pre-processed case.