### PR TITLE
Allow finding Slater–Koster files in DFTBPLUS_PARAM_DIR

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ Addded
 
 - Support for extended tight binding (xTB) Hamiltonian via tblite library
 
+- DFTBPLUS_PARAM_DIR for searching Slater-Koster parameter files, solvation parameter files,
+  and xTB parameter files
+
 Changed
 -------
 

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -1478,6 +1478,9 @@ is built with support for a communication bridge to the \texttt{tblite} library.
   be generated using the \texttt{tblite} command line driver.
   If present \kw{Method} must not be provided.
 
+  This file is additionally searched for in the directory specified with the
+  \texttt{DFTBPLUS\_PARAM\_DIR} environment variable.
+
 \item[\is{SCCTolerance}] Stopping criteria for the SCC.  Specifies the
   tolerance for the maximum difference in any charge between two SCC
   cycles.
@@ -2256,6 +2259,9 @@ S0 -> S1:                            0.2615036445 H            7.1159 eV
 There are two different ways to specify the Slater-Koster files for
 the atom type pairs, explicit specification and using the
 \iscb{Type2FileNames} method.
+
+All specified Slater-Koster files are additionally searched for in directory specified in the
+\texttt{DFTBPLUS\_PARAM\_DIR} environment variable.
 
 \subsubsection{Explicit specification}
 
@@ -3418,6 +3424,9 @@ systems.
     values for \is{FreeEnergyShift}, \is{BornOffset}, \is{BornScale}, \is{SASA\cb}
     \is{Descreening}, \is{HBondCorr} and \is{HBondStrength}.
     Usually no other keywords need to be specified when \is{ParamFile} is present.
+
+    This file is additionally searched for in the directory specified with the
+    \texttt{DFTBPLUS\_PARAM\_DIR} environment variable.
 
   \item[\is{Solvent}] Descriptors of the solvent, can be load from a database
     by providing the solvent name as string in the \is{FromName\cb} method or

