### PR TITLE
Fix wrong content of serial binary eigenvector files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,9 @@ Changed
 Fixed
 -----
 
+- Fix bug in binary eigenvector output in non-MPI builds (only eigenvectors
+  belonging to the the first k-point and spin channel were stored)
+
 
 20.2.1 (2020-12-07)
 ===================
@@ -139,7 +142,7 @@ Changed
 - Poisson solver available without libNEGF enabled compilation
 
 - Parser input can now be set according to the code release version (20.1)
-  
+
 
 Fixed
 -----

--- a/prog/dftb+/lib_dftbplus/mainio.F90
+++ b/prog/dftb+/lib_dftbplus/mainio.F90
@@ -463,14 +463,14 @@ contains
     !> optional alternative file prefix, to appear as "fileName".bin
     character(len=*), intent(in), optional :: fileName
 
-    integer :: iKS, iSpin
+    integer :: iKS
     integer :: ii, fd
 
     call prepareEigvecFileBin(fd, runId, fileName)
+    ! By construction of parallelKS, iKS runs over (iK, iS) with iK growing faster
     do iKS = 1, parallelKS%nLocalKS
-      iSpin = parallelKS%localKS(2, iKS)
       do ii = 1, size(eigvecs, dim=2)
-        write(fd) eigvecs(:,ii,iSpin)
+        write(fd) eigvecs(:, ii, iKS)
       end do
     end do
     close(fd)


### PR DESCRIPTION
Due to wrong indexing, the eigenvectors of the first k-point were written for all k-points.