### PR TITLE
WIP: Coverage build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,24 +3,18 @@ cmake_policy(VERSION 3.5)
 
 set(DFTBPLUS_VERSION "20.1")
 
-# Follow GNU conventions for installing directories
-include(GNUInstallDirs)
-
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(dftbpUtils)
 
 dftbp_ensure_out_of_source_build()
 dftbp_load_build_settings()
 
+set(CMAKE_CONFIGURATION_TYPES "Debug;Release;Coverage")
 project(dftbplus VERSION ${DFTBPLUS_VERSION} LANGUAGES Fortran C)
 
-# By default, use intrinsic Fortran 2008 erf/erfc
-set(INTERNAL_ERFC CACHE BOOL 0)
-GNUInstallDirs_get_absolute_install_dir(CMAKE_INSTALL_FULL_MODULEDIR CMAKE_INSTALL_MODULEDIR)
-
+dftbp_setup_build_type()
 dftbp_load_toolchain_settings()
 dftbp_setup_global_compiler_flags()
-message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 # Neither CMake nor we have any ideas, how gcc could link NAG-compiled Fortran code with OMP.
 if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "NAG" AND WITH_OMP)
@@ -36,6 +30,14 @@ dftbp_get_release_name(RELEASE)
 if(WITH_API)
   dftbp_get_api_version(API_VERSION API_VERSION_MAJOR API_VERSION_MINOR API_VERSION_PATCH)
 endif()
+
+# By default, use intrinsic Fortran 2008 erf/erfc
+# Follow GNU conventions for installing directories
+include(GNUInstallDirs)
+GNUInstallDirs_get_absolute_install_dir(CMAKE_INSTALL_FULL_MODULEDIR CMAKE_INSTALL_MODULEDIR)
+
+set(INTERNAL_ERFC CACHE BOOL 0)
+
 
 find_package(MPI)
 if(WITH_MPI AND NOT MPI_FORTRAN_FOUND)
@@ -130,6 +132,9 @@ list(APPEND EXPORTED_EXTERNAL_LIBRARY_DIRS ${OTHER_LIBRARY_DIRS})
 #
 set(FYPP "${PROJECT_SOURCE_DIR}/external/fypp/bin/fypp" CACHE FILEPATH "Fypp preprocessor")
 dftbp_add_fypp_defines(FYPP_FLAGS)
+set(FYPP_CONFIG_FLAGS "${FYPP_FLAGS}")
+set(FYPP_BUILD_FLAGS "${FYPP_FLAGS} $<IF:$<CONFIG:Debug>,-DDEBUG=1,-DDEBUG=0>")
+
 
 set(PYTHON_INTERPRETER "python3" CACHE STRING
   "Python interpreter to use for installing and test python components")
@@ -218,9 +223,6 @@ endif()
 # Coverage testing related targets
 #
 if(LCOV_REPORT)
-  if(NOT DEFINED COVERAGE_ANALYSIS OR NOT COVERAGE_ANALYSIS)
-    message(FATAL_ERROR "LCOV-reporting requires COVERAGE_ANALYSIS turned on")
-  endif()
   find_program(LCOV lcov REQUIRED)
   find_program(GENHTML genhtml REQUIRED)
   dftbp_create_lcov_targets(${LCOV} ${GENHTML} ${CMAKE_CURRENT_BINARY_DIR}/lcov

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,3 +212,17 @@ if(WITH_API)
   )
   
 endif()
+
+
+#
+# Coverage testing related targets
+#
+if(LCOV_REPORT)
+  if(NOT DEFINED COVERAGE_ANALYSIS OR NOT COVERAGE_ANALYSIS)
+    message(FATAL_ERROR "LCOV-reporting requires COVERAGE_ANALYSIS turned on")
+  endif()
+  find_program(LCOV lcov REQUIRED)
+  find_program(GENHTML genhtml REQUIRED)
+  dftbp_create_lcov_targets(${LCOV} ${GENHTML} ${CMAKE_CURRENT_BINARY_DIR}/lcov
+    ${CMAKE_CURRENT_BINARY_DIR})
+endif()

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -376,10 +376,13 @@ CMake configuration file, as it is declared as dependency in the DFTB+ Cmake
 config file.
 
 
