### PR TITLE
Set correct installation locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_policy(VERSION 3.5)
 
 set(DFTBPLUS_VERSION "20.1")
 
+# Follow GNU conventions for installing directories
+include(GNUInstallDirs)
+
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(dftbpUtils)
 
@@ -192,16 +195,19 @@ add_subdirectory(test)
 if(WITH_API)
 
   install(EXPORT dftbplus-targets FILE DftbPlusTargets.cmake NAMESPACE DftbPlus::
-    DESTINATION ${INSTALL_LIB_DIR}/cmake/DftbPlus)
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/DftbPlus")
   
   configure_file(utils/export/DftbPlusConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/DftbPlusConfig.cmake @ONLY)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/DftbPlusConfig.cmake DESTINATION
-    ${INSTALL_LIB_DIR}/cmake/DftbPlus)
+    "${CMAKE_INSTALL_LIBDIR}/cmake/DftbPlus")
 
   dftbp_get_pkgconfig_params(PKGCONFIG_REQUIRES PKGCONFIG_LIBS PKGCONFIG_LIBS_PRIVATE
     PKGCONFIG_C_FLAGS)
   configure_file(utils/export/dftbplus.pc.in ${CMAKE_CURRENT_BINARY_DIR}/dftbplus.pc @ONLY)
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dftbplus.pc DESTINATION ${INSTALL_LIB_DIR}/pkgconfig)
+  install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/dftbplus.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+  )
   
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ project(dftbplus VERSION ${DFTBPLUS_VERSION} LANGUAGES Fortran C)
 
 # By default, use intrinsic Fortran 2008 erf/erfc
 set(INTERNAL_ERFC CACHE BOOL 0)
+GNUInstallDirs_get_absolute_install_dir(CMAKE_INSTALL_FULL_MODULEDIR CMAKE_INSTALL_MODULEDIR)
 
 dftbp_load_toolchain_settings()
 dftbp_setup_global_compiler_flags()

--- a/cmake/dftbpUtils.cmake
+++ b/cmake/dftbpUtils.cmake
@@ -282,12 +282,13 @@ endfunction()
 #     pkgconfig_requires [out]: Value for the Requires field.
 #     pkgconfig_libs [out]: Value for the Libs field.
 #     pkgconfig_libs_private [out]: Value for the Libs.private field.
-#     pkgconfig_c_flags [out]: value for the cflags field.
+#     pkgconfig_c_flags [out]: Value for the cflags field.
+#     pkgconfig_prefix [out]: Value for the installation prefix.
 #
 function(dftbp_get_pkgconfig_params pkgconfig_requires pkgconfig_libs pkgconfig_libs_private
     pkgconfig_c_flags)
 
-  set(_pkgconfig_libs "-L${CMAKE_INSTALL_LIBDIR} -ldftbplus")
+  set(_pkgconfig_libs "-L${CMAKE_INSTALL_FULL_LIBDIR} -ldftbplus")
   set(_pkgconfig_libs_private)
 
   dftbp_add_prefix("-l" "${EXPORTED_COMPILED_LIBRARIES}" complibs)
