### PR TITLE
Cmake userexp

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -2,6 +2,9 @@
 Building and installing DFTB+
 *****************************
 
+If you have problems with the build, you find suggestions for some frequently
+occuring scenarios in the `Troubleshooting <#troubleshooting>`_ section.
+     
 
 Requirements
 ============
@@ -10,8 +13,7 @@ In order to compile DFTB+, you need the following software components:
 
 * A Fortran 2003 compliant compiler
 
-* A C-compiler (required if building with the socket interface enabled or if C
-  language API bindings are required)
+* A C-compiler
 
 * CMake (version 3.16 or newer)
 
@@ -29,7 +31,8 @@ Additionally there are optional requirements for some DFTB+ features:
 * In addition to ScaLAPACK, the `ELSI
   <https://wordpress.elsi-interchange.org/>`_ library for large scale systems
   can optionally also be used (version 2.6.0 or 2.6.1 of the library, with
-  partial support of 2.5.0).
+  partial support of 2.5.0). If ELSI was built with PEXSI, you also need a C++
+  compiler.
 
 * The ARPACK or the ARPACK-ng library for excited state DFTB functionality
 
@@ -48,10 +51,10 @@ Additionally there are optional requirements for some DFTB+ features:
   they should have been preferably built with the same compiler and with similar
   compiler flags than DFTB+.
 
-* Several external libraries provide CMake or Pkg-Config export files
-  (e.g. ELSI, PLUMED, MAGMA). It is essential for their detection that your
-  environment variables ``CMAKE_PREFIX_PATH`` and ``PKG_CONFIG_PATH`` are set up
-  correctly and contain the corresponding paths to those external libraries.
+* External libraries on non-standard locations (as typical on HPC-systems) can
+  only be reliable found by CMake if their library path occurs in the
+  ``CMAKE_PREFIX_PATH`` environment variable. **Make sure that your
+  CMAKE_PREFIX_PATH environment variable contains all relevant paths!**
 
 In order to execute the code tests and validate them against precalculated
 results, you will additionally need:
@@ -119,9 +122,8 @@ version. ::
   git clone https://github.com/dftbplus/dftbplus.git
   cd dftbplus
 
-The project uses git-submodules for some external dependencies. They are
-automatically retrieved on demand, either into the corresponding folder within
-the git working copy or into the build folder.
+The project uses git-submodules for some external dependencies, which will be
+automatically retrieved during configuration.
 
 
 Optional extra components
@@ -160,9 +162,6 @@ Building
 the build folder. Delete this file before re-running CMake after having changed
 variables in some of the config files.
 