-Generating developer documentation
-==================================
+Additional information for developers
+=====================================
 
-Developer documentation can be generated using the FORD source code
+Source code documentation
+-------------------------
+
+Source code documentation can be generated using the FORD source code
 documentation generator by issuing ::
 
   cd doc/dftb+/ford && ford dftbplus-project-file.md
@@ -388,8 +391,8 @@ in the main source directory. The documentation will be created in the
 `doc/dftb+/ford/doc` folder.
 
 
-Developer build instructions
-============================
+Customized developer builds
+---------------------------
 
 You should avoid to customize the build by changing the variables in the CMake
 config files directly as your changes may accidently be checked in into the
@@ -406,3 +409,36 @@ your config file contains toolchain dependent options, consider to define the
 See this `CMake customization file
 <https://gist.github.com/aradi/39ab88acfbacc3b2f44d1e41e4da15e7>`_ for a
 template.
+
+
+Coverage analysis
+-----------------
+
+You generate coverage reports locally using the ``lcov`` and the ``genhtml``
+tools, provided they are installed on your system (and CMake can find them). The
+workflow (assuming ``make`` as build backend) is then as follows:
+
+* Configure your project with CMake with the options ``COVERAGE_ANALYSIS`` and
+  ``LCOV_REPORT`` turned on and build the code::
+
+    cd _build
+    cmake -DCOVERAGE_ANALYSIS=True -DLCOV_REPORT=True ..
+    make -j
+
+* Delete and initialise the lcov counters by building the ``lcov_init`` target::
+
+    make lcov_init
+
+* Run the tests as usual::
+
+    ctest -j
+
+* Build the ``lcov_report`` target ::
+
+    make lcov_report
+
+The report can be found in the ``lcov/report`` folder. Just open the
+``lcov/report/index.html`` file in your browser.
+
+Note, that coverage analysis is only possible currently if all compilers are
+GNU-compilers.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -418,11 +418,11 @@ You generate coverage reports locally using the ``lcov`` and the ``genhtml``
 tools, provided they are installed on your system (and CMake can find them). The
 workflow (assuming ``make`` as build backend) is then as follows:
 
-* Configure your project with CMake with the options ``COVERAGE_ANALYSIS`` and
-  ``LCOV_REPORT`` turned on and build the code::
+* You must configure the project to build a ``Coverage`` config (to collect
+  coverage information) and must enable ``LCOV_REPORT``::
 
     cd _build
-    cmake -DCOVERAGE_ANALYSIS=True -DLCOV_REPORT=True ..
+    cmake -DCMAKE_BUILD_TYPE=Coverage -DLCOV_REPORT=True ..
     make -j
 
 * Delete and initialise the lcov counters by building the ``lcov_init`` target::

--- a/config.cmake
+++ b/config.cmake
@@ -98,3 +98,14 @@ set(PKGCONFIG_LANGUAGE "Fortran" CACHE STRING
 # Depending on the language setting ("C" or "Fortran") you would get the flags for the case of using
 # that compiler for the linking.
 
+
+#
+# Developer settings
+#
+option(COVERAGE_ANALYSIS "Whether coverage info should be collected" FALSE)
+# Works only with the GNU compiler
+
+option(LCOV_REPORT "Whether coverage report should be generated via lcov/genhtml" FALSE)
+# Requires lcov and genhtml to be installed on the system. After building the code, you have to
+# build manually the 'lcov_init' target (e.g. `make lcov_init`), then run the tests (e.g. `ctest`)
+# and finally generate the report with the lcov_report target (e.g. `make lcov_target`).

--- a/config.cmake
+++ b/config.cmake
@@ -1,11 +1,6 @@
 #
 # Global architecture independent build settings
 #
-set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type (Release|Debug)")
-
-set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE STRING
-  "Directory to install the compiled code into")
-
 option(WITH_OMP "Whether OpenMP thread parallisation should be enabled" TRUE)
 
 option(WITH_MPI "Whether DFTB+ should support MPI-parallelism" FALSE)
@@ -74,6 +69,9 @@ endif()
 #
 # Installation options
 #
+set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE STRING
+  "Directory to install the compiled code into")
+
 set(CMAKE_INSTALL_BINDIR "bin" CACHE PATH
   "Installation directory for executables")
 
