### PR TITLE
Correct typo in various hsd file comments

### DIFF
--- a/test/prog/dftb+/derivatives/C6H6_scc/dftb_in.hsd
+++ b/test/prog/dftb+/derivatives/C6H6_scc/dftb_in.hsd
@@ -16,14 +16,14 @@ Geometry = GenFormat {
 }
 
 #Driver = ConjugateGRadient {
-#  MaxForceComponent = 1.0E-8 # very tight tollerance.
+#  MaxForceComponent = 1.0E-8 # very tight tolerance.
 #}
 
 Driver = SecondDerivatives {}
 
 Hamiltonian = DFTB {
   SCC = Yes
-  SCCTolerance = 1.0E-10 # abnormally tight tollerance used for accuracy
+  SCCTolerance = 1.0E-10 # abnormally tight tolerance used for accuracy
   MaxAngularMomentum = {
     C = "p"
     H = "s"

--- a/test/prog/dftb+/timeprop/C60_kick/dftb_in.hsd
+++ b/test/prog/dftb+/timeprop/C60_kick/dftb_in.hsd
@@ -67,7 +67,7 @@ Driver = {}
 
 Hamiltonian = DFTB {
     SCC = Yes
-    SCCTolerance = 1.0E-10 # abnormally tight tollerance used for accuracy
+    SCCTolerance = 1.0E-10 # abnormally tight tolerance used for accuracy
     MaxAngularMomentum = {
         C = "p"
     }

--- a/test/prog/dftb+/timeprop/C60_triplet/dftb_in.hsd
+++ b/test/prog/dftb+/timeprop/C60_triplet/dftb_in.hsd
@@ -67,7 +67,7 @@ Driver = {}
 
 Hamiltonian = DFTB {
     SCC = Yes
-    SCCTolerance = 1.0E-10 # abnormally tight tollerance used for accuracy
+    SCCTolerance = 1.0E-10 # abnormally tight tolerance used for accuracy
     MaxAngularMomentum = {
         C = "p"
     }

--- a/test/prog/dftb+/timeprop/PDI_charged/dftb_in.hsd
+++ b/test/prog/dftb+/timeprop/PDI_charged/dftb_in.hsd
@@ -44,7 +44,7 @@ C N O H
  }
 Hamiltonian = DFTB {
   SCC = Yes
-  SCCTolerance = 1.0E-10 # abnormally tight tollerance used for accuracy
+  SCCTolerance = 1.0E-10 # abnormally tight tolerance used for accuracy
   SlaterKosterFiles = Type2FileNames {
        Separator = "-"
        Suffix = ".skf"

--- a/test/prog/dftb+/timeprop/benzene_circpol/dftb_in.hsd
+++ b/test/prog/dftb+/timeprop/benzene_circpol/dftb_in.hsd
@@ -17,7 +17,7 @@
  Driver = {}
 Hamiltonian = DFTB {
   SCC = Yes
-  SCCTolerance = 1.0E-10 # abnormally tight tollerance used for accuracy
+  SCCTolerance = 1.0E-10 # abnormally tight tolerance used for accuracy
   MaxAngularMomentum = {
     C = "p"
     H = "s"

--- a/test/prog/dftb+/timeprop/benzene_gaussian/dftb_in.hsd
+++ b/test/prog/dftb+/timeprop/benzene_gaussian/dftb_in.hsd
@@ -17,7 +17,7 @@
  Driver = {}
 Hamiltonian = DFTB {
   SCC = Yes
-  SCCTolerance = 1.0E-10 # abnormally tight tollerance used for accuracy
+  SCCTolerance = 1.0E-10 # abnormally tight tolerance used for accuracy
   MaxAngularMomentum = {
     C = "p"
     H = "s"

--- a/test/prog/dftb+/timeprop/benzene_ions_pulse/dftb_in.hsd
+++ b/test/prog/dftb+/timeprop/benzene_ions_pulse/dftb_in.hsd
@@ -17,7 +17,7 @@
  Driver = {}
 Hamiltonian = DFTB {
   SCC = Yes
-  SCCTolerance = 1.0E-10 # abnormally tight tollerance used for accuracy
+  SCCTolerance = 1.0E-10 # abnormally tight tolerance used for accuracy
   MaxAngularMomentum = {
     C = "p"
     H = "s"

--- a/test/prog/dftb+/timeprop/benzene_ions_restart/dftb_in.hsd
+++ b/test/prog/dftb+/timeprop/benzene_ions_restart/dftb_in.hsd
@@ -17,7 +17,7 @@
  Driver = {}
 Hamiltonian = DFTB {
   SCC = Yes
-  SCCTolerance = 1.0E-10 # abnormally tight tollerance used for accuracy
+  SCCTolerance = 1.0E-10 # abnormally tight tolerance used for accuracy
   MaxAngularMomentum = {
     C = "p"
     H = "s"

--- a/test/prog/dftb+/timeprop/benzene_kick_bndpop/dftb_in.hsd
+++ b/test/prog/dftb+/timeprop/benzene_kick_bndpop/dftb_in.hsd
@@ -19,7 +19,7 @@ Driver = {}
 
 Hamiltonian = DFTB {
     SCC = Yes
-    SCCTolerance = 1.0E-10 # abNormally tight tollerance used for accuracy of starting state
+    SCCTolerance = 1.0E-10 # abNormally tight tolerance used for accuracy of starting state
     MaxAngularMomentum = {
         C = "p"
         H = "s"

--- a/test/prog/dftb+/timeprop/benzene_kick_periodic/dftb_in.hsd
+++ b/test/prog/dftb+/timeprop/benzene_kick_periodic/dftb_in.hsd
@@ -24,7 +24,7 @@ Driver = {}
 
 Hamiltonian = DFTB {
     SCC = Yes
-    SCCTolerance = 1.0E-10 # abnormally tight tollerance
+    SCCTolerance = 1.0E-10 # abnormally tight tolerance
     MaxAngularMomentum = {
         C = "p"
         H = "s"

--- a/test/prog/dftb+/timeprop/benzene_kick_restart/dftb_in.hsd
+++ b/test/prog/dftb+/timeprop/benzene_kick_restart/dftb_in.hsd
@@ -17,7 +17,7 @@
  Driver = {}
 Hamiltonian = DFTB {
   SCC = Yes
-  SCCTolerance = 1.0E-10 # abnormally tight tollerance used for accuracy
+  SCCTolerance = 1.0E-10 # abnormally tight tolerance used for accuracy
   MaxAngularMomentum = {
     C = "p"
     H = "s"

--- a/test/prog/dftb+/timeprop/benzene_laser/dftb_in.hsd
+++ b/test/prog/dftb+/timeprop/benzene_laser/dftb_in.hsd
@@ -17,7 +17,7 @@
  Driver = {}
 Hamiltonian = DFTB {
   SCC = Yes
-  SCCTolerance = 1.0E-10 # abnormally tight tollerance used for accuracy
+  SCCTolerance = 1.0E-10 # abnormally tight tolerance used for accuracy
   MaxAngularMomentum = {
     C = "p"
     H = "s"

--- a/test/prog/dftb+/timeprop/benzene_sin2/dftb_in.hsd
+++ b/test/prog/dftb+/timeprop/benzene_sin2/dftb_in.hsd
@@ -17,7 +17,7 @@
  Driver = {}
 Hamiltonian = DFTB {
   SCC = Yes
-  SCCTolerance = 1.0E-10 # abnormally tight tollerance used for accuracy
+  SCCTolerance = 1.0E-10 # abnormally tight tolerance used for accuracy
   MaxAngularMomentum = {
     C = "p"
     H = "s"


### PR DESCRIPTION
Clean up comments in hsd files with the old 'tollerance' typo.