@@ -311,7 +312,7 @@ function(dftbp_get_pkgconfig_params pkgconfig_requires pkgconfig_libs pkgconfig_
     dftbp_library_linking_flags("${implibs}" implibs)
     list(APPEND _pkgconfig_libs_private "${implibs}")
 
-    set(_pkgconfig_c_flags "-I${CMAKE_INSTALL_INCLUDEDIR} ${CMAKE_C_FLAGS}")
+    set(_pkgconfig_c_flags "-I${CMAKE_INSTALL_FULL_INCLUDEDIR} ${CMAKE_C_FLAGS}")
 
   else()
 
@@ -325,7 +326,7 @@ function(dftbp_get_pkgconfig_params pkgconfig_requires pkgconfig_libs pkgconfig_
     dftbp_library_linking_flags("${implibs}" implibs)
     list(APPEND _pkgconfig_libs_private "${implibs}")
 
-    set(_pkgconfig_c_flags "-I${CMAKE_INSTALL_MODULEDIR} ${CMAKE_Fortran_FLAGS}")
+    set(_pkgconfig_c_flags "-I${CMAKE_INSTALL_FULL_MODULEDIR} ${CMAKE_Fortran_FLAGS}")
 
   endif()
 
@@ -335,6 +336,7 @@ function(dftbp_get_pkgconfig_params pkgconfig_requires pkgconfig_libs pkgconfig_
   set(_pkgconfig_libs_private "${_pkgconfig_libs_private} ${CMAKE_EXE_LINKER_FLAGS}")
   string(REPLACE ";" " " _pkgconfig_requires "${EXPORTED_EXTERNAL_PACKAGES}")
 
+  set(${pkgconfig_prefix} "${CMAKE_INSTALL_PREFIX}" PARENT_SCOPE)
   set(${pkgconfig_requires} "${_pkgconfig_requires}" PARENT_SCOPE)
   set(${pkgconfig_libs} "${_pkgconfig_libs}" PARENT_SCOPE)
   set(${pkgconfig_libs_private} "${_pkgconfig_libs_private}" PARENT_SCOPE)

--- a/cmake/dftbpUtils.cmake
+++ b/cmake/dftbpUtils.cmake
@@ -287,7 +287,7 @@ endfunction()
 function(dftbp_get_pkgconfig_params pkgconfig_requires pkgconfig_libs pkgconfig_libs_private
     pkgconfig_c_flags)
 
-  set(_pkgconfig_libs "-L${INSTALL_LIB_DIR} -ldftbplus")
+  set(_pkgconfig_libs "-L${CMAKE_INSTALL_LIBDIR} -ldftbplus")
   set(_pkgconfig_libs_private)
 
   dftbp_add_prefix("-l" "${EXPORTED_COMPILED_LIBRARIES}" complibs)
@@ -311,7 +311,7 @@ function(dftbp_get_pkgconfig_params pkgconfig_requires pkgconfig_libs pkgconfig_
     dftbp_library_linking_flags("${implibs}" implibs)
     list(APPEND _pkgconfig_libs_private "${implibs}")
 
-    set(_pkgconfig_c_flags "-I${INSTALL_INC_DIR} ${CMAKE_C_FLAGS}")
+    set(_pkgconfig_c_flags "-I${CMAKE_INSTALL_INCLUDEDIR} ${CMAKE_C_FLAGS}")
 
   else()
 
@@ -325,7 +325,7 @@ function(dftbp_get_pkgconfig_params pkgconfig_requires pkgconfig_libs pkgconfig_
     dftbp_library_linking_flags("${implibs}" implibs)
     list(APPEND _pkgconfig_libs_private "${implibs}")
 
-    set(_pkgconfig_c_flags "-I${INSTALL_MOD_DIR} ${CMAKE_Fortran_FLAGS}")
+    set(_pkgconfig_c_flags "-I${CMAKE_INSTALL_MODULEDIR} ${CMAKE_Fortran_FLAGS}")
 
   endif()
 

--- a/config.cmake
+++ b/config.cmake
@@ -72,15 +72,15 @@ endif()
 #
 # Installation options
 #
-set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH
+set(CMAKE_INSTALL_BINDIR "bin" CACHE PATH
   "Installation directory for executables")
 
-set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")
+set(CMAKE_INSTALL_LIBDIR "lib" CACHE PATH "Installation directory for libraries")
 
-set(INSTALL_INC_DIR "${CMAKE_INSTALL_PREFIX}/include/dftb+" CACHE PATH
+set(CMAKE_INSTALL_INCLUDDIR "include/dftb+" CACHE PATH
   "Installation directory for header and include files")
 
-set(INSTALL_MOD_DIR "${INSTALL_INC_DIR}/modfiles" CACHE PATH
+set(CMAKE_INSTALL_MODULEDIR "${CMAKE_INSTALL_INCLUDEDIR}/modfiles" CACHE PATH
   "Installation directory for Fortran module files")
 
 option(EXPORT_EXTLIBS_WITH_PATH

--- a/external/mudpack/CMakeLists.txt
+++ b/external/mudpack/CMakeLists.txt
@@ -9,7 +9,7 @@ set(sources-f77
 add_library(mudpack ${sources-f77})
 
 if(WITH_API OR BUILD_SHARED_LIBS)
-  install(TARGETS mudpack DESTINATION ${INSTALL_LIB_DIR} EXPORT dftbplus-targets)
+  install(TARGETS mudpack DESTINATION "${CMAKE_INSTALL_LIBDIR}" EXPORT dftbplus-targets)
 endif()
 
 set(EXPORTED_COMPILED_LIBRARIES ${EXPORTED_COMPILED_LIBRARIES} mudpack PARENT_SCOPE)

--- a/prog/dftb+/CMakeLists.txt
+++ b/prog/dftb+/CMakeLists.txt
@@ -63,10 +63,10 @@ set(includedir ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 set_target_properties(dftbplus PROPERTIES Fortran_MODULE_DIRECTORY ${includedir})
 target_include_directories(dftbplus PUBLIC
-  $<BUILD_INTERFACE:${includedir}> $<INSTALL_INTERFACE:${INSTALL_MOD_DIR}>)
+  $<BUILD_INTERFACE:${includedir}> $<INSTALL_INTERFACE:${CMAKE_INSTALL_MODULEDIR}>)
 if(WITH_API)
   target_include_directories(dftbplus INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api/mm> $<INSTALL_INTERFACE:${INSTALL_INC_DIR}>)
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api/mm> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 endif()
 
 
@@ -133,22 +133,30 @@ target_include_directories(dftbplus PUBLIC ${OTHER_INCLUDE_DIRS})
 # Installation
 
 if(WITH_API OR BUILD_SHARED_LIBS)
-  install(TARGETS dftbplus DESTINATION ${INSTALL_LIB_DIR} EXPORT dftbplus-targets)
+  install(TARGETS dftbplus DESTINATION "${CMAKE_INSTALL_LIBDIR}" EXPORT dftbplus-targets)
 endif()
 
 if(INSTALL_INCLUDE_FILES)
-  install(DIRECTORY ${includedir}/ DESTINATION ${INSTALL_MOD_DIR})
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/api/mm/dftbplus.h ${INSTALL_INC_DIR}/dftbplus.h @ONLY)
+  install(DIRECTORY ${includedir}/ DESTINATION "${CMAKE_INSTALL_MODULEDIR}")
+  CONFIGURE_FILE(
+    "${CMAKE_CURRENT_SOURCE_DIR}/api/mm/dftbplus.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/dftbplus.h"
+    @ONLY
+  )
+  install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/dftbplus.h"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  )
 
   get_target_property(moddirs xmlf90_objlib INTERFACE_INCLUDE_DIRECTORIES)
   foreach(moddir IN LISTS moddirs)
-    install(DIRECTORY "${moddir}/" DESTINATION "${INSTALL_MOD_DIR}")
+    install(DIRECTORY "${moddir}/" DESTINATION "${CMAKE_INSTALL_MODULEDIR}")
   endforeach()
 
   if (WITH_SOCKETS)
     get_target_property(moddirs fsockets_objlib INTERFACE_INCLUDE_DIRECTORIES)
     foreach(moddir IN LISTS moddirs)
-      install(DIRECTORY "${moddir}/" DESTINATION "${INSTALL_MOD_DIR}")
+      install(DIRECTORY "${moddir}/" DESTINATION "${CMAKE_INSTALL_MODULEDIR}")
     endforeach()
   endif()
 endif()
@@ -169,4 +177,4 @@ add_executable(dftb+ ${ALL-SOURCES-F90} ${all-sources-f90-preproc})
 
 target_link_libraries(dftb+ dftbplus)
 
-install(TARGETS dftb+ DESTINATION ${INSTALL_BIN_DIR})
+install(TARGETS dftb+ DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/prog/misc/skderivs/CMakeLists.txt
+++ b/prog/misc/skderivs/CMakeLists.txt
@@ -8,4 +8,4 @@ add_executable(skderivs ${sources-f90-preproc})
 
 target_link_libraries(skderivs PRIVATE dftbplus)
 
-install(TARGETS skderivs DESTINATION ${INSTALL_BIN_DIR})
+install(TARGETS skderivs DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/prog/misc/slakovalue/CMakeLists.txt
+++ b/prog/misc/slakovalue/CMakeLists.txt
@@ -15,6 +15,6 @@ foreach(target IN LISTS targets)
 
   target_link_libraries(${target} dftbplus)
 
-  install(TARGETS ${target} DESTINATION ${INSTALL_BIN_DIR})
+  install(TARGETS ${target} DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
 endforeach()

--- a/prog/modes/CMakeLists.txt
+++ b/prog/modes/CMakeLists.txt
@@ -17,4 +17,4 @@ endif()
 target_link_libraries(modes PRIVATE dftbplus)
 
 
-install(TARGETS modes DESTINATION ${INSTALL_BIN_DIR})
+install(TARGETS modes DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/prog/transporttools/CMakeLists.txt
+++ b/prog/transporttools/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_executable(buildwire buildwire.f90)
-install(TARGETS buildwire DESTINATION ${INSTALL_BIN_DIR})
+install(TARGETS buildwire DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
 add_executable(flux flux.f90)
-install(TARGETS flux DESTINATION ${INSTALL_BIN_DIR})
+install(TARGETS flux DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
 add_executable(makecube makecube.f90)
-install(TARGETS makecube DESTINATION ${INSTALL_BIN_DIR})
+install(TARGETS makecube DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
 # Sources to be pre-processed for setupgeom
 set(setupgeom-fpp
@@ -21,4 +21,4 @@ dftbp_preprocess("${FYPP}" "${FYPP_FLAGS}" "F90" "f90" "${setupgeom-fpp}" source
 add_executable(setupgeom ${sources-f90-preproc})
 target_link_libraries(setupgeom dftbplus)
 
-install(TARGETS setupgeom DESTINATION ${INSTALL_BIN_DIR})
+install(TARGETS setupgeom DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/prog/waveplot/CMakeLists.txt
+++ b/prog/waveplot/CMakeLists.txt
@@ -18,4 +18,4 @@ endif()
 
 target_link_libraries(waveplot PRIVATE dftbplus)
 
-install(TARGETS waveplot DESTINATION ${INSTALL_BIN_DIR})
+install(TARGETS waveplot DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/tools/dptools/CMakeLists.txt
+++ b/tools/dptools/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(cmake-command "
   execute_process(
-    COMMAND ${PYTHON_INTERPRETER} setup.py install --prefix=${CMAKE_INSTALL_PREFIX}
+    COMMAND ${PYTHON_INTERPRETER} setup.py install --prefix=$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 ")
 

--- a/tools/misc/CMakeLists.txt
+++ b/tools/misc/CMakeLists.txt
@@ -2,6 +2,6 @@ set(installed_scripts
   calc_timeprop_maxpoldir
   calc_timeprop_spectrum)
 
-install(FILES ${installed_scripts} DESTINATION ${INSTALL_BIN_DIR}
+install(FILES ${installed_scripts} DESTINATION "${CMAKE_INSTALL_BINDIR}"
   PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
   GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/tools/pythonapi/CMakeLists.txt
+++ b/tools/pythonapi/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(cmake-command "
   execute_process(
-    COMMAND ${PYTHON_INTERPRETER} setup.py install --prefix=${CMAKE_INSTALL_PREFIX}
+    COMMAND ${PYTHON_INTERPRETER} setup.py install --prefix=$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 ")
 

--- a/utils/test/travis-ci.sh
+++ b/utils/test/travis-ci.sh
@@ -14,6 +14,7 @@ else
 fi
 
 cmake_options=(
+   "-DCMAKE_INSTALL_PREFIX=/opt/dftbplus"
    "-DWITH_DFTD3=true"
    "-DWITH_MBD=true"
    "-DWITH_TRANSPORT=true"
@@ -35,3 +36,5 @@ pushd _build
 cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} "${cmake_options[@]}" ..
 make -j 2
 ctest -j 2
+popd
+DESTDIR=$PWD/dist make install -C _build


### PR DESCRIPTION
- follow GNU install dir standard
- don't configure files in install prefix
- add support for `DESTDIR` in `setup.py` installation
- also install DFTB+ on CI runs to allow inspection of the result

fixes #619 
fixes #621 