### PR TITLE
Add table of recent releases to manual

### DIFF
--- a/doc/dftb+/manual/GNUmakefile
+++ b/doc/dftb+/manual/GNUmakefile
@@ -2,9 +2,9 @@
 .SUFFIXES : .fig .pdf .ps .toc .bbl .aux .tex .ind .html ._tmp_
 
 MANUALCOMPONENTS = manual.tex packages.tex newcommands.tex hsd.tex	\
-    unit_mod.tex gen.tex spin_constants.tex disp_constants.tex		\
-    dftd3_constants.tex onsite_constants.tex hhubbard.tex		\
-    restart_files.tex publications.tex references.tex			\
+    unit_mod.tex releases.tex gen.tex spin_constants.tex		\
+    disp_constants.tex dftd3_constants.tex onsite_constants.tex		\
+    hhubbard.tex restart_files.tex publications.tex references.tex	\
     introduction.tex dftbp.tex transport.tex modes.tex waveplot.tex	\
     setupgeom.tex Fig_device.pdf Fig_integration.png api.tex
 

--- a/doc/dftb+/manual/introduction.tex
+++ b/doc/dftb+/manual/introduction.tex
@@ -50,3 +50,5 @@ The main features of {\dftbp} are:
   molecular orbitals, etc. (Waveplot)
 \item Excitation energies for cluster/molecular systems using the particle-particle Random Phase Approximation.   
 \end{itemize}
+
+The recent releases of the code are listed in appendix~\ref{app:releases}.

--- a/doc/dftb+/manual/manual.tex
+++ b/doc/dftb+/manual/manual.tex
@@ -28,6 +28,7 @@
 \include{api}
 
 \appendix
+\include{releases}
 \include{hsd}
 \include{unit_mod}
 \include{gen}

--- a/doc/dftb+/manual/packages.tex
+++ b/doc/dftb+/manual/packages.tex
@@ -10,6 +10,7 @@
 \usepackage{tabularx}
 \usepackage{makeidx}
 \usepackage{xfrac} % nicely formated fractions
+\usepackage[useregional]{datetime2}
 \definecolor{lightmagenta}{cmyk}{0,0.333,0,0}
 \usepackage[pdfpagemode={UseOutlines}, pdfstartview={Fit},
         bookmarks,bookmarksnumbered,bookmarksopen,bookmarksopenlevel=0,

--- a/doc/dftb+/manual/releases.tex
+++ b/doc/dftb+/manual/releases.tex
@@ -1,0 +1,24 @@
+\chapter{\dftbp{} Releases}
+\label{app:releases}
+
+The recent input and parser versions along with the relevant code release date
+is listed below:
+
+\begin{center}
+  \begin{tabular}{ccc}
+    \is{InputVersion} / Release & \is{ParserVersion} & Date
+    available\\ \hline
+    20.1 & 8 & \DTMdate{2020-07-22}\\
+    19.1 & 7 & \DTMdate{2019-07-01}\\
+    18.2 & 6 & \DTMdate{2018-08-19}\\
+    18.1 & 5 & \DTMdate{2018-03-02}\\
+    17.1 & 5 & \DTMdate{2017-06-16}\\
+    \hline
+  \end{tabular}
+\end{center}
+
+
+%%% Local Variables: 
+%%% mode: latex
+%%% TeX-master: "manual"
+%%% End: 

--- a/prog/dftb+/lib_dftbplus/oldcompat.F90
+++ b/prog/dftb+/lib_dftbplus/oldcompat.F90
@@ -74,7 +74,7 @@ contains
   end subroutine convertOldHSD
 
 
-  !> Converts input from version 1 to 2. (Version 2 introcuded in August 2006)
+  !> Converts input from version 1 to 2. (Version 2 introduced in August 2006)
   subroutine convert_1_2(root)
 
     !> Root tag of the HSD-tree


### PR DESCRIPTION
Added list of releases from 17.1 and their associated parser versions as an appendix.