### PR TITLE
Neighclass

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -10,5 +10,7 @@ if(NOT BUILD_EXPORTED_TARGETS_ONLY)
   endif()
 endif()
 
+add_subdirectory(neightester)
+
 # Propagate PKG_CONFIG_LIBS upwards
 set(PKG_CONFIG_LIBS "${PKG_CONFIG_LIBS}" PARENT_SCOPE)

--- a/app/neightester/CMakeLists.txt
+++ b/app/neightester/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(projectdir ${PROJECT_SOURCE_DIR})
+
+set(sources-fpp
+    test_neighlist.F90)
+
+set(fypp_flags ${FYPP_BUILD_FLAGS})
+list(APPEND fypp_flags -I${projectdir}/src/dftbp/include)
+
+dftbp_preprocess("${FYPP}" "${fypp_flags}" "F90" "f90" "${sources-fpp}" sources-f90-preproc)
+
+add_executable(test_neighlist ${sources-f90-preproc})
+target_link_libraries(test_neighlist PRIVATE dftbplus)

--- a/app/neightester/test_neighlist.F90
+++ b/app/neightester/test_neighlist.F90
@@ -1,0 +1,184 @@
+module test_neighlist
+  use dftbp_common_accuracy, only : dp
+  use dftbp_common_environment, only : TEnvironment, TEnvironment_init
+  use dftbp_common_globalenv, only : initGlobalEnv, destructGlobalEnv
+  use dftbp_dftb_neighbouriter, only : TNeighbourIter, TNeighbourIterFact
+  use dftbp_dftb_staticneighiter, only : TStaticNeighIterFact, TStaticNeighIterFact_init
+  use dftbp_dftbplus_hsdhelpers, only : parseHsdInput
+  use dftbp_dftbplus_initprogram, only : TDftbPlusMain
+  use dftbp_dftbplus_inputdata, only : TInputData
+  use dftbp_dftbplus_main, only : runDftbPlus
+  use dftbp_dftb_periodic, only : TNeighbourList, TNeighbourList_init, updateNeighbourList,&
+      & getCellTranslations
+  use dftbp_math_lapackroutines, only : matinv
+  implicit none
+
+  integer, parameter :: nRepeat = 1000
+  real(dp), parameter :: cutoff = 20.0_dp
+  integer, parameter :: chunkSize = 1000
+
+contains
+
+  subroutine main()
+
+    type(TEnvironment) :: env
+    type(TDftbPlusMain) :: dpmain
+    type(TNeighbourList), target :: neighList
+    real(dp), allocatable :: coords(:,:)
+    real(dp) :: resArr, resArrSum, resIter, resIterSum
+
+    type(TStaticNeighIterFact), allocatable :: staticNeighIterFact
+    class(TNeighbourIterFact), allocatable :: neighIterFact
+    real :: tArr1, tArr2, tArrSum, tIter1, tIter2, tIterSum
+    integer :: nAtom
+    integer :: iRep
+
+    call initialize(env, dpmain)
+
+    nAtom = size(dpmain%coord0, dim=2)
+    call buildNeighList(dpmain%coord0, dpmain%latVec, cutoff, neighList, coords)
+
+    allocate(staticNeighIterFact)
+    call TStaticNeighIterFact_init(staticNeighIterFact, neighList)
+    call move_alloc(staticNeighIterFact, neighIterFact)
+
+    tArrSum = 0.0_dp
+    tIterSum = 0.0_dp
+    resArrSum = 0.0_dp
+    resIterSum = 0.0_dp
+
+    do iRep = 1, nRepeat
+      call cpu_time(tArr1)
+      call iterateOverNeighArray(neighList, coords, resArr)
+      call cpu_time(tArr2)
+      resArrSum = resArrSum + resArr
+      tArrSum = tArrSum + (tArr2 - tArr1)
+
+      call cpu_time(tIter1)
+      call iterateOverNeighIter(neighIterFact, cutoff, coords, nAtom, chunkSize, resIter)
+      call cpu_time(tIter2)
+      resIterSum = resIterSum + resIter
+      tIterSum = tIterSum + (tIter2 - tIter1)
+    end do
+
+    print *, "CUTOFF:", cutoff
+    print *, "REPETITIONS:", nRepeat
+    print *, "RES ARRAY:", resArrSum, tArrSum
+    print *, "RES ITER :", resIterSum, tIterSum
+    print *, "TIMEDIFF/ATOM:", (tIterSum - tArrSum) / real(nRepeat * nAtom, dp)
+
+    call finalize(env, dpmain)
+
+  end subroutine main
+
+
+  subroutine initialize(env, main)
+    type(TEnvironment), intent(out) :: env
+    type(TDftbPlusMain), intent(out) :: main
+
+    type(TInputData), allocatable :: input
+
+    call initGlobalEnv()
+    allocate(input)
+    call parseHsdInput(input)
+    call TEnvironment_init(env)
+    call main%initProgramVariables(input, env)
+    deallocate(input)
+
+  end subroutine initialize
+
+
+  subroutine finalize(env, main)
+    type(TEnvironment), intent(inout) :: env
+    type(TDftbPlusMain), intent(inout) :: main
+
+    call main%destructProgramVariables()
+    call env%destruct()
+    call destructGlobalEnv()
+
+  end subroutine finalize
+
+
+  subroutine buildNeighList(coord0, latVecs, cutoff, neighList, coords)
+    real(dp), intent(in) :: coord0(:,:), latVecs(:,:)
+    real(dp), intent(in) :: cutoff
+    type(TNeighbourList), intent(out) :: neighList
+    real(dp), allocatable, intent(out) :: coords(:,:)
+
+    real(dp), allocatable :: cellVecs(:,:), rCellVecs(:,:)
+    integer, allocatable :: img2CentCell(:), iCellVec(:)
+    real(dp) :: recVecs2p(3, 3)
+    integer :: nAtom, nAllAtom
+
+    recVecs2p(:,:) = latVecs
+    call matinv(recVecs2p)
+    recVecs2p = transpose(recVecs2p)
+    call getCellTranslations(cellVecs, rCellVecs, latVecs, recVecs2p, cutOff)
+    nAtom = size(coord0, dim=2)
+    allocate(coords(3, nAtom), img2CentCell(nAtom), iCellVec(nAtom))
+    call TNeighbourList_init(neighList, size(coord0, dim=2), 100)
+    call updateNeighbourList(coords, img2CentCell, iCellVec, neighList, nAllAtom, coord0, cutoff,&
+      & rCellVecs)
+
+  end subroutine buildNeighList
+
+
+  subroutine iterateOverNeighArray(neighList, coords, res)
+    type(TNeighbourList), intent(in) :: neighList
+    real(dp), intent(in) :: coords(:,:)
+    real(dp), intent(out) :: res
+
+    integer :: nAtom, iAt1, iAt2, iNeigh
+
+    nAtom = size(neighList%nNeighbour)
+    res = 0.0_dp
+    do iAt1 = 1, nAtom
+      do iNeigh = 1, neighList%nNeighbour(iAt1)
+        iAt2 = neighList%iNeighbour(iNeigh, iAt1)
+        res = res + 1.0_dp / sqrt(neighList%neighDist2(iNeigh, iAt1))
+      end do
+    end do
+
+  end subroutine iterateOverNeighArray
+
+
+  subroutine iterateOverNeighIter(neighIterFact, cutoff, coords, nAtom, chunkSize, res)
+    class(TNeighbourIterFact), intent(in) :: neighIterFact
+    real(dp), intent(in) :: cutoff
+    real(dp), intent(in) :: coords(:,:)
+    integer, intent(in) :: nAtom
+    integer, intent(in) :: chunkSize
+    real(dp), intent(out) :: res
+
+    class(TNeighbourIter), allocatable :: neighIter
+    integer :: iNeighs(chunkSize)
+    real(dp) :: distances2(chunkSize)
+    integer :: iAt1, iAt2, iNeigh, nNeigh
+
+    res = 0.0_dp
+    neighIter = neighIterFact%getIterator(cutoff)
+    do iAt1 = 1, nAtom
+      call neighIter%start(iAt1, cutoff, .false., chunkSize)
+      do
+        call neighIter%get(nNeigh, iNeighs=iNeighs, distances2=distances2)
+        do iNeigh = 1, nNeigh
+          iAt2 = iNeighs(iNeigh)
+          res = res + 1.0_dp / sqrt(distances2(iNeigh))
+        end do
+        if (nNeigh < chunkSize) exit
+      end do
+    end do
+
+  end subroutine iterateOverNeighIter
+
+
+end module test_neighlist
+
+
+program test_neighlist_program
+  use test_neighlist, only : main
+  implicit none
+
+  call main()
+
+end program test_neighlist_program

