### PR TITLE
Variational ground state option

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -1071,6 +1071,7 @@ following properties:
   \kw{EwaldParameter} & r & Periodic = Yes SCC = Yes & 0.0 & \\
   \kw{EwaldTolerance} & r & Periodic = Yes SCC = Yes & 1e-9 & \\
   \kw{ShellResolvedSCC} & l & SCC = Yes & No & \\
+  \kw{VariationalEnergyTolerance} & r & SCC = Yes & \is{SCCTolerance} & \\
   \kw{Mixer} &m& SCC = Yes  & Broyden\{\} & \pref{sec:dftbp.Mixer} \\
   \kw{MaxAngularMomentum} &p&  & -  & \\
   \kw{Charge} &r& & 0.0 & \\
@@ -1159,6 +1160,16 @@ following properties:
   is set to \is{Yes}, any charge transfer between atomic shells will
   change the energy of the system compared to when it is set to set to
   \is{No}.
+
+\item[\is{VariationalEnergyTolerance}] During self-consistency cycles sets the
+  SCC tolerance at which the evaluated ground state energy only use output
+  quantities (larger than tolerance) or recycle input potentials with output
+  charges (under the tolerance), which for loose SCC tolerances can also
+  slightly affect forces. The first case is bounded from below by the
+  self-consistent energy, while the second can be faster to evaluate, but both
+  expressions agree at self-consistency. See section II of
+  ref.~\cite{hourahine07} for a short discussion of the difference between the
+  two forms.
 
 \item[\is{Mixer}]  Mixer type for mixing the charges in an SCC
   calculation. See p.~\pref{sec:dftbp.Mixer}.

--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -195,6 +195,12 @@ module dftbp_initprogram
     !> SCC module internal variables
     type(TScc), allocatable :: scc
 
+    !> If the SCC error is above this tolerance, use the expressions with only the output properties
+    !> to evaluate energy, so is bounded from below. If below the tolerance re-use the input
+    !> potentials (faster, but not bounded, only stationary). Both expressions give the same energy
+    !> at self consistency.
+    real(dp) :: variationalEgyTol
+
     !> nr. of atoms
     integer :: nAtom
 
@@ -1232,6 +1238,9 @@ contains
     ! Basic variables
     this%hamiltonianType = input%ctrl%hamiltonian
     this%tSccCalc = input%ctrl%tScc
+    if (this%tSccCalc) then
+      this%variationalEgyTol = input%ctrl%variationalEgyTol
+    end if
     if (allocated(input%ctrl%dftbUInp)) then
       allocate(this%dftbU)
       call TDftbU_init(this%dftbU, input%ctrl%dftbUInp)
@@ -2707,6 +2716,7 @@ contains
       if (.not.this%tRestartNoSC) then
         write(stdOut, "(A,':',T30,A)") "Self consistent charges", "Yes"
         write(stdOut, "(A,':',T30,E14.6)") "SCC-tolerance", this%sccTol
+        write(stdOut, "(A,':',T30,E14.6)") "Variational above SCC error", this%variationalEgyTol
         write(stdOut, "(A,':',T30,I14)") "Max. scc iterations", this%maxSccIter
       end if
       !if (this%tPeriodic) then

--- a/prog/dftb+/lib_dftbplus/inputdata.F90
+++ b/prog/dftb+/lib_dftbplus/inputdata.F90
@@ -127,13 +127,19 @@ module dftbp_inputdata
     real(dp) :: maxForce    = 0.0_dp
 
     !> SCC calculation?
-    logical :: tScc        = .false.
+    logical :: tScc = .false.
+
+    !> SCC tolerance at which the evaluated energy and forces should only use output quantities (so
+    !> energy bounded from below by the converged result) or if below this tolerance, recycle input
+    !> potentials with output charges, which can be faster to evaluate. Both expressions agree at
+    !> self-consistency
+    real(dp) :: variationalEgyTol
 
     !> l-shell resolved SCC
     logical :: tShellResolved = .false.
 
     !> SCC tolerance
-    real(dp) :: sccTol      = 0.0_dp
+    real(dp) :: sccTol = 0.0_dp
 
     !> Read starting charges from disc
     logical :: tReadChrg = .false.

