### PR TITLE
Fix api

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ env:
     -DFYPP_FLAGS='-n;-DTRAVIS'
     -DWITH_UNIT_TESTS=true
     -DWITH_CHIMES=true
+    -DWITH_PYTHON=true
 
 jobs:
   gcc-build:
@@ -128,7 +129,7 @@ jobs:
     - name: Set extra CMake flags (Linux)
       if: contains(matrix.os, 'ubuntu')
       run: |
-        echo "CMAKE_OPTIONS=${CMAKE_OPTIONS} -DBUILD_SHARED_LIBS=true -DWITH_PYTHON=true" >> $GITHUB_ENV
+        echo "CMAKE_OPTIONS=${CMAKE_OPTIONS} -DENABLE_DYNAMIC_LOADING=true" >> $GITHUB_ENV
 
     - name: Configure build
       run: >-
@@ -232,7 +233,7 @@ jobs:
 
     - name: Set extra CMake flags (Linux)
       run: |
-        echo "CMAKE_OPTIONS=${CMAKE_OPTIONS} -DBUILD_SHARED_LIBS=true -DWITH_PYTHON=true" >> $GITHUB_ENV
+        echo "CMAKE_OPTIONS=${CMAKE_OPTIONS} -DBUILD_SHARED_LIBS=true -DENABLE_DYNAMIC_LOADING=true" >> $GITHUB_ENV
 
     - name: Configure build
       run: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,11 @@ jobs:
     - name: Get external dependencies
       run: echo "y" | ./utils/get_opt_externals ALL
 
+    - name: Set extra CMake flags (Linux)
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        echo "CMAKE_OPTIONS=${CMAKE_OPTIONS} -DBUILD_SHARED_LIBS=true -DWITH_PYTHON=true" >> $GITHUB_ENV
+
     - name: Configure build
       run: >-
         cmake -B _build -G Ninja
@@ -224,6 +229,10 @@ jobs:
 
     - name: Get external dependencies
       run: echo "y" | ./utils/get_opt_externals ALL
+
+    - name: Set extra CMake flags (Linux)
+      run: |
+        echo "CMAKE_OPTIONS=${CMAKE_OPTIONS} -DBUILD_SHARED_LIBS=true -DWITH_PYTHON=true" >> $GITHUB_ENV
 
     - name: Configure build
       run: >-

--- a/cmake/DftbPlusUtils.cmake
+++ b/cmake/DftbPlusUtils.cmake
@@ -195,14 +195,6 @@ function (dftbp_ensure_config_consistency)
     message(FATAL_ERROR "Building with ARPACK requires MPI-parallel build disabled")
   endif()
 
-  if(WITH_PYTHON AND NOT WITH_API)
-    message(FATAL_ERROR "Building Python API requires building with general API support")
-  endif()
-
-  if(WITH_PYTHON AND NOT BUILD_SHARED_LIBS)
-    message(FATAL_ERROR "Building Python API requires shared libraries for dynamic loading")
-  endif()
-
   if(WITH_GPU AND WITH_MPI)
     message(FATAL_ERROR "Building with GPU support and MPI parallelisation disabled")
   endif()

