### PR TITLE
1 PL contact calc

### DIFF
--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -2470,6 +2470,7 @@ contains
       allocate(this%iAtInCentralRegion(this%nAtom))
       ! for storage of the electrostatic potential in the contact
       allocate(this%potential%coulombShell(this%orb%mShell,this%nAtom,1))
+      this%potential%coulombShell(:,:,:) = 0.0_dp
     else
       allocate(this%iAtInCentralRegion(this%transpar%idxdevice(2)))
     end if

--- a/prog/dftb+/lib_dftbplus/initprogram.F90
+++ b/prog/dftb+/lib_dftbplus/initprogram.F90
@@ -1458,13 +1458,6 @@ contains
     call initReferenceCharges(this%species0, this%orb, this%referenceN0, this%nSpin, this%q0,&
         & this%qShell0, input%ctrl%customOccAtoms, input%ctrl%customOccFillings)
 
-    this%nrChrg = input%ctrl%nrChrg
-    this%nrSpinPol = input%ctrl%nrSpinPol
-    call initElectronNumbers(this%q0, this%nrChrg, this%nrSpinPol, this%nSpin, this%orb,&
-        & this%nEl0, this%nEl)
-    call initElectronFilling_(input, this%nSpin, this%Ef, this%iDistribFn, this%tempElec,&
-        & this%tFixEf, this%tSetFillingTemp, this%tFillKSep)
-
     call ensureSolverCompatibility(input%ctrl%solver%iSolver, this%tSpin, this%kPoint,&
         & input%ctrl%parallelOpts, nIndepHam, this%tempElec)
     call getBufferedCholesky_(this%tRealHS, this%parallelKS%nLocalKS, nBufferedCholesky)
@@ -1495,6 +1488,17 @@ contains
 
     this%tPoisson = input%ctrl%tPoisson .and. this%tSccCalc
     this%updateSccAfterDiag = input%ctrl%updateSccAfterDiag
+
+    this%nrChrg = input%ctrl%nrChrg
+    this%nrSpinPol = input%ctrl%nrSpinPol
+    if (this%isAContactCalc) then
+      ! 1 PL in calculation, so half the spin
+      this%nrSpinPol = 0.5_dp * this%nrSpinPol
+    end if
+    call initElectronNumbers(this%q0, this%nrChrg, this%nrSpinPol, this%nSpin, this%orb,&
+        & this%nEl0, this%nEl)
+    call initElectronFilling_(input, this%nSpin, this%Ef, this%iDistribFn, this%tempElec,&
+        & this%tFixEf, this%tSetFillingTemp, this%tFillKSep)
 
     if (this%tSccCalc) then
       call initShortGammaDamping_(input%ctrl, this%speciesMass, shortGammaDamp)

--- a/prog/dftb+/lib_dftbplus/parser.F90
+++ b/prog/dftb+/lib_dftbplus/parser.F90
@@ -5423,8 +5423,8 @@ contains
     type(string) :: buffer, modifier
     type(fnode), pointer :: pTmp, field
     type(fnodeList), pointer :: pNodeList
-    integer :: contact
-    real(dp) :: lateralContactSeparation
+    integer :: contact, iStart, iEnd, iRange
+    real(dp) :: lateralContactSeparation, vector(3)
 
     transpar%defined = .true.
     transpar%tPeriodic1D = .not. geom%tPeriodic
@@ -5477,6 +5477,16 @@ contains
 
       call getChildValue(root, "readBinaryContact", transpar%tReadBinShift, .true.)
 
+      do contact = 1, size(transpar%contacts)
+        iRange = (transpar%contacts(contact)%idxrange(2)-transpar%contacts(contact)%idxrange(1))/2
+        iStart = transpar%contacts(contact)%idxrange(1)
+        vector(:) = geom%coords(:, iStart+iRange+1) - geom%coords(:, iStart)
+        do iStart = transpar%contacts(contact)%idxrange(1),&
+            & iRange + transpar%contacts(contact)%idxrange(1)
+          geom%coords(:, iStart+iRange+1) = geom%coords(:, iStart) + vector
+        end do
+      end do
+
     case default
 
       call getNodeHSDName(pTaskType, buffer)
@@ -5522,10 +5532,16 @@ contains
         ind = ind + 1
       end do
       newLatVecs = geom%latVecs
-      newLatVecs(:,ind) = 2.0_dp * contactVec
+      ! two PLs:
+      !newLatVecs(:,ind) = 2.0_dp * contactVec
+      ! one PL for contact:
+      newLatVecs(:,ind) = contactVec
       newOrigin = geom%origin
     else
-      newLatVecs(:,1) = 2.0_dp * contactVec
+      ! two PLs:
+      !newLatVecs(:,1) = 2.0_dp * contactVec
+      ! one PL for contact:
+      newLatVecs(:,1) = contactVec
       mask = abs(contactVec) > 1e-8_dp
       ! Workaround for bug in Intel compiler (can not use index function)
       ind = 1
