### PR TITLE
Trap for non-Fermi filling with perturbation

### DIFF
--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -2263,6 +2263,10 @@ contains
       else
         this%isRespKernelRPA = .false.
       end if
+      if (this%iDistribFn /= fillingTypes%Fermi) then
+        call error("Choice of filling function currently incompatible with perturbation&
+            & calculations")
+      end if
       if (this%tNegf) then
         call error("Currently the perturbation expressions for NEGF are not implemented")
       end if


### PR DESCRIPTION
Filling in the perturbation routines is currently only implemented for the Fermi function.