--- a/config.cmake
+++ b/config.cmake
@@ -47,6 +47,12 @@ option(WITH_API "Whether public API should be included and the DFTB+ library ins
 # This will also install necessary include and module files and further libraries needed to link the
 # DFTB+ library.
 
+option(WITH_PYTHON "Whether the Python components of DFTB+ should be tested and installed" FALSE)
+# Use this option to test and install the Python components of DFTB+. Note, that the Python API
+# based tools will only be considered, if shared library bulding (BUILD_SHARED_LIBS) and support for
+# the general API (WITH_API) and dynamic loading (ENABLE_DYNAMIC_LOADING) had been enabled.
+# Otherwise only the file I/O based tools (dptools) will be tested and installed.
+
 option(INSTANCE_SAFE_BUILD "Whether build should support concurrent DFTB+ instances" FALSE)
 # Turn this on, if you want to create multiple concurrent DFTB+ instances **within one process** via
 # the API. This option will ensure that only components without writable global variables are
@@ -61,17 +67,13 @@ option(BUILD_SHARED_LIBS "Whether the libraries built should be shared" FALSE)
 # must be present at run-time (and the correct LD_LIBRARY_PATH environment variable must be set, so
 # that they can be found by the operating system). If you want use the DFTB+ library from other
 # software packages (see WITH_API option above), they may also require a shared library (e.g.
-# calling DFTB+ functions from Python or Julia).
+# calling DFTB+ functions from Python or Julia). Note, that in order to use the library from Python
+# and Julia, you also need to turn on the ENABLE_DYNAMIC_LOADING option.
 
-if(WITH_API AND BUILD_SHARED_LIBS)
-  set(_WITH_PYTHON TRUE)
-else()
-  set(_WITH_PYTHON FALSE)
-endif()
-option(WITH_PYTHON "Whether the Python components of DFTB+ should be tested and installed" ${_WITH_PYTHON})
-unset(_WITH_PYTHON)
-# Use this option to install the Python components of DFTB+. Requires building a shared library
-# and enabling support for the general API.
+option(ENABLE_DYNAMIC_LOADING "Whether the library should be dynamically loadable" FALSE)
+# Turn this on, if you wish to load the library dynamically (typically when you want to use
+# the library from Python or Julia). Only makes sense in combination with BUILD_SHARED_LIBS and
+# WITH_API set to True.
 
 
 #

--- a/src/dftbp/api/mm/capi.F90
+++ b/src/dftbp/api/mm/capi.F90
@@ -223,8 +223,7 @@ contains
 
 
   !> process a document tree to get settings for the calculation
-  subroutine c_DftbPlus_processInput(handler, inputHandler, atomListHandler)&
-      & bind(C, name='dftbp_process_input')
+  subroutine c_DftbPlus_processInput(handler, inputHandler) bind(C, name='dftbp_process_input')
 
     !> handler for the calculation instance
     type(c_DftbPlus), intent(inout) :: handler
@@ -232,21 +231,13 @@ contains
     !> input tree handler
     type(c_DftbPlusInput), intent(inout) :: inputHandler
 
-    !> atom list structure handler
-    type(c_DftbPlusAtomList), intent(inout) :: atomListHandler
-
     type(TDftbPlusC), pointer :: instance
     type(TDftbPlusInput), pointer :: pDftbPlusInput
     type(TDftbPlusAtomList), pointer :: pDftbPlusAtomList
 
     call c_f_pointer(handler%instance, instance)
     call c_f_pointer(inputHandler%pDftbPlusInput, pDftbPlusInput)
-    if (c_associated(atomListHandler%pDftbPlusAtomList)) then
-      call c_f_pointer(atomListHandler%pDftbPlusAtomList, pDftbPlusAtomList)
-      call instance%setupCalculator(pDftbPlusInput, pDftbPlusAtomList)
-    else
-      call instance%setupCalculator(pDftbPlusInput)
-    end if
+    call instance%setupCalculator(pDftbPlusInput)
 
   end subroutine c_DftbPlus_processInput
 

--- a/src/dftbp/api/mm/dftbplus.h
+++ b/src/dftbp/api/mm/dftbplus.h
@@ -170,7 +170,7 @@ void dftbp_get_input_from_file(DftbPlus *instance, const char *filename, DftbPlu
  * \param[inout] input The tree containing the DFTB+ input. On return, it contains the tree
  *     extended by all the default options set by the parser.
  */
-void dftbp_process_input(DftbPlus *instance, DftbPlusInput *input, DftbPlusAtomList *atomListHandler);
+void dftbp_process_input(DftbPlus *instance, DftbPlusInput *input);
 
 
 /**

--- a/src/dftbp/api/mm/mmapi.F90
+++ b/src/dftbp/api/mm/mmapi.F90
@@ -362,7 +362,7 @@ contains
 
 
   !> Sets up the calculator using a given input.
-  subroutine TDftbPlus_setupCalculator(this, input, atomList)
+  subroutine TDftbPlus_setupCalculator(this, input)
 
     !> Instance.
     class(TDftbPlus), intent(inout) :: this
@@ -370,17 +370,11 @@ contains
     !> Representation of the DFTB+ input.
     type(TDftbPlusInput), intent(inout) :: input
 
-    !> List of atoms and species
-    type(TDftbPlusAtomList), intent(inout), optional :: atomList
-
     type(TParserFlags) :: parserFlags
     type(TInputData) :: inpData
 
     call this%checkInit()
 
-    if (present(atomList)) then
-      call atomList%add(inpData)
-    end if
     call parseHsdTree(input%hsdTree, inpData, parserFlags)
     call doPostParseJobs(input%hsdTree, parserFlags)
     call this%main%initProgramVariables(inpData, this%env)

--- a/src/dftbp/math/determinant.F90
+++ b/src/dftbp/math/determinant.F90
@@ -16,10 +16,10 @@ module dftbp_math_determinant
 #:if WITH_SCALAPACK
   use dftbp_extlibs_mpifx, only : mpifx_comm, MPI_SUM, mpifx_allreduceip
   use dftbp_extlibs_scalapackfx, only : DLEN_, blacsgrid, CSRC_, M_, N_, NB_, scalafx_indxl2g,&
-      & scalafx_pgetrf
+      & scalafx_pgetrf, scalafx_islocal
 #:endif
   implicit none
-  
+
   private
   public :: det
 

--- a/sys/intel.cmake
+++ b/sys/intel.cmake
@@ -70,7 +70,7 @@ set(C_FLAGS_DEBUG "-g -Wall"
 # manual settings above instead.
 if ("${BLAS_LIBRARY}" STREQUAL "")
   # In order to load the library via dlopen() in Python, special MKL library must be linked.
-  if(WITH_API AND BUILD_SHARED_LIBS AND WITH_PYTHON)
+  if(BUILD_SHARED_LIBS AND ENABLE_DYNAMIC_LOADING)
     if(WITH_MPI)
       message(FATAL_ERROR
         "Don't know how to link MKL as shared library with MPI and dlopen (Python API) support. "

--- a/test/src/dftbp/CMakeLists.txt
+++ b/test/src/dftbp/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 if(WITH_API)
   add_subdirectory(api/mm)
-  if(BUILD_SHARED_LIBS AND WITH_PYTHON)
+  if(BUILD_SHARED_LIBS AND ENABLE_DYNAMIC_LOADING)
     add_subdirectory(api/pyapi)
   endif()
 endif()

--- a/test/src/dftbp/api/mm/testers/test_fileinitc.c
+++ b/test/src/dftbp/api/mm/testers/test_fileinitc.c
@@ -66,7 +66,6 @@ int main()
 {
   DftbPlus calculator;
   DftbPlusInput input;
-  DftbPlusAtomList dummyAtomList;
 
   /* Coordinates in row major format, atomic units */
   double coords_si2[3 * NR_OF_ATOMS_SI2] = {
@@ -110,8 +109,6 @@ int main()
   int major, minor, patch;
   _Bool instsafe;
 
-  dummyAtomList.pDftbPlusAtomList = NULL;
-
   dftbp_api(&major, &minor, &patch);
   printf("API version %d.%d.%d\n", major, minor, patch);
 
@@ -140,7 +137,7 @@ int main()
     } else {
       dftbp_get_input_from_file(&calculator, "dftb_in.H2O.hsd", &input);
     }
-    dftbp_process_input(&calculator, &input, &dummyAtomList);
+    dftbp_process_input(&calculator, &input);
 
     /* Check whether the calculator was initialized with the correct nr. of atoms */
     natom = dftbp_get_nr_atoms(&calculator);

--- a/test/src/dftbp/api/mm/testers/test_qdepextpotc.c
+++ b/test/src/dftbp/api/mm/testers/test_qdepextpotc.c
@@ -208,13 +208,10 @@ int main()
 {
   DftbPlus calculator;
   DftbPlusInput input;
-  DftbPlusAtomList dummyAtomList;
 
   Context cont;
   double mermin_energy;
   double *gradients, *charges;
-
-  dummyAtomList.pDftbPlusAtomList = NULL;
 
   /* Fill up the context with all the relevant data */
   initialize_context(&cont);
@@ -227,7 +224,7 @@ int main()
   dftbp_get_input_from_file(&calculator, "dftb_in.hsd", &input);
 
   /* Set up the calculator by processing the input tree */
-  dftbp_process_input(&calculator, &input, &dummyAtomList);
+  dftbp_process_input(&calculator, &input);
 
   /* Register the callback functions calculating population dependent external potential */
   dftbp_register_ext_pot_generator(&calculator, &cont, get_external_potential,

--- a/test/src/dftbp/api/pyapi/testcases/extpot/test_extpot.py
+++ b/test/src/dftbp/api/pyapi/testcases/extpot/test_extpot.py
@@ -16,7 +16,7 @@ import dftbplus
 from testhelpers import write_autotest_tag
 
 
-LIB_PATH = '../../../../../src/dftbp/libdftbplus'
+LIB_PATH = '../../../../../../../src/dftbp/libdftbplus'
 
 # number of atoms (should match dftb_in.hsd)
 NATOM0 = 3

--- a/test/src/dftbp/api/pyapi/testcases/fileinit/test_fileinit.py
+++ b/test/src/dftbp/api/pyapi/testcases/fileinit/test_fileinit.py
@@ -19,7 +19,7 @@ import dftbplus
 from testhelpers import write_autotest_tag
 
 
-LIB_PATH = '../../../../../src/dftbp/libdftbplus'
+LIB_PATH = '../../../../../../../src/dftbp/libdftbplus'
 
 # number of atoms (should match dftb_in.hsd files)
 NATOM_SI = 2

--- a/test/src/dftbp/api/pyapi/testcases/geodisp/test_geodisp.py
+++ b/test/src/dftbp/api/pyapi/testcases/geodisp/test_geodisp.py
@@ -15,7 +15,7 @@ import dftbplus
 from testhelpers import write_autotest_tag
 
 
-LIB_PATH = '../../../../../src/dftbp/libdftbplus'
+LIB_PATH = '../../../../../../../src/dftbp/libdftbplus'
 
 # number of atoms (should match dftb_in.hsd)
 NATOM0 = 2

--- a/test/src/dftbp/api/pyapi/testcases/qdepextpot/test_qdepextpot.py
+++ b/test/src/dftbp/api/pyapi/testcases/qdepextpot/test_qdepextpot.py
@@ -17,7 +17,7 @@ import dftbplus
 from testhelpers import write_autotest_tag
 
 
-LIB_PATH = '../../../../../src/dftbp/libdftbplus'
+LIB_PATH = '../../../../../../../src/dftbp/libdftbplus'
 
 # number of atoms (should match dftb_in.hsd file)
 NATOM = 3

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,7 @@
 if (WITH_PYTHON)
   add_subdirectory(dptools)
-  add_subdirectory(pythonapi)
+  if(WITH_API AND ENABLE_DYNAMIC_LOADING)
+    add_subdirectory(pythonapi)
+  endif()
 endif()
 add_subdirectory(misc)


### PR DESCRIPTION
* Turns back the API to the original form without `atomList` argument in the `dftbp_process_input()` call
* Fixes the library paths in the pyapi tests, so that they work properly.
* Fixes several problems experienced during shared library builds
* Introduces new CMake option `ENABLE_DYNAMIC_LOADING`, which governs `dlopen()` compatibiliy. `WITH_PYTHON=True` installs dptools only, if `ENABLE_DYNAMIC_LOADING` is `False`, otherwise the Python API is also installed.

The setting of the species via API should be implemented in an other PR using a different method (allowing C interface to build up and manipulate an HSD-tree).

Closes #834.
