### PR TITLE
Fixes missing F90 API blur width internals

### DIFF
--- a/prog/dftb+/lib_dftbplus/mainapi.F90
+++ b/prog/dftb+/lib_dftbplus/mainapi.F90
@@ -251,7 +251,7 @@ contains
         allocate(chrgForces(3, size(chargeQs)))
       end if
     end if
-    call sccCalc%setExternalCharges(chargeCoords, chargeQs)
+    call sccCalc%setExternalCharges(chargeCoords, chargeQs, blurWidths=blurWidths)
 
   end subroutine setExternalCharges
 

--- a/test/api/mm/testers/test_extcharges.f90
+++ b/test/api/mm/testers/test_extcharges.f90
@@ -39,6 +39,11 @@ program test_extcharges
       & 0.43463718188810203E+01_dp,-0.58581533211004997E+01_dp, 0.26456176288841000E+01_dp, -1.9_dp&
       &], [4, nExtChrg])
 
+  !> (optional variable to API call) sets widths of Gaussians to convolve with external charges
+  !> (again set in a.u.). For this particular test, these choices are essentially still point
+  !> charges:
+  real(dp), parameter :: extChargeBlur(nExtChrg) = [0.1_dp, 0.2_dp]
+
   character(100), parameter :: slakoFiles(2, 2) = reshape([character(100) :: &
       & "./O-O.skf", "./H-O.skf", "./O-H.skf", "./H-H.skf"], [2, 2])
 
@@ -117,7 +122,7 @@ program test_extcharges
   call dftbp%setupCalculator(input)
 
   ! add external charges
-  call dftbp%setExternalCharges(extCharges(1:3,:), extCharges(4,:))
+  call dftbp%setExternalCharges(extCharges(1:3,:), extCharges(4,:), extChargeBlur)
 
   ! replace QM atom coordinates
   coords(:,:) = initialCoords


### PR DESCRIPTION
Fortran API exposes an optional argument for external charge widths, but this was not internally passed to the electrostatics.

Modified the API test example to use narrow widths, effectively giving the same results as the original point charges in this case to ~machine tolerance.