### PR TITLE
MPI loops only over atoms stored on processor

### DIFF
--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -1871,7 +1871,7 @@ contains
       end select
     end if
 
-    call this%getDenseDescCommon() !this%orb, this%nAtom, this%t2Component, this%denseDesc)
+    call this%getDenseDescCommon()
 
     if (this%electronicSolver%isElsiSolver) then
       @:ASSERT(this%parallelKS%nLocalKS == 1)

--- a/src/dftbp/type/integral.F90
+++ b/src/dftbp/type/integral.F90
@@ -5,6 +5,8 @@
 !  See the LICENSE file for terms of usage and distribution.                                       !
 !--------------------------------------------------------------------------------------------------!
 
+#:include 'common.fypp'
+
 !> Data types to handle overlap related integrals
 module dftbp_type_integral
   use dftbp_common_accuracy, only : dp
@@ -37,6 +39,16 @@ module dftbp_type_integral
 
     !> Imaginary Hamiltonian integrals in atomic block sparse form
     real(dp), allocatable :: iHamiltonian(:, :)
+
+  #:if WITH_SCALAPACK
+
+    !> Atoms corresponding to local columns of the orbital grid for dense matrix stored integrals
+    integer, allocatable :: lowerTriangleLocalAtoms(:)
+
+    !> Atoms corresponding to ocal rows of the orbital grid for dense matrix stored integrals
+    integer, allocatable :: bothTriangleLocalAtoms(:)
+
+  #:endif
 
   end type TIntegral
 
@@ -80,6 +92,11 @@ contains
       allocate(this%quadrupoleKet(nQuadrupole, 0))
       allocate(this%quadrupoleBra(nQuadrupole, 0))
     end if
+
+  #:if WITH_SCALAPACK
+    allocate(this%lowerTriangleLocalAtoms(0))
+    allocate(this%bothTriangleLocalAtoms(0))
+  #:endif
 
   end subroutine TIntegral_init
 


### PR DESCRIPTION
Stores indexing for atoms that correspond to local parts of BLACS matrices.

Should improve parallel performance on larger numbers of processors (marginal but a couple of percent speed-up present on tests with 4 processors)

- [x] BLACS unpack routines in main code
- [ ] BLACS pack routines in main code
- [ ] BLACS pack/unpack outside of main code
- [ ] Other BLACS operations on orbitals
- [ ] Trap for BLACS vs CSR
- [ ] CSR equivalent indexing