--- a/src/dftbp/common/CMakeLists.txt
+++ b/src/dftbp/common/CMakeLists.txt
@@ -9,6 +9,7 @@ set(sources-fpp
   ${curdir}/constants.F90
   ${curdir}/environment.F90
   ${curdir}/fileregistry.F90
+  ${curdir}/filesystem.F90
   ${curdir}/globalenv.F90
   ${curdir}/hamiltoniantypes.F90
   ${curdir}/memman.F90

--- a/src/dftbp/common/filesystem.F90
+++ b/src/dftbp/common/filesystem.F90
@@ -9,17 +9,28 @@
 
 !> File system utilities
 module dftbp_common_filesystem
+  use dftbp_extlibs_xmlf90, only : string, char, assignment(=)
   implicit none
   private
 
-  public :: getEnvVar, isAbsolutePath
+  public :: getEnvVar, isAbsolutePath, pathJoin, findFile, getParamSearchPath
+
+
+  !> Whether the operating system we are using is UNIX (FIXME: use preprocessor here instead)
+  logical, parameter :: is_unix = .true.
+
+  !> Path separator for this platform
+  character(len=*), parameter :: separator = merge("/", "\", is_unix)
+
+  !> Environment variable containing parameter directory for DFTB+
+  character(len=*), parameter :: paramEnv = "DFTBPLUS_PARAM_DIR"
 
 
 contains
 
 
   !> Check whether a file path is absolute
-  function isAbsolutePath(path) result(absolute)
+  pure function isAbsolutePath(path) result(absolute)
 
     !> Name of variable
     character(len=*), intent(in) :: path
@@ -27,9 +38,13 @@ contains
     !> Absolute file path
     logical :: absolute
 
-    character(len=*), parameter :: chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    character(len=*), parameter :: chars = &
+        & "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
-    absolute = index(path, "/") == 1 .or. index(path, ":\") == 2 .and. scan(path, chars) == 1
+    absolute = index(path, separator) == 1
+    if (.not.(is_unix.or.absolute)) then
+      absolute = scan(path, chars) == 1 .and. index(path, ":") == 2 .and. scan(path, "\/") == 3
+    end if
   end function isAbsolutePath
 
 
@@ -47,12 +62,12 @@ contains
     call get_environment_variable(var, length=length, status=stat)
     if (stat /= 0) then
       return
-    endif
+    end if
 
     allocate(character(len=length) :: val, stat=stat)
     if (stat /= 0) then
       return
-    endif
+    end if
 
     if (length > 0) then
       call get_environment_variable(var, val, status=stat)
@@ -62,6 +77,79 @@ contains
       end if
     end if
   end subroutine getEnvVar
+
+
+  !> Join two paths together
+  pure function pathJoin(prefix, suffix) result(path)
+
+    !> First path component
+    character(len=*), intent(in) :: prefix
+
+    !> Next path component
+    character(len=*), intent(in) :: suffix
+
+    !> Joined path
+    character(len=:), allocatable :: path
+
+    if (isAbsolutePath(suffix)) then
+      path = suffix
+    else
+      path = prefix // separator // suffix
+    end if
+  end function pathJoin
+
+
+  !> Find a file in a PATH-like context
+  subroutine findFile(searchPath, inName, outName)
+
+    !> Paths to search in, the current working directory is always searched first
+    type(string), intent(in) :: searchPath(:)
+
+    !> File to search for
+    character(len=*), intent(in) :: inName
+
+    !> Contains first match on output, unallocated if no file was found
+    character(len=:), allocatable :: outName
+
+    integer :: ip
+    logical :: exists
+
+    if (isAbsolutePath(inName)) then
+      outName = trim(inName)
+      return
+    end if
+
+    inquire(file=inName, exist=exists)
+    if (exists) then
+      outName = trim(inName)
+      return
+    end if
+
+    do ip = 1, size(searchPath)
+      outName = pathJoin(char(searchPath(ip)), trim(inName))
+      inquire(file=outName, exist=exists)
+      if (exists) exit
+    end do
+
+    if (.not.exists .and. allocated(outName)) deallocate(outName)
+  end subroutine findFile
+
+
+  !> Get the environment variable describing the search path for DFTB+
+  subroutine getParamSearchPath(path)
+    type(string), allocatable, intent(out) :: path(:)
+
+    character(len=:), allocatable :: var
+
+    call getEnvVar(paramEnv, var)
+
+    if (allocated(var)) then
+      allocate(path(1))
+      path(1) = var
+    else
+      allocate(path(0))
+    end if
+  end subroutine getParamSearchPath
 
 
 end module dftbp_common_filesystem

--- a/src/dftbp/common/filesystem.F90
+++ b/src/dftbp/common/filesystem.F90
@@ -54,7 +54,7 @@ contains
     !> Name of variable
     character(len=*), intent(in) :: var
 
-    !> Value of variable
+    !> Value of variable. Unallocated, if variable could not be retrieved.
     character(len=:), allocatable, intent(out) :: val
 
     integer :: length, stat

--- a/src/dftbp/common/filesystem.F90
+++ b/src/dftbp/common/filesystem.F90
@@ -1,0 +1,67 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2021  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+#:include 'common.fypp'
+
+!> File system utilities
+module dftbp_common_filesystem
+  implicit none
+  private
+
+  public :: getEnvVar, isAbsolutePath
+
+
+contains
+
+
+  !> Check whether a file path is absolute
+  function isAbsolutePath(path) result(absolute)
+
+    !> Name of variable
+    character(len=*), intent(in) :: path
+
+    !> Absolute file path
+    logical :: absolute
+
+    character(len=*), parameter :: chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+    absolute = index(path, "/") == 1 .or. index(path, ":\") == 2 .and. scan(path, chars) == 1
+  end function isAbsolutePath
+
+
+  !> Obtain the value of an environment variable
+  subroutine getEnvVar(var, val)
+
+    !> Name of variable
+    character(len=*), intent(in) :: var
+
+    !> Value of variable
+    character(len=:), allocatable, intent(out) :: val
+
+    integer :: length, stat
+
+    call get_environment_variable(var, length=length, status=stat)
+    if (stat /= 0) then
+      return
+    endif
+
+    allocate(character(len=length) :: val, stat=stat)
+    if (stat /= 0) then
+      return
+    endif
+
+    if (length > 0) then
+      call get_environment_variable(var, val, status=stat)
+      if (stat /= 0) then
+        deallocate(val)
+        return
+      end if
+    end if
+  end subroutine getEnvVar
+
+
+end module dftbp_common_filesystem

--- a/src/dftbp/common/filesystem.F90
+++ b/src/dftbp/common/filesystem.F90
@@ -13,7 +13,7 @@ module dftbp_common_filesystem
   implicit none
   private
 
-  public :: getEnvVar, isAbsolutePath, pathJoin, findFile, getParamSearchPath
+  public :: getEnvVar, isAbsolutePath, joinPaths, findFile, getParamSearchPath
 
 
   !> Whether the operating system we are using is UNIX (FIXME: use preprocessor here instead)
@@ -80,7 +80,7 @@ contains
 
 
   !> Join two paths together
-  pure function pathJoin(prefix, suffix) result(path)
+  pure function joinPaths(prefix, suffix) result(path)
 
     !> First path component
     character(len=*), intent(in) :: prefix
@@ -96,7 +96,7 @@ contains
     else
       path = prefix // separator // suffix
     end if
-  end function pathJoin
+  end function joinPaths
 
 
   !> Find a file in a PATH-like context
@@ -126,7 +126,7 @@ contains
     end if
 
     do ip = 1, size(searchPath)
-      outName = pathJoin(char(searchPath(ip)), trim(inName))
+      outName = joinPaths(char(searchPath(ip)), trim(inName))
       inquire(file=outName, exist=exists)
       if (exists) exit
     end do

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -3358,6 +3358,7 @@ contains
             readRep = (iSK1 == 1 .and. iSK2 == 1)
             readAtomic = (iSp1 == iSp2 .and. iSK1 == iSK2)
             call get(skFiles(iSp2, iSp1), fileName, ind)
+            write(stdOut, "(a)") trim(fileName)
             if (.not. present(rangeSepSK)) then
               if (readRep .and. repPoly(iSp2, iSp1)) then
                 call readFromFile(skData12(iSK2,iSK1), fileName, readAtomic, repPolyIn=repPolyIn1)

--- a/test/app/dftb+/CMakeLists.txt
+++ b/test/app/dftb+/CMakeLists.txt
@@ -34,4 +34,8 @@ foreach(test IN LISTS tests)
         -r ${srcdir} -w ${builddir} -d ${srcdir}/bin/tagdiff
         -P "${TEST_RUNNER}" -p "$<TARGET_FILE:dftb+>"
         -s P,R,C,S ${test})
+  set_tests_properties(
+    dftb+_${test}
+    PROPERTIES
+    ENVIRONMENT "DFTBPLUS_PATH=${PROJECT_SOURCE_DIR}/external/slakos/origin")
 endforeach()

--- a/test/app/dftb+/CMakeLists.txt
+++ b/test/app/dftb+/CMakeLists.txt
@@ -37,5 +37,5 @@ foreach(test IN LISTS tests)
   set_tests_properties(
     dftb+_${test}
     PROPERTIES
-    ENVIRONMENT "DFTBPLUS_PATH=${PROJECT_SOURCE_DIR}/external/slakos/origin")
+    ENVIRONMENT "DFTBPLUS_PARAM_DIR=${PROJECT_SOURCE_DIR}/external")
 endforeach()

--- a/test/app/dftb+/scc/10-0Ctube-extfield/C-C.skf
+++ b/test/app/dftb+/scc/10-0Ctube-extfield/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-C.skf

--- a/test/app/dftb+/scc/10-0Ctube-extfield/dftb_in.hsd
+++ b/test/app/dftb+/scc/10-0Ctube-extfield/dftb_in.hsd
@@ -58,7 +58,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 77
   }
   SlaterKosterFiles = {
-    C-C = "pbc-0-3/C-C.skf"
+    C-C = "slakos/origin/pbc-0-3/C-C.skf"
   }
   KPointsAndWeights = SupercellFolding {
    1 0 0

--- a/test/app/dftb+/scc/10-0Ctube-extfield/dftb_in.hsd
+++ b/test/app/dftb+/scc/10-0Ctube-extfield/dftb_in.hsd
@@ -58,7 +58,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 77
   }
   SlaterKosterFiles = {
-    C-C = "./C-C.skf"
+    C-C = "pbc-0-3/C-C.skf"
   }
   KPointsAndWeights = SupercellFolding {
    1 0 0

--- a/test/app/dftb+/scc/2H2O-3rdorder/H-H.skf
+++ b/test/app/dftb+/scc/2H2O-3rdorder/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/2H2O-3rdorder/H-O.skf
+++ b/test/app/dftb+/scc/2H2O-3rdorder/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/scc/2H2O-3rdorder/O-H.skf
+++ b/test/app/dftb+/scc/2H2O-3rdorder/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/scc/2H2O-3rdorder/O-O.skf
+++ b/test/app/dftb+/scc/2H2O-3rdorder/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/scc/2H2O-3rdorder/dftb_in.hsd
+++ b/test/app/dftb+/scc/2H2O-3rdorder/dftb_in.hsd
@@ -19,6 +19,7 @@ Hamiltonian = DFTB {
     O = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/2H2O-3rdorder/dftb_in.hsd
+++ b/test/app/dftb+/scc/2H2O-3rdorder/dftb_in.hsd
@@ -19,7 +19,7 @@ Hamiltonian = DFTB {
     O = "p"
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/2H2O-3rdorder_read/H-H.skf
+++ b/test/app/dftb+/scc/2H2O-3rdorder_read/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/2H2O-3rdorder_read/H-O.skf
+++ b/test/app/dftb+/scc/2H2O-3rdorder_read/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/scc/2H2O-3rdorder_read/O-H.skf
+++ b/test/app/dftb+/scc/2H2O-3rdorder_read/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/scc/2H2O-3rdorder_read/O-O.skf
+++ b/test/app/dftb+/scc/2H2O-3rdorder_read/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/scc/2H2O-3rdorder_read/dftb_in.hsd
+++ b/test/app/dftb+/scc/2H2O-3rdorder_read/dftb_in.hsd
@@ -21,6 +21,7 @@ Hamiltonian = DFTB {
     O = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/2H2O-3rdorder_read/dftb_in.hsd
+++ b/test/app/dftb+/scc/2H2O-3rdorder_read/dftb_in.hsd
@@ -21,7 +21,7 @@ Hamiltonian = DFTB {
     O = "p"
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/C2H6_3rdfull-damp/C-C.skf
+++ b/test/app/dftb+/scc/C2H6_3rdfull-damp/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/scc/C2H6_3rdfull-damp/C-H.skf
+++ b/test/app/dftb+/scc/C2H6_3rdfull-damp/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/scc/C2H6_3rdfull-damp/H-C.skf
+++ b/test/app/dftb+/scc/C2H6_3rdfull-damp/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/scc/C2H6_3rdfull-damp/H-H.skf
+++ b/test/app/dftb+/scc/C2H6_3rdfull-damp/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/C2H6_3rdfull-damp/dftb_in.hsd
+++ b/test/app/dftb+/scc/C2H6_3rdfull-damp/dftb_in.hsd
@@ -20,7 +20,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/C2H6_3rdfull-damp/dftb_in.hsd
+++ b/test/app/dftb+/scc/C2H6_3rdfull-damp/dftb_in.hsd
@@ -20,6 +20,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/C2H6_3rdfull/C-C.skf
+++ b/test/app/dftb+/scc/C2H6_3rdfull/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/scc/C2H6_3rdfull/C-H.skf
+++ b/test/app/dftb+/scc/C2H6_3rdfull/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/scc/C2H6_3rdfull/H-C.skf
+++ b/test/app/dftb+/scc/C2H6_3rdfull/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/scc/C2H6_3rdfull/H-H.skf
+++ b/test/app/dftb+/scc/C2H6_3rdfull/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/C2H6_3rdfull/dftb_in.hsd
+++ b/test/app/dftb+/scc/C2H6_3rdfull/dftb_in.hsd
@@ -20,7 +20,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/C2H6_3rdfull/dftb_in.hsd
+++ b/test/app/dftb+/scc/C2H6_3rdfull/dftb_in.hsd
@@ -20,6 +20,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/C4H8_3rdfull-damp/C-C.skf
+++ b/test/app/dftb+/scc/C4H8_3rdfull-damp/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/scc/C4H8_3rdfull-damp/C-H.skf
+++ b/test/app/dftb+/scc/C4H8_3rdfull-damp/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/scc/C4H8_3rdfull-damp/H-C.skf
+++ b/test/app/dftb+/scc/C4H8_3rdfull-damp/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/scc/C4H8_3rdfull-damp/H-H.skf
+++ b/test/app/dftb+/scc/C4H8_3rdfull-damp/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/C4H8_3rdfull-damp/dftb_in.hsd
+++ b/test/app/dftb+/scc/C4H8_3rdfull-damp/dftb_in.hsd
@@ -25,7 +25,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/C4H8_3rdfull-damp/dftb_in.hsd
+++ b/test/app/dftb+/scc/C4H8_3rdfull-damp/dftb_in.hsd
@@ -25,6 +25,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/C4H8_3rdfull/C-C.skf
+++ b/test/app/dftb+/scc/C4H8_3rdfull/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/scc/C4H8_3rdfull/C-H.skf
+++ b/test/app/dftb+/scc/C4H8_3rdfull/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/scc/C4H8_3rdfull/H-C.skf
+++ b/test/app/dftb+/scc/C4H8_3rdfull/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/scc/C4H8_3rdfull/H-H.skf
+++ b/test/app/dftb+/scc/C4H8_3rdfull/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/C4H8_3rdfull/dftb_in.hsd
+++ b/test/app/dftb+/scc/C4H8_3rdfull/dftb_in.hsd
@@ -24,7 +24,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/C4H8_3rdfull/dftb_in.hsd
+++ b/test/app/dftb+/scc/C4H8_3rdfull/dftb_in.hsd
@@ -24,6 +24,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/C60/C-C.skf
+++ b/test/app/dftb+/scc/C60/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/scc/C60/dftb_in.hsd
+++ b/test/app/dftb+/scc/C60/dftb_in.hsd
@@ -77,7 +77,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 400.000000000000
   }
   SlaterKosterFiles = {
-    C-C = "mio-1-1/C-C.skf"
+    C-C = "slakos/origin/mio-1-1/C-C.skf"
   }
 }
 

--- a/test/app/dftb+/scc/C60/dftb_in.hsd
+++ b/test/app/dftb+/scc/C60/dftb_in.hsd
@@ -77,7 +77,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 400.000000000000
   }
   SlaterKosterFiles = {
-    C-C = "C-C.skf"
+    C-C = "mio-1-1/C-C.skf"
   }
 }
 

--- a/test/app/dftb+/scc/C60_Fermi/C-C.skf
+++ b/test/app/dftb+/scc/C60_Fermi/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/scc/C60_Fermi/dftb_in.hsd
+++ b/test/app/dftb+/scc/C60_Fermi/dftb_in.hsd
@@ -79,7 +79,7 @@ Hamiltonian = DFTB {
     FixedFermiLevel [eV] = -9.2337
   }
   SlaterKosterFiles = {
-    C-C = "C-C.skf"
+    C-C = "mio-1-1/C-C.skf"
   }
 }
 

--- a/test/app/dftb+/scc/C60_Fermi/dftb_in.hsd
+++ b/test/app/dftb+/scc/C60_Fermi/dftb_in.hsd
@@ -79,7 +79,7 @@ Hamiltonian = DFTB {
     FixedFermiLevel [eV] = -9.2337
   }
   SlaterKosterFiles = {
-    C-C = "mio-1-1/C-C.skf"
+    C-C = "slakos/origin/mio-1-1/C-C.skf"
   }
 }
 