--- a/app/neightester/test_neighlist.F90
+++ b/app/neightester/test_neighlist.F90
@@ -3,11 +3,15 @@ module test_neighlist
   use dftbp_common_environment, only : TEnvironment, TEnvironment_init
   use dftbp_common_globalenv, only : initGlobalEnv, destructGlobalEnv
   use dftbp_dftb_neighbouriter, only : TNeighbourIter, TNeighbourIterFact
+  use dftbp_dftb_neighbourmap, only : TNeighbourMap
+  use dftbp_dftb_repcont, only : TRepCont, getEnergy
+  use dftbp_dftb_splinepolyrep, only : TSplinePolyRep
   use dftbp_dftb_staticneighiter, only : TStaticNeighIterFact, TStaticNeighIterFact_init
+  use dftbp_dftb_staticneighmap, only : TStaticNeighMap, TStaticNeighMap_init
   use dftbp_dftbplus_hsdhelpers, only : parseHsdInput
   use dftbp_dftbplus_initprogram, only : TDftbPlusMain
   use dftbp_dftbplus_inputdata, only : TInputData
-  use dftbp_dftbplus_main, only : runDftbPlus
+  use dftbp_dftbplus_main, only : runDftbPlus, handleCoordinateChange, handleLatticeChange
   use dftbp_dftb_periodic, only : TNeighbourList, TNeighbourList_init, updateNeighbourList,&
       & getCellTranslations
   use dftbp_math_lapackroutines, only : matinv