-**Note for developers:** Please see some further instructions at the end of the
-file.
-
 In order to build DFTB+ carry out the following steps:
 
 * Inspect the `config.cmake` file and customise the global build parameters. (If
@@ -178,16 +177,16 @@ In order to build DFTB+ carry out the following steps:
 
   Based on the detected compilers, the build system will read further settings
   from a corresponding toolchain file in the `sys/` folder. Either from a
-  specific one (e.g. `gnu.cmake`, `intel.cmake`, etc.) or a generic one
+  specific one (e.g. `gnu.cmake`, `intel.cmake`, etc.) or the generic one
   (`generic.cmake`) if the detected compiler combination does not correspond to
   any of the specific settings. (The name of the selected toolchain file is
   shown in the output.)
 
   You may adjust any variables defined in `config.make` or in the toolchain file
-  by either modifying the files directly or by overriding the definitions via
-  the ``-D`` command line option. For example, in order to use the MKL-library
-  with the GNU-compiler, you would have to override the ``LAPACK_LIBRARY``
-  variable with the CMake command line argument ``-D``::
+  by either modifying the files directly or by setting (overriding) the variable
+  via the ``-D`` command line option. For example, in order to use the
+  MKL-library with the GNU-compiler, you would have to override the
+  ``LAPACK_LIBRARY`` variable with the CMake command line argument ``-D``::
 
     -DLAPACK_LIBRARY="mkl_gf_lp64;mkl_gnu_thread;mkl_core"
 
@@ -202,23 +201,6 @@ In order to build DFTB+ carry out the following steps:
   the library search, e.g.::
 
     -DLAPACK_LIBRARY_DIR=/opt/custom-lapack/lib
-
-  Note: You can override the toolchain file selection by passing the
-  ``-DTOOLCHAIN_FILE`` option with the name of the file to read, e.g.::
-
-    -DTOOLCHAIN_FILE=/somepath/myintelgnu.cmake
-
-  or by setting the toolchain file path in the ``DFTBPLUS_TOOCHAIN_FILE``
-  environment variable. If the customized toolchain file is within the `sys/`
-  folder, you may also use the ``-DTOOLCHAIN`` option or the
-  ``DFTBPLUS_TOOLCHAIN`` environment variable with the plain name of the file
-  (without the full path) instead::
-
-    -DTOOLCHAIN=gnu .
-
-  Similarly, you can use an alternative build config file instead of
-  `config.cmake` by specifying it with the ``-DBUILD_CONFIG_FILE`` option or by
-  defining the ``DFTBPLUS_BUILD_CONFIG_FILE`` environment variable.
 
 
 * If the configuration was successful, invoke (from within the build folder)
@@ -390,3 +372,79 @@ your config file contains toolchain dependent options, consider to define the
 See this `CMake customization file
 <https://gist.github.com/aradi/39ab88acfbacc3b2f44d1e41e4da15e7>`_ for a
 template.
+
+
+Advanced build configuration (e.g. for packagers)
+=================================================
+
+Controlling the toolchain file selection
+----------------------------------------
+
+You can override the toolchain file selection by passing the
+``-DTOOLCHAIN_FILE`` option with the name of the file to read, e.g.::
+
+  -DTOOLCHAIN_FILE=/somepath/myintelgnu.cmake
+
+or by setting the toolchain file path in the ``DFTBPLUS_TOOCHAIN_FILE``
+environment variable. If the customized toolchain file is within the `sys/`
+folder, you may also use the ``-DTOOLCHAIN`` option or the
+``DFTBPLUS_TOOLCHAIN`` environment variable with the plain name of the file
+(without the full path) instead::
+
+    -DTOOLCHAIN=gnu .
+
+Similarly, you can use an alternative build config file instead of
+`config.cmake` by specifying it with the ``-DBUILD_CONFIG_FILE`` option or by
+defining the ``DFTBPLUS_BUILD_CONFIG_FILE`` environment variable.
+
+
+Preventing the download of external sources
+-------------------------------------------
+
+Depending on the value of the ``HYBRID_CONFIG_METHODS`` configuration variable,
+some dependencies (e.g. mbd, negf, mpifx, scalapackfx) are automatically
+downloaded during the configuration phase and built during the DFTB+ build
+process. If you want to ensure that nothing gets downloaded during the build,
+pass the variable definition ::
+
+  -DHYBRID_CONFIG_METHODS="Find"
+  
+to CMake during the configuration. In this case CMake will try to find those
+dependencies in the system only (by searching in the standard system paths and
+in the locations defined in the environment variable ``CMAKE_PREFIX_PATH``) and
+stop if any of components was not found.
+
+
+Troubleshooting
+===============
+
+* **CMake finds the wrong compiler**
+
+  CMake should be guided with the help of the environment variables ``FC``,
+  ``CC`` (and eventually ``CXX``) to make sure it uses the right compilers,
+  e.g. ::
+
+    FC=gfortran CC=gcc cmake [...]
+
+
+* **CMake fails to find a library / finds the wrong version of a library**
+
+  This is in most cases a problem due to a misconfigured ``CMAKE_PREFIX_PATH``
+  environment variable. It is essential, that the ``CMAKE_PREFIX_PATH``
+  environment variable contains all paths (besides the default system paths),
+  which CMake should search when trying to find a library. Extend the library
+  path if needed, e.g. ::
+
+    CMAKE_PREFIX_PATH="/opt/somelib:${CMAKE_PREFIX_PATH}" cmake [...]
+
+
+* **ScaLAPACK detection on Ubuntu 20.4 LTS fails**
+
+  The OpenMPI version of ScaLAPACK on Ubuntu 20.4 LTS exports an incorrect CMake
+  config file (as of October 2020), which refers to an non-existing
+  library. Setting the library name with the ``SCALAPACK_LIBRARY`` variable explicitely,
+  e.g. ::
+
+    cmake -DSCALAPACK_LIBRARY=scalapack-openmpi [...]
+
+  should fix the problem.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -37,7 +37,7 @@ Additionally there are optional requirements for some DFTB+ features:
 * The ARPACK or the ARPACK-ng library for excited state DFTB functionality
 
 * The `MAGMA <http://icl.cs.utk.edu/magma/>`_ library for GPU accelerated
-  computation. (
+  computation.
 
 * The `PLUMED2 <https://github.com/plumed/plumed2>`_ library for metadynamics
   simulations. If you build DFTB+ with MPI, the linked PLUMED library must be
@@ -190,18 +190,16 @@ In order to build DFTB+ carry out the following steps:
 
     -DLAPACK_LIBRARY="mkl_gf_lp64;mkl_gnu_thread;mkl_core"
 
-  When needed, you can also pass linker options in the library variables, e.g.::
+  When needed, you can specify the complete path to a libray or pass linker
+  options in those variables, e.g.::
 
+    -DLAPACK_LIBRARY="/opt/openblas/libopenblas.a"
     -DLAPACK_LIBRARY="-Wl,--start-group -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core -Wl,--end-group"
 
-  CMake by default searches for the external libraries in the paths specified
-  in the ``CMAKE_PREFIX_PATH`` environment variable. Make sure that it is set up
-  correctly in your build environment. Alternatively, you can use the respective
-  ``*_LIBRARY_DIR`` variable for each external library to add path hints for
-  the library search, e.g.::
-
-    -DLAPACK_LIBRARY_DIR=/opt/custom-lapack/lib
-
+  CMake searches in the systems standard library paths and in the paths
+  specified in the ``CMAKE_PREFIX_PATH`` environment variable for external
+  libraries . **Make sure that your ``CMAKE_PREFIX_PATH`` environment variable
+  is set up correctly and contains all the relevant paths.**
 
 * If the configuration was successful, invoke (from within the build folder)
   `make` to compile the code::

--- a/cmake/Modules/FindCustomArpack.cmake
+++ b/cmake/Modules/FindCustomArpack.cmake
@@ -45,9 +45,6 @@ The following cache variables may be set to influence the library detection:
   ``ARPACK_DETECTION``) and the variable is overwritten to contain the libraries
   with their with full path.
 
-``ARPACK_LIBRARY_DIR``
-  Directories which should be looked up in order to find the customized libraries.
-
 #]=======================================================================]
 
 include(FindPackageHandleStandardArgs)
@@ -68,13 +65,12 @@ else()
 
     if("${ARPACK_LIBRARY}" STREQUAL "")
       # Very simple ARPACK auto-detection
-      find_library(ARPACK_LIBRARY arpack HINTS ${ARPACK_LIBRARY_DIR})
+      find_library(ARPACK_LIBRARY arpack)
 
     else()
 
       # Library explicitely set by the user, search for those libraries
-      find_custom_libraries("${ARPACK_LIBRARY}" "${ARPACK_LIBRARY_DIR}"
-        "${CustomArpack_FIND_QUIETLY}" _libs)
+      find_custom_libraries("${ARPACK_LIBRARY}" "" "${CustomArpack_FIND_QUIETLY}" _libs)
       set(ARPACK_LIBRARY "${_libs}" CACHE STRING "List of ARPACK libraries to link" FORCE)
       unset(_libs)
 

--- a/cmake/Modules/FindCustomLapack.cmake
+++ b/cmake/Modules/FindCustomLapack.cmake
@@ -53,9 +53,6 @@ The following cache variables may be set to influence the library detection:
   the variable is overwritten to contain the libraries with their with full
   path.
 
-``LAPACK_LIBRARY_DIR``
-  Directories which should be looked up in order to find the customized libraries.
-
 ``LAPACK_LINKER_FLAG``
   Flags to use when linking LAPACK
 
@@ -95,8 +92,7 @@ else()
     elseif(NOT "${LAPACK_LIBRARY}" STREQUAL "NONE")
 
       # LAPACK explicitely set by the user, search for those libraries
-      find_custom_libraries("${LAPACK_LIBRARY}" "${LAPACK_LIBRARY_DIR}"
-        "${CustomLapack_FIND_QUIETLY}" _libs)
+      find_custom_libraries("${LAPACK_LIBRARY}" "" "${CustomLapack_FIND_QUIETLY}" _libs)
       set(LAPACK_LIBRARY "${_libs}" CACHE STRING "List of LAPACK libraries to link" FORCE)
       unset(_libs)
 
@@ -123,6 +119,6 @@ else()
     endif()
   endif()
 
-  mark_as_advanced(LAPACK_DETECTION LAPACK_LIBRARY LAPACK_LIBRARY_DIR LAPACK_LINKER_FLAG)
+  mark_as_advanced(LAPACK_DETECTION LAPACK_LIBRARY LAPACK_LINKER_FLAG)
 
 endif()

--- a/cmake/Modules/FindCustomMagma.cmake
+++ b/cmake/Modules/FindCustomMagma.cmake
@@ -46,9 +46,6 @@ The following cache variables may be set to influence the library detection:
   ``MAGMA_DETECTION``) and the variable is overwritten to contain the libraries
   with their with full path.
 