@@ -5543,7 +5559,10 @@ contains
       newLatVecs(:,3) = newLatVecs(:,3) / sqrt(sum(newLatVecs(:,3)**2))
       newOrigin(:) = 0.0_dp
     end if
-    call reduce(geom, contactRange(1), contactRange(2))
+    ! two PLs for contact:
+    !call reduce(geom, contactRange(1),contactRange(2))
+    ! one PL for contact:
+    call reduce(geom, contactRange(1), (contactRange(2)-contactRange(1))/2 + contactRange(1))
     if (.not. geom%tPeriodic) then
       do ii = 2, 3
         minProj = minval(matmul(newLatVecs(:,ii), geom%coords))

--- a/prog/dftb+/lib_dftbplus/transportio.F90
+++ b/prog/dftb+/lib_dftbplus/transportio.F90
@@ -138,7 +138,7 @@ contains
     !> Should a text or binary file be saved
     logical, intent(in), optional :: tWriteAscii
 
-    integer :: fdHS, nAtom, nSpin, iAt, iSp
+    integer :: fdHS, nAtom, nSpin, iAt, iSp, iPL
     logical :: tAsciiFile
 
     nSpin = size(charges, dim=3)
@@ -156,15 +156,23 @@ contains
       ! now with a version number on the top of the file:
       write(fdHS, *) contactFormatVersion
 
-      write(fdHS, *) nAtom, orb%mShell, orb%mOrb, nSpin, allocated(blockCharges)
-      write(fdHS, *) orb%nOrbAtom
-      write(fdHS, *) shiftPerL(:,:,1)
-      write(fdHS, *) charges
+      write(fdHS, *) 2*nAtom, orb%mShell, orb%mOrb, nSpin, allocated(blockCharges)
+      write(fdHS, *) orb%nOrbAtom, orb%nOrbAtom
+      do iPl = 1, 2
+        write(fdHS, *) shiftPerL(:,:nAtom,1)
+      end do
+      do iSp = 1, nSpin
+        do iPl = 1, 2
+          write(fdHS, *) charges(:,:,iSp)
+        end do
+      end do
 
       if (allocated(blockCharges)) then
         do iSp = 1, nSpin
-          do iAt = 1, nAtom
-            write(fdHS, *) blockCharges(:orb%nOrbAtom(iAt), :orb%nOrbAtom(iAt), iAt, iSp)
+          do iPL = 1, 2
+            do iAt = 1, nAtom
+              write(fdHS, *) blockCharges(:orb%nOrbAtom(iAt), :orb%nOrbAtom(iAt), iAt, iSp)
+            end do
           end do
         end do
       end if
@@ -185,15 +193,23 @@ contains
       ! now with a version number on the top of the file:
       write(fdHS) contactFormatVersion
 
-      write(fdHS) nAtom, orb%mShell, orb%mOrb, nSpin, allocated(blockCharges)
-      write(fdHS) orb%nOrbAtom
-      write(fdHS) shiftPerL(:,:,1)
-      write(fdHS) charges
+      write(fdHS) 2*nAtom, orb%mShell, orb%mOrb, nSpin, allocated(blockCharges)
+      write(fdHS) orb%nOrbAtom, orb%nOrbAtom
+      write(fdHS) shiftPerL(:,:nAtom,1), shiftPerL(:,:nAtom,1)
+      select case(nSpin)
+      case(1)
+        write(fdHS) charges(:,:nAtom,1), charges(:,:nAtom,1)
+      case(2)
+        write(fdHS) charges(:,:nAtom,1), charges(:,:nAtom,1), charges(:,:nAtom,2),&
+            & charges(:,:nAtom,2)
+      end select
 
       if (allocated(blockCharges)) then
         do iSp = 1, nSpin
-          do iAt = 1, nAtom
-            write(fdHS) blockCharges(:orb%nOrbAtom(iAt), :orb%nOrbAtom(iAt), iAt, iSp)
+          do iPL = 1, 2
+            do iAt = 1, nAtom
+              write(fdHS) blockCharges(:orb%nOrbAtom(iAt), :orb%nOrbAtom(iAt), iAt, iSp)
+            end do
           end do
         end do
       end if


### PR DESCRIPTION
Use only 1 principle layer in contact calculations, instead of 2. Increases SCC stability and speed (x8) as only half the number of atoms to be solved in the contact.
- [x] reduction to 1 PL in contact calculation
- [x] symmetrize contact PLs in device calculation (should be discussed)
- [ ] atom indexing in contact calculation refer to whole structure numbering
- [ ] Non-scc contact file only needs Fermi energy at the moment (depending on charge upload decisions)
- [ ] contact shift file store contacts and calculation details for how it was generated?