### PR TITLE
Add CI tests with Intel oneAPI classic compilers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ env:
   CMAKE_OPTIONS: >-
     -DCMAKE_BUILD_TYPE=Debug
     -DWITH_API=true
-    -DWITH_ARPACK=false
     -DWITH_DFTD3=true
     -DWITH_MBD=true
     -DWITH_TRANSPORT=true
@@ -117,3 +116,79 @@ jobs:
       run: >-
         PKG_CONFIG_PATH="${PWD}/_install/lib/pkgconfig:${PKG_CONFIG_PATH}"
         ./test/integration/pkgconfig/runtest.sh ${BUILD_DIR}_pkgconfig
+
+  intel-build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        fc: [ifort]
+        cc: [icc]
+    env:
+      FC: ${{ matrix.fc }}
+      CC: ${{ matrix.cc }}
+      WITH_MPI: false
+      APT_PACKAGES: >-
+        intel-oneapi-compiler-fortran
+        intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+        intel-oneapi-mkl
+        intel-oneapi-mkl-devel
+      CMAKE_OPTIONS: >-
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        -DWITH_API=true
+        -DWITH_DFTD3=true
+        -DWITH_MBD=true
+        -DWITH_TRANSPORT=true
+        -DFYPP_FLAGS='-DTRAVIS'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.x
+
+    - name: Add Intel repository
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
+
+    - name: Install Intel oneAPI compiler
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        sudo apt-get install ${APT_PACKAGES}
+        source /opt/intel/oneapi/setvars.sh
+        printenv >> $GITHUB_ENV
+
+    - name: Install cmake
+      run: pip3 install cmake ninja fypp numpy
+
+    - name: Get external dependencies
+      run: echo "y" | ./utils/get_opt_externals ALL
+
+    - name: Configure build
+      run: >-
+        cmake -B _build -G Ninja
+        -DCMAKE_INSTALL_PREFIX=${PWD}/_install
+        ${CMAKE_OPTIONS}
+        -DWITH_MPI=${WITH_MPI}
+
+    - name: Build project
+      run: cmake --build ${BUILD_DIR}
+
+    - name: Run regression tests
+      run: |
+        pushd ${BUILD_DIR}
+        ctest -j 2 --output-on-failure
+        popd
+
+    - name: Install project
+      run: |
+        cmake --install ${BUILD_DIR}

--- a/cmake/DftbPlusUtils.cmake
+++ b/cmake/DftbPlusUtils.cmake
@@ -191,7 +191,7 @@ Disable OpenMP (WITH_OMP) when compiling in debug mode")
   endif()
 
   # Make sure Intel has the proper flag
-  if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel")
+  if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel" AND CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 18.0)
     if(CMAKE_BUILD_TYPE)
       set(_buildtypes "${CMAKE_BUILD_TYPE}")
     else()

--- a/sys/intel.cmake
+++ b/sys/intel.cmake
@@ -18,9 +18,6 @@
 #
 # Fortran compiler settings
 #
-set(Fortran_FLAGS "-standard-semantics ${CMAKE_Fortran_FLAGS}"
-  CACHE STRING "Build type independent Fortran compiler flags")
-
 set(Fortran_FLAGS_RELEASE "-O2 -ip"
   CACHE STRING "Fortran compiler flags for Release build")
 


### PR DESCRIPTION
- shared memory build only for now
- remove -standard-semantics for Intel 18 and newer

Compiler | Install | Build | Test
--- | --- | --- | ---
GCC | 30s | 1min 25s | 6min 15s
GCC / OpenMPI | 30s | 1min 40s | 10min 30s
Intel | 3min | 4min 20s | 2min 30s