### PR TITLE
Make lapack public instead of interface

### DIFF
--- a/src/dftbp/CMakeLists.txt
+++ b/src/dftbp/CMakeLists.txt
@@ -129,7 +129,7 @@ if(WITH_ARPACK)
   target_link_libraries(dftbplus PRIVATE Arpack::Arpack)
 endif()
 
-target_link_libraries(dftbplus INTERFACE LAPACK::LAPACK)
+target_link_libraries(dftbplus PUBLIC LAPACK::LAPACK)
 
 if (WITH_GPU)
   target_link_libraries(dftbplus PUBLIC Magma::Magma)


### PR DESCRIPTION
This caused some problems for me in building a conan package of DFTB+.

Is there a special reason / argument to be made to have lapack be linked as an interface?