--- a/test/app/dftb+/scc/CH2_n_3rdfull/C-C.skf
+++ b/test/app/dftb+/scc/CH2_n_3rdfull/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/scc/CH2_n_3rdfull/C-H.skf
+++ b/test/app/dftb+/scc/CH2_n_3rdfull/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/scc/CH2_n_3rdfull/H-C.skf
+++ b/test/app/dftb+/scc/CH2_n_3rdfull/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/scc/CH2_n_3rdfull/H-H.skf
+++ b/test/app/dftb+/scc/CH2_n_3rdfull/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/CH2_n_3rdfull/dftb_in.hsd
+++ b/test/app/dftb+/scc/CH2_n_3rdfull/dftb_in.hsd
@@ -21,6 +21,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/CH2_n_3rdfull/dftb_in.hsd
+++ b/test/app/dftb+/scc/CH2_n_3rdfull/dftb_in.hsd
@@ -21,7 +21,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/CH2_n_3rdfull_damp/C-C.skf
+++ b/test/app/dftb+/scc/CH2_n_3rdfull_damp/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/scc/CH2_n_3rdfull_damp/C-H.skf
+++ b/test/app/dftb+/scc/CH2_n_3rdfull_damp/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/scc/CH2_n_3rdfull_damp/H-C.skf
+++ b/test/app/dftb+/scc/CH2_n_3rdfull_damp/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/scc/CH2_n_3rdfull_damp/H-H.skf
+++ b/test/app/dftb+/scc/CH2_n_3rdfull_damp/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/CH2_n_3rdfull_damp/dftb_in.hsd
+++ b/test/app/dftb+/scc/CH2_n_3rdfull_damp/dftb_in.hsd
@@ -21,6 +21,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/CH2_n_3rdfull_damp/dftb_in.hsd
+++ b/test/app/dftb+/scc/CH2_n_3rdfull_damp/dftb_in.hsd
@@ -21,7 +21,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/GaAs_2/As-As.skf
+++ b/test/app/dftb+/scc/GaAs_2/As-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-As.skf

