### PR TITLE
Change MPI detection logic for non-MPI builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,14 +30,12 @@ if(WITH_API)
   dftbp_get_api_version(API_VERSION API_VERSION_MAJOR API_VERSION_MINOR API_VERSION_PATCH)
 endif()
 
-find_package(MPI QUIET)
-if(WITH_MPI AND NOT MPI_FORTRAN_FOUND)
-  message(FATAL_ERROR "Compiler ${CMAKE_Fortran_COMPILER} is not MPI capable but is specified for "
-    "a WITH_MPI=TRUE build")
-elseif(NOT WITH_MPI AND MPI_FORTRAN_FOUND)
-  message(WARNING "MPI enabled compiler ${CMAKE_Fortran_COMPILER} found for a non-MPI build. Your "
-    "build will NOT be MPI-parallelised. Set WITH_MPI=TRUE in order to obtain an MPI-parallelised "
-    "build.")
+if(WITH_MPI)
+  find_package(MPI QUIET)
+  if(NOT MPI_FORTRAN_FOUND)
+    message(FATAL_ERROR "Compiler ${CMAKE_Fortran_COMPILER} is not MPI capable but is specified for "
+      "a WITH_MPI=TRUE build")
+  endif()
 endif()
 
 if(WITH_OMP AND NOT TARGET OpenMP::OpenMP_Fortran)


### PR DESCRIPTION
Removes the search for MPI in non-MPI builds. The found MPI dependency is not used in non-MPI builds and seems to mess up the build with CMake 3.19, Ninja 1.10 and Intel oneAPI 2021.1 for non-MPI builds.

Fixes #699 