-``MAGMA_LIBRARY_DIR``
-  Directories which should be looked up in order to find the customized libraries.
-
 ``MAGMA_INCLUDE_DIRECTORY``
   Customized MAGMA include directory.  
 
@@ -75,7 +72,7 @@ else()
     # Overwrite PkgConfig values by user defined input if present.
     if(NOT "${MAGMA_LIBRARY}" STREQUAL "")
       set(_magma_LIBRARIES ${MAGMA_LIBRARY})
-      set(_magma_LIBRARY_DIRS ${MAGMA_LIBRARY_DIR})
+      set(_magma_LIBRARY_DIRS)
     endif()
     if(NOT "${MAGMA_INCLUDE_DIR}" STREQUAL "")
       set(_magma_INCLUDE_DIRS ${MAGMA_INCLUDE_DIR})

--- a/cmake/Modules/FindCustomPlumed.cmake
+++ b/cmake/Modules/FindCustomPlumed.cmake
@@ -46,9 +46,6 @@ The following cache variables may be set to influence the library detection:
   ``PLUMED_DETECTION``) and the variable is overwritten to contain the libraries
   with their with full path.
 
-``PLUMED_LIBRARY_DIR``
-  Directories which should be looked up in order to find the customized libraries.
-
 
 #]=======================================================================]
 
