### PR TITLE
Allow error handling in dispersion interface

### DIFF
--- a/prog/dftb+/include/error.fypp
+++ b/prog/dftb+/include/error.fypp
@@ -50,3 +50,13 @@
     end if
   end block
 #:enddef FORMATTED_ERROR_HANDLING
+
+
+#! Propagation of error handling, for now it just returns when in error
+#:def HANDLE_ERROR(errVar)
+  if (present(${errVar}$)) then
+    if (${errVar}$ /= 0) then
+      return
+    end if
+  end if
+#:enddef

--- a/prog/dftb+/lib_dftb/dispdftd3.F90
+++ b/prog/dftb+/lib_dftb/dispdftd3.F90
@@ -163,7 +163,7 @@ contains
 
 
   !> Notifies the objects about changed coordinates.
-  subroutine updateCoords(this, env, neigh, img2CentCell, coords, species0)
+  subroutine updateCoords(this, env, neigh, img2CentCell, coords, species0, stat)
 
     !> Instance of DFTD3 data
     class(TDispDftD3), intent(inout) :: this
@@ -183,7 +183,14 @@ contains
     !> Species of the atoms in the unit cell.
     integer, intent(in) :: species0(:)
 
+    !> Status of operation
+    integer, intent(out), optional :: stat
+
     @:ASSERT(allocated(this%calculator))
+
+    if (present(stat)) then
+      stat = 0
+    end if
 
     if (this%tPeriodic) then
       ! dftd3 calculates the periodic images by itself -> only coords in central cell must be

--- a/prog/dftb+/lib_dftb/dispiface.F90
+++ b/prog/dftb+/lib_dftb/dispiface.F90
@@ -50,7 +50,7 @@ module dftbp_dispiface
   abstract interface
 
     !> Update internal stored coordinate
-    subroutine updateCoordsIface(this, env, neigh, img2CentCell, coords, species0)
+    subroutine updateCoordsIface(this, env, neigh, img2CentCell, coords, species0, stat)
       import :: TDispersionIface, TEnvironment, TNeighbourList, dp
 
       !> data structure
@@ -70,6 +70,9 @@ module dftbp_dispiface
 
       !> central cell chemical species
       integer, intent(in) :: species0(:)
+
+      !> Status of operation
+      integer, intent(out), optional :: stat
     end subroutine updateCoordsIface
 
 

--- a/prog/dftb+/lib_dftb/dispslaterkirkw.F90
+++ b/prog/dftb+/lib_dftb/dispslaterkirkw.F90
@@ -219,7 +219,7 @@ contains
 
 
   !> Notifies the objects about changed coordinates.
-  subroutine updateCoords(this, env, neigh, img2CentCell, coords, species0)
+  subroutine updateCoords(this, env, neigh, img2CentCell, coords, species0, stat)
 
     !> The data object for dispersion
     class(TDispSlaKirk), intent(inout) :: this
@@ -239,12 +239,19 @@ contains
     !> Species of the atoms in the unit cell.
     integer, intent(in) :: species0(:)
 
+    !> Status of operation
+    integer, intent(out), optional :: stat
+
 
     ! Neighbours for real space summation
     integer, allocatable :: nNeighReal(:)
 
     ! Nr. of neighbours with damping
     integer, allocatable :: nNeighDamp(:)
+
+    if (present(stat)) then
+      stat = 0
+    end if
 
     allocate(nNeighReal(this%nAtom))
     call getNrOfNeighboursForAll(nNeighReal, neigh, this%rCutoff)

--- a/prog/dftb+/lib_dftb/dispuff.F90
+++ b/prog/dftb+/lib_dftb/dispuff.F90
@@ -207,7 +207,7 @@ contains
 
 
   !> Notifies the objects about changed coordinates.
-  subroutine updateCoords(this, env, neigh, img2CentCell, coords, species0)
+  subroutine updateCoords(this, env, neigh, img2CentCell, coords, species0, stat)
 
     !> Instance of dispersion to update
     class(TDispUff), intent(inout) :: this
@@ -227,7 +227,14 @@ contains
     !> Species of the atoms in the unit cell.
     integer, intent(in) :: species0(:)
 
