### PR TITLE
Sym links

### DIFF
--- a/test/app/dftb+/analysis/C2H4_localise/C-C.skf
+++ b/test/app/dftb+/analysis/C2H4_localise/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/analysis/C2H4_localise/C-H.skf
+++ b/test/app/dftb+/analysis/C2H4_localise/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/analysis/C2H4_localise/H-C.skf
+++ b/test/app/dftb+/analysis/C2H4_localise/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/analysis/C2H4_localise/H-H.skf
+++ b/test/app/dftb+/analysis/C2H4_localise/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/analysis/C2H4_localise/dftb_in.hsd
+++ b/test/app/dftb+/analysis/C2H4_localise/dftb_in.hsd
@@ -20,6 +20,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 100.0
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/analysis/Ga4As4_ESP/As-As.skf
+++ b/test/app/dftb+/analysis/Ga4As4_ESP/As-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-As.skf

--- a/test/app/dftb+/analysis/Ga4As4_ESP/As-Ga.skf
+++ b/test/app/dftb+/analysis/Ga4As4_ESP/As-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-Ga.skf

--- a/test/app/dftb+/analysis/Ga4As4_ESP/Ga-As.skf
+++ b/test/app/dftb+/analysis/Ga4As4_ESP/Ga-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-As.skf

--- a/test/app/dftb+/analysis/Ga4As4_ESP/Ga-Ga.skf
+++ b/test/app/dftb+/analysis/Ga4As4_ESP/Ga-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-Ga.skf

