### PR TITLE
Zero allocated array for contact potential

### DIFF
--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -2470,6 +2470,7 @@ contains
       allocate(this%iAtInCentralRegion(this%nAtom))
       ! for storage of the electrostatic potential in the contact
       allocate(this%potential%coulombShell(this%orb%mShell,this%nAtom,1))
+      this%potential%coulombShell(:,:,:) = 0.0_dp
     else
       allocate(this%iAtInCentralRegion(this%transpar%idxdevice(2)))
     end if


### PR DESCRIPTION
In non-scc calculations, this would not be filled but would be
written to the contact file.