--- a/test/app/dftb+/scc/GaAs_2/As-Ga.skf
+++ b/test/app/dftb+/scc/GaAs_2/As-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-Ga.skf

--- a/test/app/dftb+/scc/GaAs_2/Ga-As.skf
+++ b/test/app/dftb+/scc/GaAs_2/Ga-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-As.skf

--- a/test/app/dftb+/scc/GaAs_2/Ga-Ga.skf
+++ b/test/app/dftb+/scc/GaAs_2/Ga-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-Ga.skf

--- a/test/app/dftb+/scc/GaAs_2/dftb_in.hsd
+++ b/test/app/dftb+/scc/GaAs_2/dftb_in.hsd
@@ -24,10 +24,10 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.0E-006
   }
   SlaterKosterFiles = {
-    Ga-Ga = "hyb-0-2/Ga-Ga.skf"
-    Ga-As = "hyb-0-2/Ga-As.skf"
-    As-Ga = "hyb-0-2/As-Ga.skf"
-    As-As = "hyb-0-2/As-As.skf"
+    Ga-Ga = "slakos/origin/hyb-0-2/Ga-Ga.skf"
+    Ga-As = "slakos/origin/hyb-0-2/Ga-As.skf"
+    As-Ga = "slakos/origin/hyb-0-2/As-Ga.skf"
+    As-As = "slakos/origin/hyb-0-2/As-As.skf"
   }
   KPointsAndWeights = {
  0.000000000000000E+000 0.000000000000000E+000 0.000000000000000E+000 1.00000000000000

--- a/test/app/dftb+/scc/GaAs_2/dftb_in.hsd
+++ b/test/app/dftb+/scc/GaAs_2/dftb_in.hsd
@@ -24,10 +24,10 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.0E-006
   }
   SlaterKosterFiles = {
-    Ga-Ga = "./Ga-Ga.skf"
-    Ga-As = "./Ga-As.skf"
-    As-Ga = "./As-Ga.skf"
-    As-As = "./As-As.skf"
+    Ga-Ga = "hyb-0-2/Ga-Ga.skf"
+    Ga-As = "hyb-0-2/Ga-As.skf"
+    As-Ga = "hyb-0-2/As-Ga.skf"
+    As-As = "hyb-0-2/As-As.skf"
   }
   KPointsAndWeights = {
  0.000000000000000E+000 0.000000000000000E+000 0.000000000000000E+000 1.00000000000000

--- a/test/app/dftb+/scc/GaAs_2_customU/As-As.skf
+++ b/test/app/dftb+/scc/GaAs_2_customU/As-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-As.skf

--- a/test/app/dftb+/scc/GaAs_2_customU/As-Ga.skf
+++ b/test/app/dftb+/scc/GaAs_2_customU/As-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-Ga.skf

--- a/test/app/dftb+/scc/GaAs_2_customU/Ga-As.skf
+++ b/test/app/dftb+/scc/GaAs_2_customU/Ga-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-As.skf

--- a/test/app/dftb+/scc/GaAs_2_customU/Ga-Ga.skf
+++ b/test/app/dftb+/scc/GaAs_2_customU/Ga-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-Ga.skf

--- a/test/app/dftb+/scc/GaAs_2_customU/dftb_in.hsd
+++ b/test/app/dftb+/scc/GaAs_2_customU/dftb_in.hsd
@@ -24,10 +24,10 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.0E-006
   }
   SlaterKosterFiles {
-    Ga-Ga = "./Ga-Ga.skf"
-    Ga-As = "./Ga-As.skf"
-    As-Ga = "./As-Ga.skf"
-    As-As = "./As-As.skf"
+    Ga-Ga = "hyb-0-2/Ga-Ga.skf"
+    Ga-As = "hyb-0-2/Ga-As.skf"
+    As-Ga = "hyb-0-2/As-Ga.skf"
+    As-As = "hyb-0-2/As-As.skf"
   }
   CustomisedHubbards {
     Ga = 0.12

--- a/test/app/dftb+/scc/GaAs_2_customU/dftb_in.hsd
+++ b/test/app/dftb+/scc/GaAs_2_customU/dftb_in.hsd
@@ -24,10 +24,10 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.0E-006
   }
   SlaterKosterFiles {
-    Ga-Ga = "hyb-0-2/Ga-Ga.skf"
-    Ga-As = "hyb-0-2/Ga-As.skf"
-    As-Ga = "hyb-0-2/As-Ga.skf"
-    As-As = "hyb-0-2/As-As.skf"
+    Ga-Ga = "slakos/origin/hyb-0-2/Ga-Ga.skf"
+    Ga-As = "slakos/origin/hyb-0-2/Ga-As.skf"
+    As-Ga = "slakos/origin/hyb-0-2/As-Ga.skf"
+    As-As = "slakos/origin/hyb-0-2/As-As.skf"
   }
   CustomisedHubbards {
     Ga = 0.12

--- a/test/app/dftb+/scc/GaAs_2_restart/As-As.skf
+++ b/test/app/dftb+/scc/GaAs_2_restart/As-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-As.skf

--- a/test/app/dftb+/scc/GaAs_2_restart/As-Ga.skf
+++ b/test/app/dftb+/scc/GaAs_2_restart/As-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-Ga.skf

--- a/test/app/dftb+/scc/GaAs_2_restart/Ga-As.skf
+++ b/test/app/dftb+/scc/GaAs_2_restart/Ga-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-As.skf

--- a/test/app/dftb+/scc/GaAs_2_restart/Ga-Ga.skf
+++ b/test/app/dftb+/scc/GaAs_2_restart/Ga-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-Ga.skf

--- a/test/app/dftb+/scc/GaAs_2_restart/dftb_in1.hsd
+++ b/test/app/dftb+/scc/GaAs_2_restart/dftb_in1.hsd
@@ -15,6 +15,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 500
     }
     SlaterKosterFiles = Type2FileNames {
+        Prefix = "hyb-0-2/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/scc/GaAs_2_restart/dftb_in1.hsd
+++ b/test/app/dftb+/scc/GaAs_2_restart/dftb_in1.hsd
@@ -15,7 +15,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 500
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "hyb-0-2/"
+        Prefix = "slakos/origin/hyb-0-2/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/scc/GaAs_2_restart/dftb_in2.hsd
+++ b/test/app/dftb+/scc/GaAs_2_restart/dftb_in2.hsd
@@ -16,7 +16,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 500
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "hyb-0-2/"
+        Prefix = "slakos/origin/hyb-0-2/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/scc/GaAs_2_restart/dftb_in2.hsd
+++ b/test/app/dftb+/scc/GaAs_2_restart/dftb_in2.hsd
@@ -16,6 +16,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 500
     }
     SlaterKosterFiles = Type2FileNames {
+        Prefix = "hyb-0-2/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/scc/H-chain/H-H.skf
+++ b/test/app/dftb+/scc/H-chain/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/H-chain/dftb_in.hsd
+++ b/test/app/dftb+/scc/H-chain/dftb_in.hsd
@@ -12,6 +12,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0
   }
   SlaterKosterFiles = Type2Filenames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/scc/H-chain/dftb_in.hsd