--- a/test/app/dftb+/analysis/Ga4As4_ESP/dftb_in.hsd
+++ b/test/app/dftb+/analysis/Ga4As4_ESP/dftb_in.hsd
@@ -22,6 +22,7 @@ Hamiltonian = DFTB {
         As = "p"
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/hyb-0-2/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/analysis/H2O_ESP/H-H.skf
+++ b/test/app/dftb+/analysis/H2O_ESP/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/analysis/H2O_ESP/H-O.skf
+++ b/test/app/dftb+/analysis/H2O_ESP/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/analysis/H2O_ESP/O-H.skf
+++ b/test/app/dftb+/analysis/H2O_ESP/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/analysis/H2O_ESP/O-O.skf
+++ b/test/app/dftb+/analysis/H2O_ESP/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/analysis/H2O_ESP/dftb_in.hsd
+++ b/test/app/dftb+/analysis/H2O_ESP/dftb_in.hsd
@@ -19,6 +19,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 100
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/analysis/H2O_mdESP/H-H.skf
+++ b/test/app/dftb+/analysis/H2O_mdESP/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/analysis/H2O_mdESP/H-O.skf
+++ b/test/app/dftb+/analysis/H2O_mdESP/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/analysis/H2O_mdESP/O-H.skf
+++ b/test/app/dftb+/analysis/H2O_mdESP/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/analysis/H2O_mdESP/O-O.skf
+++ b/test/app/dftb+/analysis/H2O_mdESP/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/analysis/H2O_mdESP/dftb_in.hsd
+++ b/test/app/dftb+/analysis/H2O_mdESP/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 273.15
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/analysis/graphene_localise/C-C.skf
+++ b/test/app/dftb+/analysis/graphene_localise/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/analysis/graphene_localise/dftb_in.hsd
+++ b/test/app/dftb+/analysis/graphene_localise/dftb_in.hsd
@@ -25,6 +25,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 100.0
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/deltadftb/H2O/H-H.skf
+++ b/test/app/dftb+/deltadftb/H2O/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/H-H.skf

--- a/test/app/dftb+/deltadftb/H2O/H-O.skf
+++ b/test/app/dftb+/deltadftb/H2O/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/H-O.skf

--- a/test/app/dftb+/deltadftb/H2O/O-H.skf
+++ b/test/app/dftb+/deltadftb/H2O/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/O-H.skf

--- a/test/app/dftb+/deltadftb/H2O/O-O.skf
+++ b/test/app/dftb+/deltadftb/H2O/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/O-O.skf

--- a/test/app/dftb+/deltadftb/H2O/dftb_in.hsd
+++ b/test/app/dftb+/deltadftb/H2O/dftb_in.hsd
@@ -51,6 +51,7 @@ Hamiltonian = DFTB {
         Hud = {0}
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/ob2-1-1/shift/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/derivatives/C6H6_scc/C-C.skf
+++ b/test/app/dftb+/derivatives/C6H6_scc/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/derivatives/C6H6_scc/C-H.skf
+++ b/test/app/dftb+/derivatives/C6H6_scc/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/derivatives/C6H6_scc/H-C.skf
+++ b/test/app/dftb+/derivatives/C6H6_scc/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/derivatives/C6H6_scc/H-H.skf
+++ b/test/app/dftb+/derivatives/C6H6_scc/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/derivatives/C6H6_scc/dftb_in.hsd
+++ b/test/app/dftb+/derivatives/C6H6_scc/dftb_in.hsd
@@ -33,6 +33,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 273.15
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/derivatives/CH3_U_noncol/C-C.skf
+++ b/test/app/dftb+/derivatives/CH3_U_noncol/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/derivatives/CH3_U_noncol/C-H.skf
+++ b/test/app/dftb+/derivatives/CH3_U_noncol/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/derivatives/CH3_U_noncol/H-C.skf
+++ b/test/app/dftb+/derivatives/CH3_U_noncol/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/derivatives/CH3_U_noncol/H-H.skf
+++ b/test/app/dftb+/derivatives/CH3_U_noncol/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/derivatives/CH3_U_noncol/dftb_in.hsd
+++ b/test/app/dftb+/derivatives/CH3_U_noncol/dftb_in.hsd
@@ -37,6 +37,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 500
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/derivatives/CH3nonsccPol/C-C.skf
+++ b/test/app/dftb+/derivatives/CH3nonsccPol/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/derivatives/CH3nonsccPol/C-H.skf
+++ b/test/app/dftb+/derivatives/CH3nonsccPol/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/derivatives/CH3nonsccPol/H-C.skf
+++ b/test/app/dftb+/derivatives/CH3nonsccPol/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/derivatives/CH3nonsccPol/H-H.skf
+++ b/test/app/dftb+/derivatives/CH3nonsccPol/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/derivatives/CH3nonsccPol/dftb_in.hsd
+++ b/test/app/dftb+/derivatives/CH3nonsccPol/dftb_in.hsd
@@ -17,6 +17,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 100
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/derivatives/CH3sccPol/C-C.skf
+++ b/test/app/dftb+/derivatives/CH3sccPol/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/derivatives/CH3sccPol/C-H.skf
+++ b/test/app/dftb+/derivatives/CH3sccPol/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/derivatives/CH3sccPol/H-C.skf
+++ b/test/app/dftb+/derivatives/CH3sccPol/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/derivatives/CH3sccPol/H-H.skf
+++ b/test/app/dftb+/derivatives/CH3sccPol/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/derivatives/CH3sccPol/dftb_in.hsd
+++ b/test/app/dftb+/derivatives/CH3sccPol/dftb_in.hsd
@@ -19,6 +19,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 100
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/derivatives/CH3spin3rdOnsPol/C-C.skf
+++ b/test/app/dftb+/derivatives/CH3spin3rdOnsPol/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/derivatives/CH3spin3rdOnsPol/C-H.skf
+++ b/test/app/dftb+/derivatives/CH3spin3rdOnsPol/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/derivatives/CH3spin3rdOnsPol/H-C.skf
+++ b/test/app/dftb+/derivatives/CH3spin3rdOnsPol/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/derivatives/CH3spin3rdOnsPol/H-H.skf
+++ b/test/app/dftb+/derivatives/CH3spin3rdOnsPol/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/derivatives/CH3spin3rdOnsPol/dftb_in.hsd
+++ b/test/app/dftb+/derivatives/CH3spin3rdOnsPol/dftb_in.hsd
@@ -19,6 +19,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 100
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/dftb+u/CH3/C-C.skf
+++ b/test/app/dftb+/dftb+u/CH3/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/dftb+u/CH3/C-H.skf
+++ b/test/app/dftb+/dftb+u/CH3/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/dftb+u/CH3/H-C.skf
+++ b/test/app/dftb+/dftb+u/CH3/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/dftb+u/CH3/H-H.skf
+++ b/test/app/dftb+/dftb+u/CH3/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dftb+u/CH3/dftb_in.hsd
+++ b/test/app/dftb+/dftb+u/CH3/dftb_in.hsd
@@ -34,6 +34,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 10
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dftb+u/GaAs_2/As-As.skf
+++ b/test/app/dftb+/dftb+u/GaAs_2/As-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-As.skf

--- a/test/app/dftb+/dftb+u/GaAs_2/As-Ga.skf
+++ b/test/app/dftb+/dftb+u/GaAs_2/As-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-Ga.skf

--- a/test/app/dftb+/dftb+u/GaAs_2/Ga-As.skf
+++ b/test/app/dftb+/dftb+u/GaAs_2/Ga-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-As.skf

--- a/test/app/dftb+/dftb+u/GaAs_2/Ga-Ga.skf
+++ b/test/app/dftb+/dftb+u/GaAs_2/Ga-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-Ga.skf

--- a/test/app/dftb+/dftb+u/GaAs_2/dftb_in.hsd
+++ b/test/app/dftb+/dftb+u/GaAs_2/dftb_in.hsd
@@ -39,6 +39,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-006
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/hyb-0-2/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/2C6H6_MBD/C-C.skf
+++ b/test/app/dftb+/dispersion/2C6H6_MBD/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/dispersion/2C6H6_MBD/C-H.skf
+++ b/test/app/dftb+/dispersion/2C6H6_MBD/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/dispersion/2C6H6_MBD/H-C.skf
+++ b/test/app/dftb+/dispersion/2C6H6_MBD/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/dispersion/2C6H6_MBD/H-H.skf
+++ b/test/app/dftb+/dispersion/2C6H6_MBD/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dispersion/2C6H6_MBD/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/2C6H6_MBD/dftb_in.hsd
@@ -22,6 +22,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0.0
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/2C6H6_TS/C-C.skf
+++ b/test/app/dftb+/dispersion/2C6H6_TS/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/dispersion/2C6H6_TS/C-H.skf
+++ b/test/app/dftb+/dispersion/2C6H6_TS/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/dispersion/2C6H6_TS/H-C.skf
+++ b/test/app/dftb+/dispersion/2C6H6_TS/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/dispersion/2C6H6_TS/H-H.skf
+++ b/test/app/dftb+/dispersion/2C6H6_TS/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dispersion/2C6H6_TS/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/2C6H6_TS/dftb_in.hsd
@@ -22,6 +22,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0.0
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/2H2O/H-H.skf
+++ b/test/app/dftb+/dispersion/2H2O/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dispersion/2H2O/H-O.skf
+++ b/test/app/dftb+/dispersion/2H2O/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/dispersion/2H2O/O-H.skf
+++ b/test/app/dftb+/dispersion/2H2O/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/dispersion/2H2O/O-O.skf
+++ b/test/app/dftb+/dispersion/2H2O/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/dispersion/2H2O/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/2H2O/dftb_in.hsd
@@ -29,6 +29,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0.0
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/2H2O_dftd3_bj/H-H.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd3_bj/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd3_bj/H-O.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd3_bj/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd3_bj/O-H.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd3_bj/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd3_bj/O-O.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd3_bj/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd3_bj/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/2H2O_dftd3_bj/dftb_in.hsd
@@ -29,6 +29,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0.0
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/2H2O_dftd3_zero/H-H.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd3_zero/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd3_zero/H-O.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd3_zero/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd3_zero/O-H.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd3_zero/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd3_zero/O-O.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd3_zero/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd3_zero/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/2H2O_dftd3_zero/dftb_in.hsd
@@ -29,6 +29,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0.0
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/2H2O_dftd4/H-H.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd4/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd4/H-O.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd4/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd4/O-H.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd4/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd4/O-O.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd4/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd4/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/2H2O_dftd4/dftb_in.hsd
@@ -29,6 +29,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0.0
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/2H2O_dftd4_sc/H-H.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd4_sc/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd4_sc/H-O.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd4_sc/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd4_sc/O-H.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd4_sc/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd4_sc/O-O.skf
+++ b/test/app/dftb+/dispersion/2H2O_dftd4_sc/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/dispersion/2H2O_dftd4_sc/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/2H2O_dftd4_sc/dftb_in.hsd
@@ -25,6 +25,7 @@ Hamiltonian = DFTB {
   Solver = DivideAndConquer {}
   Filling = Fermi { Temperature [Kelvin] = 0.0 }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/2H2O_sdftd3/H-H.skf
+++ b/test/app/dftb+/dispersion/2H2O_sdftd3/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dispersion/2H2O_sdftd3/H-O.skf
+++ b/test/app/dftb+/dispersion/2H2O_sdftd3/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/dispersion/2H2O_sdftd3/O-H.skf
+++ b/test/app/dftb+/dispersion/2H2O_sdftd3/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/dispersion/2H2O_sdftd3/O-O.skf
+++ b/test/app/dftb+/dispersion/2H2O_sdftd3/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/dispersion/2H2O_sdftd3/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/2H2O_sdftd3/dftb_in.hsd
@@ -29,6 +29,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0.0
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/2H2O_uff/H-H.skf
+++ b/test/app/dftb+/dispersion/2H2O_uff/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dispersion/2H2O_uff/H-O.skf
+++ b/test/app/dftb+/dispersion/2H2O_uff/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/dispersion/2H2O_uff/O-H.skf
+++ b/test/app/dftb+/dispersion/2H2O_uff/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/dispersion/2H2O_uff/O-O.skf
+++ b/test/app/dftb+/dispersion/2H2O_uff/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/dispersion/2H2O_uff/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/2H2O_uff/dftb_in.hsd
@@ -29,6 +29,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0.0
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/CO2_bulk_MBD/C-C.skf
+++ b/test/app/dftb+/dispersion/CO2_bulk_MBD/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/dispersion/CO2_bulk_MBD/C-O.skf
+++ b/test/app/dftb+/dispersion/CO2_bulk_MBD/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/dispersion/CO2_bulk_MBD/O-C.skf
+++ b/test/app/dftb+/dispersion/CO2_bulk_MBD/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/dispersion/CO2_bulk_MBD/O-O.skf
+++ b/test/app/dftb+/dispersion/CO2_bulk_MBD/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/dispersion/CO2_bulk_MBD/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/CO2_bulk_MBD/dftb_in.hsd
@@ -28,6 +28,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0.0
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/CO2_bulk_TS/C-C.skf
+++ b/test/app/dftb+/dispersion/CO2_bulk_TS/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/dispersion/CO2_bulk_TS/C-O.skf
+++ b/test/app/dftb+/dispersion/CO2_bulk_TS/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/dispersion/CO2_bulk_TS/O-C.skf
+++ b/test/app/dftb+/dispersion/CO2_bulk_TS/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/dispersion/CO2_bulk_TS/O-O.skf
+++ b/test/app/dftb+/dispersion/CO2_bulk_TS/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/dispersion/CO2_bulk_TS/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/CO2_bulk_TS/dftb_in.hsd
@@ -28,6 +28,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0.0
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/DNA-damped/C-C.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/dispersion/DNA-damped/C-H.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/dispersion/DNA-damped/C-N.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/dispersion/DNA-damped/C-O.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/dispersion/DNA-damped/H-C.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/dispersion/DNA-damped/H-H.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dispersion/DNA-damped/H-N.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/dispersion/DNA-damped/H-O.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/dispersion/DNA-damped/N-C.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/dispersion/DNA-damped/N-H.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/dispersion/DNA-damped/N-N.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/dispersion/DNA-damped/N-O.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/dispersion/DNA-damped/O-C.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/dispersion/DNA-damped/O-H.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/dispersion/DNA-damped/O-N.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/dispersion/DNA-damped/O-O.skf
+++ b/test/app/dftb+/dispersion/DNA-damped/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/dispersion/DNA-damped/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/DNA-damped/dftb_in.hsd
@@ -84,6 +84,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/DNA/C-C.skf
+++ b/test/app/dftb+/dispersion/DNA/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/dispersion/DNA/C-H.skf
+++ b/test/app/dftb+/dispersion/DNA/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/dispersion/DNA/C-N.skf
+++ b/test/app/dftb+/dispersion/DNA/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/dispersion/DNA/C-O.skf
+++ b/test/app/dftb+/dispersion/DNA/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/dispersion/DNA/H-C.skf
+++ b/test/app/dftb+/dispersion/DNA/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/dispersion/DNA/H-H.skf
+++ b/test/app/dftb+/dispersion/DNA/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dispersion/DNA/H-N.skf
+++ b/test/app/dftb+/dispersion/DNA/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/dispersion/DNA/H-O.skf
+++ b/test/app/dftb+/dispersion/DNA/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/dispersion/DNA/N-C.skf
+++ b/test/app/dftb+/dispersion/DNA/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/dispersion/DNA/N-H.skf
+++ b/test/app/dftb+/dispersion/DNA/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/dispersion/DNA/N-N.skf
+++ b/test/app/dftb+/dispersion/DNA/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/dispersion/DNA/N-O.skf
+++ b/test/app/dftb+/dispersion/DNA/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/dispersion/DNA/O-C.skf
+++ b/test/app/dftb+/dispersion/DNA/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/dispersion/DNA/O-H.skf
+++ b/test/app/dftb+/dispersion/DNA/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/dispersion/DNA/O-N.skf
+++ b/test/app/dftb+/dispersion/DNA/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/dispersion/DNA/O-O.skf
+++ b/test/app/dftb+/dispersion/DNA/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/dispersion/DNA/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/DNA/dftb_in.hsd
@@ -81,6 +81,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/C-C.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/C-H.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/C-N.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/C-O.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/H-C.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/H-H.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/H-N.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/H-O.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/N-C.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/N-H.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/N-N.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/N-O.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/O-C.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/O-H.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/O-N.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/O-O.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_bj/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/DNA_dftd3_bj/dftb_in.hsd
@@ -22,6 +22,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/C-C.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/C-H.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/C-N.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/C-O.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/H-C.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/H-H.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/H-N.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/H-O.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/N-C.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/N-H.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/N-N.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/N-O.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/O-C.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/O-H.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/O-N.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/O-O.skf
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/dispersion/DNA_dftd3_zero/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/DNA_dftd3_zero/dftb_in.hsd
@@ -22,6 +22,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/DNA_uff/C-C.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/dispersion/DNA_uff/C-H.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/dispersion/DNA_uff/C-N.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/dispersion/DNA_uff/C-O.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/dispersion/DNA_uff/H-C.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/dispersion/DNA_uff/H-H.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dispersion/DNA_uff/H-N.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/dispersion/DNA_uff/H-O.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/dispersion/DNA_uff/N-C.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/dispersion/DNA_uff/N-H.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/dispersion/DNA_uff/N-N.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/dispersion/DNA_uff/N-O.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/dispersion/DNA_uff/O-C.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/dispersion/DNA_uff/O-H.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/dispersion/DNA_uff/O-N.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/dispersion/DNA_uff/O-O.skf
+++ b/test/app/dftb+/dispersion/DNA_uff/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/dispersion/DNA_uff/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/DNA_uff/dftb_in.hsd
@@ -84,6 +84,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/GaAs_dftd4/As-As.skf
+++ b/test/app/dftb+/dispersion/GaAs_dftd4/As-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-As.skf

--- a/test/app/dftb+/dispersion/GaAs_dftd4/As-Ga.skf
+++ b/test/app/dftb+/dispersion/GaAs_dftd4/As-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-Ga.skf

--- a/test/app/dftb+/dispersion/GaAs_dftd4/Ga-As.skf
+++ b/test/app/dftb+/dispersion/GaAs_dftd4/Ga-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-As.skf

--- a/test/app/dftb+/dispersion/GaAs_dftd4/Ga-Ga.skf
+++ b/test/app/dftb+/dispersion/GaAs_dftd4/Ga-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-Ga.skf

--- a/test/app/dftb+/dispersion/GaAs_dftd4/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/GaAs_dftd4/dftb_in.hsd
@@ -12,6 +12,7 @@ Hamiltonian = DFTB {
     As = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/hyb-0-2/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/GaAs_dftd4_sc/As-As.skf
+++ b/test/app/dftb+/dispersion/GaAs_dftd4_sc/As-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-As.skf

--- a/test/app/dftb+/dispersion/GaAs_dftd4_sc/As-Ga.skf
+++ b/test/app/dftb+/dispersion/GaAs_dftd4_sc/As-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-Ga.skf

--- a/test/app/dftb+/dispersion/GaAs_dftd4_sc/Ga-As.skf
+++ b/test/app/dftb+/dispersion/GaAs_dftd4_sc/Ga-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-As.skf

--- a/test/app/dftb+/dispersion/GaAs_dftd4_sc/Ga-Ga.skf
+++ b/test/app/dftb+/dispersion/GaAs_dftd4_sc/Ga-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-Ga.skf

--- a/test/app/dftb+/dispersion/GaAs_dftd4_sc/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/GaAs_dftd4_sc/dftb_in.hsd
@@ -12,6 +12,7 @@ Hamiltonian = DFTB {
     As = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/hyb-0-2/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/GaAs_sdftd3/As-As.skf
+++ b/test/app/dftb+/dispersion/GaAs_sdftd3/As-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-As.skf

--- a/test/app/dftb+/dispersion/GaAs_sdftd3/As-Ga.skf
+++ b/test/app/dftb+/dispersion/GaAs_sdftd3/As-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-Ga.skf

--- a/test/app/dftb+/dispersion/GaAs_sdftd3/Ga-As.skf
+++ b/test/app/dftb+/dispersion/GaAs_sdftd3/Ga-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-As.skf

--- a/test/app/dftb+/dispersion/GaAs_sdftd3/Ga-Ga.skf
+++ b/test/app/dftb+/dispersion/GaAs_sdftd3/Ga-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-Ga.skf

--- a/test/app/dftb+/dispersion/GaAs_sdftd3/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/GaAs_sdftd3/dftb_in.hsd
@@ -12,6 +12,7 @@ Hamiltonian = DFTB {
     As = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/hyb-0-2/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/charged_dftd4/C-C.skf
+++ b/test/app/dftb+/dispersion/charged_dftd4/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/dispersion/charged_dftd4/C-H.skf
+++ b/test/app/dftb+/dispersion/charged_dftd4/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/dispersion/charged_dftd4/C-N.skf
+++ b/test/app/dftb+/dispersion/charged_dftd4/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/dispersion/charged_dftd4/H-C.skf
+++ b/test/app/dftb+/dispersion/charged_dftd4/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/dispersion/charged_dftd4/H-H.skf
+++ b/test/app/dftb+/dispersion/charged_dftd4/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/dispersion/charged_dftd4/H-N.skf
+++ b/test/app/dftb+/dispersion/charged_dftd4/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/dispersion/charged_dftd4/N-C.skf
+++ b/test/app/dftb+/dispersion/charged_dftd4/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/dispersion/charged_dftd4/N-H.skf
+++ b/test/app/dftb+/dispersion/charged_dftd4/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/dispersion/charged_dftd4/N-N.skf
+++ b/test/app/dftb+/dispersion/charged_dftd4/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/dispersion/charged_dftd4/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/charged_dftd4/dftb_in.hsd
@@ -22,6 +22,7 @@ Hamiltonian = DFTB {
   }
   MaxSCCIterations = 250
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/diamond_dftd4/C-C.skf
+++ b/test/app/dftb+/dispersion/diamond_dftd4/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/dispersion/diamond_dftd4/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/diamond_dftd4/dftb_in.hsd
@@ -38,6 +38,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/dispersion/diamond_dftd4_sc/C-C.skf
+++ b/test/app/dftb+/dispersion/diamond_dftd4_sc/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/dispersion/diamond_dftd4_sc/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/diamond_dftd4_sc/dftb_in.hsd
@@ -32,6 +32,7 @@ Hamiltonian = DFTB {
   KPointsAndWeights { 0.0 0.0 0.0  1.0 }
   MaxAngularMomentum { C = "p" }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/extpot/CH4_gross/C-C.skf
+++ b/test/app/dftb+/extpot/CH4_gross/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/extpot/CH4_gross/C-H.skf
+++ b/test/app/dftb+/extpot/CH4_gross/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/extpot/CH4_gross/H-C.skf
+++ b/test/app/dftb+/extpot/CH4_gross/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/extpot/CH4_gross/H-H.skf
+++ b/test/app/dftb+/extpot/CH4_gross/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/extpot/CH4_gross/dftb_in.hsd
+++ b/test/app/dftb+/extpot/CH4_gross/dftb_in.hsd
@@ -18,6 +18,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 100.0
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/extpot/CH4_gross2/C-C.skf
+++ b/test/app/dftb+/extpot/CH4_gross2/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/extpot/CH4_gross2/C-H.skf
+++ b/test/app/dftb+/extpot/CH4_gross2/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/extpot/CH4_gross2/H-C.skf
+++ b/test/app/dftb+/extpot/CH4_gross2/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/extpot/CH4_gross2/H-H.skf
+++ b/test/app/dftb+/extpot/CH4_gross2/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/extpot/CH4_gross2/dftb_in.hsd
+++ b/test/app/dftb+/extpot/CH4_gross2/dftb_in.hsd
@@ -18,6 +18,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 100.0
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/extpot/CH4_net/C-C.skf
+++ b/test/app/dftb+/extpot/CH4_net/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/extpot/CH4_net/C-H.skf
+++ b/test/app/dftb+/extpot/CH4_net/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/extpot/CH4_net/H-C.skf
+++ b/test/app/dftb+/extpot/CH4_net/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/extpot/CH4_net/H-H.skf
+++ b/test/app/dftb+/extpot/CH4_net/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/extpot/CH4_net/dftb_in.hsd
+++ b/test/app/dftb+/extpot/CH4_net/dftb_in.hsd
@@ -18,6 +18,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 100.0
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/extpot/CH4_net2/C-C.skf
+++ b/test/app/dftb+/extpot/CH4_net2/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/extpot/CH4_net2/C-H.skf
+++ b/test/app/dftb+/extpot/CH4_net2/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/extpot/CH4_net2/H-C.skf
+++ b/test/app/dftb+/extpot/CH4_net2/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/extpot/CH4_net2/H-H.skf
+++ b/test/app/dftb+/extpot/CH4_net2/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/extpot/CH4_net2/dftb_in.hsd
+++ b/test/app/dftb+/extpot/CH4_net2/dftb_in.hsd
@@ -18,6 +18,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 100.0
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/extpot/CH4_scc_gross/C-C.skf
+++ b/test/app/dftb+/extpot/CH4_scc_gross/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/extpot/CH4_scc_gross/C-H.skf
+++ b/test/app/dftb+/extpot/CH4_scc_gross/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/extpot/CH4_scc_gross/H-C.skf
+++ b/test/app/dftb+/extpot/CH4_scc_gross/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/extpot/CH4_scc_gross/H-H.skf
+++ b/test/app/dftb+/extpot/CH4_scc_gross/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/extpot/CH4_scc_gross/dftb_in.hsd
+++ b/test/app/dftb+/extpot/CH4_scc_gross/dftb_in.hsd
@@ -20,6 +20,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 100.0
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/extpot/CH4_scc_net/C-C.skf
+++ b/test/app/dftb+/extpot/CH4_scc_net/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/extpot/CH4_scc_net/C-H.skf
+++ b/test/app/dftb+/extpot/CH4_scc_net/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/extpot/CH4_scc_net/H-C.skf
+++ b/test/app/dftb+/extpot/CH4_scc_net/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/extpot/CH4_scc_net/H-H.skf
+++ b/test/app/dftb+/extpot/CH4_scc_net/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/extpot/CH4_scc_net/dftb_in.hsd
+++ b/test/app/dftb+/extpot/CH4_scc_net/dftb_in.hsd
@@ -20,6 +20,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 100.0
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/geoopt/Cchain_lattice/C-C.skf
+++ b/test/app/dftb+/geoopt/Cchain_lattice/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/geoopt/Cchain_lattice/dftb_in.hsd
+++ b/test/app/dftb+/geoopt/Cchain_lattice/dftb_in.hsd
@@ -24,6 +24,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/geoopt/Cchain_lattice_lbfgs/C-C.skf
+++ b/test/app/dftb+/geoopt/Cchain_lattice_lbfgs/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/geoopt/Cchain_lattice_lbfgs/dftb_in.hsd
+++ b/test/app/dftb+/geoopt/Cchain_lattice_lbfgs/dftb_in.hsd
@@ -24,6 +24,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/geoopt/GaAs_8_latconst/As-As.skf
+++ b/test/app/dftb+/geoopt/GaAs_8_latconst/As-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-As.skf

--- a/test/app/dftb+/geoopt/GaAs_8_latconst/As-Ga.skf
+++ b/test/app/dftb+/geoopt/GaAs_8_latconst/As-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-Ga.skf

--- a/test/app/dftb+/geoopt/GaAs_8_latconst/Ga-As.skf
+++ b/test/app/dftb+/geoopt/GaAs_8_latconst/Ga-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-As.skf

--- a/test/app/dftb+/geoopt/GaAs_8_latconst/Ga-Ga.skf
+++ b/test/app/dftb+/geoopt/GaAs_8_latconst/Ga-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-Ga.skf

--- a/test/app/dftb+/geoopt/GaAs_8_latconst/dftb_in.hsd
+++ b/test/app/dftb+/geoopt/GaAs_8_latconst/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     As = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/hyb-0-2/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/geoopt/GaAs_8_latconst_lbfgs/Ag-Ag.skf
+++ b/test/app/dftb+/geoopt/GaAs_8_latconst_lbfgs/Ag-Ag.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ag-Ag.skf

--- a/test/app/dftb+/geoopt/GaAs_8_latconst_lbfgs/As-As.skf
+++ b/test/app/dftb+/geoopt/GaAs_8_latconst_lbfgs/As-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-As.skf

--- a/test/app/dftb+/geoopt/GaAs_8_latconst_lbfgs/As-Ga.skf
+++ b/test/app/dftb+/geoopt/GaAs_8_latconst_lbfgs/As-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-Ga.skf

--- a/test/app/dftb+/geoopt/GaAs_8_latconst_lbfgs/Ga-As.skf
+++ b/test/app/dftb+/geoopt/GaAs_8_latconst_lbfgs/Ga-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-As.skf

--- a/test/app/dftb+/geoopt/GaAs_8_latconst_lbfgs/Ga-Ga.skf
+++ b/test/app/dftb+/geoopt/GaAs_8_latconst_lbfgs/Ga-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-Ga.skf

--- a/test/app/dftb+/geoopt/GaAs_8_latconst_lbfgs/dftb_in.hsd
+++ b/test/app/dftb+/geoopt/GaAs_8_latconst_lbfgs/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     As = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/hyb-0-2/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/geoopt/diamond_isotropic/C-C.skf
+++ b/test/app/dftb+/geoopt/diamond_isotropic/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-C.skf

--- a/test/app/dftb+/geoopt/diamond_isotropic/dftb_in.hsd
+++ b/test/app/dftb+/geoopt/diamond_isotropic/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/pbc-0-3/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/geoopt/diamond_presure/C-C.skf
+++ b/test/app/dftb+/geoopt/diamond_presure/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-C.skf

--- a/test/app/dftb+/geoopt/diamond_presure/dftb_in.hsd
+++ b/test/app/dftb+/geoopt/diamond_presure/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/pbc-0-3/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/h-bonds/D3H5_ice/H-H.skf
+++ b/test/app/dftb+/h-bonds/D3H5_ice/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/h-bonds/D3H5_ice/H-O.skf
+++ b/test/app/dftb+/h-bonds/D3H5_ice/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/h-bonds/D3H5_ice/O-H.skf
+++ b/test/app/dftb+/h-bonds/D3H5_ice/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/h-bonds/D3H5_ice/O-O.skf
+++ b/test/app/dftb+/h-bonds/D3H5_ice/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/h-bonds/D3H5_ice/dftb_in.hsd
+++ b/test/app/dftb+/h-bonds/D3H5_ice/dftb_in.hsd
@@ -63,6 +63,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/h-bonds/D3H5_water_dimer/H-H.skf
+++ b/test/app/dftb+/h-bonds/D3H5_water_dimer/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/h-bonds/D3H5_water_dimer/H-O.skf
+++ b/test/app/dftb+/h-bonds/D3H5_water_dimer/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/h-bonds/D3H5_water_dimer/O-H.skf
+++ b/test/app/dftb+/h-bonds/D3H5_water_dimer/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/h-bonds/D3H5_water_dimer/O-O.skf
+++ b/test/app/dftb+/h-bonds/D3H5_water_dimer/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/h-bonds/D3H5_water_dimer/dftb_in.hsd
+++ b/test/app/dftb+/h-bonds/D3H5_water_dimer/dftb_in.hsd
@@ -18,6 +18,7 @@ Hamiltonian = DFTB {
   }
   Charge = 0
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = -
     Suffix = .skf
     LowerCaseTypeName = No

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/C-C.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/C-H.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/C-N.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/C-O.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/C-S.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/C-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-S.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/H-C.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/H-H.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/H-N.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/H-O.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/H-S.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/H-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-S.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/N-C.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/N-H.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/N-N.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/N-O.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/N-S.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/N-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-S.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/O-C.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/O-H.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/O-N.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/O-O.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/O-S.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/O-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-S.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/S-C.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/S-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-C.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/S-H.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/S-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-H.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/S-N.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/S-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-N.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/S-O.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/S-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-O.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/S-S.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/S-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-S.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces/dftb_in.hsd
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces/dftb_in.hsd
@@ -33,6 +33,7 @@ Hamiltonian = DFTB {
   }
   Charge = 0
   SlaterKosterFiles = Type2FileNames {
+    Prefix = {slakos/origin/mio-1-1/}
     Separator = -
     Suffix = .skf
     LowerCaseTypeName = No

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/C-C.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/C-H.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/C-N.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/C-O.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/C-S.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/C-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-S.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/H-C.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/H-H.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/H-N.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/H-O.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/H-S.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/H-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-S.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/N-C.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/N-H.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/N-N.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/N-O.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/N-S.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/N-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-S.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/O-C.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/O-H.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/O-N.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/O-O.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/O-S.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/O-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-S.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/S-C.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/S-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-C.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/S-H.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/S-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-H.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/S-N.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/S-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-N.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/S-O.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/S-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-O.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/S-S.skf
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/S-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-S.skf

--- a/test/app/dftb+/h-bonds/H5_ONS_forces_eq/dftb_in.hsd
+++ b/test/app/dftb+/h-bonds/H5_ONS_forces_eq/dftb_in.hsd
@@ -33,6 +33,7 @@ Hamiltonian = DFTB {
   }
   Charge = 0
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = -
     Suffix = .skf
     LowerCaseTypeName = No

--- a/test/app/dftb+/h-bonds/H5_defaults/C-C.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/C-H.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/C-N.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/C-O.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/C-S.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/C-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-S.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/H-C.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/H-H.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/H-N.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/H-O.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/H-S.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/H-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-S.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/N-C.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/N-H.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/N-N.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/N-O.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/N-S.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/N-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-S.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/O-C.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/O-H.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/O-N.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/O-O.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/O-S.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/O-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-S.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/S-C.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/S-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-C.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/S-H.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/S-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-H.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/S-N.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/S-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-N.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/S-O.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/S-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-O.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/S-S.skf
+++ b/test/app/dftb+/h-bonds/H5_defaults/S-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-S.skf

--- a/test/app/dftb+/h-bonds/H5_defaults/dftb_in.hsd
+++ b/test/app/dftb+/h-bonds/H5_defaults/dftb_in.hsd
@@ -33,6 +33,7 @@ Hamiltonian = DFTB {
   }
   Charge = 0
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = -
     Suffix = .skf
     LowerCaseTypeName = No

--- a/test/app/dftb+/halogen/3492/Br-Br.skf
+++ b/test/app/dftb+/halogen/3492/Br-Br.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Br-Br.skf

--- a/test/app/dftb+/halogen/3492/Br-C.skf
+++ b/test/app/dftb+/halogen/3492/Br-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Br-C.skf

--- a/test/app/dftb+/halogen/3492/Br-H.skf
+++ b/test/app/dftb+/halogen/3492/Br-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Br-H.skf

--- a/test/app/dftb+/halogen/3492/Br-O.skf
+++ b/test/app/dftb+/halogen/3492/Br-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Br-O.skf

--- a/test/app/dftb+/halogen/3492/C-Br.skf
+++ b/test/app/dftb+/halogen/3492/C-Br.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-Br.skf

--- a/test/app/dftb+/halogen/3492/C-C.skf
+++ b/test/app/dftb+/halogen/3492/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-C.skf

--- a/test/app/dftb+/halogen/3492/C-H.skf
+++ b/test/app/dftb+/halogen/3492/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-H.skf

--- a/test/app/dftb+/halogen/3492/C-O.skf
+++ b/test/app/dftb+/halogen/3492/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-O.skf

--- a/test/app/dftb+/halogen/3492/H-Br.skf
+++ b/test/app/dftb+/halogen/3492/H-Br.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-Br.skf

--- a/test/app/dftb+/halogen/3492/H-C.skf
+++ b/test/app/dftb+/halogen/3492/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-C.skf

--- a/test/app/dftb+/halogen/3492/H-H.skf
+++ b/test/app/dftb+/halogen/3492/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-H.skf

--- a/test/app/dftb+/halogen/3492/H-O.skf
+++ b/test/app/dftb+/halogen/3492/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-O.skf

--- a/test/app/dftb+/halogen/3492/O-Br.skf
+++ b/test/app/dftb+/halogen/3492/O-Br.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-Br.skf

--- a/test/app/dftb+/halogen/3492/O-C.skf
+++ b/test/app/dftb+/halogen/3492/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-C.skf

--- a/test/app/dftb+/halogen/3492/O-H.skf
+++ b/test/app/dftb+/halogen/3492/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-H.skf

--- a/test/app/dftb+/halogen/3492/O-O.skf
+++ b/test/app/dftb+/halogen/3492/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-O.skf

--- a/test/app/dftb+/halogen/3492/dftb_in.hsd
+++ b/test/app/dftb+/halogen/3492/dftb_in.hsd
@@ -16,7 +16,7 @@ Hamiltonian = DFTB {
        Br = "d"
     }
     SlaterKosterFiles = Type2FileNames {
-       Prefix = "./"
+       Prefix = "slakos/origin/3ob-3-1/"
        Separator = "-"
        Suffix  = ".skf"
     }

--- a/test/app/dftb+/halogen/3499/C-C.skf
+++ b/test/app/dftb+/halogen/3499/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-C.skf

--- a/test/app/dftb+/halogen/3499/C-H.skf
+++ b/test/app/dftb+/halogen/3499/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-H.skf

--- a/test/app/dftb+/halogen/3499/C-I.skf
+++ b/test/app/dftb+/halogen/3499/C-I.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-I.skf

--- a/test/app/dftb+/halogen/3499/C-O.skf
+++ b/test/app/dftb+/halogen/3499/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-O.skf

--- a/test/app/dftb+/halogen/3499/H-C.skf
+++ b/test/app/dftb+/halogen/3499/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-C.skf

--- a/test/app/dftb+/halogen/3499/H-H.skf
+++ b/test/app/dftb+/halogen/3499/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-H.skf

--- a/test/app/dftb+/halogen/3499/H-I.skf
+++ b/test/app/dftb+/halogen/3499/H-I.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-I.skf

--- a/test/app/dftb+/halogen/3499/H-O.skf
+++ b/test/app/dftb+/halogen/3499/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-O.skf

--- a/test/app/dftb+/halogen/3499/I-C.skf
+++ b/test/app/dftb+/halogen/3499/I-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/I-C.skf

--- a/test/app/dftb+/halogen/3499/I-H.skf
+++ b/test/app/dftb+/halogen/3499/I-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/I-H.skf

--- a/test/app/dftb+/halogen/3499/I-I.skf
+++ b/test/app/dftb+/halogen/3499/I-I.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/I-I.skf

--- a/test/app/dftb+/halogen/3499/I-O.skf
+++ b/test/app/dftb+/halogen/3499/I-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/I-O.skf

--- a/test/app/dftb+/halogen/3499/O-C.skf
+++ b/test/app/dftb+/halogen/3499/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-C.skf

--- a/test/app/dftb+/halogen/3499/O-H.skf
+++ b/test/app/dftb+/halogen/3499/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-H.skf

--- a/test/app/dftb+/halogen/3499/O-I.skf
+++ b/test/app/dftb+/halogen/3499/O-I.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-I.skf

--- a/test/app/dftb+/halogen/3499/O-O.skf
+++ b/test/app/dftb+/halogen/3499/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-O.skf

--- a/test/app/dftb+/halogen/3499/dftb_in.hsd
+++ b/test/app/dftb+/halogen/3499/dftb_in.hsd
@@ -16,7 +16,7 @@ Hamiltonian = DFTB {
        I = "d"
     }
     SlaterKosterFiles = Type2FileNames {
-       Prefix = "./"
+       Prefix = "slakos/origin/3ob-3-1/"
        Separator = "-"
        Suffix  = ".skf"
     }

--- a/test/app/dftb+/halogen/3500/C-C.skf
+++ b/test/app/dftb+/halogen/3500/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-C.skf

--- a/test/app/dftb+/halogen/3500/C-Cl.skf
+++ b/test/app/dftb+/halogen/3500/C-Cl.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-Cl.skf

--- a/test/app/dftb+/halogen/3500/C-H.skf
+++ b/test/app/dftb+/halogen/3500/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-H.skf

--- a/test/app/dftb+/halogen/3500/C-N.skf
+++ b/test/app/dftb+/halogen/3500/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-N.skf

--- a/test/app/dftb+/halogen/3500/Cl-C.skf
+++ b/test/app/dftb+/halogen/3500/Cl-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Cl-C.skf

--- a/test/app/dftb+/halogen/3500/Cl-Cl.skf
+++ b/test/app/dftb+/halogen/3500/Cl-Cl.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Cl-Cl.skf

--- a/test/app/dftb+/halogen/3500/Cl-H.skf
+++ b/test/app/dftb+/halogen/3500/Cl-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Cl-H.skf

--- a/test/app/dftb+/halogen/3500/Cl-N.skf
+++ b/test/app/dftb+/halogen/3500/Cl-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Cl-N.skf

--- a/test/app/dftb+/halogen/3500/H-C.skf
+++ b/test/app/dftb+/halogen/3500/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-C.skf

--- a/test/app/dftb+/halogen/3500/H-Cl.skf
+++ b/test/app/dftb+/halogen/3500/H-Cl.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-Cl.skf

--- a/test/app/dftb+/halogen/3500/H-H.skf
+++ b/test/app/dftb+/halogen/3500/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-H.skf

--- a/test/app/dftb+/halogen/3500/H-N.skf
+++ b/test/app/dftb+/halogen/3500/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-N.skf

--- a/test/app/dftb+/halogen/3500/N-C.skf
+++ b/test/app/dftb+/halogen/3500/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-C.skf

--- a/test/app/dftb+/halogen/3500/N-Cl.skf
+++ b/test/app/dftb+/halogen/3500/N-Cl.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-Cl.skf

--- a/test/app/dftb+/halogen/3500/N-H.skf
+++ b/test/app/dftb+/halogen/3500/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-H.skf

--- a/test/app/dftb+/halogen/3500/N-N.skf
+++ b/test/app/dftb+/halogen/3500/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-N.skf

--- a/test/app/dftb+/halogen/3500/dftb_in.hsd
+++ b/test/app/dftb+/halogen/3500/dftb_in.hsd
@@ -20,7 +20,7 @@ Hamiltonian = DFTB {
        I = "d"
     }
     SlaterKosterFiles = Type2FileNames {
-       Prefix = "./"
+       Prefix = "slakos/origin/3ob-3-1/"
        Separator = "-"
        Suffix  = ".skf"
     }

--- a/test/app/dftb+/halogen/3501/Br-Br.skf
+++ b/test/app/dftb+/halogen/3501/Br-Br.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Br-Br.skf

--- a/test/app/dftb+/halogen/3501/Br-C.skf
+++ b/test/app/dftb+/halogen/3501/Br-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Br-C.skf

--- a/test/app/dftb+/halogen/3501/Br-H.skf
+++ b/test/app/dftb+/halogen/3501/Br-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Br-H.skf

--- a/test/app/dftb+/halogen/3501/Br-N.skf
+++ b/test/app/dftb+/halogen/3501/Br-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Br-N.skf

--- a/test/app/dftb+/halogen/3501/C-Br.skf
+++ b/test/app/dftb+/halogen/3501/C-Br.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-Br.skf

--- a/test/app/dftb+/halogen/3501/C-C.skf
+++ b/test/app/dftb+/halogen/3501/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-C.skf

--- a/test/app/dftb+/halogen/3501/C-H.skf
+++ b/test/app/dftb+/halogen/3501/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-H.skf

--- a/test/app/dftb+/halogen/3501/C-N.skf
+++ b/test/app/dftb+/halogen/3501/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-N.skf

--- a/test/app/dftb+/halogen/3501/H-Br.skf
+++ b/test/app/dftb+/halogen/3501/H-Br.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-Br.skf

--- a/test/app/dftb+/halogen/3501/H-C.skf
+++ b/test/app/dftb+/halogen/3501/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-C.skf

--- a/test/app/dftb+/halogen/3501/H-H.skf
+++ b/test/app/dftb+/halogen/3501/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-H.skf

--- a/test/app/dftb+/halogen/3501/H-N.skf
+++ b/test/app/dftb+/halogen/3501/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-N.skf

--- a/test/app/dftb+/halogen/3501/N-Br.skf
+++ b/test/app/dftb+/halogen/3501/N-Br.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-Br.skf

--- a/test/app/dftb+/halogen/3501/N-C.skf
+++ b/test/app/dftb+/halogen/3501/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-C.skf

--- a/test/app/dftb+/halogen/3501/N-H.skf
+++ b/test/app/dftb+/halogen/3501/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-H.skf

--- a/test/app/dftb+/halogen/3501/N-N.skf
+++ b/test/app/dftb+/halogen/3501/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-N.skf

--- a/test/app/dftb+/halogen/3501/dftb_in.hsd
+++ b/test/app/dftb+/halogen/3501/dftb_in.hsd
@@ -20,7 +20,7 @@ Hamiltonian = DFTB {
        I = "d"
     }
     SlaterKosterFiles = Type2FileNames {
-       Prefix = "./"
+       Prefix = "slakos/origin/3ob-3-1/"
        Separator = "-"
        Suffix  = ".skf"
     }

--- a/test/app/dftb+/halogen/3502/C-C.skf
+++ b/test/app/dftb+/halogen/3502/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-C.skf

--- a/test/app/dftb+/halogen/3502/C-H.skf
+++ b/test/app/dftb+/halogen/3502/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-H.skf

--- a/test/app/dftb+/halogen/3502/C-I.skf
+++ b/test/app/dftb+/halogen/3502/C-I.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-I.skf

--- a/test/app/dftb+/halogen/3502/C-N.skf
+++ b/test/app/dftb+/halogen/3502/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-N.skf

--- a/test/app/dftb+/halogen/3502/H-C.skf
+++ b/test/app/dftb+/halogen/3502/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-C.skf

--- a/test/app/dftb+/halogen/3502/H-H.skf
+++ b/test/app/dftb+/halogen/3502/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-H.skf

--- a/test/app/dftb+/halogen/3502/H-I.skf
+++ b/test/app/dftb+/halogen/3502/H-I.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-I.skf

--- a/test/app/dftb+/halogen/3502/H-N.skf
+++ b/test/app/dftb+/halogen/3502/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-N.skf

--- a/test/app/dftb+/halogen/3502/I-C.skf
+++ b/test/app/dftb+/halogen/3502/I-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/I-C.skf

--- a/test/app/dftb+/halogen/3502/I-H.skf
+++ b/test/app/dftb+/halogen/3502/I-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/I-H.skf

--- a/test/app/dftb+/halogen/3502/I-I.skf
+++ b/test/app/dftb+/halogen/3502/I-I.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/I-I.skf

--- a/test/app/dftb+/halogen/3502/I-N.skf
+++ b/test/app/dftb+/halogen/3502/I-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/I-N.skf

--- a/test/app/dftb+/halogen/3502/N-C.skf
+++ b/test/app/dftb+/halogen/3502/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-C.skf

--- a/test/app/dftb+/halogen/3502/N-H.skf
+++ b/test/app/dftb+/halogen/3502/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-H.skf

--- a/test/app/dftb+/halogen/3502/N-I.skf
+++ b/test/app/dftb+/halogen/3502/N-I.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-I.skf

--- a/test/app/dftb+/halogen/3502/N-N.skf
+++ b/test/app/dftb+/halogen/3502/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-N.skf

--- a/test/app/dftb+/halogen/3502/dftb_in.hsd
+++ b/test/app/dftb+/halogen/3502/dftb_in.hsd
@@ -20,7 +20,7 @@ Hamiltonian = DFTB {
        I = "d"
     }
     SlaterKosterFiles = Type2FileNames {
-       Prefix = "./"
+       Prefix = "slakos/origin/3ob-3-1/"
        Separator = "-"
        Suffix  = ".skf"
     }

--- a/test/app/dftb+/halogen/3518/C-C.skf
+++ b/test/app/dftb+/halogen/3518/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-C.skf

--- a/test/app/dftb+/halogen/3518/C-Cl.skf
+++ b/test/app/dftb+/halogen/3518/C-Cl.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-Cl.skf

--- a/test/app/dftb+/halogen/3518/C-H.skf
+++ b/test/app/dftb+/halogen/3518/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-H.skf

--- a/test/app/dftb+/halogen/3518/C-O.skf
+++ b/test/app/dftb+/halogen/3518/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-O.skf

--- a/test/app/dftb+/halogen/3518/Cl-C.skf
+++ b/test/app/dftb+/halogen/3518/Cl-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Cl-C.skf

--- a/test/app/dftb+/halogen/3518/Cl-Cl.skf
+++ b/test/app/dftb+/halogen/3518/Cl-Cl.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Cl-Cl.skf

--- a/test/app/dftb+/halogen/3518/Cl-H.skf
+++ b/test/app/dftb+/halogen/3518/Cl-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Cl-H.skf

--- a/test/app/dftb+/halogen/3518/Cl-O.skf
+++ b/test/app/dftb+/halogen/3518/Cl-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/Cl-O.skf

--- a/test/app/dftb+/halogen/3518/H-C.skf
+++ b/test/app/dftb+/halogen/3518/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-C.skf

--- a/test/app/dftb+/halogen/3518/H-Cl.skf
+++ b/test/app/dftb+/halogen/3518/H-Cl.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-Cl.skf

--- a/test/app/dftb+/halogen/3518/H-H.skf
+++ b/test/app/dftb+/halogen/3518/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-H.skf

--- a/test/app/dftb+/halogen/3518/H-O.skf
+++ b/test/app/dftb+/halogen/3518/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-O.skf

--- a/test/app/dftb+/halogen/3518/O-C.skf
+++ b/test/app/dftb+/halogen/3518/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-C.skf

--- a/test/app/dftb+/halogen/3518/O-Cl.skf
+++ b/test/app/dftb+/halogen/3518/O-Cl.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-Cl.skf

--- a/test/app/dftb+/halogen/3518/O-H.skf
+++ b/test/app/dftb+/halogen/3518/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-H.skf

--- a/test/app/dftb+/halogen/3518/O-O.skf
+++ b/test/app/dftb+/halogen/3518/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-O.skf

--- a/test/app/dftb+/halogen/3518/dftb_in.hsd
+++ b/test/app/dftb+/halogen/3518/dftb_in.hsd
@@ -20,7 +20,7 @@ Hamiltonian = DFTB {
        I = "d"
     }
     SlaterKosterFiles = Type2FileNames {
-       Prefix = "./"
+       Prefix = "slakos/origin/3ob-3-1/"
        Separator = "-"
        Suffix  = ".skf"
     }

--- a/test/app/dftb+/input/ammonia_poscar/H-H.skf
+++ b/test/app/dftb+/input/ammonia_poscar/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/input/ammonia_poscar/H-N.skf
+++ b/test/app/dftb+/input/ammonia_poscar/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/input/ammonia_poscar/N-H.skf
+++ b/test/app/dftb+/input/ammonia_poscar/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/input/ammonia_poscar/N-N.skf
+++ b/test/app/dftb+/input/ammonia_poscar/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/input/ammonia_poscar/dftb_in.hsd
+++ b/test/app/dftb+/input/ammonia_poscar/dftb_in.hsd
@@ -14,6 +14,7 @@ Hamiltonian = DFTB {
     N = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/input/caffeine_gen/C-C.skf
+++ b/test/app/dftb+/input/caffeine_gen/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/input/caffeine_gen/C-H.skf
+++ b/test/app/dftb+/input/caffeine_gen/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/input/caffeine_gen/C-N.skf
+++ b/test/app/dftb+/input/caffeine_gen/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/input/caffeine_gen/C-O.skf
+++ b/test/app/dftb+/input/caffeine_gen/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/input/caffeine_gen/H-C.skf
+++ b/test/app/dftb+/input/caffeine_gen/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/input/caffeine_gen/H-H.skf
+++ b/test/app/dftb+/input/caffeine_gen/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/input/caffeine_gen/H-N.skf
+++ b/test/app/dftb+/input/caffeine_gen/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/input/caffeine_gen/H-O.skf
+++ b/test/app/dftb+/input/caffeine_gen/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/input/caffeine_gen/N-C.skf
+++ b/test/app/dftb+/input/caffeine_gen/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/input/caffeine_gen/N-H.skf
+++ b/test/app/dftb+/input/caffeine_gen/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/input/caffeine_gen/N-N.skf
+++ b/test/app/dftb+/input/caffeine_gen/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/input/caffeine_gen/N-O.skf
+++ b/test/app/dftb+/input/caffeine_gen/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/input/caffeine_gen/O-C.skf
+++ b/test/app/dftb+/input/caffeine_gen/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/input/caffeine_gen/O-H.skf
+++ b/test/app/dftb+/input/caffeine_gen/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/input/caffeine_gen/O-N.skf
+++ b/test/app/dftb+/input/caffeine_gen/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/input/caffeine_gen/O-O.skf
+++ b/test/app/dftb+/input/caffeine_gen/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/input/caffeine_gen/dftb_in.hsd
+++ b/test/app/dftb+/input/caffeine_gen/dftb_in.hsd
@@ -15,6 +15,7 @@ Hamiltonian = DFTB {
   }
   EigenSolver = DivideAndConquer {}
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/input/caffeine_xyz/C-C.skf
+++ b/test/app/dftb+/input/caffeine_xyz/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/input/caffeine_xyz/C-H.skf
+++ b/test/app/dftb+/input/caffeine_xyz/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/input/caffeine_xyz/C-N.skf
+++ b/test/app/dftb+/input/caffeine_xyz/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/input/caffeine_xyz/C-O.skf
+++ b/test/app/dftb+/input/caffeine_xyz/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/input/caffeine_xyz/H-C.skf
+++ b/test/app/dftb+/input/caffeine_xyz/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/input/caffeine_xyz/H-H.skf
+++ b/test/app/dftb+/input/caffeine_xyz/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/input/caffeine_xyz/H-N.skf
+++ b/test/app/dftb+/input/caffeine_xyz/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/input/caffeine_xyz/H-O.skf
+++ b/test/app/dftb+/input/caffeine_xyz/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/input/caffeine_xyz/N-C.skf
+++ b/test/app/dftb+/input/caffeine_xyz/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/input/caffeine_xyz/N-H.skf
+++ b/test/app/dftb+/input/caffeine_xyz/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/input/caffeine_xyz/N-N.skf
+++ b/test/app/dftb+/input/caffeine_xyz/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/input/caffeine_xyz/N-O.skf
+++ b/test/app/dftb+/input/caffeine_xyz/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/input/caffeine_xyz/O-C.skf
+++ b/test/app/dftb+/input/caffeine_xyz/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/input/caffeine_xyz/O-H.skf
+++ b/test/app/dftb+/input/caffeine_xyz/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/input/caffeine_xyz/O-N.skf
+++ b/test/app/dftb+/input/caffeine_xyz/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/input/caffeine_xyz/O-O.skf
+++ b/test/app/dftb+/input/caffeine_xyz/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/input/caffeine_xyz/dftb_in.hsd
+++ b/test/app/dftb+/input/caffeine_xyz/dftb_in.hsd
@@ -14,6 +14,7 @@ Hamiltonian = DFTB {
     N = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/input/unsorted_contcar/As-As.skf
+++ b/test/app/dftb+/input/unsorted_contcar/As-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-As.skf

--- a/test/app/dftb+/input/unsorted_contcar/As-Ga.skf
+++ b/test/app/dftb+/input/unsorted_contcar/As-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-Ga.skf

--- a/test/app/dftb+/input/unsorted_contcar/Ga-As.skf
+++ b/test/app/dftb+/input/unsorted_contcar/Ga-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-As.skf

--- a/test/app/dftb+/input/unsorted_contcar/Ga-Ga.skf
+++ b/test/app/dftb+/input/unsorted_contcar/Ga-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-Ga.skf

--- a/test/app/dftb+/input/unsorted_contcar/dftb_in.hsd
+++ b/test/app/dftb+/input/unsorted_contcar/dftb_in.hsd
@@ -14,6 +14,7 @@ Hamiltonian = DFTB {
     As = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/hyb-0-2/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/md/DNA/C-C.skf
+++ b/test/app/dftb+/md/DNA/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/md/DNA/C-H.skf
+++ b/test/app/dftb+/md/DNA/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/md/DNA/C-N.skf
+++ b/test/app/dftb+/md/DNA/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/md/DNA/C-O.skf
+++ b/test/app/dftb+/md/DNA/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/md/DNA/H-C.skf
+++ b/test/app/dftb+/md/DNA/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/md/DNA/H-H.skf
+++ b/test/app/dftb+/md/DNA/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/md/DNA/H-N.skf
+++ b/test/app/dftb+/md/DNA/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/md/DNA/H-O.skf
+++ b/test/app/dftb+/md/DNA/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/md/DNA/N-C.skf
+++ b/test/app/dftb+/md/DNA/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/md/DNA/N-H.skf
+++ b/test/app/dftb+/md/DNA/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/md/DNA/N-N.skf
+++ b/test/app/dftb+/md/DNA/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/md/DNA/N-O.skf
+++ b/test/app/dftb+/md/DNA/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/md/DNA/O-C.skf
+++ b/test/app/dftb+/md/DNA/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/md/DNA/O-H.skf
+++ b/test/app/dftb+/md/DNA/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/md/DNA/O-N.skf
+++ b/test/app/dftb+/md/DNA/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/md/DNA/O-O.skf
+++ b/test/app/dftb+/md/DNA/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/md/DNA/dftb_in.hsd
+++ b/test/app/dftb+/md/DNA/dftb_in.hsd
@@ -84,7 +84,7 @@ Driver = VelocityVerlet {
 Hamiltonian = DFTB {
   SCC = Yes
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "./"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/md/DNA_Berendsen2/C-C.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/C-H.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/C-N.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/C-O.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/H-C.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/H-H.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/H-N.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/H-O.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/N-C.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/N-H.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/N-N.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/N-O.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/O-C.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/O-H.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/O-N.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/O-O.skf
+++ b/test/app/dftb+/md/DNA_Berendsen2/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/md/DNA_Berendsen2/dftb_in.hsd
+++ b/test/app/dftb+/md/DNA_Berendsen2/dftb_in.hsd
@@ -84,7 +84,7 @@ Driver = VelocityVerlet {
 Hamiltonian = DFTB {
   SCC = Yes
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "./"
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/md/H2O-extfield/H-H.skf
+++ b/test/app/dftb+/md/H2O-extfield/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/md/H2O-extfield/H-O.skf
+++ b/test/app/dftb+/md/H2O-extfield/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/md/H2O-extfield/O-H.skf
+++ b/test/app/dftb+/md/H2O-extfield/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/md/H2O-extfield/O-O.skf
+++ b/test/app/dftb+/md/H2O-extfield/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/md/H2O-extfield/dftb_in.hsd
+++ b/test/app/dftb+/md/H2O-extfield/dftb_in.hsd
@@ -28,6 +28,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/md/SiH-surface/H-H.skf
+++ b/test/app/dftb+/md/SiH-surface/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/H-H.skf

--- a/test/app/dftb+/md/SiH-surface/H-Si.skf
+++ b/test/app/dftb+/md/SiH-surface/H-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/H-Si.skf

--- a/test/app/dftb+/md/SiH-surface/Si-H.skf
+++ b/test/app/dftb+/md/SiH-surface/Si-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-H.skf

--- a/test/app/dftb+/md/SiH-surface/Si-Si.skf
+++ b/test/app/dftb+/md/SiH-surface/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-Si.skf

--- a/test/app/dftb+/md/SiH-surface/dftb_in.hsd
+++ b/test/app/dftb+/md/SiH-surface/dftb_in.hsd
@@ -72,7 +72,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 273.15
   }
   SlaterKosterFiles = Type2FileNames {
-    Prefix = "./"
+    Prefix = "slakos/origin/pbc-0-3/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/md/SiH-surface_restart/H-H.skf
+++ b/test/app/dftb+/md/SiH-surface_restart/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/H-H.skf

--- a/test/app/dftb+/md/SiH-surface_restart/H-Si.skf
+++ b/test/app/dftb+/md/SiH-surface_restart/H-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/H-Si.skf

--- a/test/app/dftb+/md/SiH-surface_restart/Si-H.skf
+++ b/test/app/dftb+/md/SiH-surface_restart/Si-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-H.skf

--- a/test/app/dftb+/md/SiH-surface_restart/Si-Si.skf
+++ b/test/app/dftb+/md/SiH-surface_restart/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-Si.skf

--- a/test/app/dftb+/md/SiH-surface_restart/dftb_in1.hsd
+++ b/test/app/dftb+/md/SiH-surface_restart/dftb_in1.hsd
@@ -67,7 +67,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 273.15
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/pbc-0-3/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/md/SiH-surface_restart/dftb_in2.hsd
+++ b/test/app/dftb+/md/SiH-surface_restart/dftb_in2.hsd
@@ -27,7 +27,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 273.15
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/pbc-0-3/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/md/Si_8_restart/Si-Si.skf
+++ b/test/app/dftb+/md/Si_8_restart/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-Si.skf

--- a/test/app/dftb+/md/Si_8_restart/dftb_in.hsd
+++ b/test/app/dftb+/md/Si_8_restart/dftb_in.hsd
@@ -42,6 +42,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1200.0
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/pbc-0-3/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/md/Vsi+O-plumed/O-O.skf
+++ b/test/app/dftb+/md/Vsi+O-plumed/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/O-O.skf

--- a/test/app/dftb+/md/Vsi+O-plumed/O-Si.skf
+++ b/test/app/dftb+/md/Vsi+O-plumed/O-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/O-Si.skf

--- a/test/app/dftb+/md/Vsi+O-plumed/Si-O.skf
+++ b/test/app/dftb+/md/Vsi+O-plumed/Si-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-O.skf

--- a/test/app/dftb+/md/Vsi+O-plumed/Si-Si.skf
+++ b/test/app/dftb+/md/Vsi+O-plumed/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-Si.skf

--- a/test/app/dftb+/md/Vsi+O-plumed/dftb_in.hsd
+++ b/test/app/dftb+/md/Vsi+O-plumed/dftb_in.hsd
@@ -26,6 +26,7 @@ Hamiltonian = DFTB {
   }
 
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/pbc-0-3/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/md/ice_Ic/H-H.skf
+++ b/test/app/dftb+/md/ice_Ic/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/md/ice_Ic/H-O.skf
+++ b/test/app/dftb+/md/ice_Ic/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/md/ice_Ic/O-H.skf
+++ b/test/app/dftb+/md/ice_Ic/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/md/ice_Ic/O-O.skf
+++ b/test/app/dftb+/md/ice_Ic/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/md/ice_Ic/dftb_in.hsd
+++ b/test/app/dftb+/md/ice_Ic/dftb_in.hsd
@@ -79,6 +79,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.0
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/md/ptcda-xlbomd-ldep/C-C.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd-ldep/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/md/ptcda-xlbomd-ldep/C-H.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd-ldep/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/md/ptcda-xlbomd-ldep/C-O.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd-ldep/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/md/ptcda-xlbomd-ldep/H-C.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd-ldep/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/md/ptcda-xlbomd-ldep/H-H.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd-ldep/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/md/ptcda-xlbomd-ldep/H-O.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd-ldep/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/md/ptcda-xlbomd-ldep/O-C.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd-ldep/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/md/ptcda-xlbomd-ldep/O-H.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd-ldep/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/md/ptcda-xlbomd-ldep/O-O.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd-ldep/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/md/ptcda-xlbomd-ldep/dftb_in.hsd
+++ b/test/app/dftb+/md/ptcda-xlbomd-ldep/dftb_in.hsd
@@ -62,7 +62,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 400
   }
   SlaterKosterFiles = Type2FileNames {
-   Prefix = "./"
+   Prefix = "slakos/origin/mio-1-1/"
    Separator = "-"
    Suffix = ".skf" 
   }

--- a/test/app/dftb+/md/ptcda-xlbomd/C-C.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/md/ptcda-xlbomd/C-H.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/md/ptcda-xlbomd/C-O.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/md/ptcda-xlbomd/H-C.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/md/ptcda-xlbomd/H-H.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/md/ptcda-xlbomd/H-O.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/md/ptcda-xlbomd/O-C.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/md/ptcda-xlbomd/O-H.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/md/ptcda-xlbomd/O-O.skf
+++ b/test/app/dftb+/md/ptcda-xlbomd/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/md/ptcda-xlbomd/dftb_in.hsd
+++ b/test/app/dftb+/md/ptcda-xlbomd/dftb_in.hsd
@@ -64,7 +64,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 400
   }
   SlaterKosterFiles = Type2FileNames {
-   Prefix = "./"
+   Prefix = "slakos/origin/mio-1-1/"
    Separator = "-"
    Suffix = ".skf" 
   }

--- a/test/app/dftb+/md/ptcda-xlbomdfast-ldep/C-C.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast-ldep/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast-ldep/C-H.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast-ldep/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast-ldep/C-O.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast-ldep/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast-ldep/H-C.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast-ldep/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast-ldep/H-H.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast-ldep/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast-ldep/H-O.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast-ldep/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast-ldep/O-C.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast-ldep/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast-ldep/O-H.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast-ldep/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast-ldep/O-O.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast-ldep/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast-ldep/dftb_in.hsd
+++ b/test/app/dftb+/md/ptcda-xlbomdfast-ldep/dftb_in.hsd
@@ -63,7 +63,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 400
   }
   SlaterKosterFiles = Type2FileNames {
-   Prefix = "./"
+   Prefix = "slakos/origin/mio-1-1/"
    Separator = "-"
    Suffix = ".skf" 
   }

--- a/test/app/dftb+/md/ptcda-xlbomdfast/C-C.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast/C-H.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast/C-O.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast/H-C.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast/H-H.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast/H-O.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast/O-C.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast/O-H.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast/O-O.skf
+++ b/test/app/dftb+/md/ptcda-xlbomdfast/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/md/ptcda-xlbomdfast/dftb_in.hsd
+++ b/test/app/dftb+/md/ptcda-xlbomdfast/dftb_in.hsd
@@ -63,7 +63,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 400
   }
   SlaterKosterFiles = Type2FileNames {
-   Prefix = "./"
+   Prefix = "slakos/origin/mio-1-1/"
    Separator = "-"
    Suffix = ".skf" 
   }

--- a/test/app/dftb+/non-scc/CH4/C-C.skf
+++ b/test/app/dftb+/non-scc/CH4/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/non-scc/CH4/C-H.skf
+++ b/test/app/dftb+/non-scc/CH4/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/non-scc/CH4/H-C.skf
+++ b/test/app/dftb+/non-scc/CH4/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/non-scc/CH4/H-H.skf
+++ b/test/app/dftb+/non-scc/CH4/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/non-scc/CH4/dftb_in.hsd
+++ b/test/app/dftb+/non-scc/CH4/dftb_in.hsd
@@ -19,6 +19,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 100.0
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/non-scc/HBDI-cationic/C-C.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/C-H.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/C-N.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/C-O.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/H-C.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/H-H.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/H-N.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/H-O.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/N-C.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/N-H.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/N-N.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/N-O.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/O-C.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/O-H.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/O-N.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/O-O.skf
+++ b/test/app/dftb+/non-scc/HBDI-cationic/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/non-scc/HBDI-cationic/dftb_in.hsd
+++ b/test/app/dftb+/non-scc/HBDI-cationic/dftb_in.hsd
@@ -45,6 +45,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/non-scc/HBDI-neutral/C-C.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/C-H.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/C-N.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/C-O.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/H-C.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/H-H.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/H-N.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/H-O.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/N-C.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/N-H.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/N-N.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/N-O.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/O-C.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/O-H.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/O-N.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/O-O.skf
+++ b/test/app/dftb+/non-scc/HBDI-neutral/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/non-scc/HBDI-neutral/dftb_in.hsd
+++ b/test/app/dftb+/non-scc/HBDI-neutral/dftb_in.hsd
@@ -45,6 +45,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/non-scc/Si41C23N35/C-C.skf
+++ b/test/app/dftb+/non-scc/Si41C23N35/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-C.skf

--- a/test/app/dftb+/non-scc/Si41C23N35/C-N.skf
+++ b/test/app/dftb+/non-scc/Si41C23N35/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-N.skf

--- a/test/app/dftb+/non-scc/Si41C23N35/C-Si.skf
+++ b/test/app/dftb+/non-scc/Si41C23N35/C-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-Si.skf

--- a/test/app/dftb+/non-scc/Si41C23N35/N-C.skf
+++ b/test/app/dftb+/non-scc/Si41C23N35/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/N-C.skf

--- a/test/app/dftb+/non-scc/Si41C23N35/N-N.skf
+++ b/test/app/dftb+/non-scc/Si41C23N35/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/N-N.skf

--- a/test/app/dftb+/non-scc/Si41C23N35/N-Si.skf
+++ b/test/app/dftb+/non-scc/Si41C23N35/N-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/N-Si.skf

--- a/test/app/dftb+/non-scc/Si41C23N35/Si-C.skf
+++ b/test/app/dftb+/non-scc/Si41C23N35/Si-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-C.skf

--- a/test/app/dftb+/non-scc/Si41C23N35/Si-N.skf
+++ b/test/app/dftb+/non-scc/Si41C23N35/Si-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-N.skf

--- a/test/app/dftb+/non-scc/Si41C23N35/Si-Si.skf
+++ b/test/app/dftb+/non-scc/Si41C23N35/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-Si.skf

--- a/test/app/dftb+/non-scc/Si41C23N35/dftb_in.hsd
+++ b/test/app/dftb+/non-scc/Si41C23N35/dftb_in.hsd
@@ -244,6 +244,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/pbc-0-3/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/non-scc/decapentaene/C-C.skf
+++ b/test/app/dftb+/non-scc/decapentaene/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/non-scc/decapentaene/C-H.skf
+++ b/test/app/dftb+/non-scc/decapentaene/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/non-scc/decapentaene/H-C.skf
+++ b/test/app/dftb+/non-scc/decapentaene/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/non-scc/decapentaene/H-H.skf
+++ b/test/app/dftb+/non-scc/decapentaene/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/non-scc/decapentaene/dftb_in.hsd
+++ b/test/app/dftb+/non-scc/decapentaene/dftb_in.hsd
@@ -37,6 +37,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 100.000000000000
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/onsite/Au13/Au-Au.skf
+++ b/test/app/dftb+/onsite/Au13/Au-Au.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/auorg-1-1/Au-Au.skf

--- a/test/app/dftb+/onsite/Au13/dftb_in.hsd
+++ b/test/app/dftb+/onsite/Au13/dftb_in.hsd
@@ -46,6 +46,7 @@ Hamiltonian = DFTB {
         Au = {0.0 0.42815 0.0274}
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/auorg-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/onsite/Au13pSIC/Au-Au.skf
+++ b/test/app/dftb+/onsite/Au13pSIC/Au-Au.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/auorg-1-1/Au-Au.skf

--- a/test/app/dftb+/onsite/Au13pSIC/dftb_in.hsd
+++ b/test/app/dftb+/onsite/Au13pSIC/dftb_in.hsd
@@ -53,6 +53,7 @@ Hamiltonian = DFTB {
         Au = {0.0 0.42815 0.0274}
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/auorg-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/onsite/H2O/H-H.skf
+++ b/test/app/dftb+/onsite/H2O/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/onsite/H2O/H-O.skf
+++ b/test/app/dftb+/onsite/H2O/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/onsite/H2O/O-H.skf
+++ b/test/app/dftb+/onsite/H2O/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/onsite/H2O/O-O.skf
+++ b/test/app/dftb+/onsite/H2O/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/onsite/H2O/dftb_in.hsd
+++ b/test/app/dftb+/onsite/H2O/dftb_in.hsd
@@ -23,6 +23,7 @@ Hamiltonian = DFTB {
         Hud = {0}
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/poisson/CH4-poisson/C-C.skf
+++ b/test/app/dftb+/poisson/CH4-poisson/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/poisson/CH4-poisson/C-H.skf
+++ b/test/app/dftb+/poisson/CH4-poisson/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/poisson/CH4-poisson/H-C.skf
+++ b/test/app/dftb+/poisson/CH4-poisson/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/poisson/CH4-poisson/H-H.skf
+++ b/test/app/dftb+/poisson/CH4-poisson/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/poisson/CH4-poisson/dftb_in.hsd
+++ b/test/app/dftb+/poisson/CH4-poisson/dftb_in.hsd
@@ -18,6 +18,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/pp-RPA/benzene_TammDancoff/C-C.skf
+++ b/test/app/dftb+/pp-RPA/benzene_TammDancoff/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/pp-RPA/benzene_TammDancoff/C-H.skf
+++ b/test/app/dftb+/pp-RPA/benzene_TammDancoff/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/pp-RPA/benzene_TammDancoff/H-C.skf
+++ b/test/app/dftb+/pp-RPA/benzene_TammDancoff/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/pp-RPA/benzene_TammDancoff/H-H.skf
+++ b/test/app/dftb+/pp-RPA/benzene_TammDancoff/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/pp-RPA/benzene_TammDancoff/dftb_in.hsd
+++ b/test/app/dftb+/pp-RPA/benzene_TammDancoff/dftb_in.hsd
@@ -14,6 +14,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 40
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/pp-RPA/ethene/C-C.skf
+++ b/test/app/dftb+/pp-RPA/ethene/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/pp-RPA/ethene/C-H.skf
+++ b/test/app/dftb+/pp-RPA/ethene/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/pp-RPA/ethene/H-C.skf
+++ b/test/app/dftb+/pp-RPA/ethene/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/pp-RPA/ethene/H-H.skf
+++ b/test/app/dftb+/pp-RPA/ethene/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/pp-RPA/ethene/dftb_in.hsd
+++ b/test/app/dftb+/pp-RPA/ethene/dftb_in.hsd
@@ -14,6 +14,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 40
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/pp-RPA/furan_OrbConst/C-C.skf
+++ b/test/app/dftb+/pp-RPA/furan_OrbConst/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/pp-RPA/furan_OrbConst/C-H.skf
+++ b/test/app/dftb+/pp-RPA/furan_OrbConst/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/pp-RPA/furan_OrbConst/C-O.skf
+++ b/test/app/dftb+/pp-RPA/furan_OrbConst/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/pp-RPA/furan_OrbConst/H-C.skf
+++ b/test/app/dftb+/pp-RPA/furan_OrbConst/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/pp-RPA/furan_OrbConst/H-H.skf
+++ b/test/app/dftb+/pp-RPA/furan_OrbConst/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/pp-RPA/furan_OrbConst/H-O.skf
+++ b/test/app/dftb+/pp-RPA/furan_OrbConst/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/pp-RPA/furan_OrbConst/O-C.skf
+++ b/test/app/dftb+/pp-RPA/furan_OrbConst/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/pp-RPA/furan_OrbConst/O-H.skf
+++ b/test/app/dftb+/pp-RPA/furan_OrbConst/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/pp-RPA/furan_OrbConst/O-O.skf
+++ b/test/app/dftb+/pp-RPA/furan_OrbConst/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/pp-RPA/furan_OrbConst/dftb_in.hsd
+++ b/test/app/dftb+/pp-RPA/furan_OrbConst/dftb_in.hsd
@@ -15,6 +15,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 40
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/rangesep/Benzene-Casida-S5-Force/C-C.skf
+++ b/test/app/dftb+/rangesep/Benzene-Casida-S5-Force/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/C-C.skf

--- a/test/app/dftb+/rangesep/Benzene-Casida-S5-Force/C-H.skf
+++ b/test/app/dftb+/rangesep/Benzene-Casida-S5-Force/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/C-H.skf

--- a/test/app/dftb+/rangesep/Benzene-Casida-S5-Force/H-C.skf
+++ b/test/app/dftb+/rangesep/Benzene-Casida-S5-Force/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/H-C.skf

--- a/test/app/dftb+/rangesep/Benzene-Casida-S5-Force/H-H.skf
+++ b/test/app/dftb+/rangesep/Benzene-Casida-S5-Force/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/H-H.skf

--- a/test/app/dftb+/rangesep/Benzene-Casida-S5-Force/dftb_in.hsd
+++ b/test/app/dftb+/rangesep/Benzene-Casida-S5-Force/dftb_in.hsd
@@ -12,7 +12,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/ob2-1-1/shift/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/rangesep/C4H6-Casida-S1-Force/C-C.skf
+++ b/test/app/dftb+/rangesep/C4H6-Casida-S1-Force/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/C-C.skf

--- a/test/app/dftb+/rangesep/C4H6-Casida-S1-Force/C-H.skf
+++ b/test/app/dftb+/rangesep/C4H6-Casida-S1-Force/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/C-H.skf

--- a/test/app/dftb+/rangesep/C4H6-Casida-S1-Force/H-C.skf
+++ b/test/app/dftb+/rangesep/C4H6-Casida-S1-Force/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/H-C.skf

--- a/test/app/dftb+/rangesep/C4H6-Casida-S1-Force/H-H.skf
+++ b/test/app/dftb+/rangesep/C4H6-Casida-S1-Force/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/H-H.skf

--- a/test/app/dftb+/rangesep/C4H6-Casida-S1-Force/dftb_in.hsd
+++ b/test/app/dftb+/rangesep/C4H6-Casida-S1-Force/dftb_in.hsd
@@ -12,7 +12,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/ob2-1-1/shift/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/C-C.skf
+++ b/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-C.skf

--- a/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/C-H.skf
+++ b/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-H.skf

--- a/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/C-N.skf
+++ b/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-N.skf

--- a/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/H-C.skf
+++ b/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-C.skf

--- a/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/H-H.skf
+++ b/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-H.skf

--- a/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/H-N.skf
+++ b/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-N.skf

--- a/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/N-C.skf
+++ b/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-C.skf

--- a/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/N-H.skf
+++ b/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-H.skf

--- a/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/N-N.skf
+++ b/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-N.skf

--- a/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/dftb_in.hsd
+++ b/test/app/dftb+/reks/PSB3_2SSR_extchrg_periodic/dftb_in.hsd
@@ -37,16 +37,10 @@ Hamiltonian = DFTB {
     C = "p"
     N = "p"
   }
-  SlaterKosterFiles = {
-    N-N = "N-N.skf"
-    N-C = "N-C.skf"
-    N-H = "N-H.skf"
-    C-N = "C-N.skf"
-    C-C = "C-C.skf"
-    C-H = "C-H.skf"
-    H-N = "H-N.skf"
-    H-C = "H-C.skf"
-    H-H = "H-H.skf"
+  SlaterKosterFiles = Type2Filenames {
+    Prefix = {slakos/origin/3ob-3-1/}
+    Separator = "-"
+    Suffix = ".skf"
   }
   ElectricField = PointCharges {
     CoordsAndCharges [Angstrom] = {

--- a/test/app/dftb+/sockets/H2O/H-H.skf
+++ b/test/app/dftb+/sockets/H2O/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/sockets/H2O/H-O.skf
+++ b/test/app/dftb+/sockets/H2O/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/sockets/H2O/O-H.skf
+++ b/test/app/dftb+/sockets/H2O/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/sockets/H2O/O-O.skf
+++ b/test/app/dftb+/sockets/H2O/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/sockets/H2O/dftb_in.hsd
+++ b/test/app/dftb+/sockets/H2O/dftb_in.hsd
@@ -19,6 +19,7 @@ Hamiltonian = DFTB {
 	Temperature [Kelvin] = 1.0
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
 	Separator = "-"
 	Suffix = ".skf"
     }

--- a/test/app/dftb+/sockets/H2O_cluster/H-H.skf
+++ b/test/app/dftb+/sockets/H2O_cluster/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/sockets/H2O_cluster/H-O.skf
+++ b/test/app/dftb+/sockets/H2O_cluster/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/sockets/H2O_cluster/O-H.skf
+++ b/test/app/dftb+/sockets/H2O_cluster/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/sockets/H2O_cluster/O-O.skf
+++ b/test/app/dftb+/sockets/H2O_cluster/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/sockets/H2O_cluster/dftb_in.hsd
+++ b/test/app/dftb+/sockets/H2O_cluster/dftb_in.hsd
@@ -19,6 +19,7 @@ Hamiltonian = DFTB {
 	Temperature [Kelvin] = 1.0
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
 	Separator = "-"
 	Suffix = ".skf"
     }

--- a/test/app/dftb+/sockets/diamond/C-C.skf
+++ b/test/app/dftb+/sockets/diamond/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-C.skf

--- a/test/app/dftb+/sockets/diamond/dftb_in.hsd
+++ b/test/app/dftb+/sockets/diamond/dftb_in.hsd
@@ -14,6 +14,7 @@ Hamiltonian = DFTB{
         C = "p"
     }
     SlaterKosterFiles = Type2FileNames{
+Prefix = {slakos/origin/pbc-0-3/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/sockets/diamond_exit/C-C.skf
+++ b/test/app/dftb+/sockets/diamond_exit/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/C-C.skf

--- a/test/app/dftb+/sockets/diamond_exit/dftb_in.hsd
+++ b/test/app/dftb+/sockets/diamond_exit/dftb_in.hsd
@@ -14,6 +14,7 @@ Hamiltonian = DFTB{
         C = "p"
     }
     SlaterKosterFiles = Type2FileNames{
+Prefix = {slakos/origin/pbc-0-3/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/solvation/alpb_anion/C-C.skf
+++ b/test/app/dftb+/solvation/alpb_anion/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-C.skf

--- a/test/app/dftb+/solvation/alpb_anion/C-F.skf
+++ b/test/app/dftb+/solvation/alpb_anion/C-F.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-F.skf

--- a/test/app/dftb+/solvation/alpb_anion/C-O.skf
+++ b/test/app/dftb+/solvation/alpb_anion/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-O.skf

--- a/test/app/dftb+/solvation/alpb_anion/C-S.skf
+++ b/test/app/dftb+/solvation/alpb_anion/C-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-S.skf

--- a/test/app/dftb+/solvation/alpb_anion/F-C.skf
+++ b/test/app/dftb+/solvation/alpb_anion/F-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/F-C.skf

--- a/test/app/dftb+/solvation/alpb_anion/F-F.skf
+++ b/test/app/dftb+/solvation/alpb_anion/F-F.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/F-F.skf

--- a/test/app/dftb+/solvation/alpb_anion/F-O.skf
+++ b/test/app/dftb+/solvation/alpb_anion/F-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/F-O.skf

--- a/test/app/dftb+/solvation/alpb_anion/F-S.skf
+++ b/test/app/dftb+/solvation/alpb_anion/F-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/F-S.skf

--- a/test/app/dftb+/solvation/alpb_anion/O-C.skf
+++ b/test/app/dftb+/solvation/alpb_anion/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-C.skf

--- a/test/app/dftb+/solvation/alpb_anion/O-F.skf
+++ b/test/app/dftb+/solvation/alpb_anion/O-F.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-F.skf

--- a/test/app/dftb+/solvation/alpb_anion/O-O.skf
+++ b/test/app/dftb+/solvation/alpb_anion/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-O.skf

--- a/test/app/dftb+/solvation/alpb_anion/O-S.skf
+++ b/test/app/dftb+/solvation/alpb_anion/O-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-S.skf

--- a/test/app/dftb+/solvation/alpb_anion/S-C.skf
+++ b/test/app/dftb+/solvation/alpb_anion/S-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/S-C.skf

--- a/test/app/dftb+/solvation/alpb_anion/S-F.skf
+++ b/test/app/dftb+/solvation/alpb_anion/S-F.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/S-F.skf

--- a/test/app/dftb+/solvation/alpb_anion/S-O.skf
+++ b/test/app/dftb+/solvation/alpb_anion/S-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/S-O.skf

--- a/test/app/dftb+/solvation/alpb_anion/S-S.skf
+++ b/test/app/dftb+/solvation/alpb_anion/S-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/S-S.skf

--- a/test/app/dftb+/solvation/alpb_anion/dftb_in.hsd
+++ b/test/app/dftb+/solvation/alpb_anion/dftb_in.hsd
@@ -42,6 +42,7 @@ Hamiltonian = DFTB {
     S = -0.1100
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/3ob-3-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/alpb_cation/C-C.skf
+++ b/test/app/dftb+/solvation/alpb_cation/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/alpb_cation/C-H.skf
+++ b/test/app/dftb+/solvation/alpb_cation/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/alpb_cation/C-N.skf
+++ b/test/app/dftb+/solvation/alpb_cation/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/solvation/alpb_cation/H-C.skf
+++ b/test/app/dftb+/solvation/alpb_cation/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/alpb_cation/H-H.skf
+++ b/test/app/dftb+/solvation/alpb_cation/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/alpb_cation/H-N.skf
+++ b/test/app/dftb+/solvation/alpb_cation/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/solvation/alpb_cation/N-C.skf
+++ b/test/app/dftb+/solvation/alpb_cation/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/solvation/alpb_cation/N-H.skf
+++ b/test/app/dftb+/solvation/alpb_cation/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/solvation/alpb_cation/N-N.skf
+++ b/test/app/dftb+/solvation/alpb_cation/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/solvation/alpb_cation/dftb_in.hsd
+++ b/test/app/dftb+/solvation/alpb_cation/dftb_in.hsd
@@ -32,6 +32,7 @@ Hamiltonian = DFTB {
     N = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/alpb_p16/C-C.skf
+++ b/test/app/dftb+/solvation/alpb_p16/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/alpb_p16/C-H.skf
+++ b/test/app/dftb+/solvation/alpb_p16/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/alpb_p16/C-N.skf
+++ b/test/app/dftb+/solvation/alpb_p16/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/solvation/alpb_p16/H-C.skf
+++ b/test/app/dftb+/solvation/alpb_p16/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/alpb_p16/H-H.skf
+++ b/test/app/dftb+/solvation/alpb_p16/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/alpb_p16/H-N.skf
+++ b/test/app/dftb+/solvation/alpb_p16/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/solvation/alpb_p16/N-C.skf
+++ b/test/app/dftb+/solvation/alpb_p16/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/solvation/alpb_p16/N-H.skf
+++ b/test/app/dftb+/solvation/alpb_p16/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/solvation/alpb_p16/N-N.skf
+++ b/test/app/dftb+/solvation/alpb_p16/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/solvation/alpb_p16/dftb_in.hsd
+++ b/test/app/dftb+/solvation/alpb_p16/dftb_in.hsd
@@ -33,6 +33,7 @@ Hamiltonian = DFTB {
     N = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/cosmo_444/C-C.skf
+++ b/test/app/dftb+/solvation/cosmo_444/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-C.skf

--- a/test/app/dftb+/solvation/cosmo_444/C-H.skf
+++ b/test/app/dftb+/solvation/cosmo_444/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-H.skf

--- a/test/app/dftb+/solvation/cosmo_444/C-N.skf
+++ b/test/app/dftb+/solvation/cosmo_444/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-N.skf

--- a/test/app/dftb+/solvation/cosmo_444/C-O.skf
+++ b/test/app/dftb+/solvation/cosmo_444/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-O.skf

--- a/test/app/dftb+/solvation/cosmo_444/H-C.skf
+++ b/test/app/dftb+/solvation/cosmo_444/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-C.skf

--- a/test/app/dftb+/solvation/cosmo_444/H-H.skf
+++ b/test/app/dftb+/solvation/cosmo_444/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-H.skf

--- a/test/app/dftb+/solvation/cosmo_444/H-N.skf
+++ b/test/app/dftb+/solvation/cosmo_444/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-N.skf

--- a/test/app/dftb+/solvation/cosmo_444/H-O.skf
+++ b/test/app/dftb+/solvation/cosmo_444/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-O.skf

--- a/test/app/dftb+/solvation/cosmo_444/N-C.skf
+++ b/test/app/dftb+/solvation/cosmo_444/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-C.skf

--- a/test/app/dftb+/solvation/cosmo_444/N-H.skf
+++ b/test/app/dftb+/solvation/cosmo_444/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-H.skf

--- a/test/app/dftb+/solvation/cosmo_444/N-N.skf
+++ b/test/app/dftb+/solvation/cosmo_444/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-N.skf

--- a/test/app/dftb+/solvation/cosmo_444/N-O.skf
+++ b/test/app/dftb+/solvation/cosmo_444/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-O.skf

--- a/test/app/dftb+/solvation/cosmo_444/O-C.skf
+++ b/test/app/dftb+/solvation/cosmo_444/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-C.skf

--- a/test/app/dftb+/solvation/cosmo_444/O-H.skf
+++ b/test/app/dftb+/solvation/cosmo_444/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-H.skf

--- a/test/app/dftb+/solvation/cosmo_444/O-N.skf
+++ b/test/app/dftb+/solvation/cosmo_444/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-N.skf

--- a/test/app/dftb+/solvation/cosmo_444/O-O.skf
+++ b/test/app/dftb+/solvation/cosmo_444/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-O.skf

--- a/test/app/dftb+/solvation/cosmo_444/dftb_in.hsd
+++ b/test/app/dftb+/solvation/cosmo_444/dftb_in.hsd
@@ -41,6 +41,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/3ob-3-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/cosmo_b33/C-C.skf
+++ b/test/app/dftb+/solvation/cosmo_b33/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-C.skf

--- a/test/app/dftb+/solvation/cosmo_b33/C-H.skf
+++ b/test/app/dftb+/solvation/cosmo_b33/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-H.skf

--- a/test/app/dftb+/solvation/cosmo_b33/C-O.skf
+++ b/test/app/dftb+/solvation/cosmo_b33/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-O.skf

--- a/test/app/dftb+/solvation/cosmo_b33/H-C.skf
+++ b/test/app/dftb+/solvation/cosmo_b33/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-C.skf

--- a/test/app/dftb+/solvation/cosmo_b33/H-H.skf
+++ b/test/app/dftb+/solvation/cosmo_b33/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-H.skf

--- a/test/app/dftb+/solvation/cosmo_b33/H-O.skf
+++ b/test/app/dftb+/solvation/cosmo_b33/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-O.skf

--- a/test/app/dftb+/solvation/cosmo_b33/O-C.skf
+++ b/test/app/dftb+/solvation/cosmo_b33/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-C.skf

--- a/test/app/dftb+/solvation/cosmo_b33/O-H.skf
+++ b/test/app/dftb+/solvation/cosmo_b33/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-H.skf

--- a/test/app/dftb+/solvation/cosmo_b33/O-O.skf
+++ b/test/app/dftb+/solvation/cosmo_b33/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/O-O.skf

--- a/test/app/dftb+/solvation/cosmo_b33/dftb_in.hsd
+++ b/test/app/dftb+/solvation/cosmo_b33/dftb_in.hsd
@@ -45,6 +45,7 @@ Hamiltonian = DFTB {
     O = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/3ob-3-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/cosmo_g1/C-C.skf
+++ b/test/app/dftb+/solvation/cosmo_g1/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/cosmo_g1/C-H.skf
+++ b/test/app/dftb+/solvation/cosmo_g1/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/cosmo_g1/C-O.skf
+++ b/test/app/dftb+/solvation/cosmo_g1/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/solvation/cosmo_g1/H-C.skf
+++ b/test/app/dftb+/solvation/cosmo_g1/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/cosmo_g1/H-H.skf
+++ b/test/app/dftb+/solvation/cosmo_g1/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/cosmo_g1/H-O.skf
+++ b/test/app/dftb+/solvation/cosmo_g1/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/solvation/cosmo_g1/O-C.skf
+++ b/test/app/dftb+/solvation/cosmo_g1/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/solvation/cosmo_g1/O-H.skf
+++ b/test/app/dftb+/solvation/cosmo_g1/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/solvation/cosmo_g1/O-O.skf
+++ b/test/app/dftb+/solvation/cosmo_g1/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/solvation/cosmo_g1/dftb_in.hsd
+++ b/test/app/dftb+/solvation/cosmo_g1/dftb_in.hsd
@@ -54,6 +54,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/cosmo_i8e/C-C.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/C-H.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/C-N.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/C-O.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/H-C.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/H-H.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/H-N.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/H-O.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/N-C.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/N-H.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/N-N.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/N-O.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/O-C.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/O-H.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/O-N.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/O-O.skf
+++ b/test/app/dftb+/solvation/cosmo_i8e/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/solvation/cosmo_i8e/dftb_in.hsd
+++ b/test/app/dftb+/solvation/cosmo_i8e/dftb_in.hsd
@@ -85,6 +85,7 @@ Hamiltonian = DFTB {
     O = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/cosmo_inf/C-C.skf
+++ b/test/app/dftb+/solvation/cosmo_inf/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/cosmo_inf/C-H.skf
+++ b/test/app/dftb+/solvation/cosmo_inf/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/cosmo_inf/C-N.skf
+++ b/test/app/dftb+/solvation/cosmo_inf/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/solvation/cosmo_inf/H-C.skf
+++ b/test/app/dftb+/solvation/cosmo_inf/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/cosmo_inf/H-H.skf
+++ b/test/app/dftb+/solvation/cosmo_inf/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/cosmo_inf/H-N.skf
+++ b/test/app/dftb+/solvation/cosmo_inf/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/solvation/cosmo_inf/N-C.skf
+++ b/test/app/dftb+/solvation/cosmo_inf/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/solvation/cosmo_inf/N-H.skf
+++ b/test/app/dftb+/solvation/cosmo_inf/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/solvation/cosmo_inf/N-N.skf
+++ b/test/app/dftb+/solvation/cosmo_inf/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/solvation/cosmo_inf/dftb_in.hsd
+++ b/test/app/dftb+/solvation/cosmo_inf/dftb_in.hsd
@@ -28,6 +28,7 @@ Hamiltonian = DFTB {
     N = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/cosmo_nitralin/C-C.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/C-H.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/C-N.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/C-O.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/C-S.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/C-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-S.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/H-C.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/H-H.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/H-N.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/H-O.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/H-S.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/H-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-S.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/N-C.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/N-H.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/N-N.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/N-O.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/N-S.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/N-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-S.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/O-C.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/O-H.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/O-N.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/O-O.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/O-S.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/O-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-S.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/S-C.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/S-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-C.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/S-H.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/S-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-H.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/S-N.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/S-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-N.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/S-O.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/S-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-O.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/S-S.skf
+++ b/test/app/dftb+/solvation/cosmo_nitralin/S-S.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/S-S.skf

--- a/test/app/dftb+/solvation/cosmo_nitralin/dftb_in.hsd
+++ b/test/app/dftb+/solvation/cosmo_nitralin/dftb_in.hsd
@@ -29,6 +29,7 @@ Hamiltonian = DFTB {
     S = "d"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/cosmo_quinoline/C-C.skf
+++ b/test/app/dftb+/solvation/cosmo_quinoline/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/cosmo_quinoline/C-H.skf
+++ b/test/app/dftb+/solvation/cosmo_quinoline/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/cosmo_quinoline/C-N.skf
+++ b/test/app/dftb+/solvation/cosmo_quinoline/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/solvation/cosmo_quinoline/H-C.skf
+++ b/test/app/dftb+/solvation/cosmo_quinoline/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/cosmo_quinoline/H-H.skf
+++ b/test/app/dftb+/solvation/cosmo_quinoline/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/cosmo_quinoline/H-N.skf
+++ b/test/app/dftb+/solvation/cosmo_quinoline/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/solvation/cosmo_quinoline/N-C.skf
+++ b/test/app/dftb+/solvation/cosmo_quinoline/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/solvation/cosmo_quinoline/N-H.skf
+++ b/test/app/dftb+/solvation/cosmo_quinoline/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/solvation/cosmo_quinoline/N-N.skf
+++ b/test/app/dftb+/solvation/cosmo_quinoline/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/solvation/cosmo_quinoline/dftb_in.hsd
+++ b/test/app/dftb+/solvation/cosmo_quinoline/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/gb_cm5/C-C.skf
+++ b/test/app/dftb+/solvation/gb_cm5/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/gb_cm5/C-H.skf
+++ b/test/app/dftb+/solvation/gb_cm5/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/gb_cm5/C-O.skf
+++ b/test/app/dftb+/solvation/gb_cm5/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/solvation/gb_cm5/H-C.skf
+++ b/test/app/dftb+/solvation/gb_cm5/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/gb_cm5/H-H.skf
+++ b/test/app/dftb+/solvation/gb_cm5/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/gb_cm5/H-O.skf
+++ b/test/app/dftb+/solvation/gb_cm5/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/solvation/gb_cm5/O-C.skf
+++ b/test/app/dftb+/solvation/gb_cm5/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/solvation/gb_cm5/O-H.skf
+++ b/test/app/dftb+/solvation/gb_cm5/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/solvation/gb_cm5/O-O.skf
+++ b/test/app/dftb+/solvation/gb_cm5/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/solvation/gb_cm5/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gb_cm5/dftb_in.hsd
@@ -35,6 +35,7 @@ Hamiltonian = DFTB {
   }
   Charge = -1
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/gb_inf/C-C.skf
+++ b/test/app/dftb+/solvation/gb_inf/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/gb_inf/C-H.skf
+++ b/test/app/dftb+/solvation/gb_inf/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/gb_inf/C-O.skf
+++ b/test/app/dftb+/solvation/gb_inf/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/solvation/gb_inf/H-C.skf
+++ b/test/app/dftb+/solvation/gb_inf/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/gb_inf/H-H.skf
+++ b/test/app/dftb+/solvation/gb_inf/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/gb_inf/H-O.skf
+++ b/test/app/dftb+/solvation/gb_inf/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/solvation/gb_inf/O-C.skf
+++ b/test/app/dftb+/solvation/gb_inf/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/solvation/gb_inf/O-H.skf
+++ b/test/app/dftb+/solvation/gb_inf/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/solvation/gb_inf/O-O.skf
+++ b/test/app/dftb+/solvation/gb_inf/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/solvation/gb_inf/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gb_inf/dftb_in.hsd
@@ -34,6 +34,7 @@ Hamiltonian = DFTB {
   }
   Charge = -1
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/gb_ionpair/C-C.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/gb_ionpair/C-H.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/gb_ionpair/C-N.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/solvation/gb_ionpair/C-O.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/solvation/gb_ionpair/H-C.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/gb_ionpair/H-H.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/gb_ionpair/H-N.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/solvation/gb_ionpair/H-O.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/solvation/gb_ionpair/N-C.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/solvation/gb_ionpair/N-H.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/solvation/gb_ionpair/N-N.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/solvation/gb_ionpair/N-O.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/solvation/gb_ionpair/O-C.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/solvation/gb_ionpair/O-H.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/solvation/gb_ionpair/O-N.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/solvation/gb_ionpair/O-O.skf
+++ b/test/app/dftb+/solvation/gb_ionpair/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/solvation/gb_ionpair/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gb_ionpair/dftb_in.hsd
@@ -35,6 +35,7 @@ Hamiltonian = DFTB {
     N = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/gb_mol1bar/C-C.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/C-H.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/C-N.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/C-O.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/H-C.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/H-H.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/H-N.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/H-O.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/N-C.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/N-H.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/N-N.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/N-O.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/O-C.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/O-H.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/O-N.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/O-O.skf
+++ b/test/app/dftb+/solvation/gb_mol1bar/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/solvation/gb_mol1bar/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gb_mol1bar/dftb_in.hsd
@@ -35,6 +35,7 @@ Hamiltonian = DFTB {
     N = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/gb_p16/C-C.skf
+++ b/test/app/dftb+/solvation/gb_p16/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/gb_p16/C-H.skf
+++ b/test/app/dftb+/solvation/gb_p16/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/gb_p16/C-O.skf
+++ b/test/app/dftb+/solvation/gb_p16/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/solvation/gb_p16/H-C.skf
+++ b/test/app/dftb+/solvation/gb_p16/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/gb_p16/H-H.skf
+++ b/test/app/dftb+/solvation/gb_p16/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/gb_p16/H-O.skf
+++ b/test/app/dftb+/solvation/gb_p16/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/solvation/gb_p16/O-C.skf
+++ b/test/app/dftb+/solvation/gb_p16/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/solvation/gb_p16/O-H.skf
+++ b/test/app/dftb+/solvation/gb_p16/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/solvation/gb_p16/O-O.skf
+++ b/test/app/dftb+/solvation/gb_p16/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/solvation/gb_p16/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gb_p16/dftb_in.hsd
@@ -36,6 +36,7 @@ Hamiltonian = DFTB {
   }
   Charge = -1
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/gb_reference/C-C.skf
+++ b/test/app/dftb+/solvation/gb_reference/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/gb_reference/C-H.skf
+++ b/test/app/dftb+/solvation/gb_reference/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/gb_reference/C-N.skf
+++ b/test/app/dftb+/solvation/gb_reference/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/solvation/gb_reference/C-O.skf
+++ b/test/app/dftb+/solvation/gb_reference/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/solvation/gb_reference/H-C.skf
+++ b/test/app/dftb+/solvation/gb_reference/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/gb_reference/H-H.skf
+++ b/test/app/dftb+/solvation/gb_reference/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/gb_reference/H-N.skf
+++ b/test/app/dftb+/solvation/gb_reference/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/solvation/gb_reference/H-O.skf
+++ b/test/app/dftb+/solvation/gb_reference/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/solvation/gb_reference/N-C.skf
+++ b/test/app/dftb+/solvation/gb_reference/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/solvation/gb_reference/N-H.skf
+++ b/test/app/dftb+/solvation/gb_reference/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/solvation/gb_reference/N-N.skf
+++ b/test/app/dftb+/solvation/gb_reference/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/solvation/gb_reference/N-O.skf
+++ b/test/app/dftb+/solvation/gb_reference/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/solvation/gb_reference/O-C.skf
+++ b/test/app/dftb+/solvation/gb_reference/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/solvation/gb_reference/O-H.skf
+++ b/test/app/dftb+/solvation/gb_reference/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/solvation/gb_reference/O-N.skf
+++ b/test/app/dftb+/solvation/gb_reference/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/solvation/gb_reference/O-O.skf
+++ b/test/app/dftb+/solvation/gb_reference/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/solvation/gb_reference/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gb_reference/dftb_in.hsd
@@ -35,6 +35,7 @@ Hamiltonian = DFTB {
     N = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/gbsa_caffeine/C-C.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/C-H.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/C-N.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/C-O.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/H-C.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/H-H.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/H-N.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/H-O.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/N-C.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/N-H.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/N-N.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/N-O.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/O-C.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/O-H.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/O-N.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/O-O.skf
+++ b/test/app/dftb+/solvation/gbsa_caffeine/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/solvation/gbsa_caffeine/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gbsa_caffeine/dftb_in.hsd
@@ -70,6 +70,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/gbsa_e35/C-C.skf
+++ b/test/app/dftb+/solvation/gbsa_e35/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/gbsa_e35/C-H.skf
+++ b/test/app/dftb+/solvation/gbsa_e35/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/gbsa_e35/H-C.skf
+++ b/test/app/dftb+/solvation/gbsa_e35/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/gbsa_e35/H-H.skf
+++ b/test/app/dftb+/solvation/gbsa_e35/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/gbsa_e35/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gbsa_e35/dftb_in.hsd
@@ -38,6 +38,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/gbsa_p16/C-C.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/gbsa_p16/C-H.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/gbsa_p16/C-N.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/solvation/gbsa_p16/C-O.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/solvation/gbsa_p16/H-C.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/gbsa_p16/H-H.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/gbsa_p16/H-N.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/solvation/gbsa_p16/H-O.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/solvation/gbsa_p16/N-C.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/solvation/gbsa_p16/N-H.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/solvation/gbsa_p16/N-N.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/solvation/gbsa_p16/N-O.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/solvation/gbsa_p16/O-C.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/solvation/gbsa_p16/O-H.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/solvation/gbsa_p16/O-N.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/solvation/gbsa_p16/O-O.skf
+++ b/test/app/dftb+/solvation/gbsa_p16/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/solvation/gbsa_p16/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gbsa_p16/dftb_in.hsd
@@ -71,6 +71,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/gbsa_param1/C-C.skf
+++ b/test/app/dftb+/solvation/gbsa_param1/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-C.skf

--- a/test/app/dftb+/solvation/gbsa_param1/C-H.skf
+++ b/test/app/dftb+/solvation/gbsa_param1/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-H.skf

--- a/test/app/dftb+/solvation/gbsa_param1/C-N.skf
+++ b/test/app/dftb+/solvation/gbsa_param1/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/C-N.skf

--- a/test/app/dftb+/solvation/gbsa_param1/H-C.skf
+++ b/test/app/dftb+/solvation/gbsa_param1/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-C.skf

--- a/test/app/dftb+/solvation/gbsa_param1/H-H.skf
+++ b/test/app/dftb+/solvation/gbsa_param1/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-H.skf

--- a/test/app/dftb+/solvation/gbsa_param1/H-N.skf
+++ b/test/app/dftb+/solvation/gbsa_param1/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/H-N.skf

--- a/test/app/dftb+/solvation/gbsa_param1/N-C.skf
+++ b/test/app/dftb+/solvation/gbsa_param1/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-C.skf

--- a/test/app/dftb+/solvation/gbsa_param1/N-H.skf
+++ b/test/app/dftb+/solvation/gbsa_param1/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-H.skf

--- a/test/app/dftb+/solvation/gbsa_param1/N-N.skf
+++ b/test/app/dftb+/solvation/gbsa_param1/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/3ob-3-1/N-N.skf

--- a/test/app/dftb+/solvation/gbsa_param1/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gbsa_param1/dftb_in.hsd
@@ -16,6 +16,7 @@ Hamiltonian = DFTB {
     N = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/3ob-3-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/gbsa_param2/C-C.skf
+++ b/test/app/dftb+/solvation/gbsa_param2/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/C-C.skf

--- a/test/app/dftb+/solvation/gbsa_param2/C-H.skf
+++ b/test/app/dftb+/solvation/gbsa_param2/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/C-H.skf

--- a/test/app/dftb+/solvation/gbsa_param2/C-N.skf
+++ b/test/app/dftb+/solvation/gbsa_param2/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/C-N.skf

--- a/test/app/dftb+/solvation/gbsa_param2/H-C.skf
+++ b/test/app/dftb+/solvation/gbsa_param2/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/H-C.skf

--- a/test/app/dftb+/solvation/gbsa_param2/H-H.skf
+++ b/test/app/dftb+/solvation/gbsa_param2/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/H-H.skf

--- a/test/app/dftb+/solvation/gbsa_param2/H-N.skf
+++ b/test/app/dftb+/solvation/gbsa_param2/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/H-N.skf

--- a/test/app/dftb+/solvation/gbsa_param2/N-C.skf
+++ b/test/app/dftb+/solvation/gbsa_param2/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/N-C.skf

--- a/test/app/dftb+/solvation/gbsa_param2/N-H.skf
+++ b/test/app/dftb+/solvation/gbsa_param2/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/N-H.skf

--- a/test/app/dftb+/solvation/gbsa_param2/N-N.skf
+++ b/test/app/dftb+/solvation/gbsa_param2/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/ob2-1-1/shift/N-N.skf

--- a/test/app/dftb+/solvation/gbsa_param2/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gbsa_param2/dftb_in.hsd
@@ -22,6 +22,7 @@ Hamiltonian = DFTB {
     N = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/ob2-1-1/shift/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvation/sasa_i10e/C-C.skf
+++ b/test/app/dftb+/solvation/sasa_i10e/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/solvation/sasa_i10e/C-H.skf
+++ b/test/app/dftb+/solvation/sasa_i10e/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/solvation/sasa_i10e/C-O.skf
+++ b/test/app/dftb+/solvation/sasa_i10e/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/solvation/sasa_i10e/H-C.skf
+++ b/test/app/dftb+/solvation/sasa_i10e/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/solvation/sasa_i10e/H-H.skf
+++ b/test/app/dftb+/solvation/sasa_i10e/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvation/sasa_i10e/H-O.skf
+++ b/test/app/dftb+/solvation/sasa_i10e/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/solvation/sasa_i10e/O-C.skf
+++ b/test/app/dftb+/solvation/sasa_i10e/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/solvation/sasa_i10e/O-H.skf
+++ b/test/app/dftb+/solvation/sasa_i10e/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/solvation/sasa_i10e/O-O.skf
+++ b/test/app/dftb+/solvation/sasa_i10e/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/solvation/sasa_i10e/dftb_in.hsd
+++ b/test/app/dftb+/solvation/sasa_i10e/dftb_in.hsd
@@ -25,6 +25,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvers/Si8_LSdual/Si-Si.skf
+++ b/test/app/dftb+/solvers/Si8_LSdual/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/pbc-0-3/Si-Si.skf

--- a/test/app/dftb+/solvers/Si8_LSdual/dftb_in.hsd
+++ b/test/app/dftb+/solvers/Si8_LSdual/dftb_in.hsd
@@ -24,6 +24,7 @@ Hamiltonian = DFTB {
     Si = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/pbc-0-3/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvers/ice_NTPoly/H-H.skf
+++ b/test/app/dftb+/solvers/ice_NTPoly/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvers/ice_NTPoly/H-O.skf
+++ b/test/app/dftb+/solvers/ice_NTPoly/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/solvers/ice_NTPoly/O-H.skf
+++ b/test/app/dftb+/solvers/ice_NTPoly/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/solvers/ice_NTPoly/O-O.skf
+++ b/test/app/dftb+/solvers/ice_NTPoly/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/solvers/ice_NTPoly/dftb_in.hsd
+++ b/test/app/dftb+/solvers/ice_NTPoly/dftb_in.hsd
@@ -63,6 +63,7 @@ Hamiltonian = DFTB {
   }
   Eigensolver = NTPoly {}
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/solvers/ice_OMM/H-H.skf
+++ b/test/app/dftb+/solvers/ice_OMM/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/solvers/ice_OMM/H-O.skf
+++ b/test/app/dftb+/solvers/ice_OMM/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/solvers/ice_OMM/O-H.skf
+++ b/test/app/dftb+/solvers/ice_OMM/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/solvers/ice_OMM/O-O.skf
+++ b/test/app/dftb+/solvers/ice_OMM/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/solvers/ice_OMM/dftb_in.hsd
+++ b/test/app/dftb+/solvers/ice_OMM/dftb_in.hsd
@@ -63,6 +63,7 @@ Hamiltonian = DFTB {
   }
   Eigensolver = OMM {}
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/spin/H2O-periodic/H-H.skf
+++ b/test/app/dftb+/spin/H2O-periodic/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/spin/H2O-periodic/H-O.skf
+++ b/test/app/dftb+/spin/H2O-periodic/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/spin/H2O-periodic/O-H.skf
+++ b/test/app/dftb+/spin/H2O-periodic/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/spin/H2O-periodic/O-O.skf
+++ b/test/app/dftb+/spin/H2O-periodic/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/spin/H2O-periodic/dftb_in.hsd
+++ b/test/app/dftb+/spin/H2O-periodic/dftb_in.hsd
@@ -46,6 +46,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-006
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/spin/H2O/H-H.skf
+++ b/test/app/dftb+/spin/H2O/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/spin/H2O/H-O.skf
+++ b/test/app/dftb+/spin/H2O/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/spin/H2O/O-H.skf
+++ b/test/app/dftb+/spin/H2O/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/spin/H2O/O-O.skf
+++ b/test/app/dftb+/spin/H2O/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/spin/H2O/dftb_in.hsd
+++ b/test/app/dftb+/spin/H2O/dftb_in.hsd
@@ -42,6 +42,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-006
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/spin/OH_commonFermi/H-H.skf
+++ b/test/app/dftb+/spin/OH_commonFermi/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/spin/OH_commonFermi/H-O.skf
+++ b/test/app/dftb+/spin/OH_commonFermi/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/spin/OH_commonFermi/O-H.skf
+++ b/test/app/dftb+/spin/OH_commonFermi/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/spin/OH_commonFermi/O-O.skf
+++ b/test/app/dftb+/spin/OH_commonFermi/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/spin/OH_commonFermi/dftb_in.hsd
+++ b/test/app/dftb+/spin/OH_commonFermi/dftb_in.hsd
@@ -45,6 +45,7 @@ Hamiltonian = DFTB {
   }
   
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/spinorbit/EuN/EuEu.skf
+++ b/test/app/dftb+/spinorbit/EuN/EuEu.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/rare-0-2/EuEu.skf

--- a/test/app/dftb+/spinorbit/EuN/EuN.skf
+++ b/test/app/dftb+/spinorbit/EuN/EuN.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/rare-0-2/EuN.skf

--- a/test/app/dftb+/spinorbit/EuN/NEu.skf
+++ b/test/app/dftb+/spinorbit/EuN/NEu.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/rare-0-2/NEu.skf

--- a/test/app/dftb+/spinorbit/EuN/NN.skf
+++ b/test/app/dftb+/spinorbit/EuN/NN.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/rare-0-2/NN.skf

--- a/test/app/dftb+/spinorbit/EuN/dftb_in.hsd
+++ b/test/app/dftb+/spinorbit/EuN/dftb_in.hsd
@@ -58,6 +58,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 250
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/rare-0-2/}
     Separator = ""
     Suffix = ".skf"
   }

--- a/test/app/dftb+/spinorbit/EuN_customU/EuEu.skf
+++ b/test/app/dftb+/spinorbit/EuN_customU/EuEu.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/rare-0-2/EuEu.skf

--- a/test/app/dftb+/spinorbit/EuN_customU/EuN.skf
+++ b/test/app/dftb+/spinorbit/EuN_customU/EuN.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/rare-0-2/EuN.skf

--- a/test/app/dftb+/spinorbit/EuN_customU/NEu.skf
+++ b/test/app/dftb+/spinorbit/EuN_customU/NEu.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/rare-0-2/NEu.skf

--- a/test/app/dftb+/spinorbit/EuN_customU/NN.skf
+++ b/test/app/dftb+/spinorbit/EuN_customU/NN.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/rare-0-2/NN.skf

--- a/test/app/dftb+/spinorbit/EuN_customU/dftb_in.hsd
+++ b/test/app/dftb+/spinorbit/EuN_customU/dftb_in.hsd
@@ -59,6 +59,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 250
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/rare-0-2/}
     Separator = ""
     Suffix = ".skf"
   }

--- a/test/app/dftb+/spinorbit/GaAs_2/As-As.skf
+++ b/test/app/dftb+/spinorbit/GaAs_2/As-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-As.skf

--- a/test/app/dftb+/spinorbit/GaAs_2/As-Ga.skf
+++ b/test/app/dftb+/spinorbit/GaAs_2/As-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/As-Ga.skf

--- a/test/app/dftb+/spinorbit/GaAs_2/Ga-As.skf
+++ b/test/app/dftb+/spinorbit/GaAs_2/Ga-As.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-As.skf

--- a/test/app/dftb+/spinorbit/GaAs_2/Ga-Ga.skf
+++ b/test/app/dftb+/spinorbit/GaAs_2/Ga-Ga.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/hyb-0-2/Ga-Ga.skf

--- a/test/app/dftb+/spinorbit/GaAs_2/dftb_in.hsd
+++ b/test/app/dftb+/spinorbit/GaAs_2/dftb_in.hsd
@@ -26,6 +26,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 77
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/hyb-0-2/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/timedep/2CH3-Temp-Stratmann/C-C.skf
+++ b/test/app/dftb+/timedep/2CH3-Temp-Stratmann/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/2CH3-Temp-Stratmann/C-H.skf
+++ b/test/app/dftb+/timedep/2CH3-Temp-Stratmann/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/2CH3-Temp-Stratmann/H-C.skf
+++ b/test/app/dftb+/timedep/2CH3-Temp-Stratmann/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/2CH3-Temp-Stratmann/H-H.skf
+++ b/test/app/dftb+/timedep/2CH3-Temp-Stratmann/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/2CH3-Temp-Stratmann/dftb_in.hsd
+++ b/test/app/dftb+/timedep/2CH3-Temp-Stratmann/dftb_in.hsd
@@ -15,7 +15,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 1000.0
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/2CH3-Temp/C-C.skf
+++ b/test/app/dftb+/timedep/2CH3-Temp/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/2CH3-Temp/C-H.skf
+++ b/test/app/dftb+/timedep/2CH3-Temp/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/2CH3-Temp/H-C.skf
+++ b/test/app/dftb+/timedep/2CH3-Temp/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/2CH3-Temp/H-H.skf
+++ b/test/app/dftb+/timedep/2CH3-Temp/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/2CH3-Temp/dftb_in.hsd
+++ b/test/app/dftb+/timedep/2CH3-Temp/dftb_in.hsd
@@ -15,7 +15,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 1000.0
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/2CH3-Triplet-Temp/C-C.skf
+++ b/test/app/dftb+/timedep/2CH3-Triplet-Temp/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/2CH3-Triplet-Temp/C-H.skf
+++ b/test/app/dftb+/timedep/2CH3-Triplet-Temp/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/2CH3-Triplet-Temp/H-C.skf
+++ b/test/app/dftb+/timedep/2CH3-Triplet-Temp/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/2CH3-Triplet-Temp/H-H.skf
+++ b/test/app/dftb+/timedep/2CH3-Triplet-Temp/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/2CH3-Triplet-Temp/dftb_in.hsd
+++ b/test/app/dftb+/timedep/2CH3-Triplet-Temp/dftb_in.hsd
@@ -15,7 +15,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 1000.0
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/C4H6-S1-Force/C-C.skf
+++ b/test/app/dftb+/timedep/C4H6-S1-Force/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/C4H6-S1-Force/C-H.skf
+++ b/test/app/dftb+/timedep/C4H6-S1-Force/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/C4H6-S1-Force/H-C.skf
+++ b/test/app/dftb+/timedep/C4H6-S1-Force/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/C4H6-S1-Force/H-H.skf
+++ b/test/app/dftb+/timedep/C4H6-S1-Force/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/C4H6-S1-Force/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C4H6-S1-Force/dftb_in.hsd
@@ -12,7 +12,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/C4H6-S1-Force_uncache-Stratmann/C-C.skf
+++ b/test/app/dftb+/timedep/C4H6-S1-Force_uncache-Stratmann/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/C4H6-S1-Force_uncache-Stratmann/C-H.skf
+++ b/test/app/dftb+/timedep/C4H6-S1-Force_uncache-Stratmann/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/C4H6-S1-Force_uncache-Stratmann/H-C.skf
+++ b/test/app/dftb+/timedep/C4H6-S1-Force_uncache-Stratmann/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/C4H6-S1-Force_uncache-Stratmann/H-H.skf
+++ b/test/app/dftb+/timedep/C4H6-S1-Force_uncache-Stratmann/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/C4H6-S1-Force_uncache-Stratmann/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C4H6-S1-Force_uncache-Stratmann/dftb_in.hsd
@@ -12,7 +12,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/C4H6-S1-Force_uncache/C-C.skf
+++ b/test/app/dftb+/timedep/C4H6-S1-Force_uncache/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/C4H6-S1-Force_uncache/C-H.skf
+++ b/test/app/dftb+/timedep/C4H6-S1-Force_uncache/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/C4H6-S1-Force_uncache/H-C.skf
+++ b/test/app/dftb+/timedep/C4H6-S1-Force_uncache/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/C4H6-S1-Force_uncache/H-H.skf
+++ b/test/app/dftb+/timedep/C4H6-S1-Force_uncache/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/C4H6-S1-Force_uncache/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C4H6-S1-Force_uncache/dftb_in.hsd
@@ -12,7 +12,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/C4H6-Singlet-Stratmann/C-C.skf
+++ b/test/app/dftb+/timedep/C4H6-Singlet-Stratmann/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/C4H6-Singlet-Stratmann/C-H.skf
+++ b/test/app/dftb+/timedep/C4H6-Singlet-Stratmann/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/C4H6-Singlet-Stratmann/H-C.skf
+++ b/test/app/dftb+/timedep/C4H6-Singlet-Stratmann/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/C4H6-Singlet-Stratmann/H-H.skf
+++ b/test/app/dftb+/timedep/C4H6-Singlet-Stratmann/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/C4H6-Singlet-Stratmann/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C4H6-Singlet-Stratmann/dftb_in.hsd
@@ -12,7 +12,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/C4H6-Singlet/C-C.skf
+++ b/test/app/dftb+/timedep/C4H6-Singlet/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/C4H6-Singlet/C-H.skf
+++ b/test/app/dftb+/timedep/C4H6-Singlet/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/C4H6-Singlet/H-C.skf
+++ b/test/app/dftb+/timedep/C4H6-Singlet/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/C4H6-Singlet/H-H.skf
+++ b/test/app/dftb+/timedep/C4H6-Singlet/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/C4H6-Singlet/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C4H6-Singlet/dftb_in.hsd
@@ -12,7 +12,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/C4H6-Singlet_wfn/C-C.skf
+++ b/test/app/dftb+/timedep/C4H6-Singlet_wfn/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/C4H6-Singlet_wfn/C-H.skf
+++ b/test/app/dftb+/timedep/C4H6-Singlet_wfn/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/C4H6-Singlet_wfn/H-C.skf
+++ b/test/app/dftb+/timedep/C4H6-Singlet_wfn/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/C4H6-Singlet_wfn/H-H.skf
+++ b/test/app/dftb+/timedep/C4H6-Singlet_wfn/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/C4H6-Singlet_wfn/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C4H6-Singlet_wfn/dftb_in.hsd
@@ -12,7 +12,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/C4H6-T1-Force/C-C.skf
+++ b/test/app/dftb+/timedep/C4H6-T1-Force/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/C4H6-T1-Force/C-H.skf
+++ b/test/app/dftb+/timedep/C4H6-T1-Force/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/C4H6-T1-Force/H-C.skf
+++ b/test/app/dftb+/timedep/C4H6-T1-Force/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/C4H6-T1-Force/H-H.skf
+++ b/test/app/dftb+/timedep/C4H6-T1-Force/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/C4H6-T1-Force/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C4H6-T1-Force/dftb_in.hsd
@@ -12,7 +12,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/C4H6-Triplet-Stratmann/C-C.skf
+++ b/test/app/dftb+/timedep/C4H6-Triplet-Stratmann/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/C4H6-Triplet-Stratmann/C-H.skf
+++ b/test/app/dftb+/timedep/C4H6-Triplet-Stratmann/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/C4H6-Triplet-Stratmann/H-C.skf
+++ b/test/app/dftb+/timedep/C4H6-Triplet-Stratmann/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/C4H6-Triplet-Stratmann/H-H.skf
+++ b/test/app/dftb+/timedep/C4H6-Triplet-Stratmann/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/C4H6-Triplet-Stratmann/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C4H6-Triplet-Stratmann/dftb_in.hsd
@@ -12,7 +12,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/C4H6-Triplet/C-C.skf
+++ b/test/app/dftb+/timedep/C4H6-Triplet/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/C4H6-Triplet/C-H.skf
+++ b/test/app/dftb+/timedep/C4H6-Triplet/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/C4H6-Triplet/H-C.skf
+++ b/test/app/dftb+/timedep/C4H6-Triplet/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/C4H6-Triplet/H-H.skf
+++ b/test/app/dftb+/timedep/C4H6-Triplet/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/C4H6-Triplet/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C4H6-Triplet/dftb_in.hsd
@@ -12,7 +12,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/C-C.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/C-H.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/C-N.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/C-O.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/H-C.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/H-H.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/H-N.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/H-O.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/N-C.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/N-H.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/N-N.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/N-O.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/O-C.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/O-H.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/O-N.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/O-O.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_Ewindow/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C66O10N4H44_Ewindow/dftb_in.hsd
@@ -18,7 +18,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 0.0
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix ="./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/C-C.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/C-H.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/C-N.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/C-O.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/H-C.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/H-H.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/H-N.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/H-O.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/N-C.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/N-H.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/N-N.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/N-O.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/O-C.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/O-H.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/O-N.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/O-O.skf
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/timedep/C66O10N4H44_OscWindow/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C66O10N4H44_OscWindow/dftb_in.hsd
@@ -19,7 +19,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 0.0
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix ="./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/C6H6-Sym/C-C.skf
+++ b/test/app/dftb+/timedep/C6H6-Sym/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/C6H6-Sym/C-H.skf
+++ b/test/app/dftb+/timedep/C6H6-Sym/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/C6H6-Sym/H-C.skf
+++ b/test/app/dftb+/timedep/C6H6-Sym/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/C6H6-Sym/H-H.skf
+++ b/test/app/dftb+/timedep/C6H6-Sym/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/C6H6-Sym/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C6H6-Sym/dftb_in.hsd
@@ -12,7 +12,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/C6H6-Sym_Arnoldi/C-C.skf
+++ b/test/app/dftb+/timedep/C6H6-Sym_Arnoldi/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/C6H6-Sym_Arnoldi/C-H.skf
+++ b/test/app/dftb+/timedep/C6H6-Sym_Arnoldi/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/C6H6-Sym_Arnoldi/H-C.skf
+++ b/test/app/dftb+/timedep/C6H6-Sym_Arnoldi/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/C6H6-Sym_Arnoldi/H-H.skf
+++ b/test/app/dftb+/timedep/C6H6-Sym_Arnoldi/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/C6H6-Sym_Arnoldi/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C6H6-Sym_Arnoldi/dftb_in.hsd
@@ -12,7 +12,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/N2_onsite/N-N.skf
+++ b/test/app/dftb+/timedep/N2_onsite/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/timedep/N2_onsite/dftb_in.hsd
+++ b/test/app/dftb+/timedep/N2_onsite/dftb_in.hsd
@@ -22,6 +22,7 @@ Hamiltonian = DFTB {
                0.12770  0.03246}
     }   
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/NH-Force-spinpol-Stratmann/H-H.skf
+++ b/test/app/dftb+/timedep/NH-Force-spinpol-Stratmann/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/NH-Force-spinpol-Stratmann/H-N.skf
+++ b/test/app/dftb+/timedep/NH-Force-spinpol-Stratmann/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/timedep/NH-Force-spinpol-Stratmann/N-H.skf
+++ b/test/app/dftb+/timedep/NH-Force-spinpol-Stratmann/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/timedep/NH-Force-spinpol-Stratmann/N-N.skf
+++ b/test/app/dftb+/timedep/NH-Force-spinpol-Stratmann/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/timedep/NH-Force-spinpol-Stratmann/dftb_in.hsd
+++ b/test/app/dftb+/timedep/NH-Force-spinpol-Stratmann/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     }
 
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/NH-Force-spinpol/H-H.skf
+++ b/test/app/dftb+/timedep/NH-Force-spinpol/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/NH-Force-spinpol/H-N.skf
+++ b/test/app/dftb+/timedep/NH-Force-spinpol/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/timedep/NH-Force-spinpol/N-H.skf
+++ b/test/app/dftb+/timedep/NH-Force-spinpol/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/timedep/NH-Force-spinpol/N-N.skf
+++ b/test/app/dftb+/timedep/NH-Force-spinpol/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/timedep/NH-Force-spinpol/dftb_in.hsd
+++ b/test/app/dftb+/timedep/NH-Force-spinpol/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     }
 
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/NO-Stratmann/N-N.skf
+++ b/test/app/dftb+/timedep/NO-Stratmann/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/timedep/NO-Stratmann/N-O.skf
+++ b/test/app/dftb+/timedep/NO-Stratmann/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/timedep/NO-Stratmann/O-N.skf
+++ b/test/app/dftb+/timedep/NO-Stratmann/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/timedep/NO-Stratmann/O-O.skf
+++ b/test/app/dftb+/timedep/NO-Stratmann/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/timedep/NO-Stratmann/dftb_in.hsd
+++ b/test/app/dftb+/timedep/NO-Stratmann/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     }
     
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/NO/N-N.skf
+++ b/test/app/dftb+/timedep/NO/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/timedep/NO/N-O.skf
+++ b/test/app/dftb+/timedep/NO/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/timedep/NO/O-N.skf
+++ b/test/app/dftb+/timedep/NO/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/timedep/NO/O-O.skf
+++ b/test/app/dftb+/timedep/NO/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/timedep/NO/dftb_in.hsd
+++ b/test/app/dftb+/timedep/NO/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     }
     
     SlaterKosterFiles = Type2FileNames {
+        Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/NO_onsite/N-N.skf
+++ b/test/app/dftb+/timedep/NO_onsite/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/timedep/NO_onsite/N-O.skf
+++ b/test/app/dftb+/timedep/NO_onsite/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/timedep/NO_onsite/O-N.skf
+++ b/test/app/dftb+/timedep/NO_onsite/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/timedep/NO_onsite/O-O.skf
+++ b/test/app/dftb+/timedep/NO_onsite/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/timedep/NO_onsite/dftb_in.hsd
+++ b/test/app/dftb+/timedep/NO_onsite/dftb_in.hsd
@@ -35,6 +35,7 @@ Hamiltonian = DFTB {
                0.12770  0.03246}
     }   
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/OCH2-S1-Opt/C-C.skf
+++ b/test/app/dftb+/timedep/OCH2-S1-Opt/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/OCH2-S1-Opt/C-H.skf
+++ b/test/app/dftb+/timedep/OCH2-S1-Opt/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/OCH2-S1-Opt/C-O.skf
+++ b/test/app/dftb+/timedep/OCH2-S1-Opt/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/timedep/OCH2-S1-Opt/H-C.skf
+++ b/test/app/dftb+/timedep/OCH2-S1-Opt/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/OCH2-S1-Opt/H-H.skf
+++ b/test/app/dftb+/timedep/OCH2-S1-Opt/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/OCH2-S1-Opt/H-O.skf
+++ b/test/app/dftb+/timedep/OCH2-S1-Opt/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/timedep/OCH2-S1-Opt/O-C.skf
+++ b/test/app/dftb+/timedep/OCH2-S1-Opt/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/timedep/OCH2-S1-Opt/O-H.skf
+++ b/test/app/dftb+/timedep/OCH2-S1-Opt/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/timedep/OCH2-S1-Opt/O-O.skf
+++ b/test/app/dftb+/timedep/OCH2-S1-Opt/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/timedep/OCH2-S1-Opt/dftb_in.hsd
+++ b/test/app/dftb+/timedep/OCH2-S1-Opt/dftb_in.hsd
@@ -15,7 +15,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/OCH2-md/C-C.skf
+++ b/test/app/dftb+/timedep/OCH2-md/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/OCH2-md/C-H.skf
+++ b/test/app/dftb+/timedep/OCH2-md/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/OCH2-md/C-O.skf
+++ b/test/app/dftb+/timedep/OCH2-md/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/timedep/OCH2-md/H-C.skf
+++ b/test/app/dftb+/timedep/OCH2-md/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/OCH2-md/H-H.skf
+++ b/test/app/dftb+/timedep/OCH2-md/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/OCH2-md/H-O.skf
+++ b/test/app/dftb+/timedep/OCH2-md/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/timedep/OCH2-md/O-C.skf
+++ b/test/app/dftb+/timedep/OCH2-md/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/timedep/OCH2-md/O-H.skf
+++ b/test/app/dftb+/timedep/OCH2-md/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/timedep/OCH2-md/O-O.skf
+++ b/test/app/dftb+/timedep/OCH2-md/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/timedep/OCH2-md/dftb_in.hsd
+++ b/test/app/dftb+/timedep/OCH2-md/dftb_in.hsd
@@ -26,7 +26,7 @@ Hamiltonian = DFTB {
         H = "s"
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/cyclopentadienyl/C-C.skf
+++ b/test/app/dftb+/timedep/cyclopentadienyl/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/cyclopentadienyl/C-H.skf
+++ b/test/app/dftb+/timedep/cyclopentadienyl/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/cyclopentadienyl/H-C.skf
+++ b/test/app/dftb+/timedep/cyclopentadienyl/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/cyclopentadienyl/H-H.skf
+++ b/test/app/dftb+/timedep/cyclopentadienyl/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/cyclopentadienyl/dftb_in.hsd
+++ b/test/app/dftb+/timedep/cyclopentadienyl/dftb_in.hsd
@@ -31,7 +31,7 @@ Hamiltonian = DFTB {
         UnpairedElectrons = 1
     }
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/propadiene_OscWindow-Stratmann/C-C.skf
+++ b/test/app/dftb+/timedep/propadiene_OscWindow-Stratmann/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/propadiene_OscWindow-Stratmann/C-H.skf
+++ b/test/app/dftb+/timedep/propadiene_OscWindow-Stratmann/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/propadiene_OscWindow-Stratmann/H-C.skf
+++ b/test/app/dftb+/timedep/propadiene_OscWindow-Stratmann/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/propadiene_OscWindow-Stratmann/H-H.skf
+++ b/test/app/dftb+/timedep/propadiene_OscWindow-Stratmann/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/propadiene_OscWindow-Stratmann/dftb_in.hsd
+++ b/test/app/dftb+/timedep/propadiene_OscWindow-Stratmann/dftb_in.hsd
@@ -21,7 +21,7 @@ Hamiltonian = DFTB {
     }
     
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timedep/propadiene_OscWindow/C-C.skf
+++ b/test/app/dftb+/timedep/propadiene_OscWindow/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timedep/propadiene_OscWindow/C-H.skf
+++ b/test/app/dftb+/timedep/propadiene_OscWindow/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timedep/propadiene_OscWindow/H-C.skf
+++ b/test/app/dftb+/timedep/propadiene_OscWindow/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timedep/propadiene_OscWindow/H-H.skf
+++ b/test/app/dftb+/timedep/propadiene_OscWindow/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timedep/propadiene_OscWindow/dftb_in.hsd
+++ b/test/app/dftb+/timedep/propadiene_OscWindow/dftb_in.hsd
@@ -21,7 +21,7 @@ Hamiltonian = DFTB {
     }
     
     SlaterKosterFiles = Type2FileNames {
-        Prefix = "./"
+        Prefix = "slakos/origin/mio-1-1/"
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timeprop/C60_kick/C-C.skf
+++ b/test/app/dftb+/timeprop/C60_kick/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/C60_kick/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/C60_kick/dftb_in.hsd
@@ -76,6 +76,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 273.15
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timeprop/C60_triplet/C-C.skf
+++ b/test/app/dftb+/timeprop/C60_triplet/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/C60_triplet/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/C60_triplet/dftb_in.hsd
@@ -82,6 +82,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 273.15
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timeprop/CH3_dftbu_singlet/C-C.skf
+++ b/test/app/dftb+/timeprop/CH3_dftbu_singlet/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/CH3_dftbu_singlet/C-H.skf
+++ b/test/app/dftb+/timeprop/CH3_dftbu_singlet/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/CH3_dftbu_singlet/H-C.skf
+++ b/test/app/dftb+/timeprop/CH3_dftbu_singlet/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/CH3_dftbu_singlet/H-H.skf
+++ b/test/app/dftb+/timeprop/CH3_dftbu_singlet/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/CH3_dftbu_singlet/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/CH3_dftbu_singlet/dftb_in.hsd
@@ -35,6 +35,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 10
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/timeprop/GNR_kpoint_kick/C-C.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_kick/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_kick/C-H.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_kick/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_kick/H-C.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_kick/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_kick/H-H.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_kick/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_kick/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/GNR_kpoint_kick/dftb_in.hsd
@@ -44,6 +44,7 @@
      WeightFactor = 0.01
    }
    SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
        Separator = "-"
        Suffix = ".skf"
    }   

--- a/test/app/dftb+/timeprop/GNR_kpoint_laser/C-C.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_laser/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_laser/C-H.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_laser/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_laser/H-C.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_laser/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_laser/H-H.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_laser/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_laser/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/GNR_kpoint_laser/dftb_in.hsd
@@ -44,6 +44,7 @@
      WeightFactor = 0.01
    }
    SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
        Separator = "-"
        Suffix = ".skf"
    }   

--- a/test/app/dftb+/timeprop/GNR_kpoint_laser_restart/C-C.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_laser_restart/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_laser_restart/C-H.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_laser_restart/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_laser_restart/H-C.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_laser_restart/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_laser_restart/H-H.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_laser_restart/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_laser_restart/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/GNR_kpoint_laser_restart/dftb_in.hsd
@@ -44,6 +44,7 @@
      WeightFactor = 0.01
    }
    SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
        Separator = "-"
        Suffix = ".skf"
    }   

--- a/test/app/dftb+/timeprop/GNR_kpoint_restart/C-C.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_restart/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_restart/C-H.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_restart/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_restart/H-C.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_restart/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_restart/H-H.skf
+++ b/test/app/dftb+/timeprop/GNR_kpoint_restart/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/GNR_kpoint_restart/step1.hsd
+++ b/test/app/dftb+/timeprop/GNR_kpoint_restart/step1.hsd
@@ -37,6 +37,7 @@ Hamiltonian = DFTB {
     Scc = Yes
     SccTolerance = 1.0E-7
     SlaterKosterFiles = Type2FileNames {
+        Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timeprop/GNR_kpoint_restart/step2.hsd
+++ b/test/app/dftb+/timeprop/GNR_kpoint_restart/step2.hsd
@@ -37,6 +37,7 @@ Hamiltonian = DFTB {
     Scc = Yes
     SccTolerance = 1.0E-7
     SlaterKosterFiles = Type2FileNames {
+        Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timeprop/GNR_periodic_ions/C-C.skf
+++ b/test/app/dftb+/timeprop/GNR_periodic_ions/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/GNR_periodic_ions/C-H.skf
+++ b/test/app/dftb+/timeprop/GNR_periodic_ions/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/GNR_periodic_ions/H-C.skf
+++ b/test/app/dftb+/timeprop/GNR_periodic_ions/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/GNR_periodic_ions/H-H.skf
+++ b/test/app/dftb+/timeprop/GNR_periodic_ions/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/GNR_periodic_ions/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/GNR_periodic_ions/dftb_in.hsd
@@ -39,6 +39,7 @@
      H = "s"
    }
    SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
        Separator = "-"
        Suffix = ".skf"
    }   

--- a/test/app/dftb+/timeprop/GNR_periodic_kick/C-C.skf
+++ b/test/app/dftb+/timeprop/GNR_periodic_kick/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/GNR_periodic_kick/C-H.skf
+++ b/test/app/dftb+/timeprop/GNR_periodic_kick/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/GNR_periodic_kick/H-C.skf
+++ b/test/app/dftb+/timeprop/GNR_periodic_kick/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/GNR_periodic_kick/H-H.skf
+++ b/test/app/dftb+/timeprop/GNR_periodic_kick/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/GNR_periodic_kick/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/GNR_periodic_kick/dftb_in.hsd
@@ -39,6 +39,7 @@
      H = "s"
    }
    SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
        Separator = "-"
        Suffix = ".skf"
    }   

--- a/test/app/dftb+/timeprop/GNR_periodic_laser/C-C.skf
+++ b/test/app/dftb+/timeprop/GNR_periodic_laser/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/GNR_periodic_laser/C-H.skf
+++ b/test/app/dftb+/timeprop/GNR_periodic_laser/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/GNR_periodic_laser/H-C.skf
+++ b/test/app/dftb+/timeprop/GNR_periodic_laser/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/GNR_periodic_laser/H-H.skf
+++ b/test/app/dftb+/timeprop/GNR_periodic_laser/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/GNR_periodic_laser/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/GNR_periodic_laser/dftb_in.hsd
@@ -39,6 +39,7 @@
      H = "s"
    }
    SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
        Separator = "-"
        Suffix = ".skf"
    }   

--- a/test/app/dftb+/timeprop/NO_ions_restart/N-N.skf
+++ b/test/app/dftb+/timeprop/NO_ions_restart/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/timeprop/NO_ions_restart/N-O.skf
+++ b/test/app/dftb+/timeprop/NO_ions_restart/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/timeprop/NO_ions_restart/O-N.skf
+++ b/test/app/dftb+/timeprop/NO_ions_restart/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/timeprop/NO_ions_restart/O-O.skf
+++ b/test/app/dftb+/timeprop/NO_ions_restart/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/timeprop/NO_ions_restart/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/NO_ions_restart/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     }
     
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timeprop/NO_onsite/N-N.skf
+++ b/test/app/dftb+/timeprop/NO_onsite/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/timeprop/NO_onsite/N-O.skf
+++ b/test/app/dftb+/timeprop/NO_onsite/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/timeprop/NO_onsite/O-N.skf
+++ b/test/app/dftb+/timeprop/NO_onsite/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/timeprop/NO_onsite/O-O.skf
+++ b/test/app/dftb+/timeprop/NO_onsite/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/timeprop/NO_onsite/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/NO_onsite/dftb_in.hsd
@@ -38,6 +38,7 @@ Hamiltonian = DFTB {
     }
 
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timeprop/NO_pSIC/N-N.skf
+++ b/test/app/dftb+/timeprop/NO_pSIC/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/timeprop/NO_pSIC/N-O.skf
+++ b/test/app/dftb+/timeprop/NO_pSIC/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/timeprop/NO_pSIC/O-N.skf
+++ b/test/app/dftb+/timeprop/NO_pSIC/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/timeprop/NO_pSIC/O-O.skf
+++ b/test/app/dftb+/timeprop/NO_pSIC/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/timeprop/NO_pSIC/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/NO_pSIC/dftb_in.hsd
@@ -39,6 +39,7 @@ Hamiltonian = DFTB {
     }
 
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timeprop/PDI_charged/C-C.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/PDI_charged/C-H.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/PDI_charged/C-N.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/C-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-N.skf

--- a/test/app/dftb+/timeprop/PDI_charged/C-O.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/timeprop/PDI_charged/H-C.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/PDI_charged/H-H.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/PDI_charged/H-N.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/H-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-N.skf

--- a/test/app/dftb+/timeprop/PDI_charged/H-O.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/app/dftb+/timeprop/PDI_charged/N-C.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/N-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-C.skf

--- a/test/app/dftb+/timeprop/PDI_charged/N-H.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/N-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-H.skf

--- a/test/app/dftb+/timeprop/PDI_charged/N-N.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/N-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-N.skf

--- a/test/app/dftb+/timeprop/PDI_charged/N-O.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/N-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/N-O.skf

--- a/test/app/dftb+/timeprop/PDI_charged/O-C.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/timeprop/PDI_charged/O-H.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/app/dftb+/timeprop/PDI_charged/O-N.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/O-N.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-N.skf

--- a/test/app/dftb+/timeprop/PDI_charged/O-O.skf
+++ b/test/app/dftb+/timeprop/PDI_charged/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/timeprop/PDI_charged/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/PDI_charged/dftb_in.hsd
@@ -46,6 +46,7 @@ Hamiltonian = DFTB {
   SCC = Yes
   SCCTolerance = 1.0E-10 # abnormally tight tolerance used for accuracy
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
        Separator = "-"
        Suffix = ".skf"
    }   

--- a/test/app/dftb+/timeprop/benzene_Ehrenfest_restart/C-C.skf
+++ b/test/app/dftb+/timeprop/benzene_Ehrenfest_restart/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/benzene_Ehrenfest_restart/C-H.skf
+++ b/test/app/dftb+/timeprop/benzene_Ehrenfest_restart/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/benzene_Ehrenfest_restart/H-C.skf
+++ b/test/app/dftb+/timeprop/benzene_Ehrenfest_restart/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/benzene_Ehrenfest_restart/H-H.skf
+++ b/test/app/dftb+/timeprop/benzene_Ehrenfest_restart/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/benzene_Ehrenfest_restart/step1.hsd
+++ b/test/app/dftb+/timeprop/benzene_Ehrenfest_restart/step1.hsd
@@ -29,6 +29,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 273.15
     }
     SlaterKosterFiles = Type2FileNames {
+        Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timeprop/benzene_Ehrenfest_restart/step2.hsd
+++ b/test/app/dftb+/timeprop/benzene_Ehrenfest_restart/step2.hsd
@@ -29,6 +29,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 273.15
     }
     SlaterKosterFiles = Type2FileNames {
+        Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timeprop/benzene_Ehrenfest_restartAscii/C-C.skf
+++ b/test/app/dftb+/timeprop/benzene_Ehrenfest_restartAscii/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/benzene_Ehrenfest_restartAscii/C-H.skf
+++ b/test/app/dftb+/timeprop/benzene_Ehrenfest_restartAscii/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/benzene_Ehrenfest_restartAscii/H-C.skf
+++ b/test/app/dftb+/timeprop/benzene_Ehrenfest_restartAscii/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/benzene_Ehrenfest_restartAscii/H-H.skf
+++ b/test/app/dftb+/timeprop/benzene_Ehrenfest_restartAscii/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/benzene_Ehrenfest_restartAscii/step1.hsd
+++ b/test/app/dftb+/timeprop/benzene_Ehrenfest_restartAscii/step1.hsd
@@ -29,6 +29,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 273.15
     }
     SlaterKosterFiles = Type2FileNames {
+        Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timeprop/benzene_Ehrenfest_restartAscii/step2.hsd
+++ b/test/app/dftb+/timeprop/benzene_Ehrenfest_restartAscii/step2.hsd
@@ -29,6 +29,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 273.15
     }
     SlaterKosterFiles = Type2FileNames {
+        Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timeprop/benzene_circpol/C-C.skf
+++ b/test/app/dftb+/timeprop/benzene_circpol/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/benzene_circpol/C-H.skf
+++ b/test/app/dftb+/timeprop/benzene_circpol/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/benzene_circpol/H-C.skf
+++ b/test/app/dftb+/timeprop/benzene_circpol/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/benzene_circpol/H-H.skf
+++ b/test/app/dftb+/timeprop/benzene_circpol/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/benzene_circpol/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/benzene_circpol/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 273.15
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/timeprop/benzene_gaussian/C-C.skf
+++ b/test/app/dftb+/timeprop/benzene_gaussian/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/benzene_gaussian/C-H.skf
+++ b/test/app/dftb+/timeprop/benzene_gaussian/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/benzene_gaussian/H-C.skf
+++ b/test/app/dftb+/timeprop/benzene_gaussian/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/benzene_gaussian/H-H.skf
+++ b/test/app/dftb+/timeprop/benzene_gaussian/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/benzene_gaussian/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/benzene_gaussian/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 273.15
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/timeprop/benzene_ions_pulse/C-C.skf
+++ b/test/app/dftb+/timeprop/benzene_ions_pulse/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/benzene_ions_pulse/C-H.skf
+++ b/test/app/dftb+/timeprop/benzene_ions_pulse/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/benzene_ions_pulse/H-C.skf
+++ b/test/app/dftb+/timeprop/benzene_ions_pulse/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/benzene_ions_pulse/H-H.skf
+++ b/test/app/dftb+/timeprop/benzene_ions_pulse/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/benzene_ions_pulse/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/benzene_ions_pulse/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 273.15
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/timeprop/benzene_ions_restart/C-C.skf
+++ b/test/app/dftb+/timeprop/benzene_ions_restart/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/benzene_ions_restart/C-H.skf
+++ b/test/app/dftb+/timeprop/benzene_ions_restart/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/benzene_ions_restart/H-C.skf
+++ b/test/app/dftb+/timeprop/benzene_ions_restart/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/benzene_ions_restart/H-H.skf
+++ b/test/app/dftb+/timeprop/benzene_ions_restart/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/benzene_ions_restart/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/benzene_ions_restart/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 273.15
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/timeprop/benzene_kick_bndpop/C-C.skf
+++ b/test/app/dftb+/timeprop/benzene_kick_bndpop/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/benzene_kick_bndpop/C-H.skf
+++ b/test/app/dftb+/timeprop/benzene_kick_bndpop/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/benzene_kick_bndpop/H-C.skf
+++ b/test/app/dftb+/timeprop/benzene_kick_bndpop/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/benzene_kick_bndpop/H-H.skf
+++ b/test/app/dftb+/timeprop/benzene_kick_bndpop/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/benzene_kick_bndpop/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/benzene_kick_bndpop/dftb_in.hsd
@@ -29,6 +29,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 273.15
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timeprop/benzene_kick_periodic/C-C.skf
+++ b/test/app/dftb+/timeprop/benzene_kick_periodic/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/benzene_kick_periodic/C-H.skf
+++ b/test/app/dftb+/timeprop/benzene_kick_periodic/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/benzene_kick_periodic/H-C.skf
+++ b/test/app/dftb+/timeprop/benzene_kick_periodic/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/benzene_kick_periodic/H-H.skf
+++ b/test/app/dftb+/timeprop/benzene_kick_periodic/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/benzene_kick_periodic/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/benzene_kick_periodic/dftb_in.hsd
@@ -40,6 +40,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 273.15
     }
     SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/timeprop/benzene_kick_restart/C-C.skf
+++ b/test/app/dftb+/timeprop/benzene_kick_restart/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/benzene_kick_restart/C-H.skf
+++ b/test/app/dftb+/timeprop/benzene_kick_restart/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/benzene_kick_restart/H-C.skf
+++ b/test/app/dftb+/timeprop/benzene_kick_restart/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/benzene_kick_restart/H-H.skf
+++ b/test/app/dftb+/timeprop/benzene_kick_restart/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/benzene_kick_restart/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/benzene_kick_restart/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 273.15
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/timeprop/benzene_laser/C-C.skf
+++ b/test/app/dftb+/timeprop/benzene_laser/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/benzene_laser/C-H.skf
+++ b/test/app/dftb+/timeprop/benzene_laser/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/benzene_laser/H-C.skf
+++ b/test/app/dftb+/timeprop/benzene_laser/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/benzene_laser/H-H.skf
+++ b/test/app/dftb+/timeprop/benzene_laser/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/benzene_laser/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/benzene_laser/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 273.15
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/timeprop/benzene_sin2/C-C.skf
+++ b/test/app/dftb+/timeprop/benzene_sin2/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/benzene_sin2/C-H.skf
+++ b/test/app/dftb+/timeprop/benzene_sin2/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/benzene_sin2/H-C.skf
+++ b/test/app/dftb+/timeprop/benzene_sin2/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/benzene_sin2/H-H.skf
+++ b/test/app/dftb+/timeprop/benzene_sin2/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/benzene_sin2/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/benzene_sin2/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 273.15
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/timeprop/graphite_dispersion_pulse/C-C.skf
+++ b/test/app/dftb+/timeprop/graphite_dispersion_pulse/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/timeprop/graphite_dispersion_pulse/C-H.skf
+++ b/test/app/dftb+/timeprop/graphite_dispersion_pulse/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/timeprop/graphite_dispersion_pulse/H-C.skf
+++ b/test/app/dftb+/timeprop/graphite_dispersion_pulse/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/timeprop/graphite_dispersion_pulse/H-H.skf
+++ b/test/app/dftb+/timeprop/graphite_dispersion_pulse/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/timeprop/graphite_dispersion_pulse/dftb_in.hsd
+++ b/test/app/dftb+/timeprop/graphite_dispersion_pulse/dftb_in.hsd
@@ -63,6 +63,7 @@
      H = "s"
    }
    SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
        Separator = "-"
        Suffix = ".skf"
    }   

--- a/test/app/dftb+/transport/CH4-poisson/C-C.skf
+++ b/test/app/dftb+/transport/CH4-poisson/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/transport/CH4-poisson/C-H.skf
+++ b/test/app/dftb+/transport/CH4-poisson/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/transport/CH4-poisson/H-C.skf
+++ b/test/app/dftb+/transport/CH4-poisson/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/transport/CH4-poisson/H-H.skf
+++ b/test/app/dftb+/transport/CH4-poisson/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/transport/CH4-poisson/dftb_in.hsd
+++ b/test/app/dftb+/transport/CH4-poisson/dftb_in.hsd
@@ -18,6 +18,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/CH4/C-C.skf
+++ b/test/app/dftb+/transport/CH4/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/transport/CH4/C-H.skf
+++ b/test/app/dftb+/transport/CH4/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/transport/CH4/H-C.skf
+++ b/test/app/dftb+/transport/CH4/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/transport/CH4/H-H.skf
+++ b/test/app/dftb+/transport/CH4/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/transport/CH4/dftb_in.hsd
+++ b/test/app/dftb+/transport/CH4/dftb_in.hsd
@@ -21,6 +21,7 @@ Hamiltonian = DFTB {
 	Temperature [K] = 300
   } 
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/H-chain-fullspin/H-H.skf
+++ b/test/app/dftb+/transport/H-chain-fullspin/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/transport/H-chain-fullspin/device.hsd
+++ b/test/app/dftb+/transport/H-chain-fullspin/device.hsd
@@ -30,6 +30,7 @@ Hamiltonian = DFTB {
         }
     }
     SlaterKosterFiles = Type2Filenames {
+        Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/transport/H-chain-fullspin/drain.hsd
+++ b/test/app/dftb+/transport/H-chain-fullspin/drain.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 300
     }
     SlaterKosterFiles = Type2Filenames {
+        Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/transport/H-chain-fullspin/source.hsd
+++ b/test/app/dftb+/transport/H-chain-fullspin/source.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
         Temperature [Kelvin] = 300
     }
     SlaterKosterFiles = Type2Filenames {
+        Prefix = {slakos/origin/mio-1-1/}
         Separator = "-"
         Suffix = ".skf"
     }

--- a/test/app/dftb+/transport/SiH-chain-cont/H-H.skf
+++ b/test/app/dftb+/transport/SiH-chain-cont/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/H-H.skf

--- a/test/app/dftb+/transport/SiH-chain-cont/H-Si.skf
+++ b/test/app/dftb+/transport/SiH-chain-cont/H-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/H-Si.skf

--- a/test/app/dftb+/transport/SiH-chain-cont/Si-H.skf
+++ b/test/app/dftb+/transport/SiH-chain-cont/Si-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/Si-H.skf

--- a/test/app/dftb+/transport/SiH-chain-cont/Si-Si.skf
+++ b/test/app/dftb+/transport/SiH-chain-cont/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/Si-Si.skf

--- a/test/app/dftb+/transport/SiH-chain-cont/dftb_in.hsd
+++ b/test/app/dftb+/transport/SiH-chain-cont/dftb_in.hsd
@@ -32,6 +32,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0
   }
   SlaterKosterFiles = Type2Filenames {
+Prefix = {slakos/origin/transtest/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/SiH-chain-parallel/H-H.skf
+++ b/test/app/dftb+/transport/SiH-chain-parallel/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/H-H.skf

--- a/test/app/dftb+/transport/SiH-chain-parallel/H-Si.skf
+++ b/test/app/dftb+/transport/SiH-chain-parallel/H-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/H-Si.skf

--- a/test/app/dftb+/transport/SiH-chain-parallel/Si-H.skf
+++ b/test/app/dftb+/transport/SiH-chain-parallel/Si-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/Si-H.skf

--- a/test/app/dftb+/transport/SiH-chain-parallel/Si-Si.skf
+++ b/test/app/dftb+/transport/SiH-chain-parallel/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/Si-Si.skf

--- a/test/app/dftb+/transport/SiH-chain-parallel/dftb_in.hsd
+++ b/test/app/dftb+/transport/SiH-chain-parallel/dftb_in.hsd
@@ -30,6 +30,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0
   }
   SlaterKosterFiles = Type2Filenames {
+Prefix = {slakos/origin/transtest/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/SiH-chain/H-H.skf
+++ b/test/app/dftb+/transport/SiH-chain/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/H-H.skf

--- a/test/app/dftb+/transport/SiH-chain/H-Si.skf
+++ b/test/app/dftb+/transport/SiH-chain/H-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/H-Si.skf

--- a/test/app/dftb+/transport/SiH-chain/Si-H.skf
+++ b/test/app/dftb+/transport/SiH-chain/Si-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/Si-H.skf

--- a/test/app/dftb+/transport/SiH-chain/Si-Si.skf
+++ b/test/app/dftb+/transport/SiH-chain/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/Si-Si.skf

--- a/test/app/dftb+/transport/SiH-chain/dftb_in.hsd
+++ b/test/app/dftb+/transport/SiH-chain/dftb_in.hsd
@@ -30,6 +30,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0
   }
   SlaterKosterFiles = Type2Filenames {
+    Prefix = {slakos/origin/transtest/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/SiH-chain_allSteps/H-H.skf
+++ b/test/app/dftb+/transport/SiH-chain_allSteps/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/H-H.skf

--- a/test/app/dftb+/transport/SiH-chain_allSteps/H-Si.skf
+++ b/test/app/dftb+/transport/SiH-chain_allSteps/H-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/H-Si.skf

--- a/test/app/dftb+/transport/SiH-chain_allSteps/Si-H.skf
+++ b/test/app/dftb+/transport/SiH-chain_allSteps/Si-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/Si-H.skf

--- a/test/app/dftb+/transport/SiH-chain_allSteps/Si-Si.skf
+++ b/test/app/dftb+/transport/SiH-chain_allSteps/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/Si-Si.skf

--- a/test/app/dftb+/transport/SiH-chain_allSteps/device.hsd
+++ b/test/app/dftb+/transport/SiH-chain_allSteps/device.hsd
@@ -25,6 +25,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 300
   }
   SlaterKosterFiles = Type2Filenames {
+    Prefix = {slakos/origin/transtest/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/SiH-chain_allSteps/drain.hsd
+++ b/test/app/dftb+/transport/SiH-chain_allSteps/drain.hsd
@@ -32,6 +32,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 300
   }
   SlaterKosterFiles = Type2Filenames {
+    Prefix = {slakos/origin/transtest/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/SiH-chain_allSteps/source.hsd
+++ b/test/app/dftb+/transport/SiH-chain_allSteps/source.hsd
@@ -32,6 +32,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 300
   }
   SlaterKosterFiles = Type2Filenames {
+    Prefix = {slakos/origin/transtest/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/SiH-chain_bin/H-H.skf
+++ b/test/app/dftb+/transport/SiH-chain_bin/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/H-H.skf

--- a/test/app/dftb+/transport/SiH-chain_bin/H-Si.skf
+++ b/test/app/dftb+/transport/SiH-chain_bin/H-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/H-Si.skf

--- a/test/app/dftb+/transport/SiH-chain_bin/Si-H.skf
+++ b/test/app/dftb+/transport/SiH-chain_bin/Si-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/Si-H.skf

--- a/test/app/dftb+/transport/SiH-chain_bin/Si-Si.skf
+++ b/test/app/dftb+/transport/SiH-chain_bin/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/Si-Si.skf

--- a/test/app/dftb+/transport/SiH-chain_bin/device.hsd
+++ b/test/app/dftb+/transport/SiH-chain_bin/device.hsd
@@ -25,6 +25,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 300
   }
   SlaterKosterFiles = Type2Filenames {
+    Prefix = {slakos/origin/transtest/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/SiH-chain_bin/drain.hsd
+++ b/test/app/dftb+/transport/SiH-chain_bin/drain.hsd
@@ -32,6 +32,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 300
   }
   SlaterKosterFiles = Type2Filenames {
+    Prefix = {slakos/origin/transtest/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/SiH-chain_bin/source.hsd
+++ b/test/app/dftb+/transport/SiH-chain_bin/source.hsd
@@ -32,6 +32,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 300
   }
   SlaterKosterFiles = Type2Filenames {
+    Prefix = {slakos/origin/transtest/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/SiH-chain_semiInf/H-H.skf
+++ b/test/app/dftb+/transport/SiH-chain_semiInf/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/H-H.skf

--- a/test/app/dftb+/transport/SiH-chain_semiInf/H-Si.skf
+++ b/test/app/dftb+/transport/SiH-chain_semiInf/H-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/H-Si.skf

--- a/test/app/dftb+/transport/SiH-chain_semiInf/Si-H.skf
+++ b/test/app/dftb+/transport/SiH-chain_semiInf/Si-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/Si-H.skf

--- a/test/app/dftb+/transport/SiH-chain_semiInf/Si-Si.skf
+++ b/test/app/dftb+/transport/SiH-chain_semiInf/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/Si-Si.skf

--- a/test/app/dftb+/transport/SiH-chain_semiInf/wireBulk.hsd
+++ b/test/app/dftb+/transport/SiH-chain_semiInf/wireBulk.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
       Temperature [Kelvin] = 300
     }
     SlaterKosterFiles = Type2Filenames {
+      Prefix = {slakos/origin/transtest/}
       Separator = "-"
       Suffix = ".skf"
     }

--- a/test/app/dftb+/transport/SiH-chain_semiInf/wireEnd.hsd
+++ b/test/app/dftb+/transport/SiH-chain_semiInf/wireEnd.hsd
@@ -22,6 +22,7 @@ Hamiltonian = DFTB {
       Temperature [Kelvin] = 300
     }
     SlaterKosterFiles = Type2Filenames {
+      Prefix = {slakos/origin/transtest/}
       Separator = "-"
       Suffix = ".skf"
     }

--- a/test/app/dftb+/transport/SiH-cont-poiss/H-H.skf
+++ b/test/app/dftb+/transport/SiH-cont-poiss/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/H-H.skf

--- a/test/app/dftb+/transport/SiH-cont-poiss/H-Si.skf
+++ b/test/app/dftb+/transport/SiH-cont-poiss/H-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/H-Si.skf

--- a/test/app/dftb+/transport/SiH-cont-poiss/Si-H.skf
+++ b/test/app/dftb+/transport/SiH-cont-poiss/Si-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/Si-H.skf

--- a/test/app/dftb+/transport/SiH-cont-poiss/Si-Si.skf
+++ b/test/app/dftb+/transport/SiH-cont-poiss/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/transtest/Si-Si.skf

--- a/test/app/dftb+/transport/SiH-cont-poiss/dftb_in.hsd
+++ b/test/app/dftb+/transport/SiH-cont-poiss/dftb_in.hsd
@@ -32,6 +32,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 0
   }
   SlaterKosterFiles = Type2Filenames {
+Prefix = {slakos/origin/transtest/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/deph_C25_ve/C-C.skf
+++ b/test/app/dftb+/transport/deph_C25_ve/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/transport/deph_C25_ve/dftb_in.hsd
+++ b/test/app/dftb+/transport/deph_C25_ve/dftb_in.hsd
@@ -45,7 +45,7 @@ Hamiltonian = DFTB {
     C = "p"
   }  
   SlaterKosterFiles = Type2FileNames {
-    Prefix = ""
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/deph_C25_ve_scc/C-C.skf
+++ b/test/app/dftb+/transport/deph_C25_ve_scc/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/transport/deph_C25_ve_scc/dftb_in.hsd
+++ b/test/app/dftb+/transport/deph_C25_ve_scc/dftb_in.hsd
@@ -31,7 +31,7 @@ Hamiltonian = DFTB {
     C = "p"
   }  
   SlaterKosterFiles = Type2FileNames {
-    Prefix = ""
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/deph_CH4-poisson/C-C.skf
+++ b/test/app/dftb+/transport/deph_CH4-poisson/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/transport/deph_CH4-poisson/C-H.skf
+++ b/test/app/dftb+/transport/deph_CH4-poisson/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/transport/deph_CH4-poisson/H-C.skf
+++ b/test/app/dftb+/transport/deph_CH4-poisson/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/transport/deph_CH4-poisson/H-H.skf
+++ b/test/app/dftb+/transport/deph_CH4-poisson/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/transport/deph_CH4-poisson/dftb_in.hsd
+++ b/test/app/dftb+/transport/deph_CH4-poisson/dftb_in.hsd
@@ -19,6 +19,7 @@ Hamiltonian = DFTB {
     C = "p"
   }
   SlaterKosterFiles = Type2FileNames {
+Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/deph_H57_bp/C-C.skf
+++ b/test/app/dftb+/transport/deph_H57_bp/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/transport/deph_H57_bp/C-H.skf
+++ b/test/app/dftb+/transport/deph_H57_bp/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/transport/deph_H57_bp/H-C.skf
+++ b/test/app/dftb+/transport/deph_H57_bp/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/transport/deph_H57_bp/H-H.skf
+++ b/test/app/dftb+/transport/deph_H57_bp/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/transport/deph_H57_bp/dftb_in.hsd
+++ b/test/app/dftb+/transport/deph_H57_bp/dftb_in.hsd
@@ -34,7 +34,7 @@ Hamiltonian = DFTB {
     H = "s"
   }  
   SlaterKosterFiles = Type2FileNames {
-    Prefix = ""
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"    
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/deph_vacancy1/C-C.skf
+++ b/test/app/dftb+/transport/deph_vacancy1/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/transport/deph_vacancy1/C-H.skf
+++ b/test/app/dftb+/transport/deph_vacancy1/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/transport/deph_vacancy1/H-C.skf
+++ b/test/app/dftb+/transport/deph_vacancy1/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/transport/deph_vacancy1/H-H.skf
+++ b/test/app/dftb+/transport/deph_vacancy1/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/transport/deph_vacancy1/dftb_in.hsd
+++ b/test/app/dftb+/transport/deph_vacancy1/dftb_in.hsd
@@ -31,7 +31,7 @@ Hamiltonian = DFTB {
   }
   
   SlaterKosterFiles = Type2FileNames {
-    Prefix = ""
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix = ".skf"
   }

--- a/test/app/dftb+/transport/local-curr/C-C.skf
+++ b/test/app/dftb+/transport/local-curr/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/transport/local-curr/C-H.skf
+++ b/test/app/dftb+/transport/local-curr/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/transport/local-curr/H-C.skf
+++ b/test/app/dftb+/transport/local-curr/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/transport/local-curr/H-H.skf
+++ b/test/app/dftb+/transport/local-curr/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/transport/local-curr/dftb_in.hsd
+++ b/test/app/dftb+/transport/local-curr/dftb_in.hsd
@@ -44,7 +44,7 @@ Hamiltonian = DFTB {
   }
   		
   SlaterKosterFiles = Type2FileNames{
-    prefix =  "./"    
+    Prefix = "slakos/origin/mio-1-1/"    
     separator  = "-"
     suffix  = ".skf"
   }

--- a/test/app/dftb+/transport/polyacetylene_semiInf/C-C.skf
+++ b/test/app/dftb+/transport/polyacetylene_semiInf/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/transport/polyacetylene_semiInf/C-H.skf
+++ b/test/app/dftb+/transport/polyacetylene_semiInf/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/app/dftb+/transport/polyacetylene_semiInf/H-C.skf
+++ b/test/app/dftb+/transport/polyacetylene_semiInf/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/app/dftb+/transport/polyacetylene_semiInf/H-H.skf
+++ b/test/app/dftb+/transport/polyacetylene_semiInf/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/app/dftb+/transport/polyacetylene_semiInf/wireBulk.hsd
+++ b/test/app/dftb+/transport/polyacetylene_semiInf/wireBulk.hsd
@@ -25,6 +25,7 @@ Hamiltonian = DFTB {
       Temperature [Kelvin] = 300
     }
     SlaterKosterFiles = Type2Filenames {
+      Prefix = {slakos/origin/mio-1-1/}
       Separator = "-"
       Suffix = ".skf"
     }

--- a/test/app/dftb+/transport/polyacetylene_semiInf/wireEnd.hsd
+++ b/test/app/dftb+/transport/polyacetylene_semiInf/wireEnd.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB {
       Temperature [Kelvin] = 300
     }
     SlaterKosterFiles = Type2Filenames {
+      Prefix = {slakos/origin/mio-1-1/}
       Separator = "-"
       Suffix = ".skf"
     }


### PR DESCRIPTION
Removed a large number (but not all) of the symlinks from the regression tests.
Outstanding issues:
What to do about cases with explicit specification ( H-H = "./H-H.skf" ) as the prefix mechanism won't(?) work for this case.