+    !> Status of operation
+    integer, intent(out), optional :: stat
+
     integer, allocatable :: nNeigh(:)
+
+    if (present(stat)) then
+      stat = 0
+    end if
 
     allocate(nNeigh(this%nAtom))
     call getNrOfNeighboursForAll(nNeigh, neigh, this%rCutoff)

--- a/prog/dftb+/lib_dftbplus/main.F90
+++ b/prog/dftb+/lib_dftbplus/main.F90
@@ -6,6 +6,7 @@
 !--------------------------------------------------------------------------------------------------!
 
 #:include 'common.fypp'
+#:include 'error.fypp'
 
 !> The main routines for DFTB+
 module dftbp_main
@@ -339,7 +340,7 @@ contains
 
   !> Process current geometry
   subroutine processGeometry(env, iGeoStep, iLatGeoStep, tWriteRestart, tStopScc,&
-      & tExitGeoOpt)
+      & tExitGeoOpt, stat)
     use dftbp_initprogram
 
     !> Environment settings
@@ -359,6 +360,9 @@ contains
 
     !> Whether main code should exit the geometry optimisation loop
     logical, intent(out) :: tExitGeoOpt
+
+    !> Status of operation
+    integer, intent(out), optional :: stat
 
     ! Charge error in the last iterations
     real(dp) :: sccErrorQ, diffElec
@@ -405,7 +409,8 @@ contains
           & tPeriodic, tHelical, sccCalc, dispersion, solvation, thirdOrd, rangeSep, reks,&
           & img2CentCell, iCellVec, neighbourList, nAllAtom, coord0Fold, coord, species, rCellVec,&
           & nNeighbourSk, nNeighbourRep, nNeighbourLC, ham, over, H0, rhoPrim, iRhoPrim, iHam,&
-          & ERhoPrim, iSparseStart, tPoisson, cm5Cont)
+          & ERhoPrim, iSparseStart, tPoisson, cm5Cont, stat)
+        @:HANDLE_ERROR(stat)
     end if
 
     #:if WITH_TRANSPORT
@@ -1278,7 +1283,7 @@ contains
       & tPeriodic, tHelical, sccCalc, dispersion, solvation, thirdOrd, rangeSep, reks,&
       & img2CentCell, iCellVec, neighbourList, nAllAtom, coord0Fold, coord, species, rCellVec,&
       & nNeighbourSK, nNeighbourRep, nNeighbourLC, ham, over, H0, rhoPrim, iRhoPrim, iHam,&
-      & ERhoPrim, iSparseStart, tPoisson, cm5Cont)
+      & ERhoPrim, iSparseStart, tPoisson, cm5Cont, stat)
 
     use dftbp_initprogram, only : TCutoffs
 
@@ -1391,6 +1396,9 @@ contains
     !> Charge model 5
     type(TChargeModel5), allocatable, intent(inout) :: cm5Cont
 
+    !> Status of operation
+    integer, intent(out), optional :: stat
+
     !> Total size of orbitals in the sparse data structures, where the decay of the overlap sets the
     !> sparsity pattern
     integer :: sparseSize
@@ -1436,7 +1444,8 @@ contains
     end if
 
     if (allocated(dispersion)) then
-      call dispersion%updateCoords(env, neighbourList, img2CentCell, coord, species0)
+      call dispersion%updateCoords(env, neighbourList, img2CentCell, coord, species0, stat)
+      @:HANDLE_ERROR(stat)
     end if
     if (allocated(solvation)) then
       call solvation%updateCoords(env, neighbourList, img2CentCell, coord, species0)


### PR DESCRIPTION
- allows passing a status indicator to the dispersion interface
- only require error handling from routines performing work, like `updateCoords`, since most other routines should use cached values or just update and invalidate internal caches
- `handleLatticeChanges` can propagate an error from a dispersion interface back to `processGeometry`
- DFT-D4 can propagate an error from the EEQ-container back to the caller
- the EEQ-container can return an error from the LAPACK wrapper back
- error handling is done by `HANDLE_ERROR` macro, which might later produce a stack trace on back propagation
- status indicator is currently not passed to `processGeometry`, therefore the LAPACK handler will still perform the kill on error (something for a later change)

Requires #601 to avoid merge conflicts later
Useful for #545 to implement error handling