### PR TITLE
Checks for use of external field and solvents

### DIFF
--- a/prog/dftb+/api/mm/mmapi.F90
+++ b/prog/dftb+/api/mm/mmapi.F90
@@ -161,7 +161,7 @@ contains
 
     if (.not. associated(this%hsdTree)) then
       print *, 'ERROR: input has not been created yet!'
-      stop
+      error stop
     end if
     call getChild(this%hsdTree, rootTag, root)
 
@@ -231,7 +231,7 @@ contains
 
     if (geo%nSpecies /= maxval(geo%species) .or. minval(geo%species) /= 1) then
       write (*, *) "Nr. of species and nr. of specified elements do not match."
-      stop
+      error stop
     end if
 
   end subroutine TDftbPlusAtomList_addToInpData
@@ -394,7 +394,7 @@ contains
     if (allocated(this%main%solvation)) then
       if (this%main%solvation%isEFieldModified()) then
         write(stdOut, "(A)") "Error: External fields currently unsupported for this solvent model"
-        stop
+        error stop
       end if
     end if
 
@@ -423,7 +423,7 @@ contains
     if (allocated(this%main%solvation)) then
       if (this%main%solvation%isEFieldModified()) then
         write(stdOut, "(A)") "Error: External fields currently unsupported for this solvent model"
-        stop
+        error stop
       end if
     end if
 
@@ -449,7 +449,7 @@ contains
     if (allocated(this%main%solvation)) then
       if (this%main%solvation%isEFieldModified()) then
         write(stdOut, "(A)") "Error: External fields currently unsupported for this solvent model"
-        stop
+        error stop
       end if
     end if
 
@@ -582,7 +582,7 @@ contains
 
     if (.not. this%tInit) then
       write(stdOut, "(A)") "Error: Received uninitialized TDftbPlus instance"
-      stop
+      error stop
     end if
 
   end subroutine TDftbPlus_checkInit
@@ -766,7 +766,7 @@ contains
     if (allocated(this%main%solvation)) then
       if (this%main%solvation%isEFieldModified()) then
         write(stdOut, "(A)") "Error: External fields currently unsupported for this solvent model"
-        stop
+        error stop
       end if
     end if
 

--- a/prog/dftb+/api/mm/mmapi.F90
+++ b/prog/dftb+/api/mm/mmapi.F90
@@ -391,6 +391,13 @@ contains
 
     call this%checkInit()
 
+    if (allocated(this%main%solvation)) then
+      if (this%main%solvation%isEFieldModified()) then
+        write(stdOut, "(A)") "Error: External fields currently unsupported for this solvent model"
+        stop
+      end if
+    end if
+
     call setExternalPotential(this%main, atomPot=atomPot, potGrad=potGrad)
 
   end subroutine TDftbPlus_setExternalPotential
@@ -413,6 +420,13 @@ contains
 
     call this%checkInit()
 
+    if (allocated(this%main%solvation)) then
+      if (this%main%solvation%isEFieldModified()) then
+        write(stdOut, "(A)") "Error: External fields currently unsupported for this solvent model"
+        stop
+      end if
+    end if
+
     call setExternalCharges(this%main, chargeCoords, chargeQs, blurWidths)
 
   end subroutine TDftbPlus_setExternalCharges
@@ -431,6 +445,13 @@ contains
     type(TQDepExtPotProxy) :: extPotProxy
 
     call this%checkInit()
+
+    if (allocated(this%main%solvation)) then
+      if (this%main%solvation%isEFieldModified()) then
+        write(stdOut, "(A)") "Error: External fields currently unsupported for this solvent model"
+        stop
+      end if
+    end if
 
     allocate(extPotGenWrapper%instance, source=extPotGen)
     call TQDepExtPotProxy_init(extPotProxy, [extPotGenWrapper])
@@ -727,8 +748,8 @@ contains
     !> molecular orbital projected populations
     real(dp), optional, intent(out) :: occ(:)
 
