### PR TITLE
Fix for MBD use in getenergies

### DIFF
--- a/prog/dftb+/lib_dftb/getenergies.F90
+++ b/prog/dftb+/lib_dftb/getenergies.F90
@@ -28,7 +28,9 @@ module dftbp_getenergies
   use dftbp_qdepextpotproxy, only : TQDepExtPotProxy
   use dftbp_onsitecorrection
   use dftbp_dispiface
+#:if WITH_MBD
   use dftbp_dispmbd, only: TDispMbd
+#:endif
   use dftbp_solvation, only : TSolvation
   use dftbp_repcont
   use dftbp_repulsive


### PR DESCRIPTION
Needed for compilation without MBD