+++ b/test/app/dftb+/scc/H-chain/dftb_in.hsd
@@ -12,7 +12,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0
   }
   SlaterKosterFiles = Type2Filenames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/C-C.skf
+++ b/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/C-H.skf
+++ b/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/C-O.skf
+++ b/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/H-C.skf
+++ b/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/H-H.skf
+++ b/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/H-O.skf
+++ b/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/O-C.skf
+++ b/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/O-H.skf
+++ b/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/O-O.skf
+++ b/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/dftb_in.hsd
@@ -24,7 +24,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O+CH3COOH-3rdorder/dftb_in.hsd
@@ -24,6 +24,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/H2O-extchrg-blur/H-H.skf
+++ b/test/app/dftb+/scc/H2O-extchrg-blur/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/H2O-extchrg-blur/H-O.skf
+++ b/test/app/dftb+/scc/H2O-extchrg-blur/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/scc/H2O-extchrg-blur/O-H.skf
+++ b/test/app/dftb+/scc/H2O-extchrg-blur/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/scc/H2O-extchrg-blur/O-O.skf
+++ b/test/app/dftb+/scc/H2O-extchrg-blur/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/scc/H2O-extchrg-blur/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O-extchrg-blur/dftb_in.hsd
@@ -20,6 +20,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/scc/H2O-extchrg-blur/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O-extchrg-blur/dftb_in.hsd
@@ -20,7 +20,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/scc/H2O-extchrg-direct/H-H.skf
+++ b/test/app/dftb+/scc/H2O-extchrg-direct/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/H2O-extchrg-direct/H-O.skf
+++ b/test/app/dftb+/scc/H2O-extchrg-direct/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/scc/H2O-extchrg-direct/O-H.skf
+++ b/test/app/dftb+/scc/H2O-extchrg-direct/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/scc/H2O-extchrg-direct/O-O.skf
+++ b/test/app/dftb+/scc/H2O-extchrg-direct/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/scc/H2O-extchrg-direct/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O-extchrg-direct/dftb_in.hsd
@@ -20,6 +20,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/scc/H2O-extchrg-direct/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O-extchrg-direct/dftb_in.hsd
@@ -20,7 +20,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/scc/H2O-extchrg-periodic/H-H.skf
+++ b/test/app/dftb+/scc/H2O-extchrg-periodic/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/H2O-extchrg-periodic/H-O.skf
+++ b/test/app/dftb+/scc/H2O-extchrg-periodic/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/scc/H2O-extchrg-periodic/O-H.skf
+++ b/test/app/dftb+/scc/H2O-extchrg-periodic/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/scc/H2O-extchrg-periodic/O-O.skf
+++ b/test/app/dftb+/scc/H2O-extchrg-periodic/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/scc/H2O-extchrg-periodic/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O-extchrg-periodic/dftb_in.hsd
@@ -25,7 +25,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/scc/H2O-extchrg-periodic/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O-extchrg-periodic/dftb_in.hsd
@@ -25,6 +25,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/scc/H2O-extchrg/H-H.skf
+++ b/test/app/dftb+/scc/H2O-extchrg/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/H2O-extchrg/H-O.skf
+++ b/test/app/dftb+/scc/H2O-extchrg/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/scc/H2O-extchrg/O-H.skf
+++ b/test/app/dftb+/scc/H2O-extchrg/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/scc/H2O-extchrg/O-O.skf
+++ b/test/app/dftb+/scc/H2O-extchrg/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/scc/H2O-extchrg/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O-extchrg/dftb_in.hsd
@@ -20,7 +20,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/H2O-extchrg/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O-extchrg/dftb_in.hsd
@@ -20,6 +20,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/H2O-extfield/H-H.skf
+++ b/test/app/dftb+/scc/H2O-extfield/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/H2O-extfield/H-O.skf
+++ b/test/app/dftb+/scc/H2O-extfield/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/scc/H2O-extfield/O-H.skf
+++ b/test/app/dftb+/scc/H2O-extfield/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/scc/H2O-extfield/O-O.skf
+++ b/test/app/dftb+/scc/H2O-extfield/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/scc/H2O-extfield/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O-extfield/dftb_in.hsd
@@ -20,6 +20,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/scc/H2O-extfield/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O-extfield/dftb_in.hsd
@@ -20,7 +20,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/scc/H2O2-3rdfull-ldep/H-H.skf
+++ b/test/app/dftb+/scc/H2O2-3rdfull-ldep/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/H2O2-3rdfull-ldep/H-O.skf
+++ b/test/app/dftb+/scc/H2O2-3rdfull-ldep/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/scc/H2O2-3rdfull-ldep/O-H.skf
+++ b/test/app/dftb+/scc/H2O2-3rdfull-ldep/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/scc/H2O2-3rdfull-ldep/O-O.skf
+++ b/test/app/dftb+/scc/H2O2-3rdfull-ldep/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/scc/H2O2-3rdfull-ldep/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O2-3rdfull-ldep/dftb_in.hsd
@@ -12,6 +12,7 @@ Hamiltonian = DFTB {
     O = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/H2O2-3rdfull-ldep/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O2-3rdfull-ldep/dftb_in.hsd
@@ -12,7 +12,7 @@ Hamiltonian = DFTB {
     O = "p"
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/H2O2_3rdfull-damp/H-H.skf
+++ b/test/app/dftb+/scc/H2O2_3rdfull-damp/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/H2O2_3rdfull-damp/H-O.skf
+++ b/test/app/dftb+/scc/H2O2_3rdfull-damp/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/scc/H2O2_3rdfull-damp/O-H.skf
+++ b/test/app/dftb+/scc/H2O2_3rdfull-damp/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/scc/H2O2_3rdfull-damp/O-O.skf
+++ b/test/app/dftb+/scc/H2O2_3rdfull-damp/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/scc/H2O2_3rdfull-damp/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O2_3rdfull-damp/dftb_in.hsd
@@ -16,6 +16,7 @@ Hamiltonian = DFTB {
     O = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/H2O2_3rdfull-damp/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O2_3rdfull-damp/dftb_in.hsd
@@ -16,7 +16,7 @@ Hamiltonian = DFTB {
     O = "p"
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/H2O2_3rdfull/H-H.skf
+++ b/test/app/dftb+/scc/H2O2_3rdfull/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/H2O2_3rdfull/H-O.skf
+++ b/test/app/dftb+/scc/H2O2_3rdfull/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/scc/H2O2_3rdfull/O-H.skf
+++ b/test/app/dftb+/scc/H2O2_3rdfull/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/scc/H2O2_3rdfull/O-O.skf
+++ b/test/app/dftb+/scc/H2O2_3rdfull/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/scc/H2O2_3rdfull/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O2_3rdfull/dftb_in.hsd
@@ -16,6 +16,7 @@ Hamiltonian = DFTB {
     O = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/H2O2_3rdfull/dftb_in.hsd
+++ b/test/app/dftb+/scc/H2O2_3rdfull/dftb_in.hsd
@@ -16,7 +16,7 @@ Hamiltonian = DFTB {
     O = "p"
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "mio-1-1/"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/app/dftb+/scc/H3/H-H.skf
+++ b/test/app/dftb+/scc/H3/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/H3/dftb_in.hsd
+++ b/test/app/dftb+/scc/H3/dftb_in.hsd
@@ -24,7 +24,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 20
   }
   SlaterKosterFiles = {
-    H-H = "mio-1-1/H-H.skf"
+    H-H = "slakos/origin/mio-1-1/H-H.skf"
   }
 }
 

--- a/test/app/dftb+/scc/H3/dftb_in.hsd
+++ b/test/app/dftb+/scc/H3/dftb_in.hsd
@@ -24,7 +24,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 20
   }
   SlaterKosterFiles = {
-    H-H = "H-H.skf"
+    H-H = "mio-1-1/H-H.skf"
   }
 }
 

--- a/test/app/dftb+/scc/H3_skipcheck/H-H.skf
+++ b/test/app/dftb+/scc/H3_skipcheck/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/H3_skipcheck/dftb_in.hsd
+++ b/test/app/dftb+/scc/H3_skipcheck/dftb_in.hsd
@@ -20,7 +20,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 20
   }
   SlaterKosterFiles = {
-    H-H = "mio-1-1/H-H.skf"
+    H-H = "slakos/origin/mio-1-1/H-H.skf"
   }
 }
 