-    call doOneTdStep(this%env, this%main, iStep, dipole=dipole, energy=energy, atomNetCharges=atomNetCharges,&
-        & coordOut = coord, force=force, occ=occ)
+    call doOneTdStep(this%env, this%main, iStep, dipole=dipole, energy=energy,&
+        & atomNetCharges=atomNetCharges, coordOut = coord, force=force, occ=occ)
 
   end subroutine TDftbPlus_doOneTdStep
 
@@ -741,6 +762,13 @@ contains
 
     ! electric field components
     real(dp), intent(in) :: field(3)
+
+    if (allocated(this%main%solvation)) then
+      if (this%main%solvation%isEFieldModified()) then
+        write(stdOut, "(A)") "Error: External fields currently unsupported for this solvent model"
+        stop
+      end if
+    end if
 
     call setTdElectricField(this%main, field)
 

--- a/prog/dftb+/lib_dftbplus/mainio.F90
+++ b/prog/dftb+/lib_dftbplus/mainio.F90
@@ -3364,7 +3364,7 @@ contains
 
   !> Fifth group of data for detailed.out
   subroutine writeDetailedOut7(fd, tGeoOpt, tGeomEnd, tMd, tDerivs, tEField, absEField,&
-      & dipoleMoment, deltaDftb)
+      & dipoleMoment, deltaDftb, solvation)
 
     !> File ID
     integer, intent(in) :: fd
@@ -3392,6 +3392,9 @@ contains
 
     !> type for DFTB determinants
     type(TDftbDeterminants), intent(in) :: deltaDftb
+
+    !> Instance of the solvation model
+    class(TSolvation), intent(in), allocatable :: solvation
 
     if (allocated(dipoleMoment)) then
       if (deltaDftb%isNonAufbau) then
@@ -3428,6 +3431,11 @@ contains
         write(fd, "(A, 3F14.8, A)")'Dipole moment:', dipoleMoment(:,deltaDftb%iGround)&
             & * au__Debye, ' Debye'
         write(fd, *)
+      end if
+      if (allocated(solvation)) then
+        if (solvation%isEFieldModified()) then
+          write(fd, "(A)")'Warning! Unmodified vacuum dielectric used for dipole moment.'
+        end if
       end if
     end if
 
@@ -3486,7 +3494,7 @@ contains
   !> Second group of output data during molecular dynamics
   subroutine writeMdOut2(fd, tStress, tPeriodic, tBarostat, isLinResp, tEField, tFixEf,&
       & tPrintMulliken, energy, energiesCasida, latVec, cellVol, cellPressure, pressure, tempIon,&
-      & absEField, qOutput, q0, dipoleMoment)
+      & absEField, qOutput, q0, dipoleMoment, solvation)
 
     !> File ID
     integer, intent(in) :: fd
@@ -3545,6 +3553,9 @@ contains
     !> dipole moment if available
     real(dp), intent(inout), allocatable :: dipoleMoment(:,:)
 
+    !> Instance of the solvation model
+    class(TSolvation), intent(in), allocatable :: solvation
+
     integer :: ii
     character(lc) :: strTmp
 
@@ -3594,6 +3605,11 @@ contains
       ii = size(dipoleMoment, dim=2)
       write(fd, "(A, 3F14.8, A)") 'Dipole moment:', dipoleMoment(:,ii),  'au'
       write(fd, "(A, 3F14.8, A)") 'Dipole moment:', dipoleMoment(:,ii) * au__Debye,  'Debye'
+      if (allocated(solvation)) then
+        if (solvation%isEFieldModified()) then
+          write(fd, "(A)")'Warning! Unmodified vacuum dielectric used for dipole moment.'
+        end if
+      end if
     end if
 
   end subroutine writeMdOut2

--- a/prog/dftb+/lib_solvation/born.F90
+++ b/prog/dftb+/lib_solvation/born.F90
@@ -187,6 +187,9 @@ module dftbp_born
 
     !> Query if object is actually an analytical linearized Poisson Boltzmann model
     procedure :: isALPB
