### PR TITLE
Fixes stray 19.x version numbers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 cmake_policy(VERSION 3.5)
 
-set(DFTBPLUS_VERSION "19.2")
+set(DFTBPLUS_VERSION "20.1")
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(dftbpUtils)

--- a/doc/api/doxygen/Doxyfile
+++ b/doc/api/doxygen/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = DFTB+API
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 19.1
+PROJECT_NUMBER         = 20.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a


### PR DESCRIPTION
Cherry-Pick of #580 on top of 20.1 tag

Back-port comment from #580 [review](https://github.com/dftbplus/dftbplus/pull/580#pullrequestreview-458567366) still relevant.