--- a/prog/dftb+/lib_dftbplus/oldcompat.F90
+++ b/prog/dftb+/lib_dftbplus/oldcompat.F90
@@ -520,6 +520,15 @@ contains
       call detailedWarning(ch2, "Set 'oldLineSearch = Yes'")
     end if
 
+    call getDescendant(root, "Hamiltonian/DFTB/SCC", ch1, parent=par)
+    if (associated(ch1)) then
+      call getChildValue(ch1, "", tVal1)
+      call setUnprocessed(ch1)
+      if (tVal1) then
+        call setChildValue(par, "VariationalEnergyTolerance", epsilon(0.0_dp), child=ch2)
+      end if
+    end if
+
   end subroutine convert_8_9
 
 

--- a/prog/dftb+/lib_dftbplus/parser.F90
+++ b/prog/dftb+/lib_dftbplus/parser.F90
@@ -2844,6 +2844,8 @@ contains
 
     call getChildValue(node, "SCCTolerance", ctrl%sccTol, 1.0e-5_dp)
 
+    call getChildValue(node, "VariationalEnergyTolerance", ctrl%variationalEgyTol, ctrl%sccTol)
+
     ! temporararily removed until debugged
     !call getChildValue(node, "WriteShifts", ctrl%tWriteShifts, .false.)
     ctrl%tWriteShifts = .false.

--- a/test/prog/dftb+/scc/2H2O_nonvariational/H-H.skf
+++ b/test/prog/dftb+/scc/2H2O_nonvariational/H-H.skf
@@ -1,0 +1,1 @@
+../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/prog/dftb+/scc/2H2O_nonvariational/H-O.skf
+++ b/test/prog/dftb+/scc/2H2O_nonvariational/H-O.skf
@@ -1,0 +1,1 @@
+../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/prog/dftb+/scc/2H2O_nonvariational/O-H.skf
+++ b/test/prog/dftb+/scc/2H2O_nonvariational/O-H.skf
@@ -1,0 +1,1 @@
+../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/prog/dftb+/scc/2H2O_nonvariational/O-O.skf
+++ b/test/prog/dftb+/scc/2H2O_nonvariational/O-O.skf
@@ -1,0 +1,1 @@
+../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/prog/dftb+/scc/2H2O_nonvariational/dftb_in.hsd
+++ b/test/prog/dftb+/scc/2H2O_nonvariational/dftb_in.hsd
@@ -1,0 +1,44 @@
+Geometry = GenFormat {
+6 C
+ O H
+   1   2     -.499735     -.006429      .000000
+   2   1    -1.467047     -.147444      .000000
+   3   1     1.392547      .133948      .000000
+   4   2    -1.876914      .729873      .000000
+   5   2     1.737135     -.325150     -.779513
+   6   2     1.737135     -.325150      .779513
+}
+
+Driver = {}
+
+Hamiltonian = DFTB {
+  SCC = Yes
+  VariationalEnergy = No
+  SCCTolerance = 1E-8
+  MaxAngularMomentum = {
+    O = "p"
+    H = "s"
+  }
+  SlaterKosterFiles = Type2FileNames {
+    Separator = "-"
+    Suffix = ".skf"
+  }
+}
+
+Analysis = {
+  CalculateForces = Yes
+}
+
+Options = {
+  WriteAutotestTag = Yes
+}
+
+ParserOptions = {
+  ParserVersion = 9
+}
+
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+}

--- a/test/prog/dftb+/tests
+++ b/test/prog/dftb+/tests
@@ -144,6 +144,7 @@ analysis/graphene_localise             #? not WITH_MPI
 onsite/H2O                             #? MPI_PROCS <= 1
 dftb+u/CH3                             #? MPI_PROCS <= 1
 dispersion/2H2O                        #? MPI_PROCS <= 1
+dispersion/2H2O_nonvariational         #? MPI_PROCS <= 1
 dispersion/2H2O_uff                    #? MPI_PROCS <= 1
 dispersion/2H2O_dftd3_zero             #? WITH_DFTD3 and MPI_PROCS <= 1
 dispersion/2H2O_dftd3_bj               #? WITH_DFTD3 and MPI_PROCS <= 1


### PR DESCRIPTION
Optional use of output potential in energy expression, skipping a re-evaluation. This would be relevant for expensive electrostatics (q dependent external media, self-consistent dispersion models, ...)
- [x] ground state case
- [x] regression test
- [x] document option
- [x] Intersection with Poisson solver RecomputeAfterDensity