@@ -22,50 +26,91 @@ contains
   subroutine main()
 
     type(TEnvironment) :: env
-    type(TDftbPlusMain) :: dpmain
+    type(TDftbPlusMain), target :: dpmain
     type(TNeighbourList), target :: neighList
     real(dp), allocatable :: coords(:,:)
-    real(dp) :: resArr, resArrSum, resIter, resIterSum
+    real(dp) :: resArr, resArrSum, resIter, resIterSum, resMap, resMapSum
 
     type(TStaticNeighIterFact), allocatable :: staticNeighIterFact
     class(TNeighbourIterFact), allocatable :: neighIterFact
-    real :: tArr1, tArr2, tArrSum, tIter1, tIter2, tIterSum
+    type(TStaticNeighMap), allocatable :: staticNeighMap
+    class(TNeighbourMap), allocatable :: neighMap
+    type(TRepCont), pointer :: pRepCont
+
+    real :: tArr1, tArr2, tArrSum, tIter1, tIter2, tIterSum, tMap1, tMap2, tMapSum
     integer :: nAtom
-    integer :: iRep
+    integer :: iRep, errStatus
 
     call initialize(env, dpmain)
 
     nAtom = size(dpmain%coord0, dim=2)
-    call buildNeighList(dpmain%coord0, dpmain%latVec, cutoff, neighList, coords)
+
+    call handleLatticeChange(dpmain%latVec, dpmain%scc, dpmain%tblite, dpmain%tStress, dpmain%extPressure,&
+        & dpmain%cutOff%mCutoff, dpmain%dispersion, dpmain%solvation, dpmain%cm5Cont, dpmain%recVec,&
+        & dpmain%invLatVec, dpmain%cellVol, dpmain%recCellVol, dpmain%extLatDerivs, dpmain%cellVec,&
+        & dpmain%rCellVec)
+
+    call handleCoordinateChange(env, dpmain%coord0, dpmain%latVec, dpmain%invLatVec, dpmain%species0,&
+        & dpmain%cutoff, dpmain%orb, dpmain%tPeriodic, dpmain%tHelical, dpmain%scc, dpmain%tblite,&
+        & dpmain%repulsive, dpmain%dispersion,dpmain%solvation, dpmain%thirdOrd, dpmain%rangeSep,&
+        & dpmain%reks, dpmain%img2CentCell, dpmain%iCellVec, dpmain%neighbourList, dpmain%nAllAtom,&
+        & dpmain%coord0Fold, dpmain%coord,dpmain%species, dpmain%rCellVec, dpmain%nNeighbourSk,&
+        & dpmain%nNeighbourLC, dpmain%ints, dpmain%H0, dpmain%rhoPrim, dpmain%iRhoPrim,&
+        & dpmain%ERhoPrim, dpmain%iSparseStart, dpmain%cm5Cont, errStatus)
+
 
     allocate(staticNeighIterFact)
-    call TStaticNeighIterFact_init(staticNeighIterFact, neighList)
+    call TStaticNeighIterFact_init(staticNeighIterFact, dpmain%neighbourList)
     call move_alloc(staticNeighIterFact, neighIterFact)
+
+    allocate(staticNeighMap)
+    call TStaticNeighMap_init(staticNeighMap, dpmain%neighbourList)
+    call move_alloc(staticNeighMap, neighMap)
+
+    select type (rep => dpmain%repulsive)
+    type is (TSplinePolyRep)
+      pRepCont => rep%twoBodyCont_
+    class default
+      error stop "Can not repulsive handle class"
+    end select
 
     tArrSum = 0.0_dp
     tIterSum = 0.0_dp
+    tMapSum = 0.0_dp
     resArrSum = 0.0_dp
     resIterSum = 0.0_dp
+    resMapSum = 0.0_dp
 
     do iRep = 1, nRepeat
       call cpu_time(tArr1)
-      call iterateOverNeighArray(neighList, coords, resArr)
+      call iterateOverNeighArray(dpmain%neighbourList, pRepCont, dpmain%img2CentCell, dpmain%coord,&
+          & dpmain%species, resArr)
       call cpu_time(tArr2)
       resArrSum = resArrSum + resArr
       tArrSum = tArrSum + (tArr2 - tArr1)
 
       call cpu_time(tIter1)
-      call iterateOverNeighIter(neighIterFact, cutoff, coords, nAtom, chunkSize, resIter)
+      call iterateOverNeighIter(neighIterFact, pRepCont, dpmain%coord, dpmain%species,&
+          & dpmain%img2CentCell, cutoff, nAtom, chunkSize, resIter)
       call cpu_time(tIter2)
       resIterSum = resIterSum + resIter
       tIterSum = tIterSum + (tIter2 - tIter1)
+
+      call cpu_time(tMap1)
+      call iterateOverNeighMap(neighMap, pRepCont, dpmain%coord, dpmain%species, cutoff, nAtom,&
+          & resMap)
+      call cpu_time(tMap2)
+      resMapSum = resMapSum + resMap
+      tMapSum = tMapSum + (tMap2 - tMap1)
     end do
 
     print *, "CUTOFF:", cutoff
     print *, "REPETITIONS:", nRepeat
