### PR TITLE
Add coverage testing via lcov

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,3 +258,15 @@ if(WITH_API)
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
 endif()
+
+
+#
+# Coverage testing related targets
+#
+if(LCOV_REPORT)
+  find_program(LCOV lcov REQUIRED)
+  find_program(GENHTML genhtml)
+  dftbp_create_lcov_targets("${LCOV}" "${GENHTML}" "${CMAKE_CURRENT_BINARY_DIR}/lcov"
+    "${CMAKE_CURRENT_BINARY_DIR}"
+    "${CMAKE_CURRENT_BINARY_DIR}/prog")
+endif()

--- a/config.cmake
+++ b/config.cmake
@@ -131,3 +131,14 @@ set(HYBRID_CONFIG_METHODS "Submodule;Find;Fetch" CACHE STRING
 #
 # Fetch: Fetch the source into the build folder and build the dependency as part of the build
 #     process (works also in cases where the source tree is not a Git repository)
+
+
+#
+# Developer settings
+#
+option(LCOV_REPORT "Whether coverage report should be generated via lcov/genhtml" FALSE)
+# Makes only sense for build type 'Coverage'. Requires lcov and and optionally genhtml to be
+# installed on the system. After building the code, you have to build manually the 'lcov_init'
+# target (e.g. `make lcov_init`), then run the tests (e.g. `ctest`) and finally generate the report
+# with the lcov_report target (e.g. `make lcov_report`). If you only need the evaluated coverage
+# data, but no HTML report, build the `lcov_eval` target instead.

--- a/sys/gnu.cmake
+++ b/sys/gnu.cmake
@@ -33,10 +33,12 @@ set(Fortran_FLAGS_RELWITHDEBINFO "-g ${Fortran_FLAGS_RELEASE}"
 set(Fortran_FLAGS_DEBUG "-g -Wall -std=f2008ts -pedantic -fbounds-check"
   CACHE STRING "Fortran compiler flags for Debug build")
 
+set(Fortran_FLAGS_COVERAGE "-O0 -g --coverage")
+
 # Use intrinsic Fortran 2008 erf/erfc functions
 set(INTERNAL_ERFC CACHE BOOL 0)
 
-set(FYPP_FLAGS "" CACHE STRING "Fypp preprocessor flags")
+set(FYPP_FLAGS "-n" CACHE STRING "Fypp preprocessor flags")
 
 
 #
@@ -53,6 +55,8 @@ set(C_FLAGS_RELWITDEBINFO "-g ${C_FLAGS_RELEASE}"
 
 set(C_FLAGS_DEBUG "-g -Wall -pedantic -fbounds-check"
   CACHE STRING "C compiler flags for Debug build")
+
+set(C_FLAGS_COVERAGE "-O0 -g --coverage")
 
 
 #


### PR DESCRIPTION
Implements local code coverages via LCOV. Codecov integration should be implemented in a follow-up PR.