### PR TITLE
Fix for intent out accumulation in SK stress

### DIFF
--- a/prog/dftb+/lib_dftb/dispslaterkirkw.F90
+++ b/prog/dftb+/lib_dftb/dispslaterkirkw.F90
@@ -500,7 +500,7 @@ contains
     energies(:) = energies + localEnergies
     gradients(:,:) = gradients + localDeriv
     if (present(stress) .and. present(vol)) then
-      stress(:,:) = stress + localSigma / vol
+      stress(:,:) = localSigma / vol
     end if
 
   end subroutine addDispEnergyAndGrad_cluster


### PR DESCRIPTION
Fix for accumulation onto an intent out variable in Slater-Kirkwood stress .

Note, dispersion/DNA-damped still fails with some compilers, so not a complete fix.