### PR TITLE
neighbour based range separated Hamiltonian

### DIFF
--- a/src/dftbp/dftb/rangeseparated.F90
+++ b/src/dftbp/dftb/rangeseparated.F90
@@ -549,6 +549,7 @@ contains
 
     call allocateAndInit(tmpHH, tmpDRho)
     call evaluateHamiltonian()
+    call symmetrizeHS(tmpHH)
     HH(:,:) = HH + tmpHH
     this%lrEnergy = this%lrEnergy + evaluateEnergy(tmpHH, tmpDRho)
 

--- a/src/dftbp/dftb/rangeseparated.F90
+++ b/src/dftbp/dftb/rangeseparated.F90
@@ -746,7 +746,7 @@ contains
 
     complex(dp), allocatable :: Smat(:,:)
     complex(dp), allocatable :: Dmat(:,:)
-    real(dp), allocatable :: LRgammaAO(:,:)
+    real(dp), allocatable :: LrGammaAO(:,:)
     complex(dp), allocatable :: gammaCmplx(:,:)
     complex(dp), allocatable :: Hlr(:,:)
 
@@ -756,11 +756,11 @@ contains
 
     allocate(Smat(nOrb,nOrb))
     allocate(Dmat(nOrb,nOrb))
-    allocate(LRgammaAO(nOrb,nOrb))
+    allocate(LrGammaAO(nOrb,nOrb))
     allocate(gammaCmplx(nOrb,nOrb))
     allocate(Hlr(nOrb,nOrb))
 
-    call allocateAndInit(this, iSquare, overlap, densSqr, HH, Smat, Dmat, LRgammaAO, gammaCmplx)
+    call allocateAndInit(this, iSquare, overlap, densSqr, HH, Smat, Dmat, LrGammaAO, gammaCmplx)
 
     call evaluateHamiltonian(this, Smat, Dmat, gammaCmplx, Hlr)
 
@@ -770,7 +770,7 @@ contains
 
   contains
 
-    subroutine allocateAndInit(this, iSquare, overlap, densSqr, HH, Smat, Dmat, LRgammaAO,&
+    subroutine allocateAndInit(this, iSquare, overlap, densSqr, HH, Smat, Dmat, LrGammaAO,&
         & gammaCmplx)
 
       !> instance
@@ -795,7 +795,7 @@ contains
       complex(dp), intent(out) :: Dmat(:,:)
 
       !> Symmetrized long-range gamma matrix
-      real(dp), intent(out) :: LRgammaAO(:,:)
+      real(dp), intent(out) :: LrGammaAO(:,:)
 
       !> Symmetrized long-range gamma matrix
       complex(dp), intent(out) :: gammaCmplx(:,:)
@@ -812,14 +812,14 @@ contains
       call hermitianSquareMatrix(Dmat)
 
       ! Get long-range gamma variable
-      LRgammaAO(:,:) = 0.0_dp
+      LrGammaAO(:,:) = 0.0_dp
       do iAt = 1, nAtom
         do jAt = 1, nAtom
-          LRgammaAO(iSquare(jAt):iSquare(jAt+1)-1,iSquare(iAt):iSquare(iAt+1)-1) =&
+          LrGammaAO(iSquare(jAt):iSquare(jAt+1)-1,iSquare(iAt):iSquare(iAt+1)-1) =&
               & this%lrGammaEval(jAt,iAt)
         end do
       end do
-      gammaCmplx = LRgammaAO
+      gammaCmplx = LrGammaAO
 
     end subroutine allocateAndInit
 

--- a/src/dftbp/reks/reksgrad.F90
+++ b/src/dftbp/reks/reksgrad.F90
@@ -2753,10 +2753,10 @@ contains
 
         if (isRangeSep) then
 
-          tmpL1 = LRgammaAO(mu,gam)
-          tmpL2 = LRgammaAO(mu,nu)
-          tmpL3 = LRgammaAO(tau,gam)
-          tmpL4 = LRgammaAO(tau,nu)
+          tmpL1 = LrGammaAO(mu,gam)
+          tmpL2 = LrGammaAO(mu,nu)
+          tmpL3 = LrGammaAO(tau,gam)
+          tmpL4 = LrGammaAO(tau,nu)
 
           HxcSqrS(mu,nu,tau,gam) = HxcSqrS(mu,nu,tau,gam) - 0.25_dp &
               & * overSqr(mu,tau) * overSqr(nu,gam) * (tmpL1+tmpL2+tmpL3+tmpL4)

--- a/src/dftbp/reks/reksinterface.F90
+++ b/src/dftbp/reks/reksinterface.F90
@@ -997,8 +997,7 @@ module dftbp_reks_reksinterface
     !> data type for REKS
     type(TReksCalc), intent(inout) :: this
 
-    ! get gamma, spinW, gamma deriv, LR-gamma deriv, on-site constants
-    ! LRgamma is already defined in 1st scc loop
+    ! get gamma, spinW, gamma deriv, LR-gamma, LR-gamma deriv, on-site constants
     call getSccSpinLrPars(env, sccCalc, rangeSep, coord, species, &
         & neighbourList%iNeighbour, img2CentCell, denseDesc%iAtomStart, &
         & spinW, this%getAtomIndex, this%isRangeSep, this%GammaAO, &


### PR DESCRIPTION
When we use 'NeighbourBased' screening method, only upper-triangular LC matrix is generated.
Since REKS calculation requires fully-symmetrized LC hamiltonian, I simply add single line.