### PR TITLE
Increase size of long strings

### DIFF
--- a/prog/dftb+/lib_common/accuracy.F90
+++ b/prog/dftb+/lib_common/accuracy.F90
@@ -27,7 +27,7 @@ module dftbp_accuracy
   integer, parameter :: mc = 50
 
   !> length of a long string
-  integer, parameter :: lc = 200
+  integer, parameter :: lc = 1024
 
 
   !> Real double precision - do not edit


### PR DESCRIPTION
As `character(lc)` is often used as container for file paths, its size should be big enough to contain really long path names.