### PR TITLE
Enable writing of cavity information as cosmofile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Added
 - Conductor like screening model (COSMO)
   implicit solvation model for SCC calculations
 
+- Printout of cavity information as a cosmo file
+
 - Extended syntax for selecting atoms in HSD input
 
 Changed

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -4174,6 +4174,7 @@ calculation and/or calculate properties.
 \begin{ptable}
   \kw{AtomResolvedEnergies} & l & & No & \\
   \kw{MullikenAnalysis} & l & & Yes & \\
+  \kw{WriteCosmoFile} & l & & No & \\
   \kw{CM5} & m & MullikenAnalysis = Yes & & \pref{sec:dftbp.CM5} \\
   \kw{WriteNetCharges} & l & MullikenAnalysis = Yes & No & \\
   \kw{ProjectStates} & m & & \cb & \\
@@ -4196,6 +4197,9 @@ calculation and/or calculate properties.
 \item[\is{WriteNetCharges}] If \is{Yes}, the net charges (component of the
   charge associated only with the on-site part of the atomic orbitals, not the
   off-site hybridisation).
+
+\item[\is{WriteCosmoFile}] If \is{Yes}, the cavitity information is written as
+  cosmo file to dftbp.cosmo. Only works if the solvation model is COSMO.
 
 \item[\is{CM5}] If present the charge model 5 (CM5)\cite{marenich2012} corrected
   atomic partial charges will be written.

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -4199,7 +4199,7 @@ calculation and/or calculate properties.
   off-site hybridisation).
 
 \item[\is{WriteCosmoFile}] If \is{Yes}, the cavitity information is written as
-  cosmo file to dftbp.cosmo. Only works if the solvation model is COSMO.
+  a cosmo file to dftbp.cosmo. Only works if the solvation model is COSMO.
 
 \item[\is{CM5}] If present the charge model 5 (CM5)\cite{marenich2012} corrected
   atomic partial charges will be written.

--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -771,6 +771,9 @@ module dftbp_initprogram
     !> Charge Model 5 for printout
     type(TChargeModel5), allocatable :: cm5Cont
 
+    !> Write cavity information as cosmo file
+    logical :: tWriteCosmoFile
+
     !> Can stress be calculated?
     logical :: tStress
 
@@ -1684,6 +1687,7 @@ contains
     this%tMD = input%ctrl%tMD
     this%tDerivs = input%ctrl%tDerivs
     this%tPrintMulliken = input%ctrl%tPrintMulliken
+    this%tWriteCosmoFile = input%ctrl%tWriteCosmoFile
     this%tEField = input%ctrl%tEfield
     this%tExtField = this%tEField
     this%tMulliken = input%ctrl%tMulliken .or. this%tPrintMulliken .or. this%tExtField .or.&

--- a/prog/dftb+/lib_dftbplus/inputdata.F90
+++ b/prog/dftb+/lib_dftbplus/inputdata.F90
@@ -517,6 +517,9 @@ module dftbp_inputdata
     !> Could be set to .false. to prevent costly recalculations (e.g. when using Poisson-solver)
     logical :: updateSccAfterDiag = .true.
 
+    !> Write cavity information as COSMO file
+    logical :: tWriteCosmoFile = .false.
+
   end type TControl
 
 

--- a/prog/dftb+/lib_dftbplus/main.F90
+++ b/prog/dftb+/lib_dftbplus/main.F90
@@ -395,6 +395,10 @@ contains
           & this%tStress, this%totalStress, this%pDynMatrix, this%tPeriodic, this%cellVol,&
           & this%tMulliken, this%qOutput, this%q0, this%taggedWriter, this%cm5Cont)
     end if