--- a/test/app/dftb+/scc/H3_skipcheck/dftb_in.hsd
+++ b/test/app/dftb+/scc/H3_skipcheck/dftb_in.hsd
@@ -20,7 +20,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 20
   }
   SlaterKosterFiles = {
-    H-H = "H-H.skf"
+    H-H = "mio-1-1/H-H.skf"
   }
 }
 

--- a/test/app/dftb+/scc/HH_custom-ref/H1-H1.skf
+++ b/test/app/dftb+/scc/HH_custom-ref/H1-H1.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/HH_custom-ref/H1-H2.skf
+++ b/test/app/dftb+/scc/HH_custom-ref/H1-H2.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/HH_custom-ref/H2-H1.skf
+++ b/test/app/dftb+/scc/HH_custom-ref/H2-H1.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/HH_custom-ref/H2-H2.skf
+++ b/test/app/dftb+/scc/HH_custom-ref/H2-H2.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/scc/HH_custom-ref/dftb_in.hsd
+++ b/test/app/dftb+/scc/HH_custom-ref/dftb_in.hsd
@@ -15,7 +15,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0
   }
   SlaterKosterFiles = {
-    H-H = "mio-1-1/H-H.skf" "mio-1-1/H-H.skf" "mio-1-1/H-H.skf" "mio-1-1/H-H.skf"
+    H-H = "slakos/origin/mio-1-1/H-H.skf" "slakos/origin/mio-1-1/H-H.skf" "slakos/origin/mio-1-1/H-H.skf" "slakos/origin/mio-1-1/H-H.skf"
   }
 
   CustomisedOccupations{

--- a/test/app/dftb+/scc/HH_custom-ref/dftb_in.hsd
+++ b/test/app/dftb+/scc/HH_custom-ref/dftb_in.hsd
@@ -15,7 +15,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0
   }
   SlaterKosterFiles = {
-    H-H = "./H1-H1.skf" "./H1-H2.skf" "./H2-H1.skf" "./H2-H2.skf"
+    H-H = "mio-1-1/H-H.skf" "mio-1-1/H-H.skf" "mio-1-1/H-H.skf" "mio-1-1/H-H.skf"
   }
 
   CustomisedOccupations{

--- a/test/app/dftb+/scc/SiC64+V_chgconstr/C-C.skf
+++ b/test/app/dftb+/scc/SiC64+V_chgconstr/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-C.skf

--- a/test/app/dftb+/scc/SiC64+V_chgconstr/C-Si.skf
+++ b/test/app/dftb+/scc/SiC64+V_chgconstr/C-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-Si.skf

--- a/test/app/dftb+/scc/SiC64+V_chgconstr/Si-C.skf
+++ b/test/app/dftb+/scc/SiC64+V_chgconstr/Si-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-C.skf

--- a/test/app/dftb+/scc/SiC64+V_chgconstr/Si-Si.skf
+++ b/test/app/dftb+/scc/SiC64+V_chgconstr/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-Si.skf

--- a/test/app/dftb+/scc/SiC64+V_chgconstr/dftb_in.hsd
+++ b/test/app/dftb+/scc/SiC64+V_chgconstr/dftb_in.hsd
@@ -88,10 +88,10 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 40.0
   }
   SlaterKosterFiles = {
-    Si-Si = "./Si-Si.skf"
-    Si-C = "./Si-C.skf"
-    C-Si = "./C-Si.skf"
-    C-C = "./C-C.skf"
+    Si-Si = "pbc-0-3/Si-Si.skf"
+    Si-C = "pbc-0-3/Si-C.skf"
+    C-Si = "pbc-0-3/C-Si.skf"
+    C-C = "pbc-0-3/C-C.skf"
   }
   LocalPotentials = {
     ChargeConstraint = {

--- a/test/app/dftb+/scc/SiC64+V_chgconstr/dftb_in.hsd
+++ b/test/app/dftb+/scc/SiC64+V_chgconstr/dftb_in.hsd
@@ -88,10 +88,10 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 40.0
   }
   SlaterKosterFiles = {
-    Si-Si = "pbc-0-3/Si-Si.skf"
-    Si-C = "pbc-0-3/Si-C.skf"
-    C-Si = "pbc-0-3/C-Si.skf"
-    C-C = "pbc-0-3/C-C.skf"
+    Si-Si = "slakos/origin/pbc-0-3/Si-Si.skf"
+    Si-C = "slakos/origin/pbc-0-3/Si-C.skf"
+    C-Si = "slakos/origin/pbc-0-3/C-Si.skf"
+    C-C = "slakos/origin/pbc-0-3/C-C.skf"
   }
   LocalPotentials = {
     ChargeConstraint = {

--- a/test/app/dftb+/scc/SiC64+V_dynforce/C-C.skf
+++ b/test/app/dftb+/scc/SiC64+V_dynforce/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-C.skf

--- a/test/app/dftb+/scc/SiC64+V_dynforce/C-Si.skf
+++ b/test/app/dftb+/scc/SiC64+V_dynforce/C-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-Si.skf

--- a/test/app/dftb+/scc/SiC64+V_dynforce/Si-C.skf
+++ b/test/app/dftb+/scc/SiC64+V_dynforce/Si-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-C.skf

--- a/test/app/dftb+/scc/SiC64+V_dynforce/Si-Si.skf
+++ b/test/app/dftb+/scc/SiC64+V_dynforce/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-Si.skf

--- a/test/app/dftb+/scc/SiC64+V_dynforce/dftb_in.hsd
+++ b/test/app/dftb+/scc/SiC64+V_dynforce/dftb_in.hsd
@@ -84,10 +84,10 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 300.0
   }
   SlaterKosterFiles {
-    Si-Si = "pbc-0-3/Si-Si.skf"
-    Si-C = "pbc-0-3/Si-C.skf"
-    C-Si = "pbc-0-3/C-Si.skf"
-    C-C = "pbc-0-3/C-C.skf"
+    Si-Si = "slakos/origin/pbc-0-3/Si-Si.skf"
+    Si-C = "slakos/origin/pbc-0-3/Si-C.skf"
+    C-Si = "slakos/origin/pbc-0-3/C-Si.skf"
+    C-C = "slakos/origin/pbc-0-3/C-C.skf"
   }
   Eigensolver = QR {}
   ForceEvaluation = 'dynamics'

--- a/test/app/dftb+/scc/SiC64+V_dynforce/dftb_in.hsd
+++ b/test/app/dftb+/scc/SiC64+V_dynforce/dftb_in.hsd
@@ -84,10 +84,10 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 300.0
   }
   SlaterKosterFiles {
-    Si-Si = "./Si-Si.skf"
-    Si-C = "./Si-C.skf"
-    C-Si = "./C-Si.skf"
-    C-C = "./C-C.skf"
+    Si-Si = "pbc-0-3/Si-Si.skf"
+    Si-C = "pbc-0-3/Si-C.skf"
+    C-Si = "pbc-0-3/C-Si.skf"
+    C-C = "pbc-0-3/C-C.skf"
   }
   Eigensolver = QR {}
   ForceEvaluation = 'dynamics'

--- a/test/app/dftb+/scc/SiC64+V_dynforce_groups/C-C.skf
+++ b/test/app/dftb+/scc/SiC64+V_dynforce_groups/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-C.skf

--- a/test/app/dftb+/scc/SiC64+V_dynforce_groups/C-Si.skf
+++ b/test/app/dftb+/scc/SiC64+V_dynforce_groups/C-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-Si.skf

--- a/test/app/dftb+/scc/SiC64+V_dynforce_groups/Si-C.skf
+++ b/test/app/dftb+/scc/SiC64+V_dynforce_groups/Si-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-C.skf

--- a/test/app/dftb+/scc/SiC64+V_dynforce_groups/Si-Si.skf
+++ b/test/app/dftb+/scc/SiC64+V_dynforce_groups/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-Si.skf

--- a/test/app/dftb+/scc/SiC64+V_dynforce_groups/dftb_in.hsd
+++ b/test/app/dftb+/scc/SiC64+V_dynforce_groups/dftb_in.hsd
@@ -84,10 +84,10 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 300.0
   }
   SlaterKosterFiles {
-    Si-Si = "./Si-Si.skf"
-    Si-C = "./Si-C.skf"
-    C-Si = "./C-Si.skf"
-    C-C = "./C-C.skf"
+    Si-Si = "pbc-0-3/Si-Si.skf"
+    Si-C = "pbc-0-3/Si-C.skf"
+    C-Si = "pbc-0-3/C-Si.skf"
+    C-C = "pbc-0-3/C-C.skf"
   }
       
   ForceEvaluation = 'dynamics'

