### PR TITLE
Rename files and types for clarity over energy

### DIFF
--- a/prog/dftb+/lib_dftb/CMakeLists.txt
+++ b/prog/dftb+/lib_dftb/CMakeLists.txt
@@ -20,12 +20,12 @@ set(sources-fpp
   ${curdir}/elecconstraints.F90
   ${curdir}/elstatpot.F90
   #${curdir}/emfields.F90
-  ${curdir}/energies.F90
+  ${curdir}/energytypes.F90
   ${curdir}/encharges.F90
   ${curdir}/etemp.F90
   ${curdir}/externalcharges.F90
-  ${curdir}/evaluateenergies.F90
   ${curdir}/forces.F90
+  ${curdir}/getenergies.F90
   ${curdir}/h5correction.F90
   ${curdir}/halogenx.F90
   ${curdir}/hamiltonian.F90

--- a/prog/dftb+/lib_dftb/energytypes.F90
+++ b/prog/dftb+/lib_dftb/energytypes.F90
@@ -8,13 +8,13 @@
 #:include 'common.fypp'
 
 !> Module to wrap around the different energy components in the DFTB total energy expression
-module dftbp_energies
+module dftbp_energyTypes
   use dftbp_assert
   use dftbp_accuracy
   implicit none
   private
 
-  public :: TEnergies, init
+  public :: TEnergies, energies_init
 
 
   !> Data type to store components of the energy as named variables instead of
@@ -140,16 +140,11 @@ module dftbp_energies
   end type TEnergies
 
 
-  !> initialise the data type for storing energies
-  interface init
-    module procedure Energies_init
-  end interface init
-
 contains
 
 
   !> Allocates storage for the energy components
-  subroutine Energies_init(this, nAtom)
+  subroutine energies_init(this, nAtom)
 
     !> data structure to allocate
     type(TEnergies), intent(out) :: this
@@ -207,6 +202,6 @@ contains
     this%EMerminKin = 0.0_dp
     this%EGibbsKin = 0.0_dp
 
-  end subroutine Energies_init
+  end subroutine energies_init
 
-end module dftbp_energies
+end module dftbp_energyTypes

--- a/prog/dftb+/lib_dftb/energytypes.F90
+++ b/prog/dftb+/lib_dftb/energytypes.F90
@@ -8,13 +8,13 @@
 #:include 'common.fypp'
 
 !> Module to wrap around the different energy components in the DFTB total energy expression
-module dftbp_energyTypes
+module dftbp_energytypes
   use dftbp_assert
   use dftbp_accuracy
   implicit none
   private
 
-  public :: TEnergies, energies_init
+  public :: TEnergies, TEnergies_init
 
 
   !> Data type to store components of the energy as named variables instead of
@@ -144,7 +144,7 @@ contains
 
 
   !> Allocates storage for the energy components
-  subroutine energies_init(this, nAtom)
+  subroutine TEnergies_init(this, nAtom)
 
     !> data structure to allocate
     type(TEnergies), intent(out) :: this
@@ -202,6 +202,6 @@ contains
     this%EMerminKin = 0.0_dp
     this%EGibbsKin = 0.0_dp
 
-  end subroutine energies_init
+  end subroutine TEnergies_init
 
-end module dftbp_energyTypes
+end module dftbp_energytypes

--- a/prog/dftb+/lib_dftb/getenergies.F90
+++ b/prog/dftb+/lib_dftb/getenergies.F90
@@ -8,10 +8,10 @@
 #:include 'common.fypp'
 
 !> Evaluate energies
-module dftb_evaluateenergies
+module dftbp_getenergies
   use dftbp_accuracy, only : dp, lc
   use dftbp_assert
-  use dftbp_energies
+  use dftbp_energytypes, only : TEnergies
   use dftbp_populations
   use dftbp_commontypes, only : TOrbitals
   use dftbp_periodic, only : TNeighbourList
@@ -333,4 +333,4 @@ contains
 
   end subroutine calcDispersionEnergy
 
-end module dftb_evaluateenergies
+end module dftbp_getenergies

--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -4363,7 +4363,7 @@ contains
       end if
     end if
 
-    call energies_init(energy, nAtom)
+    call TEnergies_init(energy, nAtom)
     call init(potential, orb, nAtom, nSpin)
 
     ! Nr. of independent spin Hamiltonians

--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -95,7 +95,7 @@ module dftbp_initprogram
 #:endif
   use dftbp_elstatpot
   use dftbp_pmlocalisation
-  use dftbp_energies
+  use dftbp_energytypes
   use dftbp_potentials
   use dftbp_taggedoutput
   use dftbp_formatout
@@ -4363,7 +4363,7 @@ contains
       end if
     end if
 
-    call init(energy, nAtom)
+    call energies_init(energy, nAtom)
     call init(potential, orb, nAtom, nSpin)
 
     ! Nr. of independent spin Hamiltonians

--- a/prog/dftb+/lib_dftbplus/main.F90
+++ b/prog/dftb+/lib_dftbplus/main.F90
@@ -37,7 +37,7 @@ module dftbp_main
   use dftbp_stress
   use dftbp_scc
   use dftbp_hamiltonian
-  use dftbp_getenergies
+  use dftbp_getenergies, only : getEnergies, calcRepulsiveEnergy, calcDispersionEnergy
   use dftbp_sccinit
   use dftbp_onsitecorrection
   use dftbp_externalcharges

--- a/prog/dftb+/lib_dftbplus/main.F90
+++ b/prog/dftb+/lib_dftbplus/main.F90
@@ -37,7 +37,7 @@ module dftbp_main
   use dftbp_stress
   use dftbp_scc
   use dftbp_hamiltonian
-  use dftb_evaluateenergies
+  use dftbp_getenergies
   use dftbp_sccinit
   use dftbp_onsitecorrection
   use dftbp_externalcharges
@@ -48,7 +48,7 @@ module dftbp_main
   use dftbp_spin
   use dftbp_dftbplusu
   use dftbp_mdcommon
-  use dftbp_energies
+  use dftbp_energytypes, only : TEnergies
   use dftbp_potentials
   use dftbp_orbitalequiv
   use dftbp_parser

--- a/prog/dftb+/lib_dftbplus/mainio.F90
+++ b/prog/dftb+/lib_dftbplus/mainio.F90
@@ -36,7 +36,7 @@ module dftbp_mainio
   use dftbp_fileid
   use dftbp_spin, only : qm2ud
   use dftbp_elecsolvers, only : TElectronicSolver, electronicSolverTypes
-  use dftbp_energies
+  use dftbp_energytypes, only : TEnergies
   use dftbp_xmlf90
   use dftbp_hsdutils, only : writeChildValue
   use dftbp_mdintegrator, only : TMdIntegrator, state

--- a/prog/dftb+/lib_elecsolvers/elsisolver.F90
+++ b/prog/dftb+/lib_elecsolvers/elsisolver.F90
@@ -23,7 +23,7 @@ module dftbp_elsisolver
   use dftbp_orbitals
   use dftbp_message, only : error, warning, cleanshutdown
   use dftbp_commontypes, only : TParallelKS, TOrbitals
-  use dftbp_energies, only : TEnergies
+  use dftbp_energytypes, only : TEnergies
   use dftbp_etemp, only : fillingTypes
   use dftbp_sparse2dense
   use dftbp_assert

--- a/prog/dftb+/lib_md/nhctherm.F90
+++ b/prog/dftb+/lib_md/nhctherm.F90
@@ -15,7 +15,6 @@ module dftbp_nhctherm
   use dftbp_mdcommon
   use dftbp_ranlux
   use dftbp_tempprofile
-  use dftbp_energies
   use dftbp_message
   implicit none
 

--- a/prog/dftb+/lib_reks/reksen.F90
+++ b/prog/dftb+/lib_reks/reksen.F90
@@ -20,7 +20,7 @@ module dftbp_reksen
   use dftbp_densedescr
   use dftbp_eigenvects
   use dftbp_elecsolvers
-  use dftbp_energies
+  use dftbp_energytypes, only : TEnergies
   use dftbp_environment
   use dftbp_globalenv
   use dftbp_message

--- a/prog/dftb+/lib_timedep/dynamics.F90
+++ b/prog/dftb+/lib_timedep/dynamics.F90
@@ -42,8 +42,8 @@ module dftbp_timeprop
   use dftbp_periodic
   use dftbp_velocityverlet
   use dftbp_nonscc
-  use dftbp_energytypes
-  use dftbp_getenergies
+  use dftbp_energytypes, only : TEnergies, TEnergies_init
+  use dftbp_getenergies, only : getEnergies, calcRepulsiveEnergy, calcDispersionEnergy
   use dftbp_thirdorder, only : TThirdOrder
   use dftbp_solvation, only : TSolvation
   use dftbp_populations
@@ -1985,7 +1985,7 @@ contains
     end if
 
     call init(potential, orb, this%nAtom, this%nSpin)
-    call energies_init(energy, this%nAtom)
+    call TEnergies_init(energy, this%nAtom)
 
     if ((size(UJ) /= 0) .or. allocated(onSiteElements)) then
       allocate(qBlock(orb%mOrb, orb%mOrb, this%nAtom, this%nSpin))

--- a/prog/dftb+/lib_timedep/dynamics.F90
+++ b/prog/dftb+/lib_timedep/dynamics.F90
@@ -42,8 +42,8 @@ module dftbp_timeprop
   use dftbp_periodic
   use dftbp_velocityverlet
   use dftbp_nonscc
-  use dftbp_energies, only: TEnergies, init
-  use dftb_evaluateenergies
+  use dftbp_energytypes
+  use dftbp_getenergies
   use dftbp_thirdorder, only : TThirdOrder
   use dftbp_solvation, only : TSolvation
   use dftbp_populations
@@ -1985,7 +1985,7 @@ contains
     end if
 
     call init(potential, orb, this%nAtom, this%nSpin)
-    call init(energy, this%nAtom)
+    call energies_init(energy, this%nAtom)
 
     if ((size(UJ) /= 0) .or. allocated(onSiteElements)) then
       allocate(qBlock(orb%mOrb, orb%mOrb, this%nAtom, this%nSpin))


### PR DESCRIPTION
Also directly expose energy_init instead of requiring signature
detection. Additionally fix a dftb_ module name for dftbp_.