### PR TITLE
Removed labels in section macros

### DIFF
--- a/doc/dftb+/manual/newcommands.tex
+++ b/doc/dftb+/manual/newcommands.tex
@@ -32,12 +32,12 @@
 
 %%% Sections, subsections etc. as hyperreference targets (if title is a 
 %%% curly braced keyword).
-\newcommand{\htcbchapter}[1]{\chapter{\kwcb{#1}}\label{#1}}
-\newcommand{\htcbsection}[1]{\section{\kwcb{#1}}\label{#1}}
-\newcommand{\htcbsubsection}[1]{\subsection{\kwcb{#1}}\label{#1}}
-\newcommand{\htcbsubsubsection}[1]{\subsubsection{\kwcb{#1}}\label{#1}}
-\newcommand{\htcbparagraph}[1]{\paragraph{\kwcb{#1}}\label{#1}}
-\newcommand{\htcbsubparagraph}[1]{\subparagraph{\kwcb{#1}}\label{#1}}
+\newcommand{\htcbchapter}[1]{\chapter{\kwcb{#1}}}
+\newcommand{\htcbsection}[1]{\section{\kwcb{#1}}}
+\newcommand{\htcbsubsection}[1]{\subsection{\kwcb{#1}}}
+\newcommand{\htcbsubsubsection}[1]{\subsubsection{\kwcb{#1}}}
+\newcommand{\htcbparagraph}[1]{\paragraph{\kwcb{#1}}}
+\newcommand{\htcbsubparagraph}[1]{\subparagraph{\kwcb{#1}}}
 
 %%% Table of properties
 \renewcommand{\tabularxcolumn}[1]{>{\raggedright\arraybackslash}p{#1}}

--- a/doc/dftb+/manual/transport.tex
+++ b/doc/dftb+/manual/transport.tex
@@ -108,8 +108,8 @@ the system into a {\em device} and the {\em contact} regions and additional
 information needed to calculate the required self-energies associated with the
 contacts. The transport block contains the following properties:
 \begin{ptable}
-  \kw{Device} &p& & - & \pref{Device} \\
-  \kw{Contact} &p& & - & \pref{Contact} \\
+  \kw{Device} &p& & - & \pref{sec:transport.Device} \\
+  \kw{Contact} &p& & - & \pref{sec:transport.Contact} \\
   \kw{Task} & m & & UploadContacts & \pref{Task} \\
 \end{ptable}
 
@@ -138,6 +138,8 @@ layers (atoms 9--16 and 17--24 in the ``source'' contact, atoms 25--32 and
 33--40 in the ``drain'' contact).
 
 \htcbsubsection{Device}
+\label{sec:transport.Device}
+
 The Device blocks contains the following properties:
 
 \begin{ptable}
@@ -166,7 +168,10 @@ The Device blocks contains the following properties:
 
 \end{description}
 
-\htcbsubsection{Contact} The contact block contains the following properties:
+\htcbsubsection{Contact}
+\label{sec:transport.Contact}
+
+The contact block contains the following properties:
 
 \begin{ptable}
   \kw{Id} & s &  & &  \\


### PR DESCRIPTION
Also fixed label collision in phonon/transport sections.