--- a/test/app/dftb+/scc/SiC64+V_dynforce_groups/dftb_in.hsd
+++ b/test/app/dftb+/scc/SiC64+V_dynforce_groups/dftb_in.hsd
@@ -84,10 +84,10 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 300.0
   }
   SlaterKosterFiles {
-    Si-Si = "pbc-0-3/Si-Si.skf"
-    Si-C = "pbc-0-3/Si-C.skf"
-    C-Si = "pbc-0-3/C-Si.skf"
-    C-C = "pbc-0-3/C-C.skf"
+    Si-Si = "slakos/origin/pbc-0-3/Si-Si.skf"
+    Si-C = "slakos/origin/pbc-0-3/Si-C.skf"
+    C-Si = "slakos/origin/pbc-0-3/C-Si.skf"
+    C-C = "slakos/origin/pbc-0-3/C-C.skf"
   }
       
   ForceEvaluation = 'dynamics'

--- a/test/app/dftb+/scc/SiC_32-extchrg-blur/C-C.skf
+++ b/test/app/dftb+/scc/SiC_32-extchrg-blur/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-C.skf

--- a/test/app/dftb+/scc/SiC_32-extchrg-blur/C-Si.skf
+++ b/test/app/dftb+/scc/SiC_32-extchrg-blur/C-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-Si.skf

--- a/test/app/dftb+/scc/SiC_32-extchrg-blur/Si-C.skf
+++ b/test/app/dftb+/scc/SiC_32-extchrg-blur/Si-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-C.skf

--- a/test/app/dftb+/scc/SiC_32-extchrg-blur/Si-Si.skf
+++ b/test/app/dftb+/scc/SiC_32-extchrg-blur/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-Si.skf

