### PR TITLE
Fix the running out of mpi-communicators bug

### DIFF
--- a/prog/dftb+/lib_common/blacsenv.F90
+++ b/prog/dftb+/lib_common/blacsenv.F90
@@ -105,7 +105,7 @@ contains
   subroutine TBlacsEnv_final(this)
 
     !> Initialized instance.
-    type(TBlacsEnv), intent(out) :: this
+    type(TBlacsEnv), intent(inout) :: this
 
     call this%orbitalGrid%destruct()
     call this%atomGrid%destruct()


### PR DESCRIPTION
Even a single little can make much. Hopefully, this fixes the running out of mpi-communicators bug when DFTB+ is called via the API.