### PR TITLE
Trim return value from unquote for ParameterFile entry

### DIFF
--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -1794,7 +1794,7 @@ contains
       ctrl%tbliteInp%info%name = trim(unquote(char(buffer)))
     else
       call getChildValue(node, "ParameterFile", buffer)
-      call ctrl%tbliteInp%setupCalculator(unquote(char(buffer)))
+      call ctrl%tbliteInp%setupCalculator(trim(unquote(char(buffer))))
     end if
 
     call getChildValue(node, "ShellResolvedSCC", ctrl%tShellResolved, .true.)


### PR DESCRIPTION
```cson
Hamiltonian = xTB {
   ParameterFile = gfn2-xtb.toml  # works
   ParameterFile = "gfn2-xtb.toml"  # failed due to two trailing spaces produced by unquote
}
```