### PR TITLE
Tighten sorting for degeneracies in TD routine

### DIFF
--- a/prog/dftb+/lib_timedep/linrespgrad.F90
+++ b/prog/dftb+/lib_timedep/linrespgrad.F90
@@ -351,7 +351,7 @@ contains
       ! use a stable sort so that degenerate transitions from the same single particle state are
       ! grouped together in the results, allowing these to be selected together (since how intensity
       ! is shared out over degenerate transitions is arbitrary between eigensolvers/platforms).
-      call merge_sort(win, wij, 1.0_dp*epsilon(1.0))
+      call merge_sort(win, wij, epsilon(0.0_dp))
     else
       ! do not require stability, use the usual routine to sort, saving an O(N) workspace
       call index_heap_sort(win, wij)

--- a/prog/dftb+/lib_timedep/linrespgrad.F90
+++ b/prog/dftb+/lib_timedep/linrespgrad.F90
@@ -351,7 +351,7 @@ contains
       ! use a stable sort so that degenerate transitions from the same single particle state are
       ! grouped together in the results, allowing these to be selected together (since how intensity
       ! is shared out over degenerate transitions is arbitrary between eigensolvers/platforms).
-      call merge_sort(win, wij, epsilon(0.0_dp))
+      call merge_sort(win, wij, 1.0E-4_dp*epsilon(0.0_rsp))
     else
       ! do not require stability, use the usual routine to sort, saving an O(N) workspace
       call index_heap_sort(win, wij)

--- a/prog/dftb+/lib_timedep/rs_linresp.F90
+++ b/prog/dftb+/lib_timedep/rs_linresp.F90
@@ -994,7 +994,7 @@ contains
       ! use a stable sort so that degenerate transitions from the same single particle state are
       ! grouped together in the results, allowing these to be selected together (since how intensity
       ! is shared out over degenerate transitions is arbitrary between eigensolvers/platforms).
-      call merge_sort(win, wIJ, 1.0_dp * epsilon(1.0))
+      call merge_sort(win, wIJ, 1.0E-4_dp*epsilon(1.0))
     else
       ! do not require stability, use the usual routine to sort, saving an O(N) workspace
       call index_heap_sort(win, wIJ)


### PR DESCRIPTION
Needed for C60 Casida test example with openBlas on 2 threads with gcc 10. Changes from degeneracy in sorting being single precision eps to double. For some reason openBlas has much nearer degeneracies than other tested compiler/library combinations (~1E-2 eps_single) in this test specifically for 2 threads (but not 1, 4 or 8).
