### PR TITLE
Add workaround for ifort 202x compiler bug

### DIFF
--- a/app/waveplot/waveplot.F90
+++ b/app/waveplot/waveplot.F90
@@ -193,7 +193,8 @@ program waveplot
     ! of the lattice unit cell as possible.
     cellMiddle(:) = 0.5_dp * sum(wp%input%geo%latVecs, dim=2)
     boxMiddle(:) = wp%opt%origin(:) + 0.5_dp * sum(wp%opt%boxVecs, dim=2)
-    frac(:) = matmul(boxMiddle - cellMiddle, recVecs2p)
+    shift(:) = boxMiddle - cellMiddle
+    frac(:) = matmul(shift, recVecs2p)
     wp%opt%origin(:) = wp%opt%origin(:) - matmul(wp%input%geo%latVecs, real(anint(frac), dp))
     wp%opt%gridOrigin(:) = wp%opt%gridOrigin(:)&
         & - matmul(wp%input%geo%latVecs, real(anint(frac), dp))


### PR DESCRIPTION
Offers workaround for the iforts ICE (reported in https://community.intel.com/t5/Intel-Fortran-Compiler/ICE-for-simple-matmul-expression-when-checks-are-turned-on/m-p/1350570#M159304)