-    print *, "RES ARRAY:", resArrSum, tArrSum
-    print *, "RES ITER :", resIterSum, tIterSum
-    print *, "TIMEDIFF/ATOM:", (tIterSum - tArrSum) / real(nRepeat * nAtom, dp)
+    print *, "RES ARRAY:", resArrSum, tArrSum / real(nRepeat, dp)
+    print *, "RES ITER :", resIterSum, tIterSum / real(nRepeat, dp)
+    print *, "RES Map :", resMapSum, tMapSum / real(nRepeat, dp)
+    print *, "TIMEDIFF/ITER:", (tIterSum - tArrSum) / real(nRepeat, dp),&
+        & (tMapSum - tArrSum) / real(nRepeat, dp)
 
     call finalize(env, dpmain)
 
@@ -123,65 +168,128 @@ contains
   end subroutine buildNeighList
 
 
-  subroutine iterateOverNeighArray(neighList, coords, res)
+  subroutine iterateOverNeighArray(neighList, repCont, img2CentCell, coords, species, res)
     type(TNeighbourList), intent(in) :: neighList
+    type(TRepCont), intent(in) :: repCont
+    integer, intent(in) :: img2CentCell(:)
     real(dp), intent(in) :: coords(:,:)
+    integer, intent(in) :: species(:)
     real(dp), intent(out) :: res
 
-    integer :: nAtom, iAt1, iAt2, iNeigh
+    integer :: nAtom, iAt1, iAt2, iAt2f, iNeigh
+    real(dp) :: resAtom(size(neighlist%nNeighbour))
+    real(dp) :: vect(3), dist, intermed
 
     nAtom = size(neighList%nNeighbour)
-    res = 0.0_dp
-    !$omp parallel do default(none) reduction(+:res) private(iAt1, iNeigh, iAt2)&
-    !$omp& shared(neighList, nAtom)
+    resAtom(:) = 0.0_dp
+    !$omp parallel do default(none) private(iAt1, iNeigh, iAt2, iAt2f, intermed, vect, dist)&
+    !$omp& shared(neighList, repCont, img2CentCell, coords, species, resAtom, nAtom)
     do iAt1 = 1, nAtom
-      do iNeigh = 1, neighList%nNeighbour(iAt1)
+      do iNeigh = 1, min(4, neighList%nNeighbour(iAt1))
         iAt2 = neighList%iNeighbour(iNeigh, iAt1)
-        res = res + 1.0_dp / sqrt(neighList%neighDist2(iNeigh, iAt1))
+        vect(:) = coords(:,iAt1) - coords(:,iAt2)
+        dist = sqrt(sum(vect**2))
+        call getEnergy(repCont, intermed, dist, species(iAt1), species(iAt2))
+        resAtom(iAt1) = resAtom(iAt1) + 0.5_dp * intermed
+        !if (iAt2f /= iAt1) then
+        !  resAtom(iAt2f) = resAtom(iAt2f) + 0.5_dp * intermed
+        !end if
+        !res = res + 1.0_dp / sqrt(neighList%neighDist2(iNeigh, iAt1))
       end do
     end do
     !$omp end parallel do
-
+    res = sum(resAtom)
   end subroutine iterateOverNeighArray
 
 
-  subroutine iterateOverNeighIter(neighIterFact, cutoff, coords, nAtom, chunkSize, res)
+  subroutine iterateOverNeighIter(neighIterFact, repCont, coords, species, img2CentCell, cutoff, nAtom, chunkSize, res)
     class(TNeighbourIterFact), intent(in) :: neighIterFact
-    real(dp), intent(in) :: cutoff
+    type(TRepCont), intent(in) :: repCont
     real(dp), intent(in) :: coords(:,:)
+    integer, intent(in) :: species(:), img2CentCell(:)
+    real(dp), intent(in) :: cutoff
     integer, intent(in) :: nAtom
     integer, intent(in) :: chunkSize
     real(dp), intent(out) :: res
 
     class(TNeighbourIter), allocatable :: neighIter
     integer :: iNeighs(chunkSize)
-    real(dp) :: distances2(chunkSize)
-    integer :: iAt1, iAt2, iNeigh, nNeigh
+    real(dp) :: distances2(chunkSize), vect(3), dist, intermed
+    integer :: iAt1, iAt2, iAt2f, iNeigh, nNeigh
+    real(dp) :: resAtom(nAtom)
 
-    res = 0.0_dp
-    !$omp parallel default(none) reduction(+:res)&
+    resAtom(:) = 0.0_dp
+    !$omp parallel default(none)&
     !$omp& firstprivate(neighIter)&
-    !$omp& private(iAt1, nNeigh, iNeigh, iAt2, iNeighs, distances2)&
-    !$omp& shared(cutoff, nAtom, chunkSize, neighIterFact)
-    neighIter = neighIterFact%getIterator(cutoff)
+    !$omp& private(iAt1, nNeigh, iNeigh, iAt2, iAt2f, dist, iNeighs, distances2, vect, intermed)&
+    !$omp& shared(cutoff, nAtom, chunkSize, neighIterFact, repCont, resAtom, img2CentCell, coords, species)
+    call neighIterFact%getIterator(cutoff, neighIter)
 
     !$omp do
     do iAt1 = 1, nAtom
       call neighIter%start(iAt1, cutoff, .false., chunkSize)
       do
         call neighIter%get(nNeigh, iNeighs=iNeighs, distances2=distances2)
