### PR TITLE
Submodules updated automatically using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,15 @@ set(EXPORTED_EXTERNAL_LIBRARY_DIRS)
 set(EXPORTED_EXTERNAL_PACKAGES)
 set(EXPORTED_EXPORTED_COMPILED_LIBRARIES)
 
+# Pull git submodules into the repository.
+find_package(Git)
+if (Git_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+  execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+else()
+  message(WARNING "External libraries could not be downloaded using Git submodule")
+endif()
+
 if(WITH_MPI)
   dftbp_create_library_targets("${SCALAPACK_LIBRARIES}" "${SCALAPACK_LIBRARY_DIRS}")
   list(APPEND EXPORTED_EXTERNAL_LIBRARIES ${SCALAPACK_LIBRARIES})


### PR DESCRIPTION
DFTB+ Developers,

As you know, DFTB+ depends on various git submodules. As a result, when you clone the repository you have to remember to type `git submodule update --init --recursive`. To me, it seems reasonable to just have cmake do this automatically during the configure step. I have inserted some code into the CMakeLists to do just that in this pull request. Unfortunately, this solution doesn't automatically pull the submodules in the case of the github release (#212), but it will only print a warning about the submodules and not stop compilation.

Of course, if you prefer to keep this a manual process I understand. Whatever you think!

