### PR TITLE
Correct intent for stress component

### DIFF
--- a/prog/dftb+/lib_dftb/dispslaterkirkw.F90
+++ b/prog/dftb+/lib_dftb/dispslaterkirkw.F90
@@ -417,7 +417,7 @@ contains
     real(dp), intent(in), optional :: dampCorrection
 
     !> Stress tensor
-    real(dp), intent(out), optional :: stress(:,:)
+    real(dp), intent(inout), optional :: stress(:,:)
 
     !> Volume of the unit cell
     real(dp), intent(in), optional :: vol


### PR DESCRIPTION
Slater-Kirkwood stress as intent(inout). Waiting for regression tests before marking as ready.