-        do iNeigh = 1, nNeigh
+        do iNeigh = 1, min(4, nNeigh)
           iAt2 = iNeighs(iNeigh)
-          res = res + 1.0_dp / sqrt(distances2(iNeigh))
+          vect(:) = coords(:,iAt1) - coords(:,iAt2)
+          dist = sqrt(sum(vect**2))
+          call getEnergy(repCont, intermed, dist, species(iAt1), species(iAt2))
+          resAtom(iAt1) = resAtom(iAt1) + 0.5_dp * intermed
+          !if (iAt2f /= iAt1) then
+          !  resAtom(iAt2f) = resAtom(iAt2f) + 0.5_dp * intermed
+          !end if
+          !res = res + 1.0_dp / sqrt(distances2(iNeigh))
         end do
-        if (nNeigh < chunkSize) exit
+        exit
+        !if (nNeigh < chunkSize) exit
       end do
     end do
     !$omp end do
     deallocate(neighIter)
     !$omp end parallel
+    res = sum(resAtom)
 
   end subroutine iterateOverNeighIter
+
+
+  subroutine iterateOverNeighMap(neighMap, repCont, coords, species, cutoff, nAtom, res)
+    class(TNeighbourMap), intent(in) :: neighMap
+    type(TRepCont), intent(in) :: repCont
+    real(dp), intent(in) :: coords(:,:)
+    integer, intent(in) :: species(:)
+    real(dp), intent(in) :: cutoff
+    integer, intent(in) :: nAtom
+    real(dp), intent(out) :: res
+
+    integer, allocatable :: iNeighs(:)
+    real(dp), allocatable :: distances2(:)
+    integer :: iAt1, iAt2, iNeigh
+    real(dp) :: vect(3), dist, intermed
+    real(dp) :: resAtom(nAtom)
+
+    resAtom(:) = 0.0_dp
+
+    !$omp parallel do default(none)&
+    !$omp& firstprivate(distances2, iNeighs)&
+    !$omp& private(iAt1, iNeigh, iAt2, vect, dist, intermed)&
+    !$omp& shared(nAtom, cutoff, neighMap, coords, species, repCont, resAtom)
+    do iAt1 = 1, nAtom
+      call neighMap%getNeighbours(iAt1, cutoff, includeSelf=.false., iNeighs=iNeighs,&
+          & distances2=distances2)
+      do iNeigh = 1, min(4, size(iNeighs))
+          iAt2 = iNeighs(iNeigh)
+          vect(:) = coords(:,iAt1) - coords(:,iAt2)
+          dist = sqrt(sum(vect**2))
+          call getEnergy(repCont, intermed, dist, species(iAt1), species(iAt2))
+          resAtom(iAt1) = resAtom(iAt1) + 0.5_dp * intermed
+          !res = res + 1.0_dp / sqrt(distances2(iNeigh))
+      end do
+    end do
+    !$omp end parallel do
+    res = sum(resAtom)
+
+  end subroutine iterateOverNeighMap
 
 
 end module test_neighlist

