### PR TITLE
Bug fix for unallocated write attempt

### DIFF
--- a/prog/dftb+/lib_dftbplus/main.F90
+++ b/prog/dftb+/lib_dftbplus/main.F90
@@ -188,7 +188,7 @@ contains
       end if
     #:endif
       tWriteCharges = tWriteRestart .and. tMulliken .and. tSccCalc .and. .not. tDerivs&
-          & .and. maxSccIter > 1
+          & .and. maxSccIter > 1 .and. .not.allocated(reks)
       if (tWriteCharges) then
         call writeCharges(fCharges, tWriteChrgAscii, orb, qInput, qBlockIn, qiBlockIn, deltaRhoIn)
       end if

--- a/prog/dftb+/lib_dftbplus/main.F90
+++ b/prog/dftb+/lib_dftbplus/main.F90
@@ -187,8 +187,8 @@ contains
         call sendEnergyAndForces(env, socket, energy, TS, derivs, totalStress, cellVol)
       end if
     #:endif
-      tWriteCharges = tWriteRestart .and. tMulliken .and. tSccCalc .and. .not. tDerivs&
-          & .and. maxSccIter > 1 .and. .not.allocated(reks)
+      tWriteCharges =  allocated(qInput) .and. tWriteRestart .and. tMulliken .and. tSccCalc&
+          & .and. .not. tDerivs .and. maxSccIter > 1
       if (tWriteCharges) then
         call writeCharges(fCharges, tWriteChrgAscii, orb, qInput, qBlockIn, qiBlockIn, deltaRhoIn)
       end if


### PR DESCRIPTION
qInput is not allocated for REKS, so should not be printed