### PR TITLE
Update before Intel one apt-get

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,6 +163,7 @@ jobs:
     - name: Install Intel oneAPI compiler
       if: contains(matrix.os, 'ubuntu')
       run: |
+        sudo apt-get update
         sudo apt-get install ${APT_PACKAGES}
         source /opt/intel/oneapi/setvars.sh
         printenv >> $GITHUB_ENV


### PR DESCRIPTION
As the action failed for the Intel one API build with a not-found error requiring an apt-get update.