--- a/test/app/dftb+/scc/SiC_32-extchrg-blur/dftb_in.hsd
+++ b/test/app/dftb+/scc/SiC_32-extchrg-blur/dftb_in.hsd
@@ -52,10 +52,10 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 100
     }
     SlaterKosterFiles = {
-        Si-Si = "./Si-Si.skf"
-        Si-C = "./Si-C.skf"
-        C-Si = "./C-Si.skf"
-        C-C = "./C-C.skf"
+        Si-Si = "pbc-0-3/Si-Si.skf"
+        Si-C = "pbc-0-3/Si-C.skf"
+        C-Si = "pbc-0-3/C-Si.skf"
+        C-C = "pbc-0-3/C-C.skf"
     }
     KPointsAndWeights = {
         0.0 0.0 0.0 1.0

--- a/test/app/dftb+/scc/SiC_32-extchrg-blur/dftb_in.hsd
+++ b/test/app/dftb+/scc/SiC_32-extchrg-blur/dftb_in.hsd
@@ -52,10 +52,10 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 100
     }
     SlaterKosterFiles = {
-        Si-Si = "pbc-0-3/Si-Si.skf"
-        Si-C = "pbc-0-3/Si-C.skf"
-        C-Si = "pbc-0-3/C-Si.skf"
-        C-C = "pbc-0-3/C-C.skf"
+        Si-Si = "slakos/origin/pbc-0-3/Si-Si.skf"
+        Si-C = "slakos/origin/pbc-0-3/Si-C.skf"
+        C-Si = "slakos/origin/pbc-0-3/C-Si.skf"
+        C-C = "slakos/origin/pbc-0-3/C-C.skf"
     }
     KPointsAndWeights = {
         0.0 0.0 0.0 1.0

--- a/test/app/dftb+/scc/SiC_512_GPU/C-C.skf
+++ b/test/app/dftb+/scc/SiC_512_GPU/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-C.skf

--- a/test/app/dftb+/scc/SiC_512_GPU/C-Si.skf
+++ b/test/app/dftb+/scc/SiC_512_GPU/C-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-Si.skf

--- a/test/app/dftb+/scc/SiC_512_GPU/Si-C.skf
+++ b/test/app/dftb+/scc/SiC_512_GPU/Si-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-C.skf

--- a/test/app/dftb+/scc/SiC_512_GPU/Si-Si.skf
+++ b/test/app/dftb+/scc/SiC_512_GPU/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-Si.skf

--- a/test/app/dftb+/scc/SiC_512_GPU/dftb_in.hsd
+++ b/test/app/dftb+/scc/SiC_512_GPU/dftb_in.hsd
@@ -15,7 +15,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 100.0
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "pbc-0-3/"
+        Prefix = "slakos/origin/pbc-0-3/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/scc/SiC_512_GPU/dftb_in.hsd
+++ b/test/app/dftb+/scc/SiC_512_GPU/dftb_in.hsd
@@ -15,6 +15,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 100.0
     }
     SlaterKosterFiles = Type2FileNames {
+        Prefix = "pbc-0-3/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/scc/SiC_64/C-C.skf
+++ b/test/app/dftb+/scc/SiC_64/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-C.skf

--- a/test/app/dftb+/scc/SiC_64/C-Si.skf
+++ b/test/app/dftb+/scc/SiC_64/C-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-Si.skf

--- a/test/app/dftb+/scc/SiC_64/Si-C.skf
+++ b/test/app/dftb+/scc/SiC_64/Si-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-C.skf

--- a/test/app/dftb+/scc/SiC_64/Si-Si.skf
+++ b/test/app/dftb+/scc/SiC_64/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-Si.skf

--- a/test/app/dftb+/scc/SiC_64/dftb_in.hsd
+++ b/test/app/dftb+/scc/SiC_64/dftb_in.hsd
@@ -88,10 +88,10 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0.000000000000000E+000
   }
   SlaterKosterFiles = {
-    Si-Si = "./Si-Si.skf"
-    Si-C = "./Si-C.skf"
-    C-Si = "./C-Si.skf"
-    C-C = "./C-C.skf"
+    Si-Si = "pbc-0-3/Si-Si.skf"
+    Si-C = "pbc-0-3/Si-C.skf"
+    C-Si = "pbc-0-3/C-Si.skf"
+    C-C = "pbc-0-3/C-C.skf"
   }
 
 KPointsAndWeights = {

--- a/test/app/dftb+/scc/SiC_64/dftb_in.hsd
+++ b/test/app/dftb+/scc/SiC_64/dftb_in.hsd
@@ -88,10 +88,10 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0.000000000000000E+000
   }
   SlaterKosterFiles = {
-    Si-Si = "pbc-0-3/Si-Si.skf"
-    Si-C = "pbc-0-3/Si-C.skf"
-    C-Si = "pbc-0-3/C-Si.skf"
-    C-C = "pbc-0-3/C-C.skf"
+    Si-Si = "slakos/origin/pbc-0-3/Si-Si.skf"
+    Si-C = "slakos/origin/pbc-0-3/Si-C.skf"
+    C-Si = "slakos/origin/pbc-0-3/C-Si.skf"
+    C-C = "slakos/origin/pbc-0-3/C-C.skf"
   }
 
 KPointsAndWeights = {

--- a/test/app/dftb+/scc/SiH_custom-ref/H-H.skf
+++ b/test/app/dftb+/scc/SiH_custom-ref/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/H-H.skf

--- a/test/app/dftb+/scc/SiH_custom-ref/H-Si.skf
+++ b/test/app/dftb+/scc/SiH_custom-ref/H-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/H-Si.skf

--- a/test/app/dftb+/scc/SiH_custom-ref/Si-H.skf
+++ b/test/app/dftb+/scc/SiH_custom-ref/Si-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-H.skf

--- a/test/app/dftb+/scc/SiH_custom-ref/Si-Si.skf
+++ b/test/app/dftb+/scc/SiH_custom-ref/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-Si.skf

--- a/test/app/dftb+/scc/SiH_custom-ref/dftb_in.hsd
+++ b/test/app/dftb+/scc/SiH_custom-ref/dftb_in.hsd
@@ -13,6 +13,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0
   }
   SlaterKosterFiles = Type2Filenames {
+    Prefix = "pbc-0-3/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/scc/SiH_custom-ref/dftb_in.hsd
+++ b/test/app/dftb+/scc/SiH_custom-ref/dftb_in.hsd
@@ -13,7 +13,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0
   }
   SlaterKosterFiles = Type2Filenames {
-    Prefix = "pbc-0-3/"
+    Prefix = "slakos/origin/pbc-0-3/"
     Separator = "-"
     Suffix = ".skf"
   }


### PR DESCRIPTION
Adds environment variable `DFTBPLUS_PARAM_DIR` to search for Slater–Koster files. Variable is set automatically in testsuite to avoid using a user-specified variable while testing.

- [x] document in manual
- [x] add to changelog