@@ -74,7 +71,7 @@ else()
     # Overwrite PkgConfig values by user defined input if present.
     if(NOT "${PLUMED_LIBRARY}" STREQUAL "")
       set(_plumed_LIBRARIES ${PLUMED_LIBRARY})
-      set(_plumed_LIBRARY_DIRS ${PLUMED_LIBRARY_DIR})
+      set(_plumed_LIBRARY_DIRS)
     endif()
 
     find_custom_libraries("${_plumed_LIBRARIES}" "${_plumed_LIBRARY_DIRS}"

--- a/sys/generic.cmake
+++ b/sys/generic.cmake
@@ -58,32 +58,27 @@ set(C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}"
 # External libraries
 #
 
+# NOTE: CMake searches for the external libraries in the standard system library paths and in the
+# paths defined in the CMAKE_PREFIX_PATH environment variable. Make sure, CMAKE_PREFIX_PATH contains
+# the path to your libraries in case those are not installed in the standard locations (e.g. when
+# using custom installed libraries or environment modules in HPC centers).
+
 # LAPACK and BLAS
 #set(LAPACK_LIBRARY "lapack;blas" CACHE STRING "LAPACK and BLAS libraries to link")
-#set(LAPACK_LIBRARY_DIR "" CACHE STRING
-#  "Directories where LAPACK and BLAS libraries can be found")
 
 # ARPACK -- only needed when built with ARPACK support
 #set(ARPACK_LIBRARY "arpack" CACHE STRING "Arpack libraries")
-#set(ARPACK_LIBRARY_DIR "" CACHE STRING "Directories where Arpack library can be found")
 
 # ScaLAPACK -- only needed for MPI-parallel build
 #set(SCALAPACK_LIBRARY "scalapack" CACHE STRING "Scalapack libraries to link")
-#set(SCALAPACK_LIBRARY_DIR "" CACHE STRING "Directories where Scalapack libraries can be found")
 
 # Note: The libraries below provide CMake and/or Pkg-Conf export files.
 # If your CMAKE_PREFIX_PATH and PKG_CONFIG_PATH environment variables are set up correctly
 # (containing the paths to these libraries), no adjustment should be necessary below.
 
-# ELSI -- only needed when compiled with ELSI support
-# 
-#set(ELSI_ROOT "" CACHE STRING "Root directory of the ELSI installation")
-
 # PLUMED -- only needed when compiled with PLUMED support
 #set(PLUMED_LIBRARY "plumed;plumedKernel" CACHE STRING "Libraries to link for PLUMED support")
-#set(PLUMED_LIBRARY_DIR "" CACHE STRING "Directories to scan for PLUMED libraries")
 
 # MAGMA -- only needed when compiled with GPU support
 #set(MAGMA_LIBRARY "magma" CACHE STRING "Magma library")
-#set(MAGMA_LIBRARY_DIR "" CACHE STRING "Directories to scan for MAGMA library")
 #set(MAGMA_INCLUDE_DIRECTORY "" CACHE STRING "Directories to scan for MAGMA include files")

--- a/sys/gnu.cmake
+++ b/sys/gnu.cmake
@@ -59,32 +59,23 @@ set(C_FLAGS_DEBUG "-g -Wall -pedantic -fbounds-check"
 # External libraries
 #
 
+# NOTE: CMake searches for the external libraries in the standard system library paths and in the
+# paths defined in the CMAKE_PREFIX_PATH environment variable. Make sure, CMAKE_PREFIX_PATH contains
+# the path to your libraries in case those are not installed in the standard locations (e.g. when
+# using custom installed libraries or environment modules in HPC centers).
+
 # LAPACK and BLAS
 #set(LAPACK_LIBRARY "openblas" CACHE STRING "LAPACK and BLAS libraries to link")
-#set(LAPACK_LIBRARY_DIR "" CACHE STRING
-#  "Directories where LAPACK and BLAS libraries can be found")
 
 # ARPACK -- only needed when built with ARPACK support
 #set(ARPACK_LIBRARY "arpack" CACHE STRING "Arpack libraries")
-#set(ARPACK_LIBRARY_DIR "" CACHE STRING "Directories where Arpack library can be found")
 
 # ScaLAPACK -- only needed for MPI-parallel build
 #set(SCALAPACK_LIBRARY "scalapack-openmpi" CACHE STRING "Scalapack libraries to link")
-#set(SCALAPACK_LIBRARY_DIR "" CACHE STRING "Directories where Scalapack libraries can be found")
-
-# Note: The libraries below provide CMake and/or Pkg-Conf export files.
-# If your CMAKE_PREFIX_PATH and PKG_CONFIG_PATH environment variables are set up correctly
-# (containing the paths to these libraries), no adjustment should be necessary below.
-
-# ELSI -- only needed when compiled with ELSI support
-# 
-#set(ELSI_ROOT "" CACHE STRING "Root directory of the ELSI installation")
 
 # PLUMED -- only needed when compiled with PLUMED support
 #set(PLUMED_LIBRARY "plumed;plumedKernel" CACHE STRING "Libraries to link for PLUMED support")
-#set(PLUMED_LIBRARY_DIR "" CACHE STRING "Directories to scan for PLUMED libraries")
 
 # MAGMA -- only needed when compiled with GPU support
 #set(MAGMA_LIBRARY "magma" CACHE STRING "Magma library")
-#set(MAGMA_LIBRARY_DIR "" CACHE STRING "Directories to scan for MAGMA library")
 #set(MAGMA_INCLUDE_DIRECTORY "" CACHE STRING "Directories to scan for MAGMA include files")

--- a/sys/intel.cmake
+++ b/sys/intel.cmake
@@ -53,6 +53,11 @@ set(C_FLAGS_DEBUG "-g -Wall"
 # External libraries
 #
 
+# NOTE: CMake searches for the external libraries in the standard system library paths and in the
+# paths defined in the CMAKE_PREFIX_PATH environment variable. Make sure, CMAKE_PREFIX_PATH contains
+# the path to your libraries in case those are not installed in the standard locations (e.g. when
+# using custom installed libraries or environment modules in HPC centers).
+
 # LAPACK and BLAS
 if(WITH_OMP)
   set(LAPACK_LIBRARY "mkl_intel_lp64;mkl_intel_thread;mkl_core" CACHE STRING
@@ -62,32 +67,16 @@ else()
     "LAPACK and BLAS libraries to link")
 endif()
 
-set(LAPACK_LIBRARY_DIR "$ENV{MKLROOT}/lib/intel64" CACHE STRING
-  "Directories where LAPACK and BLAS libraries can be found")
-
 # ARPACK -- only needed when built with ARPACK support
 #set(ARPACK_LIBRARY "arpack" CACHE STRING "Arpack library")
-#set(ARPACK_LIBRARY_DIR "" CACHE STRING "Directories where Arpack library can be found")
 
 # ScaLAPACK -- only needed for MPI-parallel build
 set(SCALAPACK_LIBRARY "mkl_scalapack_lp64;mkl_blacs_intelmpi_lp64" CACHE STRING
   "Scalapack libraries to link")
-set(SCALAPACK_LIBRARY_DIR "$ENV{MKLROOT}/lib/intel64" CACHE STRING
-  "Directories where Scalapack libraries can be found")
-
-# Note: The libraries below provide CMake and/or Pkg-Conf export files.
-# If your CMAKE_PREFIX_PATH and PKG_CONFIG_PATH environment variables are set up correctly
-# (containing the paths to these libraries), no adjustment should be necessary below.
-
-# ELSI -- only needed when compiled with ELSI support
-# 
-#set(ELSI_ROOT "" CACHE STRING "Root directory of the ELSI installation")
 
 # PLUMED -- only needed when compiled with PLUMED support
 #set(PLUMED_LIBRARY "plumed;plumedKernel" CACHE STRING "Libraries to link for PLUMED support")
-#set(PLUMED_LIBRARY_DIR "" CACHE STRING "Directories to scan for PLUMED libraries")
 
 # MAGMA -- only needed when compiled with GPU support
 #set(MAGMA_LIBRARY "magma" CACHE STRING "Magma library")
-#set(MAGMA_LIBRARY_DIR "" CACHE STRING "Directories to scan for MAGMA library")
 #set(MAGMA_INCLUDE_DIRECTORY "" CACHE STRING "Directories to scan for MAGMA include files")

--- a/sys/nag.cmake
+++ b/sys/nag.cmake
@@ -52,33 +52,23 @@ set(C_FLAGS_DEBUG "-g -Wall -pedantic -fbounds-check"
 # External libraries
 #
 
+# NOTE: CMake searches for the external libraries in the standard system library paths and in the
+# paths defined in the CMAKE_PREFIX_PATH environment variable. Make sure, CMAKE_PREFIX_PATH contains
+# the path to your libraries in case those are not installed in the standard locations (e.g. when
+# using custom installed libraries or environment modules in HPC centers).
+
 # LAPACK and BLAS
 #set(LAPACK_LIBRARY "openblas" CACHE STRING "LAPACK and BLAS libraries to link")
-#set(LAPACK_LIBRARY_DIR "" CACHE STRING
-#  "Directories where LAPACK and BLAS libraries can be found")
 
 # ARPACK -- only needed when built with ARPACK support
 #set(ARPACK_LIBRARY "arpack" CACHE STRING "Arpack library")
-#set(ARPACK_LIBRARY_DIR "" CACHE STRING "Directories where Arpack library can be found")
 
 # ScaLAPACK -- only needed for MPI-parallel build
 #set(SCALAPACK_LIBRARY "scalapack" CACHE STRING "Scalapack libraries to link")
-#set(SCALAPACK_LIBRARY_DIR "" CACHE STRING
-#  "Directories where Scalapack libraries can be found")
-
-# Note: The libraries below provide CMake and/or Pkg-Conf export files.
-# If your CMAKE_PREFIX_PATH and PKG_CONFIG_PATH environment variables are set up correctly
-# (containing the paths to these libraries), no adjustment should be necessary below.
-
-# ELSI -- only needed when compiled with ELSI support
-# 
-#set(ELSI_ROOT "" CACHE STRING "Root directory of the ELSI installation")
 
 # PLUMED -- only needed when compiled with PLUMED support
 #set(PLUMED_LIBRARY "plumed;plumedKernel" CACHE STRING "Libraries to link for PLUMED support")
-#set(PLUMED_LIBRARY_DIR "" CACHE STRING "Directories to scan for PLUMED libraries")
 
 # MAGMA -- only needed when compiled with GPU support
 #set(MAGMA_LIBRARY "magma" CACHE STRING "Magma library")
-#set(MAGMA_LIBRARY_DIR "" CACHE STRING "Directories to scan for MAGMA library")
 #set(MAGMA_INCLUDE_DIRECTORY "" CACHE STRING "Directories to scan for MAGMA include files")


### PR DESCRIPTION
Open for discussion: This could simplify user experience by using exclusively the `CMAKE_PREFIX_PATH` for specifying library search paths. So users won't have to deal with various `_LIBRARY_DIR` variables (less errors for mistakes/typos), but only make sure, that `CMAKE_PREFIX_PATH` contains all relevant paths.