+
+    !> Is the electrostic field modified by this solvent model?
+    procedure :: isEFieldModified
   end type TGeneralizedBorn
 
 
@@ -1604,5 +1607,18 @@ contains
 
   end subroutine getADetDeriv
 
+
+  !> Is the electrostic field modified by this solvent model?
+  function isEFieldModified(this) result(isChanged)
+
+    !> Data structure
+    class(TGeneralizedBorn), intent(in) :: this
+
+    !> Has the solvent model changed the electrostatic environment
+    logical :: isChanged
+
+    isChanged = .true.
+
+  end function isEFieldModified
 
 end module dftbp_born

--- a/prog/dftb+/lib_solvation/cosmo.F90
+++ b/prog/dftb+/lib_solvation/cosmo.F90
@@ -139,6 +139,9 @@ module dftbp_cosmo
     !> Returns shifts per atom
     procedure :: getShifts
 
+    !> Is the electrostic field modified by this solvent model?
+    procedure :: isEFieldModified
+
     !> Write cavity information
     procedure :: writeCosmoFile
 
@@ -557,6 +560,19 @@ contains
 
   end subroutine getShifts
 
+
+  !> Is the electrostic field modified by this solvent model?
+  function isEFieldModified(this) result(isChanged)
+
+    !> Data structure
+    class(TCosmo), intent(in) :: this
+
+    !> Has the solvent model changed the electrostatic environment
+    logical :: isChanged
+
+    isChanged = .false.
+
+  end function isEFieldModified
 
   !> Evaluate the Coulomb interactions between the atomic sides (xyz) and the
   !> surface elements of the cavity (ccav).

--- a/prog/dftb+/lib_solvation/sasa.F90
+++ b/prog/dftb+/lib_solvation/sasa.F90
@@ -144,6 +144,9 @@ module dftbp_sasa
     !> Returns shifts per atom
     procedure :: getShifts
 
+    !> Is the electrostic field modified by this solvent model?
+    procedure :: isEFieldModified
+
   end type TSASACont
 
 
@@ -624,5 +627,18 @@ contains
 
   end subroutine getSASA
 
+
+  !> Is the electrostic field modified by this solvent model?
+  function isEFieldModified(this) result(isChanged)
+
+    !> Data structure
+    class(TSASACont), intent(in) :: this
+
+    !> Has the solvent model changed the electrostatic environment
+    logical :: isChanged
+
+    isChanged = .false.
+
+  end function isEFieldModified
 
 end module dftbp_sasa

--- a/prog/dftb+/lib_solvation/solvation.F90
+++ b/prog/dftb+/lib_solvation/solvation.F90
@@ -45,6 +45,9 @@ module dftbp_solvation
 
     !> Returns shifts per atom
     procedure(getShifts), deferred :: getShifts
+
+    !> Does the solvent model modify the electrostatics
+    procedure(isEFieldModified), deferred :: isEFieldModified
   end type TSolvation
 
   abstract interface
@@ -190,6 +193,19 @@ module dftbp_solvation
       !> Shift per shell
       real(dp), intent(out) :: shiftPerShell(:,:)
     end subroutine getShifts
+
+    !> Is the electrostic field modified by this solvent model?
+    function isEFieldModified(this) result(isChanged)
+      import :: TSolvation
+
+      !> Data structure
+      class(TSolvation), intent(in) :: this
+
+      !> Has the solvent model changed the electrostatic environment
+      logical :: isChanged
+
+    end function isEFieldModified
+
   end interface
 
 end module dftbp_solvation


### PR DESCRIPTION
As there is a missing electrostatic term for extra fields from the solvent bulk at the moment.
- [x] stop external fields for program and API if solvent modifies the electrostatic environment
- [x] stop external polarizable media calculations if solvent modifies the electrostatic environment
- [x]  print description/warnings about dipole an/or electrostatic potentials in the presence of field modifying solvents
- [x] Block time propagation being used in cases modified by the electrostatic environment of the solvent