### PR TITLE
Clean up and add transport compatibility checks

### DIFF
--- a/prog/dftb+/lib_dftbplus/inputdata.F90
+++ b/prog/dftb+/lib_dftbplus/inputdata.F90
@@ -464,7 +464,8 @@ module dftbp_inputdata
 
     !> 3rd order
     real(dp), allocatable :: hubDerivs(:,:)
-    logical :: t3rd, t3rdFull
+    logical :: t3rd = .false.
+    logical :: t3rdFull = .false.
 
 
     !> XLBOMD


### PR DESCRIPTION
Covers contact generation and upload cases that are incompatible with transport at the moment.

Also has initialisation for the 3rd order logicals to work around a problem with the mac regression testing on github (did not manifest on any other tested compiler combination).