### PR TITLE
Print norm of gradient and lattice gradient in optimization

### DIFF
--- a/prog/dftb+/lib_dftbplus/main.F90
+++ b/prog/dftb+/lib_dftbplus/main.F90
@@ -6453,20 +6453,36 @@ contains
 
   end subroutine calcPipekMezeyLocalisation
 
+  
+  !> Prints information about maximal forces in the system.
   subroutine printMaxForces(derivs, constrLatDerivs, tCoordOpt, tLatOpt, indMovedAtoms)
+    
+    !> Gradients on atoms ]3, nAtom]
     real(dp), intent(in), allocatable :: derivs(:,:)
+    
+    !> Lattcie derivatives. Shape: [9]
     real(dp), intent(in) :: constrLatDerivs(:)
+    
+    !> Whether coordinate optimization is on.
     logical, intent(in) :: tCoordOpt
+    
+    !> Wheter lattice optimization is on.
     logical, intent(in) :: tLatOpt
+    
+    !> Indices of moved atoms. Shape [nMovedAtoms].
     integer, intent(in) :: indMovedAtoms(:)
 
+    real(dp) :: normedDeriv
+    
     if (tCoordOpt) then
       call printMaxForce(maxval(abs(derivs(:, indMovedAtoms))))
-      call printForceNorm(norm2(derivs(:, indMovedAtoms)))
+      normedDeriv = norm2(derivs(:, indMovedAtoms)) / sqrt(real(size(indMovedAtoms), dp))
+      call printForceNorm(normedDeriv)
     end if
     if (tLatOpt) then
       call printMaxLatticeForce(maxval(abs(constrLatDerivs)))
-      call printLatticeForceNorm(norm2(constrLatDerivs))
+      normedDeriv = norm2(constrLatDerivs) / sqrt(3.0_dp)
+      call printLatticeForceNorm(normedDeriv)
     end if
 
   end subroutine printMaxForces

--- a/prog/dftb+/lib_dftbplus/main.F90
+++ b/prog/dftb+/lib_dftbplus/main.F90
@@ -6462,9 +6462,11 @@ contains
 
     if (tCoordOpt) then
       call printMaxForce(maxval(abs(derivs(:, indMovedAtoms))))
+      call printForceNorm(norm2(derivs(:, indMovedAtoms)))
     end if
     if (tLatOpt) then
       call printMaxLatticeForce(maxval(abs(constrLatDerivs)))
+      call printLatticeForceNorm(norm2(constrLatDerivs))
     end if
 
   end subroutine printMaxForces

--- a/prog/dftb+/lib_dftbplus/mainio.F90
+++ b/prog/dftb+/lib_dftbplus/mainio.F90
@@ -76,6 +76,7 @@ module dftbp_mainio
   public :: writeHSAndStop, writeHS
   public :: printGeoStepInfo, printSccHeader, printSccInfo, printEnergies, printVolume
   public :: printPressureAndFreeEnergy, printMaxForce, printMaxLatticeForce
+  public :: printForceNorm, printLatticeForceNorm
   public :: printMdInfo, printBlankLine
   public :: printReksSccHeader, printReksSccInfo
   public :: writeReksDetailedOut1
@@ -4257,6 +4258,17 @@ contains
   end subroutine printMaxForce
 
 
+  !> Writes norm of the force
+  subroutine printForceNorm(forceNorm)
+
+    !> Norm of the force
+    real(dp), intent(in) :: forceNorm
+
+    write(stdOut, "(A, ':', T30, E20.6)") "Norm of forces", forceNorm
+
+  end subroutine printForceNorm
+
+
   !> Print maximal lattice force component
   subroutine printMaxLatticeForce(maxLattForce)
 
@@ -4266,6 +4278,17 @@ contains
     write(stdOut, format1Ue) "Maximal Lattice force component", maxLattForce, 'au'
 
   end subroutine printMaxLatticeForce
+
+
+  !> Print norm of lattice force
+  subroutine printLatticeForceNorm(lattForceNorm)
+
+    !> Norm of the lattice force
+    real(dp), intent(in) :: lattForceNorm
+
+    write(stdOut, format1Ue) "Norm of lattice forces", lattForceNorm, 'au'
+
+  end subroutine printLatticeForceNorm
 
 
   !> Prints out info about current MD step.

--- a/prog/dftb+/lib_dftbplus/mainio.F90
+++ b/prog/dftb+/lib_dftbplus/mainio.F90
@@ -4264,7 +4264,7 @@ contains
     !> Norm of the force
     real(dp), intent(in) :: forceNorm
 
-    write(stdOut, "(A, ':', T30, E20.6)") "Norm of forces", forceNorm
+    write(stdOut, "(A, ':', T30, E20.6)") "Averaged force norm", forceNorm
 
   end subroutine printForceNorm
 
@@ -4286,7 +4286,7 @@ contains
     !> Norm of the lattice force
     real(dp), intent(in) :: lattForceNorm
 
-    write(stdOut, format1Ue) "Norm of lattice forces", lattForceNorm, 'au'
+    write(stdOut, format1Ue) "Averaged lattice force norm", lattForceNorm, 'au'
 
   end subroutine printLatticeForceNorm
 


### PR DESCRIPTION
I'm was missing a good way to track the optimization progress in DFTB+ so far since the used maximum force component is not always representative for the complete system. This PR adds a printout of a norm of the gradient while performing optimizations.