+    if (this%tWriteCosmoFile .and. allocated(this%solvation)) then
+      call writeCosmoFile(this%solvation, this%species0, this%speciesName, this%coord0, &
+          & this%dftbEnergy(this%deltaDftb%iFinal)%EMermin)
+    end if
     if (this%tWriteDetailedXML) then
       call writeDetailedXml(this%runId, this%speciesName, this%species0, this%pCoord0Out,&
           & this%tPeriodic, this%tHelical, this%latVec, this%origin, this%tRealHS, this%nKPoint,&

--- a/prog/dftb+/lib_dftbplus/parser.F90
+++ b/prog/dftb+/lib_dftbplus/parser.F90
@@ -4819,6 +4819,14 @@ contains
     call getChildValue(node, "AtomResolvedEnergies", ctrl%tAtomicEnergy, &
         &.false.)
 
+    if (allocated(ctrl%solvInp)) then
+      call getChildValue(node, "writeCosmoFile", ctrl%tWriteCosmoFile, &
+          & allocated(ctrl%solvInp%cosmoInp), child=child)
+      if (ctrl%tWriteCosmoFile .and. .not.allocated(ctrl%solvInp%cosmoInp)) then
+        call detailedError(child, "Cosmo file can only be written for Cosmo calculations")
+      end if
+    end if
+
     call getChildValue(node, "CalculateForces", ctrl%tPrintForces, .false.)
 
   #:if WITH_TRANSPORT

--- a/prog/dftb+/lib_solvation/cosmo.F90
+++ b/prog/dftb+/lib_solvation/cosmo.F90
@@ -935,14 +935,8 @@ contains
     real(dp), intent(in) :: energy
 
     integer :: ii, ig, iat
-    real(dp) :: cosmoEnergy, keps
+    real(dp) :: dielEnergy, keps
     real(dp), allocatable :: phi(:), zeta(:), area(:)
-
-    keps = 0.5_dp * (1.0_dp - 1.0_dp/this%dielectricConst)
-    cosmoEnergy = this%freeEnergyShift
-    do iat = 1, this%nAtom
-      cosmoEnergy = cosmoEnergy + keps*dot_product(this%sigma(:, iat), this%psi(:, iat))
-    end do
 
     allocate(phi(this%ddCosmo%ncav), zeta(this%ddCosmo%ncav), area(this%ddCosmo%ncav))
     ! Reset potential on the cavity, note that the potential is expected in e/Å
@@ -961,6 +955,10 @@ contains
       end do
     end do
 
+    ! Dielectric energy is the energy on the dielectric continuum
+    keps = 0.5_dp * (1.0_dp - 1.0_dp/this%dielectricConst)
+    dielEnergy = keps * dot_product(zeta, phi)
+
     write(unit, '(a)') &
         & "$info", &
         & "prog.: dftb+"
@@ -973,6 +971,7 @@ contains
     write(unit, '(a)') &
         & "$cosmo_data"
     write(unit, '(2x, a:, "=", g0)') &
+        & "fepsi", keps, &
         & "area", sum(area)
 
     write(unit, '(a)') &
@@ -1011,8 +1010,8 @@ contains
         & "Total energy [a.u.]            ", energy, &
         & "Total energy + OC corr. [a.u.] ", energy, &
         & "Total energy corrected [a.u.]  ", energy, &
-        & "Dielectric energy [a.u.]       ", cosmoEnergy, &
-        & "Diel. energy + OC corr. [a.u.] ", cosmoEnergy
+        & "Dielectric energy [a.u.]       ", dielEnergy, &
+        & "Diel. energy + OC corr. [a.u.] ", dielEnergy
 
     write(unit, '(a)') &
         & "$segment_information", &

--- a/prog/dftb+/lib_solvation/cosmo.F90
+++ b/prog/dftb+/lib_solvation/cosmo.F90
@@ -12,8 +12,9 @@ module dftbp_cosmo
   use dftbp_accuracy, only : dp
   use dftbp_blasroutines, only : gemv
   use dftbp_charges, only : getSummedCharges
+  use dftbp_charmanip, only : tolower
   use dftbp_commontypes, only : TOrbitals
-  use dftbp_constants, only : pi, Hartree__eV
+  use dftbp_constants, only : pi, Hartree__eV, Bohr__AA
   use dftbp_environment, only : TEnvironment
   use dftbp_extlibs_ddcosmo
   use dftbp_lebedev, only : getAngGrid, gridSize
@@ -131,6 +132,9 @@ module dftbp_cosmo
 
     !> Returns shifts per atom
     procedure :: getShifts
+
+    !> Write cavity information
+    procedure :: writeCosmoFile
 
   end type TCosmo
 
@@ -907,6 +911,134 @@ contains
     end do
 
   end subroutine efld
+
+
+  !> Write a COSMO file output
+  subroutine writeCosmoFile(this, unit, species0, speciesNames, coords0, energy)
+
+    !> COSMO container
+    class(TCosmo), intent(in) :: this
+
+    !> Formatted unit for output
+    integer, intent(in) :: unit
+
+    !> Symbols of the species
+    character(len=*), intent(in) :: speciesNames(:)
+
+    !> Species of every atom in the unit cell
+    integer, intent(in) :: species0(:)
+
+    !> Atomic coordinates
+    real(dp), intent(in) :: coords0(:,:)
+
+    !> Total energy
+    real(dp), intent(in) :: energy
+
+    integer :: ii, ig, iat
+    real(dp) :: cosmoEnergy, keps
+    real(dp), allocatable :: phi(:), zeta(:), area(:)
+
+    keps = 0.5_dp * ((this%dielectricConst - 1.0_dp)/this%dielectricConst)
+    cosmoEnergy = this%freeEnergyShift
+    do iat = 1, this%nAtom
+      cosmoEnergy = cosmoEnergy + keps*dot_product(this%sigma(:, iat), this%psi(:, iat))
+    end do
+
+    allocate(phi(this%ddCosmo%ncav), zeta(this%ddCosmo%ncav), area(this%ddCosmo%ncav))
+    ! Reset potential on the cavity, note that the potential is expected in e/Å
+    call getPhi(this%chargesPerAtom, this%jmat, phi)
+    ii = 0
+    do iat = 1, this%ddCosmo%nat
+      do ig = 1, this%ddCosmo%ngrid
+        if (this%ddCosmo%ui(ig, iat) > 0.0_dp) then
+          ii = ii + 1
+          ! Calculate surface charge per area
+          zeta(ii) = this%ddCosmo%w(ig) * this%ddCosmo%ui(ig, iat) &
+              & * dot_product(this%ddCosmo%basis(:, ig), this%s(:, iat))
+          ! Save surface area in Ångström²
+          area(ii) = this%ddCosmo%w(ig) * Bohr__AA**2 * this%vdwRad(iat)**2
+        end if
+      end do
+    end do
+
+    write(unit, '(a)') &
+        & "$info", &
+        & "prog.: dftb+"
+
+    write(unit, '(a)') &
+        & "$cosmo"
+    write(unit, '(2x, a:, "=", g0)') &
+        & "epsilon", this%dielectricConst
+
+    write(unit, '(a)') &
+        & "$cosmo_data"
+    write(unit, '(2x, a:, "=", g0)') &
+        & "area", sum(area)
+
+    write(unit, '(a)') &
+        & "$coord_rad", &
+        & "#atom   x                  y                  z             element  radius [A]"
+    do iat = 1, size(coords0, 2)
+      write(unit, '(i4, 3(1x, f18.14), 2x, a4, 1x, f9.5)') &
+          & iat, coords0(:, iat), trim(tolower(speciesNames(species0(iat)))), &
+          & this%vdwRad(iat)*Bohr__AA
+    end do
+
+    write(unit, '(a)') &
+        & "$coord_car", &
+        & "!BIOSYM archive 3", &
+        & "PBC=OFF", &
+        & "coordinates from COSMO calculation", &
+        & "!DATE"
+    do iat = 1, size(coords0, 2)
+      write(unit, '(a, i0, t5, 3(1x, f14.9), 1x, "COSM 1", 2(6x, a2), 1x, f6.3)') &
+          & trim(speciesNames(species0(iat))), iat, coords0(:, iat)*Bohr__AA, &
+          & tolower(speciesNames(species0(iat))), speciesNames(species0(iat)), 0.0_dp
+    end do
+    write(unit, '(a)') &
+        & "end", "end"
+
+    write(unit, '(a)') &
+        & "$screening_charge"
+    write(unit, '(2x, a:, "=", g0)') &
+        & "cosmo", sum(zeta), &
+        & "correction", 0.0_dp, &
+        & "total", sum(zeta)
+
+    write(unit, '(a)') &
+        & "$cosmo_energy"
+    write(unit, '(2x, a:, "=", f21.10)') &
+        & "Total energy [a.u.]            ", energy, &
+        & "Total energy + OC corr. [a.u.] ", energy, &
+        & "Total energy corrected [a.u.]  ", energy, &
+        & "Dielectric energy [a.u.]       ", cosmoEnergy, &
+        & "Diel. energy + OC corr. [a.u.] ", cosmoEnergy
+
+    write(unit, '(a)') &
+        & "$segment_information", &
+        & "# n             - segment number", &
+        & "# atom          - atom associated with segment n", &
+        & "# position      - segment coordinates [a.u.]", &
+        & "# charge        - segment charge (corrected)", &
+        & "# area          - segment area [A**2]", &
+        & "# potential     - solute potential on segment (A length scale)", &
+        & "#", &
+        & "#  n   atom              position (X, Y, Z)                   charge         area        charge/area     potential", &
+        & "#", &
+        & "#"
+
+    ii = 0
+    do iat = 1, this%ddCosmo%nat
+      do ig = 1, this%ddCosmo%ngrid
+        if (this%ddCosmo%ui(ig, iat) > 0.0_dp) then
+          ii = ii + 1
+          write(unit, '(2i5, 7(1x, f14.9))') &
+              & ii, iat, this%ddCosmo%ccav(:, ii), &
+              & zeta(ii), area(ii), zeta(ii)/area(ii), phi(ii)/Bohr__AA
+        end if
+      end do
+    end do
+  end subroutine writeCosmoFile
 
 
 end module dftbp_cosmo

--- a/prog/dftb+/lib_solvation/cosmo.F90
+++ b/prog/dftb+/lib_solvation/cosmo.F90
@@ -938,7 +938,7 @@ contains
     real(dp) :: cosmoEnergy, keps
     real(dp), allocatable :: phi(:), zeta(:), area(:)
 
-    keps = 0.5_dp * ((this%dielectricConst - 1.0_dp)/this%dielectricConst)
+    keps = 0.5_dp * (1.0_dp - 1.0_dp/this%dielectricConst)
     cosmoEnergy = this%freeEnergyShift
     do iat = 1, this%nAtom
       cosmoEnergy = cosmoEnergy + keps*dot_product(this%sigma(:, iat), this%psi(:, iat))


### PR DESCRIPTION
Allows writing of the Cosmo cavity as cosmo file. The cosmo format uses a strange unit convention mixing Ångström with atomic units, but I tried to get all of those units in the printout as correct as possible.

#### New input

```cson
Analysis {
  WriteCosmoFile = Yes
}
```