@@ -102,10 +100,8 @@ set(PKGCONFIG_LANGUAGE "Fortran" CACHE STRING
 #
 # Developer settings
 #
-option(COVERAGE_ANALYSIS "Whether coverage info should be collected" FALSE)
-# Works only with the GNU compiler
-
 option(LCOV_REPORT "Whether coverage report should be generated via lcov/genhtml" FALSE)
 # Requires lcov and genhtml to be installed on the system. After building the code, you have to
 # build manually the 'lcov_init' target (e.g. `make lcov_init`), then run the tests (e.g. `ctest`)
-# and finally generate the report with the lcov_report target (e.g. `make lcov_target`).
+# and finally generate the report with the lcov_report target (e.g. `make lcov_target`). Makes
+# only sense for build type 'Coverage'.

--- a/prog/dftb+/CMakeLists.txt
+++ b/prog/dftb+/CMakeLists.txt
@@ -1,17 +1,5 @@
 #
-# General options for all targets
-#
-list(APPEND FYPP_FLAGS -I${CMAKE_CURRENT_SOURCE_DIR}/include -DRELEASE="'${RELEASE}'")
-
-if(WITH_API)
-  message(STATUS "DFTB+ API version: ${API_VERSION}")
-  list(APPEND FYPP_FLAGS -DAPIVERSION="'${API_VERSION}'")
-  list(APPEND FYPP_FLAGS -DAPIMAJOR=${API_VERSION_MAJOR} -DAPIMINOR=${API_VERSION_MINOR}
-    -DAPIPATCH=${API_VERSION_PATCH})
-endif()
-
-#
-# Compile and install library
+# Include necessary sources
 #
 
 set(ALL-SOURCES-F90)
@@ -41,7 +29,21 @@ if(WITH_GPU)
   add_subdirectory(lib_magmahelper)
 endif()
 
-dftbp_preprocess("${FYPP}" "${FYPP_FLAGS}" "F90" "f90" "${ALL-SOURCES-FPP}" all-sources-f90-preproc)
+
+#
+# Set up preprocessing
+#
+set(fypp_flags ${FYPP_BUILD_FLAGS} -I${CMAKE_CURRENT_SOURCE_DIR}/include 
+  -DRELEASE=\"'${releasename}'\")
+
+if(WITH_API)
+  message(STATUS "DFTB+ API version: ${API_VERSION}")
+  list(APPEND fypp_flags -DAPIVERSION="'${API_VERSION}'")
+  list(APPEND fypp_flags -DAPIMAJOR=${API_VERSION_MAJOR} -DAPIMINOR=${API_VERSION_MINOR}
+    -DAPIPATCH=${API_VERSION_PATCH})
+endif()
+
+dftbp_preprocess("${FYPP}" "${fypp_flags}" "F90" "f90" "${ALL-SOURCES-FPP}" all-sources-f90-preproc)
 
 
 # Library components
@@ -171,7 +173,7 @@ set(ALL-SOURCES-FPP)
 
 add_subdirectory(prg_dftb)
 
-dftbp_preprocess("${FYPP}" "${FYPP_FLAGS}" "F90" "f90" "${ALL-SOURCES-FPP}" all-sources-f90-preproc)
+dftbp_preprocess("${FYPP}" "${fypp_flags}" "F90" "f90" "${ALL-SOURCES-FPP}" all-sources-f90-preproc)
 
 add_executable(dftb+ ${ALL-SOURCES-F90} ${all-sources-f90-preproc})
 

--- a/prog/modes/CMakeLists.txt
+++ b/prog/modes/CMakeLists.txt
@@ -3,9 +3,9 @@ set(sources-fpp
   modeprojection.F90
   modes.F90)
 
-list(APPEND FYPP_FLAGS -I${CMAKE_SOURCE_DIR}/prog/dftb+/include)
+set(fypp_flags ${FYPP_BUILD_FLAGS} -I${CMAKE_SOURCE_DIR}/prog/dftb+/include)
 
-dftbp_preprocess("${FYPP}" "${FYPP_FLAGS}" "F90" "f90" "${sources-fpp}" sources-f90-preproc)
+dftbp_preprocess("${FYPP}" "${fypp_flags}" "F90" "f90" "${sources-fpp}" sources-f90-preproc)
 
 add_executable(modes ${sources-f90-preproc})
 

--- a/prog/transporttools/CMakeLists.txt
+++ b/prog/transporttools/CMakeLists.txt
@@ -14,9 +14,9 @@ set(setupgeom-fpp
   parser_setup.F90
   setupgeom.F90)
 
-list(APPEND FYPP_FLAGS -I${CMAKE_SOURCE_DIR}/prog/dftb+/include)
+set(fypp_flags ${FYPP_BUILD_FLAGS} -I${CMAKE_SOURCE_DIR}/prog/dftb+/include)
 
-dftbp_preprocess("${FYPP}" "${FYPP_FLAGS}" "F90" "f90" "${setupgeom-fpp}" sources-f90-preproc)
+dftbp_preprocess("${FYPP}" "${fypp_flags}" "F90" "f90" "${setupgeom-fpp}" sources-f90-preproc)
 
 add_executable(setupgeom ${sources-f90-preproc})
 

--- a/prog/waveplot/CMakeLists.txt
+++ b/prog/waveplot/CMakeLists.txt
@@ -5,9 +5,9 @@ set(sources-fpp
   slater.F90
   waveplot.F90)
 
-list(APPEND FYPP_FLAGS -I${CMAKE_SOURCE_DIR}/prog/dftb+/include)
+set(fypp_flags ${FYPP_BUILD_FLAGS} -I${CMAKE_SOURCE_DIR}/prog/dftb+/include)
 
-dftbp_preprocess("${FYPP}" "${FYPP_FLAGS}" "F90" "f90" "${sources-fpp}" sources-f90-preproc)
+dftbp_preprocess("${FYPP}" "${fypp_flags}" "F90" "f90" "${sources-fpp}" sources-f90-preproc)
 
 add_executable(waveplot ${sources-f90-preproc})
 

--- a/sys/gnu.cmake
+++ b/sys/gnu.cmake
@@ -30,6 +30,9 @@ set(Fortran_FLAGS_RELEASE "-O2 -funroll-all-loops"
 set(Fortran_FLAGS_DEBUG "-g -Wall -std=f2008ts -pedantic -fbounds-check"
   CACHE STRING "Fortran compiler flags for Debug build")
 
+set(Fortran_FLAGS_COVERAGE "-O0 --coverage" CACHE STRING
+  "Fortran compiler flags for coverage analysis build")
+
 set(FYPP_FLAGS "" CACHE STRING "Flags for the preprocessor")
 
 
@@ -41,6 +44,8 @@ set(C_FLAGS "${CMAKE_C_FLAGS}"
 
 set(C_FLAGS_RELEASE "-O2 -funroll-all-loops"
   CACHE STRING  "C compiler flags for Release build")
+
+set(C_FLAGS_COVERAGE "-O0 --coverage" CACHE STRING "C compiler flags for coverage analysis build")
 
 set(C_FLAGS_DEBUG "-g -Wall -pedantic -fbounds-check"
   CACHE STRING "C compiler flags for Debug build")
@@ -92,11 +97,3 @@ set(OTHER_LIBRARIES "" CACHE STRING "Other libraries to link")
 set(OTHER_LIBRARY_DIRS "" CACHE STRING "Directories where the other libraries can be found")
 set(OTHER_INCLUDE_DIRS "" CACHE STRING "Other include directories to consider")
 
-
-#
-# Developer settings
-#
-set(Fortran_FLAGS_COVERAGE "--coverage" CACHE STRING
-  "Fortran compiler flag for obtaining coverage info")
-
-set(C_FLAGS_COVERAGE "--coverage" CACHE STRING "C compiler flag for obtaining coverage info")

--- a/sys/gnu.cmake
+++ b/sys/gnu.cmake
@@ -91,3 +91,12 @@ set(MAGMA_INCLUDE_DIRS "" CACHE STRING "Directories to scan for MAGMA include fi
 set(OTHER_LIBRARIES "" CACHE STRING "Other libraries to link")
 set(OTHER_LIBRARY_DIRS "" CACHE STRING "Directories where the other libraries can be found")
 set(OTHER_INCLUDE_DIRS "" CACHE STRING "Other include directories to consider")
+
+
+#
+# Developer settings
+#
+set(Fortran_FLAGS_COVERAGE "--coverage" CACHE STRING
+  "Fortran compiler flag for obtaining coverage info")
+
+set(C_FLAGS_COVERAGE "--coverage" CACHE STRING "C compiler flag for obtaining coverage info")

--- a/test/api/mm/CMakeLists.txt
+++ b/test/api/mm/CMakeLists.txt
@@ -4,9 +4,10 @@ set(srcdir ${CMAKE_CURRENT_SOURCE_DIR})
 # execute_process is verbatim, therefore ";" must be replaced with " "
 string(REGEX REPLACE ";" " " releasename "${RELEASE}")
 
-list(APPEND FYPP_FLAGS -I${CMAKE_SOURCE_DIR}/prog/dftb+/include -DRELEASE="'${releasename}'")
-
 add_subdirectory(testers)
+
+set(fypp_flags ${FYPP_CONFIG_FLAGS} -I${CMAKE_SOURCE_DIR}/prog/dftb+/include 
+  -DRELEASE=\"'${releasename}'\")
 
 execute_process(
   COMMAND ${CMAKE_SOURCE_DIR}/utils/test/testlist_to_fypp
@@ -14,7 +15,7 @@ execute_process(
   OUTPUT_FILE ${builddir}/_api_tests.fypp)
 
 execute_process(
-  COMMAND ${FYPP} ${FYPP_FLAGS} -DMPI_PROCS=${TEST_MPI_PROCS} -DOMP_THREADS=${TEST_OMP_THREADS}
+  COMMAND ${FYPP} ${fypp_flags} -DMPI_PROCS=${TEST_MPI_PROCS} -DOMP_THREADS=${TEST_OMP_THREADS}
   INPUT_FILE ${builddir}/_api_tests.fypp
   OUTPUT_FILE ${builddir}/_api_tests)
 

--- a/test/api/mm/testers/CMakeLists.txt
+++ b/test/api/mm/testers/CMakeLists.txt
@@ -29,14 +29,11 @@ target_link_libraries(test_extcharges dftbplus)
 add_executable(test_qdepextpot test_qdepextpot.f90 $<TARGET_OBJECTS:test_api_mm_utils>)
 target_link_libraries(test_qdepextpot dftbplus)
 
-# required to pick up common.fypp
-set(FYPP_FLAGS -I${CMAKE_SOURCE_DIR}/prog/dftb+/include -DRELEASE="'${releasename}'")
-dftbp_add_fypp_defines(FYPP_FLAGS)
-# Make sure, the line-marker option is not set in fypp
-set(fyppflags ${FYPP_FLAGS})
-list(REMOVE_ITEM fyppflags "-n")
+set(fypp_flags ${FYPP_BUILD_FLAGS} -I${CMAKE_SOURCE_DIR}/prog/dftb+/include 
+  -DRELEASE=\"'${releasename}'\")
+list(REMOVE_ITEM fypp_flags "-n")
 
-dftbp_preprocess("${FYPP}" "${fyppflags}" "F90" "f90" "test_setspeciesanddependents.F90"
+dftbp_preprocess("${FYPP}" "${fypp_flags}" "F90" "f90" "test_setspeciesanddependents.F90"
   test_setspeciesanddependents.f90)
 
 # NAG compiler won't compile files with mpi calls without the '-mismatch' option

--- a/test/api/pyapi/CMakeLists.txt
+++ b/test/api/pyapi/CMakeLists.txt
@@ -1,7 +1,8 @@
 set(builddir ${CMAKE_CURRENT_BINARY_DIR})
 set(srcdir ${CMAKE_CURRENT_SOURCE_DIR})
 
-list(APPEND FYPP_FLAGS -I${CMAKE_SOURCE_DIR}/prog/dftb+/include -DRELEASE="'${releasename}'")
+set(fypp_flags ${FYPP_CONFIG_FLAGS} -I${CMAKE_SOURCE_DIR}/prog/dftb+/include 
+  -DRELEASE=\"'${releasename}'\")
 
 execute_process(
   COMMAND ${CMAKE_SOURCE_DIR}/utils/test/testlist_to_fypp
@@ -9,7 +10,7 @@ execute_process(
   OUTPUT_FILE ${builddir}/_pyapi_tests.fypp)
 
 execute_process(
-  COMMAND ${FYPP} ${FYPP_FLAGS} -DMPI_PROCS=${TEST_MPI_PROCS} -DOMP_THREADS=${TEST_OMP_THREADS}
+  COMMAND ${FYPP} ${fypp_flags} -DMPI_PROCS=${TEST_MPI_PROCS} -DOMP_THREADS=${TEST_OMP_THREADS}
   INPUT_FILE ${builddir}/_pyapi_tests.fypp
   OUTPUT_FILE ${builddir}/_pyapi_tests)
 

--- a/test/prog/dftb+/CMakeLists.txt
+++ b/test/prog/dftb+/CMakeLists.txt
@@ -4,19 +4,17 @@ set(srcdir ${CMAKE_CURRENT_SOURCE_DIR})
 # execute_process is verbatim, therefore ";" must be replaced with " "
 string(REGEX REPLACE ";" " " releasename "${RELEASE}")
 
-list(APPEND FYPP_FLAGS -I${CMAKE_SOURCE_DIR}/prog/dftb+/include -DRELEASE="'${releasename}'")
+set(fypp_flags ${FYPP_CONFIG_FLAGS} -I${CMAKE_SOURCE_DIR}/prog/dftb+/include 
+  -DRELEASE=\"'${releasename}'\")
+list(REMOVE_ITEM fypp_flags "-n")
 
 execute_process(
   COMMAND ${CMAKE_SOURCE_DIR}/utils/test/testlist_to_fypp
   INPUT_FILE ${srcdir}/tests
   OUTPUT_FILE ${builddir}/_dftbplus_tests.fypp)
 
-# Make sure, the line-marker option is not set in fypp
-set(fyppflags ${FYPP_FLAGS})
-list(REMOVE_ITEM fyppflags "-n")
-
 execute_process(
-  COMMAND ${FYPP} ${fyppflags} -DMPI_PROCS=${TEST_MPI_PROCS} -DOMP_THREADS=${TEST_OMP_THREADS}
+  COMMAND ${FYPP} ${fypp_flags} -DMPI_PROCS=${TEST_MPI_PROCS} -DOMP_THREADS=${TEST_OMP_THREADS}
   INPUT_FILE ${builddir}/_dftbplus_tests.fypp
   OUTPUT_FILE ${builddir}/_dftbplus_tests)
 

--- a/test/prog/modes/CMakeLists.txt
+++ b/test/prog/modes/CMakeLists.txt
@@ -4,20 +4,17 @@ set(srcdir ${CMAKE_CURRENT_SOURCE_DIR})
 # execute_process is verbatim, therefore ";" must be replaced with " "
 string(REGEX REPLACE ";" " " releasename "${RELEASE}")
 
-# required to pick up common.fypp
-list(APPEND FYPP_FLAGS -I${CMAKE_SOURCE_DIR}/prog/dftb+/include -DRELEASE="'${releasename}'")
+set(fypp_flags ${FYPP_CONFIG_FLAGS} -I${CMAKE_SOURCE_DIR}/prog/dftb+/include 
+  -DRELEASE=\"'${releasename}'\")
+list(REMOVE_ITEM fypp_flags "-n")
 
 execute_process(
   COMMAND ${CMAKE_SOURCE_DIR}/utils/test/testlist_to_fypp
   INPUT_FILE ${srcdir}/tests
   OUTPUT_FILE ${builddir}/_modes_tests.fypp)
 
-# Make sure, the line-marker option is not set in fypp
-set(fyppflags ${FYPP_FLAGS})
-list(REMOVE_ITEM fyppflags "-n")
-
 execute_process(
-  COMMAND ${FYPP} ${fyppflags} -DMPI_PROCS=${TEST_MPI_PROCS} -DOMP_THREADS=${TEST_OMP_THREADS}
+  COMMAND ${FYPP} ${fypp_flags} -DMPI_PROCS=${TEST_MPI_PROCS} -DOMP_THREADS=${TEST_OMP_THREADS}
   INPUT_FILE ${builddir}/_modes_tests.fypp
   OUTPUT_FILE ${builddir}/_modes_tests)
 


### PR DESCRIPTION
This attempts to implement the coverage testing as a special build type. It also cleans up CMake in order to enable multi-config builds (as possible with Ninja since CMake 3.17).