### PR TITLE
Disable pythonapi tests without python

### DIFF
--- a/test/src/dftbp/CMakeLists.txt
+++ b/test/src/dftbp/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 if(WITH_API)
   add_subdirectory(api/mm)
-  if(BUILD_SHARED_LIBS)
+  if(BUILD_SHARED_LIBS AND WITH_PYTHON)
     add_subdirectory(api/pyapi)
   endif()
 endif()

--- a/tools/pythonapi/README
+++ b/tools/pythonapi/README
@@ -17,14 +17,15 @@ Compiling DFTB+
 In order to be able to use the Python interface, DFTB+ has to be
 compiled as a shared library with API support enabled. To instruct
 cmake that a dynamically linked shared library should be created
-containing DFTB+. This can be done by setting the WITH_API and
-BUILD_SHARED_LIBS flags to be TRUE in the configuration file
-config.cmake, before starting the configuration and compilation
-process. Alternatively, if you do not want to modify files, a
-construct like the following is a convenient way to specify these
-flags on the command line while configuring with CMake:
+containing DFTB+. This can be done by setting the WITH_API,
+WITH_PYTHON, and BUILD_SHARED_LIBS flags to be TRUE in the 
+configuration file config.cmake, before starting the configuration 
+and compilation process. Alternatively, if you do not want to 
+modify files, a construct like the following is a convenient way 
+to specify these flags on the command line while configuring with 
+CMake:
 
-cmake -DBUILD_SHARED_LIBS=1 -DWITH_API=1 ..
+cmake -DBUILD_SHARED_LIBS=1 -DWITH_API=1 -DWITH_PYTHON=1 ..
 
 
 Testing pythonapi


### PR DESCRIPTION
Allows to only have the C API without the Python API and still have all unittests passing