--- a/src/dftbp/dftb/CMakeLists.txt
+++ b/src/dftbp/dftb/CMakeLists.txt
@@ -34,6 +34,7 @@ set(sources-fpp
   ${curdir}/halogenx.F90
   ${curdir}/hamiltonian.F90
   ${curdir}/neighbouriter.F90
+  ${curdir}/neighbourmap.F90
   ${curdir}/nonscc.F90
   ${curdir}/onscorrection.F90
   ${curdir}/orbitalequiv.F90
@@ -60,6 +61,7 @@ set(sources-fpp
   ${curdir}/spin.F90
   ${curdir}/spinorbit.F90
   ${curdir}/staticneighiter.F90
+  ${curdir}/staticneighmap.F90
   ${curdir}/stress.F90
   ${curdir}/thirdorder.F90
   ${curdir}/uniquehubbard.F90

--- a/src/dftbp/dftb/CMakeLists.txt
+++ b/src/dftbp/dftb/CMakeLists.txt
@@ -33,6 +33,7 @@ set(sources-fpp
   ${curdir}/h5correction.F90
   ${curdir}/halogenx.F90
   ${curdir}/hamiltonian.F90
+  ${curdir}/neighbouriter.F90
   ${curdir}/nonscc.F90
   ${curdir}/onscorrection.F90
   ${curdir}/orbitalequiv.F90
@@ -58,6 +59,7 @@ set(sources-fpp
   ${curdir}/splinepolyrep.F90
   ${curdir}/spin.F90
   ${curdir}/spinorbit.F90
+  ${curdir}/staticneighiter.F90
   ${curdir}/stress.F90
   ${curdir}/thirdorder.F90
   ${curdir}/uniquehubbard.F90

--- a/src/dftbp/dftb/neighbouriter.F90
+++ b/src/dftbp/dftb/neighbouriter.F90
@@ -48,13 +48,13 @@ module dftbp_dftb_neighbouriter
     end subroutine TNeighbourIter_get
 
 
-    function TNeighbourIterFact_getIterator(this, maxCutoff) result(neighIter)
+    subroutine TNeighbourIterFact_getIterator(this, maxCutoff, neighIter)
       import :: TNeighbourIterFact, TNeighbourIter, dp
       implicit none
       class(TNeighbourIterFact), intent(in) :: this
       real(dp), intent(in) :: maxCutoff
-      class(TNeighbourIter), allocatable :: neighIter
-    end function TNeighbourIterFact_getIterator
+      class(TNeighbourIter), allocatable, intent(out) :: neighIter
+    end subroutine TNeighbourIterFact_getIterator
 
   end interface
 

--- a/src/dftbp/dftb/neighbouriter.F90
+++ b/src/dftbp/dftb/neighbouriter.F90
@@ -1,0 +1,61 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2021  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+module dftbp_dftb_neighbouriter
+  use dftbp_common_accuracy, only : dp
+  implicit none
+
+  private
+  public :: TNeighbourIter, TNeighbourIterFact
+
+
+  type, abstract :: TNeighbourIter
+  contains
+    procedure(TNeighbourIter_start), deferred :: start
+    procedure(TNeighbourIter_get), deferred :: get
+  end type TNeighbourIter
+
+
+  type, abstract :: TNeighbourIterFact
+  contains
+    procedure(TNeighbourIterFact_getIterator), deferred :: getIterator
+  end type TNeighbourIterFact
+
+
+  abstract interface
+
+    subroutine TNeighbourIter_start(this, iAtom, cutoff, includeSelf, chunkSize)
+      import :: TNeighbourIter, dp
+      implicit none
+      class(TNeighbourIter), intent(inout) :: this
+      integer, intent(in) :: iAtom
+      real(dp), intent(in) :: cutoff
+      logical, intent(in) :: includeSelf
+      integer, intent(in) :: chunkSize
+    end subroutine TNeighbourIter_start
+
+
+    subroutine TNeighbourIter_get(this, nNeighs, iNeighs, distances2)
+      import :: TNeighbourIter, dp
+      implicit none
+      class(TNeighbourIter), intent(inout) :: this
+      integer, intent(out) :: nNeighs
+      integer, optional, intent(out) :: iNeighs(:)
+      real(dp), optional, intent(out) :: distances2(:)
+    end subroutine TNeighbourIter_get
+
+
+    function TNeighbourIterFact_getIterator(this, maxCutoff) result(neighIter)
+      import :: TNeighbourIterFact, TNeighbourIter, dp
+      implicit none
+      class(TNeighbourIterFact), intent(in) :: this
+      real(dp), intent(in) :: maxCutoff
+      class(TNeighbourIter), allocatable :: neighIter
+    end function TNeighbourIterFact_getIterator
+
+  end interface
+
+end module dftbp_dftb_neighbouriter

--- a/src/dftbp/dftb/neighbourmap.F90
+++ b/src/dftbp/dftb/neighbourmap.F90
@@ -1,0 +1,35 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2021  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+module dftbp_dftb_neighbourmap
+  use dftbp_common_accuracy, only : dp
+  implicit none
+
+  private
+  public :: TNeighbourMap
+
+
+  type, abstract :: TNeighbourMap
+  contains
+    procedure(TNeighbourMap_getNeighbours), deferred :: getNeighbours
+  end type TNeighbourMap
+
+  abstract interface
+
+    subroutine TNeighbourMap_getNeighbours(this, iAtom, cutoff, includeSelf, iNeighs, distances2)
+      import :: TNeighbourMap, dp
+      implicit none
+      class(TNeighbourMap), intent(in) :: this
+      integer, intent(in) :: iAtom
+      real(dp), intent(in) :: cutoff
+      logical, optional, intent(in) :: includeSelf
+      integer, allocatable, optional, intent(out) :: iNeighs(:)
+      real(dp), allocatable, optional, intent(out) :: distances2(:)
+    end subroutine TNeighbourMap_getNeighbours
+
+  end interface
+
+end module dftbp_dftb_neighbourmap

--- a/src/dftbp/dftb/periodic.F90
+++ b/src/dftbp/dftb/periodic.F90
@@ -82,6 +82,7 @@ module dftbp_dftb_periodic
 
     !> initialised data
     logical :: initialized = .false.
+
   end type TNeighbourList
 
 contains

--- a/src/dftbp/dftb/repcont.F90
+++ b/src/dftbp/dftb/repcont.F90
@@ -17,7 +17,7 @@ module dftbp_dftb_repcont
   use dftbp_dftb_reppoly, only : TRepPoly, getEnergyDeriv, getEnergy, getCutoff
   use dftbp_dftb_repspline, only : TRepSpline, getEnergyDeriv, getEnergy, getCutoff
   implicit none
-  
+
   private
   public :: TRepCont, init
   public :: addRepulsive, getCutoff, getEnergy, getEnergyDeriv
@@ -39,7 +39,7 @@ module dftbp_dftb_repcont
 
   !> Contains the repulsive interactions for the species pairs.
   type TRepCont
-    private
+    !private
 
     !> repulsive functions
     type(PRep_), allocatable :: repulsives(:,:)

--- a/src/dftbp/dftb/splinepolyrep.F90
+++ b/src/dftbp/dftb/splinepolyrep.F90
@@ -45,10 +45,10 @@ module dftbp_dftb_splinepolyrep
     private
 
     !> Container for two body repulsives
-    type(TRepCont), allocatable :: twoBodyCont_
+    type(TRepCont), allocatable, public :: twoBodyCont_
 
     !> Nr. of neighbours for the two body repulsive
-    integer, allocatable :: nNeighTwoBody_(:)
+    integer, allocatable, public :: nNeighTwoBody_(:)
 
     !> Whether repulsive must be calculated for a helical system
     logical :: isHelical_

--- a/src/dftbp/dftb/staticneighiter.F90
+++ b/src/dftbp/dftb/staticneighiter.F90
@@ -103,10 +103,10 @@ contains
   end subroutine TStaticNeighIterFact_init
 
 
-  function TStaticNeighIterFact_getIterator(this, maxCutoff) result(neighIter)
+  subroutine TStaticNeighIterFact_getIterator(this, maxCutoff, neighIter)
     class(TStaticNeighIterFact), intent(in) :: this
     real(dp), intent(in) :: maxCutoff
-    class(TNeighbourIter), allocatable :: neighIter
+    class(TNeighbourIter), allocatable, intent(out) :: neighIter
 
     type(TStaticNeighIter), allocatable :: staticNeighIter
 
@@ -116,7 +116,7 @@ contains
     call TStaticNeighIter_init(staticNeighIter, this%pNeighList)
     call move_alloc(staticNeighIter, neighIter)
 
-  end function TStaticNeighIterFact_getIterator
+  end subroutine TStaticNeighIterFact_getIterator
 
 
 end module dftbp_dftb_staticneighiter

--- a/src/dftbp/dftb/staticneighiter.F90
+++ b/src/dftbp/dftb/staticneighiter.F90
@@ -1,0 +1,122 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2021  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+#:include "common.fypp"
+
+!> Provides a neighour list iterator over a pre-generated static list of neighours.
+module dftbp_dftb_staticneighiter
+  use dftbp_common_accuracy, only : dp
+  use dftbp_dftb_neighbouriter, only : TNeighbourIter, TNeighbourIterFact
+  use dftbp_dftb_periodic, only : TNeighbourList
+  implicit none
+
+  private
+  public :: TStaticNeighIter, TStaticNeighIter_init
+  public :: TStaticNeighIterFact, TStaticNeighIterFact_init
+
+
+  type, extends(TNeighbourIter) :: TStaticNeighIter
+    private
+    type(TNeighbourList), pointer :: pNeighList => null()
+    integer :: iAtom = 0
+    real(dp) :: cutoff2 = 0.0_dp
+    integer :: lastServed = -1
+    integer :: chunkSize = 0
+  contains
+    procedure :: start => TStaticNeighIter_start
+    procedure :: get => TStaticNeighIter_get
+  end type TStaticNeighIter
+
+
+  type, extends(TNeighbourIterFact) :: TStaticNeighIterFact
+    type(TNeighbourList), pointer :: pNeighList => null()
+  contains
+    procedure :: getIterator => TStaticNeighIterFact_getIterator
+  end type TStaticNeighIterFact
+
+
+contains
+
+  subroutine TStaticNeighIter_init(this, pNeighList)
+    type(TStaticNeighIter), intent(out) :: this
+    type(TNeighbourList), pointer, intent(in) :: pNeighList
+
+    this%pNeighList => pNeighList
+
+  end subroutine TStaticNeighIter_init
+
+
+  subroutine TStaticNeighIter_start(this, iAtom, cutoff, includeSelf, chunkSize)
+    class(TStaticNeighIter), intent(inout) :: this
+    integer, intent(in) :: iAtom
+    real(dp), intent(in) :: cutoff
+    logical, intent(in) :: includeSelf
+    integer, intent(in) :: chunkSize
+
+    this%iAtom = iAtom
+    this%cutoff2 = cutoff**2
+    if (includeSelf) then
+      this%lastServed = -1
+    else
+      this%lastServed = 0
+    end if
+    this%chunkSize = chunkSize
+
+  end subroutine TStaticNeighIter_start
+
+
+  subroutine TStaticNeighIter_get(this, nNeighs, iNeighs, distances2)
+    class(TStaticNeighIter), intent(inout) :: this
+    integer, intent(out) :: nNeighs
+    integer, optional, intent(out) :: iNeighs(:)
+    real(dp), optional, intent(out) :: distances2(:)
+
+    integer :: iFirst, iLast
+
+    do nNeighs = 1, min(this%chunkSize, this%pNeighList%nNeighbour(this%iAtom) - this%lastServed)
+      if (this%pNeighList%neighDist2(this%lastServed + nNeighs, this%iAtom) > this%cutoff2) exit
+    end do
+    nNeighs = nNeighs - 1
+    iFirst = this%lastServed + 1
+    iLast = this%lastServed + nNeighs
+    if (present(iNeighs)) then
+      iNeighs(1 : nNeighs) = this%pNeighList%iNeighbour(iFirst : iLast, this%iAtom)
+    end if
+    if (present(distances2)) then
+      distances2(1 : nNeighs) = this%pNeighList%neighDist2(iFirst : iLast, this%iAtom)
+    end if
+    this%lastServed = iLast
+
+  end subroutine TStaticNeighIter_get
+
+
+  subroutine TStaticNeighIterFact_init(this, pNeighList)
+    type(TStaticNeighIterFact), intent(out) :: this
+    type(TNeighbourList), pointer, intent(in) :: pNeighList
+
+    this%pNeighList => pNeighList
+
+  end subroutine TStaticNeighIterFact_init
+
+
+  function TStaticNeighIterFact_getIterator(this, maxCutoff) result(neighIter)
+    class(TStaticNeighIterFact), intent(in) :: this
+    real(dp), intent(in) :: maxCutoff
+    class(TNeighbourIter), allocatable :: neighIter
+
+    type(TStaticNeighIter), allocatable :: staticNeighIter
+
+    @:ASSERT(associated(this%pNeighList))
+    @:ASSERT(this%pNeighList%cutoff >= maxCutoff)
+    allocate(staticNeighIter)
+    call TStaticNeighIter_init(staticNeighIter, this%pNeighList)
+    call move_alloc(staticNeighIter, neighIter)
+
+  end function TStaticNeighIterFact_getIterator
+
+
+end module dftbp_dftb_staticneighiter

--- a/src/dftbp/dftb/staticneighmap.F90
+++ b/src/dftbp/dftb/staticneighmap.F90
@@ -1,0 +1,67 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2021  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+module dftbp_dftb_staticneighmap
+  use dftbp_common_accuracy, only : dp, tolSameDist2
+  use dftbp_dftb_neighbourmap, only : TNeighbourMap
+  use dftbp_dftb_periodic, only : TNeighbourList
+  use dftbp_math_bisect, only : bisection
+  implicit none
+
+  private
+  public :: TStaticNeighMap, TStaticNeighMap_init
+
+
+  type, extends(TNeighbourMap) :: TStaticNeighMap
+    private
+    type(TNeighbourList), pointer :: pNeighList => null()
+  contains
+    procedure :: getNeighbours => TStaticNeighMap_getNeighbours
+  end type TStaticNeighMap
+
+
+contains
+
+
+  subroutine TStaticNeighMap_init(this, pNeighList)
+    type(TStaticNeighMap), intent(out) :: this
+    type(TNeighbourList), pointer, intent(in) :: pNeighList
+
+    this%pNeighList => pNeighList
+
+  end subroutine TStaticNeighMap_init
+
+
+  subroutine TStaticNeighMap_getNeighbours(this, iAtom, cutoff, includeSelf, iNeighs, distances2)
+    class(TStaticNeighMap), intent(in) :: this
+    integer, intent(in) :: iAtom
+    real(dp), intent(in) :: cutoff
+    logical, optional, intent(in) :: includeSelf
+    integer, allocatable, optional, intent(out) :: iNeighs(:)
+    real(dp), allocatable, optional, intent(out) :: distances2(:)
+
+    integer :: nNeighs
+    integer :: iFirst, iLast
+    logical :: includeSelf_
+
+    call bisection(nNeighs,&
+        & this%pNeighList%neighDist2(1 : this%pNeighList%nNeighbour(iAtom), iAtom), cutoff**2,&
+        & tolSameDist2)
+    includeSelf_ = .false.
+    if (present(includeSelf)) includeSelf_ = includeSelf
+    iFirst = 1
+    iLast = nNeighs
+    if (includeSelf_) then
+      iFirst = 0
+      nNeighs = nNeighs + 1
+    end if
+    if (present(iNeighs)) iNeighs = this%pNeighList%iNeighbour(iFirst : iLast, iAtom)
+    if (present(distances2)) distances2 = this%pNeighList%neighDist2(iFirst : iLast, iAtom)
+
+  end subroutine TStaticNeighMap_getNeighbours
+
+
+end module dftbp_dftb_staticneighmap

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -135,7 +135,7 @@ module dftbp_dftbplus_main
 
   private
   public :: runDftbPlus
-  public :: processGeometry
+  public :: processGeometry, handleLatticeChange, handleCoordinateChange
 
   !> O(N^2) density matrix creation
   logical, parameter :: tDensON2 = .false.


### PR DESCRIPTION
This is not a PR, just base for discussions about hiding the neighbour list details.

I've implemented a simple test `app/neightester/test_neighlist` which sums up repulsives, up to max. 4 neighbours per atom using 3 different approaches:

* Classical one: iterating directly over the arrays in `TNeighbourLIst`
* Using an abstract factory, which (for every thread) creates a neighbour iterator, which retursn neighbours in chunks for any atoms.
* Using an abstract neighbour map, which returns the neighbours as allocatable arrays with the correct size.

Testing on SiC512, it seems the the abstract approaches come with a penalty of ca. 0.5ms. Does not sound much, but makes the calculation 10 times slower in this case...