### PR TITLE
Update to libMBD with fixed CMake problem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,5 +12,5 @@
         branch = release
 [submodule "external/mbd/origin"]
 	path = external/mbd/origin
-	url = https://github.com/jhrmnn/libmbd.git
-        branch = master
+	url = https://github.com/aradi/libmbd.git
+        branch = cmake-fix

--- a/external/mbd/CMakeLists.txt
+++ b/external/mbd/CMakeLists.txt
@@ -14,6 +14,6 @@ endmacro()
 
 set(MBD_GIT_REPOSITORY "https://github.com/jhrmnn/libmbd.git")
 # Use utils/test/check_submodule_commits to update commit hash below
-set(MBD_GIT_TAG "3e70b0cc64557b1bf06467bb2d2d50cee8e2e7ef")
+set(MBD_GIT_TAG "729c079e7745195f7ad4c14c36bff27f59469926")
 
 dftbp_config_hybrid_source_dependency(${MBD_GIT_REPOSITORY} ${MBD_GIT_TAG})


### PR DESCRIPTION
Gitmodule URL still has to be rewritten back before merge.
Needs [PR #21](https://github.com/jhrmnn/libmbd/pull/21) to be merged first.