### PR TITLE
DFTB sparse matrices with dense operations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "external/mpifx/origin"]
-    path = external/mpifx/origin
-    url = https://github.com/dftbplus/mpifx.git
+	path = external/mpifx/origin
+	url = https://github.com/dftbplus/mpifx.git
 [submodule "external/libnegf/origin"]
 	path = external/libnegf/origin
 	url = https://github.com/libnegf/libnegf.git
 [submodule "external/scalapackfx/origin"]
-    path = external/scalapackfx/origin
-    url = https://github.com/dftbplus/scalapackfx.git
+	path = external/scalapackfx/origin
+	url = https://github.com/dftbplus/scalapackfx.git
 [submodule "external/mbd/origin"]
 	path = external/mbd/origin
 	url = https://github.com/libmbd/libmbd.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ if(WITH_MPI)
   find_package(CustomScalapack REQUIRED)
 
   set(SCALAPACKFX_GIT_REPOSITORY "https://github.com/dftbplus/scalapackfx.git")
-  set(SCALAPACKFX_GIT_TAG "0d5750d4b1d185e5dfae5b7e99f1828e736ec43a")  # do not change manually!
+  set(SCALAPACKFX_GIT_TAG "7b98ba99d595a0760da12895b1a63959e881182c")  # do not change manually!
   dftbp_config_hybrid_dependency(ScalapackFx ScalapackFx::ScalapackFx "${HYBRID_CONFIG_METHODS}"
     "QUIET" external/scalapackfx "${exclude}" "${SCALAPACKFX_GIT_REPOSITORY}"
     "${SCALAPACKFX_GIT_TAG}")

--- a/src/dftbp/dftb/boundarycond.F90
+++ b/src/dftbp/dftb/boundarycond.F90
@@ -6,23 +6,28 @@
 !--------------------------------------------------------------------------------------------------!
 
 #:include 'common.fypp'
+#:include 'error.fypp'
 
 !> Contains geometrical boundary condition information on the calculation
 module dftbp_dftb_boundarycond
   use dftbp_common_accuracy, only : dp
+  use dftbp_common_constants, only : pi
+  use dftbp_common_status, only : TStatus
+  use dftbp_math_angmomentum, only : rotateZ
+  use dftbp_math_quaternions, only : rotate3
   use dftbp_type_commontypes, only : TOrbitals
   implicit none
 
   private
-  public :: zAxis
-  public :: boundaryConditions
+  public :: zAxis, boundaryConditions, TBoundaryConditions, TBoundaryConditions_init
 
+#:set FLAVOURS = [('complex', 'cplx'), ('real', 'real')]
 
-  !> z direction vector for rotation
+  !> z direction vector for screw rotation
   real(dp), parameter :: zAxis(3) = [0.0_dp, 0.0_dp, 1.0_dp]
 
 
-  !> Enumerator containign possible boundary conditions
+  !> Enumerator containing possible boundary conditions
   type :: TBoundaryConditionEnum_
 
     !> Unknown/undefined boundary condition
@@ -43,5 +48,208 @@ module dftbp_dftb_boundarycond
   !> Actual instance of the boundary condition enumerator
   type(TBoundaryConditionEnum_), parameter :: boundaryConditions = TBoundaryConditionEnum_()
 
+
+  type TBoundaryConditions
+
+    integer :: iBoundaryCondition = boundaryConditions%unknown
+
+  contains
+
+    procedure :: foldInDiatomicBlock_real
+    procedure :: foldInDiatomicBlock_cplx
+    generic :: foldInDiatomicBlock => foldInDiatomicBlock_real, foldInDiatomicBlock_cplx
+
+    procedure :: foldOutDiatomicBlock_real
+    procedure :: foldOutDiatomicBlock_cplx
+    generic :: foldOutDiatomicBlock => foldOutDiatomicBlock_real, foldOutDiatomicBlock_cplx
+
+    procedure :: alignVectorCentralCell
+
+  end type TBoundaryConditions
+
+contains
+
+  subroutine TBoundaryConditions_init(this, iBoundaryCondition, errStatus)
+
+    !> Instance
+    type(TBoundaryConditions), intent(out) :: this
+
+    !> Boundary condition choice
+    integer, intent(in) :: iBoundaryCondition
+
+    !> Status of routine
+    type(TStatus), intent(out) :: errStatus
+
+    if (.not. any([boundaryConditions%cluster, boundaryConditions%pbc3d,&
+        & boundaryConditions%helical] == iBoundaryCondition)) then
+      @:RAISE_ERROR(errStatus, -1, "Unknown boundary condition specified")
+    end if
+
+    this%iBoundaryCondition = iBoundaryCondition
+
+  end subroutine TBoundaryConditions_init
+
+
+#:for TYPE, LABEL in FLAVOURS
+
+  !> convert matrix elements from image to central cell atoms
+  pure subroutine foldInDiatomicBlock_${LABEL}$(this, sqrBlock, iAt1, iAt2, coords, species,&
+      & img2CentCell, orb)
+
+    !> Instance
+    class(TBoundaryConditions), intent(in) :: this
+
+    !> Basis set expanded quantity to manipulate as per boundary conditions
+    ${TYPE}$(dp), intent(inout) :: sqrBlock(:,:)
+
+    !> Atom already in central cell
+    integer, intent(in) :: iAt1
+
+    !> Atom to be folded in
+    integer, intent(in) :: iAt2
+
+    !> Coordinates of all atoms
+    real(dp), intent(in) :: coords(:,:)
+
+    !> Species of each atom
+    integer, intent(in) :: species(:)
+
+    !> Map from images of atoms to central cell atoms
+    integer, intent(in) :: img2CentCell(:)
+
+    !> data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
+
+    integer :: iAt2f, iSp, iSh, nOrb1, nOrb2, lShellVals(orb%mShell)
+    real(dp) :: theta, rotZ(orb%mOrb,orb%mOrb)
+
+    select case(this%iBoundaryCondition)
+
+    case(boundaryConditions%cluster, boundaryConditions%pbc3d)
+
+      ! orbitals all in the same orientation in space
+
+      return
+
+    case(boundaryConditions%helical)
+
+      if (iAt1 == iAt2) then
+        return
+      end if
+      iAt2f = img2CentCell(iAt2)
+      iSp = species(iAt2f)
+      iSh = orb%nShell(iSp)
+      nOrb1 = orb%nOrbAtom(iAt1)
+      nOrb2 = orb%nOrbAtom(iAt2f)
+      lShellVals(:iSh) = orb%angShell(:iSh,iSp)
+      theta = atan2(coords(2,iAt2f),coords(1,iAt2f)) - atan2(coords(2,iAt2),coords(1,iAt2))
+      theta = mod(theta,2.0_dp*pi)
+      call rotateZ(rotZ, lShellVals(:iSh), theta)
+      sqrBlock(:nOrb2, :nOrb1) = matmul(rotZ(:nOrb2, :nOrb2), sqrBlock(:nOrb2, :nOrb1))
+
+    end select
+
+  end subroutine foldInDiatomicBlock_${LABEL}$
+
+
+  !> convert matrix elements from central cell to image atoms
+  pure subroutine foldOutDiatomicBlock_${LABEL}$(this, sqrBlock, iAt1, iAt2, coords, species,&
+      & img2CentCell, orb)
+
+    !> Instance
+    class(TBoundaryConditions), intent(in) :: this
+
+    !> Basis set expanded quantity to manipulate as per boundary conditions
+    ${TYPE}$(dp), intent(inout) :: sqrBlock(:,:)
+
+    !> Atom already in central cell
+    integer, intent(in) :: iAt1
+
+    !> Atom to be folded in
+    integer, intent(in) :: iAt2
+
+    !> Coordinates of all atoms
+    real(dp), intent(in) :: coords(:,:)
+
+    !> Species of each atom
+    integer, intent(in) :: species(:)
+
+    !> Map from images of atoms to central cell atoms
+    integer, intent(in) :: img2CentCell(:)
+
+    !> data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
+
+    integer :: iAt2f, iSp, iSh, nOrb1, nOrb2, lShellVals(orb%mShell)
+    real(dp) :: theta, rotZ(orb%mOrb,orb%mOrb)
+
+    select case(this%iBoundaryCondition)
+
+    case(boundaryConditions%cluster, boundaryConditions%pbc3d)
+
+      ! orbitals all in the same orientation in space
+
+      return
+
+    case(boundaryConditions%helical)
+
+      if (iAt1 == iAt2) then
+        return
+      end if
+      iAt2f = img2CentCell(iAt2)
+      iSp = species(iAt2f)
+      iSh = orb%nShell(iSp)
+      nOrb1 = orb%nOrbAtom(iAt1)
+      nOrb2 = orb%nOrbAtom(iAt2f)
+      lShellVals(:iSh) = orb%angShell(:iSh,iSp)
+      theta = atan2(coords(2,iAt2),coords(1,iAt2)) - atan2(coords(2,iAt2f),coords(1,iAt2f))
+      theta = mod(theta,2.0_dp*pi)
+      call rotateZ(rotZ, lShellVals(:iSh), theta)
+      sqrBlock(:nOrb2, :nOrb1) = matmul(rotZ(:nOrb2, :nOrb2), sqrBlock(:nOrb2, :nOrb1))
+
+    end select
+
+  end subroutine foldOutDiatomicBlock_${LABEL}$
+
+#:endfor
+
+
+  !> Transform alignment of vector array between alignment of coord0 and coord (central cell only)
+  subroutine alignVectorCentralCell(this, vectors, coords, coords0, nAtom)
+
+    !> Instance
+    class(TBoundaryConditions), intent(in) :: this
+
+    !> vectors to transform
+    real(dp), intent(inout) :: vectors(:,:)
+
+    !> Coordinates in central/objective cell
+    real(dp), intent(in) :: coords(:,:)
+
+    !> Coordinates in (potentially) extended structure
+    real(dp), intent(in) :: coords0(:,:)
+
+    !> Number of atoms in central/objective cell
+    integer, intent(in) :: nAtom
+
+    integer :: iAt
+    real(dp) :: deltaTheta
+
+    select case(this%iBoundaryCondition)
+
+    case(boundaryConditions%helical)
+
+      do iAt = 1, nAtom
+        deltaTheta = atan2(coords0(2,iAt),coords0(1,iAt)) - atan2(coords(2,iAt),coords(1,iAt))
+        call rotate3(vectors(:,iAt), deltaTheta, zAxis)
+      end do
+
+    case default
+
+      return
+
+    end select
+
+  end subroutine alignVectorCentralCell
 
 end module dftbp_dftb_boundarycond

--- a/src/dftbp/dftb/sparse2dense.F90
+++ b/src/dftbp/dftb/sparse2dense.F90
@@ -309,7 +309,7 @@ contains
     integer :: nAtom, iOrig, ii, jj, iNeigh, iOldVec, iVec, iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2, iSh, iSp
     real(dp) :: kPoint2p(2), rotZ(orb%mOrb,orb%mOrb), theta, tmpSqr(orb%mOrb,orb%mOrb)
-    integer  :: lShellVals(orb%mShell)
+    integer :: lShellVals(orb%mShell)
 
     nAtom = size(iNeighbour, dim=2)
     square(:, :) = cmplx(0, 0, dp)
@@ -388,7 +388,7 @@ contains
 
     integer :: nAtom, iOrig, ii, jj, iNeigh, iAtom1, iAtom2, iAtom2f, nOrb1, nOrb2
     real(dp) :: rotZ(orb%mOrb,orb%mOrb), theta, tmpSqr(orb%mOrb,orb%mOrb)
-    integer  :: lShellVals(orb%mShell), iSh, iSp
+    integer :: lShellVals(orb%mShell), iSh, iSp
 
     nAtom = size(iNeighbour, dim=2)
     square(:, :) = 0.0_dp
@@ -3034,7 +3034,7 @@ contains
 
     integer :: nAtom, iOrig, ii, jj, nOrb1, nOrb2, iNeigh, iAtom1, iAtom2, iAtom2f
     real(dp) :: rotZ(orb%mOrb,orb%mOrb), theta, tmpSqr(orb%mOrb,orb%mOrb)
-    integer  :: lShellVals(orb%mShell), iSh, iSp
+    integer :: lShellVals(orb%mShell), iSh, iSp
 
     nAtom = size(iNeighbour, dim=2)
     square(:, :) = 0.0_dp
@@ -3120,7 +3120,7 @@ contains
     complex(dp) :: phase, tmpSqr(orb%mOrb,orb%mOrb)
     integer :: nAtom, iOrig, nOrb1, nOrb2, ii, jj, iNeigh, iOldVec, iVec, iAtom1, iAtom2, iAtom2f
     real(dp) :: kPoint2p(2), rotZ(orb%mOrb,orb%mOrb), theta
-    integer  :: iSh, iSp, lShellVals(orb%mShell)
+    integer :: iSh, iSp, lShellVals(orb%mShell)
 
     nAtom = size(iNeighbour, dim=2)
     square(:, :) = cmplx(0, 0, dp)

--- a/src/dftbp/dftbplus/mainapi.F90
+++ b/src/dftbp/dftbplus/mainapi.F90
@@ -681,7 +681,7 @@ contains
     ! Specificaly, denseDesc uses orb%nOrbAtom
     call main%getDenseDescCommon()
     call getDenseDescBlacs(env, env%blacs%rowBlockSize, env%blacs%columnBlockSize,&
-        & main%denseDesc)
+        & main%denseDesc, main%isSparseReorderRequired)
 
   end subroutine updateBLACSDecomposition
 

--- a/src/dftbp/math/CMakeLists.txt
+++ b/src/dftbp/math/CMakeLists.txt
@@ -21,7 +21,8 @@ set(sources-fpp
   ${curdir}/ranlux.F90
   ${curdir}/scalafxext.F90
   ${curdir}/simplealgebra.F90
-  ${curdir}/sorting.F90)
+  ${curdir}/sorting.F90
+  ${curdir}/sparseblas.F90)
 
 
 set(ALL-SOURCES-FPP ${ALL-SOURCES-FPP} ${sources-fpp} PARENT_SCOPE)

--- a/src/dftbp/math/sparseblas.F90
+++ b/src/dftbp/math/sparseblas.F90
@@ -1,0 +1,1183 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2021  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+#:include 'common.fypp'
+#:include 'error.fypp'
+
+#! suffix and kinds for sparse with dense types
+#:set ROUTINE_KINDS = [('real', 'r'), ('complex', 'c')]
+
+!> DFTB+ sparse structure operations for a few blas matrix operations
+module dftbp_math_sparseblas
+  use dftbp_common_accuracy, only : dp
+  use dftbp_common_constants, only : imag, pi
+  use dftbp_dftb_boundarycond, only : TBoundaryConditions
+  use dftbp_type_commontypes, only : TOrbitals
+#:if WITH_SCALAPACK
+  use dftbp_common_blacsenv, only : TBlacsEnv
+  use dftbp_extlibs_scalapackfx, only : blacsfx_gemr2d
+  use dftbp_type_densedescr, only : TDenseDescr
+#:endif
+  implicit none
+  private
+
+  public :: symv, symm
+#:if WITH_SCALAPACK
+  public :: redist_sqr2rows, redist_rows2sqr
+
+  interface redist_sqr2rows
+    module procedure sqr2rows_real
+    module procedure sqr2rows_complex
+  end interface redist_sqr2rows
+
+  interface redist_rows2sqr
+    module procedure rows2sqr_real
+    module procedure rows2sqr_complex
+  end interface redist_rows2sqr
+
+#:endif
+
+  ! Rank 2 routines
+
+  !> Routine for symmetric sparse matrix with dense vector multiply
+  interface symv
+  #:for _, suffix in ROUTINE_KINDS
+    module procedure symv_${suffix}$_gamma
+    module procedure symv_bc_${suffix}$_gamma
+  #:endfor
+    module procedure symv_kpt
+    module procedure symv_bc_kpt
+  end interface symv
+
+  ! Rank 3 routines
+
+  !> Routine for multiplication between a symmetric sparse matrix and a general
+  !> dense matrix
+  interface symm
+  #:for _, suffix in ROUTINE_KINDS
+    module procedure symm_${suffix}$_gamma
+    module procedure symm_bc_${suffix}$_gamma
+  #:endfor
+    module procedure symm_kpt
+    module procedure symm_bc_kpt
+  end interface symm
+
+contains
+
+#:for typename, suffix in ROUTINE_KINDS
+
+  !> Sparse Gamma point matrix with a ${typename}$ vector as a symv operation,
+  !> y = alpha A x + beta * y
+  subroutine symv_${suffix}$_gamma(y, A, x, iNeighbour, nNeighbour, img2CentCell, iSparseStart,&
+      & iAtomStart, orb, alpha, beta)
+
+    !> Vector on return
+    ${typename}$(dp), intent(inout):: y(:)
+
+    !> Sparse matrix
+    real(dp), intent(in) :: A(:)
+
+    !> Vector on entry
+    ${typename}$(dp), intent(in) :: x(:)
+
+    !> Atom neighbour list
+    integer, intent(in) :: iNeighbour(0:,:)
+
+    !> Number of neighbours for atoms
+    integer, intent(in) :: nNeighbour(:)
+
+    !> Image to central cell mapping
+    integer, intent(in) :: img2CentCell(:)
+
+    !> Sparse indexing
+    integer, intent(in) :: iSparseStart(0:,:)
+
+    !> Dense indexing
+    integer, intent(in) :: iAtomStart(:)
+
+    !> data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
+
+    !> Scaling factor for A * x
+    ${typename}$(dp), optional, intent(in) :: alpha
+
+    !> Scaling factor for incoming y
+    ${typename}$(dp), optional, intent(in) :: beta
+
+    integer :: iOrig, ix, iy, jx, jy, iNeigh, nAtom, iAtom1, iAtom2, iAtom2f, nOrb1, nOrb2, ii
+    real(dp) :: sqrTmp(orb%mOrb, orb%mOrb)
+    ${typename}$(dp) :: alphaTmp
+
+    @:ASSERT(size(x) == size(y))
+
+    nAtom = size(iAtomStart)-1
+
+    if (present(alpha)) then
+      alphaTmp = alpha
+    else
+      alphaTmp = 1.0_dp
+    end if
+
+    if (present(beta)) then
+      y(:) = beta * y
+    else
+      y(:) = 0.0_dp
+    end if
+
+    !$OMP PARALLEL DO DEFAULT(SHARED) &
+    !$OMP &PRIVATE(iAtom1,nOrb1,ix,jx,iNeigh,sqrTmp,iAtom2,iAtom2f,nOrb2,iOrig,ii,iy,jy) &
+    !$OMP & REDUCTION(+:y) SCHEDULE(RUNTIME)
+    do iAtom1 = 1, nAtom
+      ix = iAtomStart(iAtom1)
+      jx = iAtomStart(iAtom1 + 1) -1
+      nOrb1 = jx - ix + 1
+      do iNeigh = 0, nNeighbour(iAtom1)
+        iOrig = iSparseStart(iNeigh,iAtom1) + 1
+        sqrTmp(:,:) = 0.0_dp
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
+        iAtom2f = img2CentCell(iAtom2)
+        iy = iAtomStart(iAtom2f)
+        jy = iAtomStart(iAtom2f + 1) - 1
+        nOrb2 = jy - iy + 1
+        sqrTmp(:nOrb2,:nOrb1) = reshape(A(iOrig:iOrig+nOrb2*nOrb1-1), [nOrb2,nOrb1])
+        ! symmetrize on-diagonal blocks just in case
+        if (iAtom1 == iAtom2f) then
+          do ii = 1, nOrb1
+            sqrTmp(ii,ii+1:nOrb2) = sqrTmp(ii+1:nOrb2,ii)
+          end do
+        end if
+        y(iy:jy) = y(iy:jy) + alphaTmp * matmul(sqrTmp(:nOrb2,:nOrb1),x(ix:jx))
+        ! other triangle due to symmetry of matrix
+        if (iAtom1 /= iAtom2f) then
+          y(ix:jx) = y(ix:jx) + alphaTmp * matmul(transpose(sqrTmp(:nOrb2,:nOrb1)),x(iy:jy))
+        end if
+      end do
+    end do
+    !$OMP  END PARALLEL DO
+
+  end subroutine symv_${suffix}$_gamma
+
+
+  !> Sparse Gamma point matrix with a ${typename}$ vector as a symv operation, using specified
+  !> boundary conditions, y = alpha A x + beta * y
+  subroutine symv_bc_${suffix}$_gamma(y, A, x, bcs, iNeighbour, nNeighbour, img2CentCell,&
+      & iSparseStart, iAtomStart, coords, species, orb, alpha, beta)
+
+    !> Vector on return
+    ${typename}$(dp), intent(inout):: y(:)
+
+    !> Sparse matrix
+    real(dp), intent(in) :: A(:)
+
+    !> Vector on entry
+    ${typename}$(dp), intent(in) :: x(:)
+
+    !> Boundary conditions on the system
+    type(TBoundaryConditions), intent(in) :: bcs
+
+    !> Atom neighbour list
+    integer, intent(in) :: iNeighbour(0:,:)
+
+    !> Number of neighbours for atoms
+    integer, intent(in) :: nNeighbour(:)
+
+    !> Image to central cell mapping
+    integer, intent(in) :: img2CentCell(:)
+
+    !> Sparse indexing
+    integer, intent(in) :: iSparseStart(0:,:)
+
+    !> Dense indexing
+    integer, intent(in) :: iAtomStart(:)
+
+    !> Coordinates of all atoms
+    real(dp), intent(in) :: coords(:,:)
+
+    !> Species of each atom
+    integer, intent(in) :: species(:)
+
+    !> data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
+
+    !> Scaling factor for A * x
+    ${typename}$(dp), optional, intent(in) :: alpha
+
+    !> Scaling factor for incoming y
+    ${typename}$(dp), optional, intent(in) :: beta
+
+    integer :: iOrig, ix, iy, jx, jy, iNeigh, nAtom, iAtom1, iAtom2, iAtom2f, nOrb1, nOrb2, ii
+    real(dp) :: sqrTmp(orb%mOrb, orb%mOrb)
+    ${typename}$(dp) :: alphaTmp
+
+    @:ASSERT(size(x) == size(y))
+
+    nAtom = size(iAtomStart)-1
+
+    if (present(alpha)) then
+      alphaTmp = alpha
+    else
+      alphaTmp = 1.0_dp
+    end if
+
+    if (present(beta)) then
+      y(:) = beta * y
+    else
+      y(:) = 0.0_dp
+    end if
+
+    !$OMP PARALLEL DO DEFAULT(SHARED) &
+    !$OMP &PRIVATE(iAtom1,nOrb1,ix,jx,iNeigh,sqrTmp,iAtom2,iAtom2f,nOrb2,iOrig,ii,iy,jy) &
+    !$OMP & REDUCTION(+:y) SCHEDULE(RUNTIME)
+    do iAtom1 = 1, nAtom
+      ix = iAtomStart(iAtom1)
+      jx = iAtomStart(iAtom1 + 1) -1
+      nOrb1 = jx - ix + 1
+      do iNeigh = 0, nNeighbour(iAtom1)
+        iOrig = iSparseStart(iNeigh,iAtom1) + 1
+        sqrTmp(:,:) = 0.0_dp
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
+        iAtom2f = img2CentCell(iAtom2)
+        iy = iAtomStart(iAtom2f)
+        jy = iAtomStart(iAtom2f + 1) - 1
+        nOrb2 = jy - iy + 1
+        sqrTmp(:nOrb2,:nOrb1) = reshape(A(iOrig:iOrig+nOrb2*nOrb1-1), [nOrb2,nOrb1])
+        call bcs%foldInDiatomicBlock(sqrTmp, iAtom1, iAtom2, coords, species, img2centCell, orb)
+        ! symmetrize on-diagonal blocks just in case
+        if (iAtom1 == iAtom2f) then
+          do ii = 1, nOrb1
+            sqrTmp(ii,ii+1:nOrb2) = sqrTmp(ii+1:nOrb2,ii)
+          end do
+        end if
+        y(iy:jy) = y(iy:jy) + alphaTmp * matmul(sqrTmp(:nOrb2,:nOrb1),x(ix:jx))
+        ! other triangle due to symmetry of matrix
+        if (iAtom1 /= iAtom2f) then
+          y(ix:jx) = y(ix:jx) + alphaTmp * matmul(transpose(sqrTmp(:nOrb2,:nOrb1)),x(iy:jy))
+        end if
+      end do
+    end do
+    !$OMP  END PARALLEL DO
+
+  end subroutine symv_bc_${suffix}$_gamma
+
+#:endfor
+
+
+  !> Sparse matrix at specified k-point with a vector as a symv operation, y = alpha A x + beta * y
+  subroutine symv_kpt(y, A, x, iNeighbour, nNeighbour, kPoint, iCellVec, cellVec, img2CentCell,&
+      & iSparseStart, iAtomStart, orb, alpha, beta)
+
+    !> Vector on return
+    complex(dp), intent(inout):: y(:)
+
+    !> Sparse matrix
+    real(dp), intent(in) :: A(:)
+
+    !> Vector on entry
+    complex(dp), intent(in) :: x(:)
+
+    !> Atom neighbour list
+    integer, intent(in) :: iNeighbour(0:,:)
+
+    !> Number of neighbours for atoms
+    integer, intent(in) :: nNeighbour(:)
+
+    !> Relative coordinates of the k-point where the sparse matrix should be unfolded.
+    real(dp), intent(in) :: kPoint(:)
+
+    !> Index of the cell translation vector for each atom.
+    integer, intent(in) :: iCellVec(:)
+
+    !> Relative coordinates of the cell translation vectors.
+    real(dp), intent(in) :: cellVec(:, :)
+
+    !> Image to central cell mapping
+    integer, intent(in) :: img2CentCell(:)
+
+    !> Sparse indexing
+    integer, intent(in) :: iSparseStart(0:,:)
+
+    !> Dense indexing
+    integer, intent(in) :: iAtomStart(:)
+
+    !> data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
+
+    !> Scaling factor for A * x
+    complex(dp), optional, intent(in) :: alpha
+
+    !> Scaling factor for incoming y
+    complex(dp), optional, intent(in) :: beta
+
+    integer :: iOrig, ix, iy, jx, jy, iNeigh, nAtom, iAtom1, iAtom2, iAtom2f, nOrb1, nOrb2, ii, iVec
+    complex(dp) :: sqrTmp(orb%mOrb, orb%mOrb), alphaTmp, phase
+    real(dp) :: kPoint2p(3)
+
+    @:ASSERT(size(x) == size(y))
+
+    nAtom = size(iAtomStart)-1
+
+    kPoint2p(:) = 2.0_dp * pi * kPoint
+
+    if (present(alpha)) then
+      alphaTmp = alpha
+    else
+      alphaTmp = 1.0_dp
+    end if
+
+    if (present(beta)) then
+      y(:) = beta * y
+    else
+      y(:) = 0.0_dp
+    end if
+
+    !$OMP PARALLEL DO DEFAULT(SHARED) &
+    !$OMP &PRIVATE(iAtom1,nOrb1,ix,jx,iNeigh,sqrTmp,iAtom2,iAtom2f,nOrb2,iOrig,ii,iy,jy,iVec,phase)&
+    !$OMP &REDUCTION(+:y) SCHEDULE(RUNTIME)
+    do iAtom1 = 1, nAtom
+      ix = iAtomStart(iAtom1)
+      jx = iAtomStart(iAtom1 + 1) -1
+      nOrb1 = jx - ix + 1
+      do iNeigh = 0, nNeighbour(iAtom1)
+        iOrig = iSparseStart(iNeigh,iAtom1) + 1
+        sqrTmp(:,:) = 0.0_dp
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
+        iAtom2f = img2CentCell(iAtom2)
+        iy = iAtomStart(iAtom2f)
+        jy = iAtomStart(iAtom2f + 1) - 1
+        nOrb2 = jy - iy + 1
+        iVec = iCellVec(iAtom2)
+        phase = exp(imag * dot_product(kPoint2p, cellVec(:, iVec)))
+        sqrTmp(:nOrb2,:nOrb1) = phase * reshape(A(iOrig:iOrig+nOrb2*nOrb1-1), [nOrb2,nOrb1])
+        ! hermitian symmetry for on-diagonal blocks, just in case
+        if (iAtom1 == iAtom2f) then
+          do ii = 1, nOrb1
+            sqrTmp(ii,ii+1:nOrb2) = conjg(sqrTmp(ii+1:nOrb2,ii))
+          end do
+        end if
+        y(iy:jy) = y(iy:jy) + alphaTmp * matmul(sqrTmp(:nOrb2,:nOrb1),x(ix:jx))
+        ! other triangle due to symmetry of matrix
+        if (iAtom1 /= iAtom2f) then
+          y(ix:jx) = y(ix:jx) + alphaTmp*matmul(transpose(conjg(sqrTmp(:nOrb2,:nOrb1))),x(iy:jy))
+        end if
+      end do
+    end do
+    !$OMP  END PARALLEL DO
+
+  end subroutine symv_kpt
+
+
+  !> Sparse matrix at specified k-point with a vector as a symv operation, using specified boundary
+  !> conditions, y = alpha A x + beta * y
+  subroutine symv_bc_kpt(y, A, x, bcs, iNeighbour, nNeighbour, kPoint, iCellVec, cellVec,&
+      & img2CentCell, iSparseStart, iAtomStart, coords, species, orb, alpha, beta)
+
+    !> Vector on return
+    complex(dp), intent(inout):: y(:)
+
+    !> Sparse matrix
+    real(dp), intent(in) :: A(:)
+
+    !> Vector on entry
+    complex(dp), intent(in) :: x(:)
+
+    !> Boundary conditions on the system
+    type(TBoundaryConditions), intent(in) :: bcs
+
+    !> Atom neighbour list
+    integer, intent(in) :: iNeighbour(0:,:)
+
+    !> Number of neighbours for atoms
+    integer, intent(in) :: nNeighbour(:)
+
+    !> Relative coordinates of the k-point where the sparse matrix should be unfolded.
+    real(dp), intent(in) :: kPoint(:)
+
+    !> Index of the cell translation vector for each atom.
+    integer, intent(in) :: iCellVec(:)
+
+    !> Relative coordinates of the cell translation vectors.
+    real(dp), intent(in) :: cellVec(:, :)
+
+    !> Image to central cell mapping
+    integer, intent(in) :: img2CentCell(:)
+
+    !> Sparse indexing
+    integer, intent(in) :: iSparseStart(0:,:)
+
+    !> Dense indexing
+    integer, intent(in) :: iAtomStart(:)
+
+    !> Coordinates of all atoms
+    real(dp), intent(in) :: coords(:,:)
+
+    !> Species of each atom
+    integer, intent(in) :: species(:)
+
+    !> data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
+
+    !> Scaling factor for A * x
+    complex(dp), optional, intent(in) :: alpha
+
+    !> Scaling factor for incoming y
+    complex(dp), optional, intent(in) :: beta
+
+    integer :: iOrig, ix, iy, jx, jy, iNeigh, nAtom, iAtom1, iAtom2, iAtom2f, nOrb1, nOrb2, ii, iVec
+    complex(dp) :: sqrTmp(orb%mOrb, orb%mOrb), alphaTmp, phase
+    real(dp) :: kPoint2p(2)
+
+    @:ASSERT(size(x) == size(y))
+
+    nAtom = size(iAtomStart)-1
+
+    kPoint2p(:) = 2.0_dp * pi * kPoint
+
+    if (present(alpha)) then
+      alphaTmp = alpha
+    else
+      alphaTmp = 1.0_dp
+    end if
+
+    if (present(beta)) then
+      y(:) = beta * y
+    else
+      y(:) = 0.0_dp
+    end if
+
+    !$OMP PARALLEL DO DEFAULT(SHARED) &
+    !$OMP &PRIVATE(iAtom1,nOrb1,ix,jx,iNeigh,sqrTmp,iAtom2,iAtom2f,nOrb2,iOrig,ii,iy,jy,iVec,phase)&
+    !$OMP &REDUCTION(+:y) SCHEDULE(RUNTIME)
+    do iAtom1 = 1, nAtom
+      ix = iAtomStart(iAtom1)
+      jx = iAtomStart(iAtom1 + 1) -1
+      nOrb1 = jx - ix + 1
+      do iNeigh = 0, nNeighbour(iAtom1)
+        iOrig = iSparseStart(iNeigh,iAtom1) + 1
+        sqrTmp(:,:) = 0.0_dp
+        iAtom2 = iNeighbour(iNeigh, iAtom1)
+        iAtom2f = img2CentCell(iAtom2)
+        iy = iAtomStart(iAtom2f)
+        jy = iAtomStart(iAtom2f + 1) - 1
+        nOrb2 = jy - iy + 1
+        iVec = iCellVec(iAtom2)
+        phase = exp(imag * dot_product(kPoint2p, cellVec(:, iVec)))
+        sqrTmp(:nOrb2,:nOrb1) = reshape(A(iOrig:iOrig+nOrb2*nOrb1-1), [nOrb2,nOrb1])
+        call bcs%foldInDiatomicBlock(sqrTmp, iAtom1, iAtom2, coords, species, img2centCell, orb)
+        sqrTmp(:nOrb2,:nOrb1) = phase * sqrTmp
+        ! hermitian symmetry for on-diagonal blocks, just in case
+        if (iAtom1 == iAtom2f) then
+          do ii = 1, nOrb1
+            sqrTmp(ii,ii+1:nOrb2) = conjg(sqrTmp(ii+1:nOrb2,ii))
+          end do
+        end if
+        y(iy:jy) = y(iy:jy) + alphaTmp * matmul(sqrTmp(:nOrb2,:nOrb1),x(ix:jx))
+        ! other triangle due to symmetry of matrix
+        if (iAtom1 /= iAtom2f) then
+          y(ix:jx) = y(ix:jx) + alphaTmp*matmul(transpose(conjg(sqrTmp(:nOrb2,:nOrb1))),x(iy:jy))
+        end if
+      end do
+    end do
+    !$OMP  END PARALLEL DO
+
+  end subroutine symv_bc_kpt
+
+
+#:for typename, suffix in ROUTINE_KINDS
+
+  !> Sparse Gamma point matrix with dense ${typename}$ matrix as a symm operation,
+  !> symmetric matrix on 'l'eft or 'r'ight , where A is symmetric and sparse and B is general.
+  subroutine symm_${suffix}$_gamma(C, side, A, B, iNeighbour, nNeighbour, img2CentCell,&
+      & iSparseStart, iAtomStart, orb, alpha, beta)
+
+    !> Dense matrix on return
+    ${typename}$(dp), intent(inout):: C(:,:)
+
+    !> Sparse matrix
+    real(dp), intent(in) :: A(:)
+
+    !> Side which is the sparse matrix. SIDE = 'L' or 'l' C := alpha*A*B + beta*C; SIDE = 'R' or 'r'
+    !> C := alpha*B*A + beta*C
+    character, intent(in) :: side
+
+    !> Dense matrix on entry
+    ${typename}$(dp), intent(in) :: B(:,:)
+
+    !> Atom neighbour list
+    integer, intent(in) :: iNeighbour(0:,:)
+
+    !> Number of neighbours for atoms
+    integer, intent(in) :: nNeighbour(:)
+
+    !> Image to central cell mapping
+    integer, intent(in) :: img2CentCell(:)
+
+    !> Sparse indexing
+    integer, intent(in) :: iSparseStart(0:,:)
+
+    !> Dense indexing
+    integer, intent(in) :: iAtomStart(:)
+
+    !> data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
+
+    !> Scaling factor for A * B
+    ${typename}$(dp), optional, intent(in) :: alpha
+
+    !> Scaling factor for incoming C
+    ${typename}$(dp), optional, intent(in) :: beta
+
+    integer :: iOrig, iB, iC, jB, jC, iNeigh, nAtom, iAtom1, iAtom2, iAtom2f, nOrb1, nOrb2, ii
+    real(dp) :: sqrTmp(orb%mOrb, orb%mOrb)
+    ${typename}$(dp) :: alphaTmp
+
+    @:ASSERT(all(shape(C) == shape(B)))
+    @:ASSERT(side == 'r' .or. side == 'R' .or. side == 'l' .or. side == 'L')
+
+    nAtom = size(iAtomStart)-1
+
+    if (present(alpha)) then
+      alphaTmp = alpha
+    else
+      alphaTmp = 1.0_dp
+    end if
+
+    if (present(beta)) then
+      C(:,:) = beta * C
+    else
+      C(:,:) = 0.0_dp
+    end if
+
+    select case(side)
+
+    case ("L", "l")
+
+      !$OMP PARALLEL DO DEFAULT(SHARED) &
+      !$OMP &PRIVATE(iAtom1,nOrb1,iB,jB,iNeigh,sqrTmp,iAtom2,iAtom2f,nOrb2,iOrig,ii,iC,jC) &
+      !$OMP & REDUCTION(+:C) SCHEDULE(RUNTIME)
+      do iAtom1 = 1, nAtom
+        iB = iAtomStart(iAtom1)
+        jB = iAtomStart(iAtom1 + 1) - 1
+        nOrb1 = jB - iB + 1
+        do iNeigh = 0, nNeighbour(iAtom1)
+          iOrig = iSparseStart(iNeigh,iAtom1) + 1
+          sqrTmp(:,:) = 0.0_dp
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
+          iAtom2f = img2CentCell(iAtom2)
+          iC = iAtomStart(iAtom2f)
+          jC = iAtomStart(iAtom2f + 1) - 1
+          nOrb2 = jC - iC + 1
+          sqrTmp(:nOrb2,:nOrb1) = reshape(A(iOrig:iOrig+nOrb2*nOrb1-1), [nOrb2,nOrb1])
+          ! symmetrize on-diagonal blocks just in case
+          if (iAtom1 == iAtom2f) then
+            do ii = 1, nOrb1
+              sqrTmp(ii,ii+1:nOrb2) = sqrTmp(ii+1:nOrb2,ii)
+            end do
+          end if
+          C(iC:jC,:) = C(iC:jC,:) + alphaTmp*matmul(sqrTmp(:nOrb2,:nOrb1),B(iB:jB,:))
+          ! other triangle due to symmetry of matrix
+          if (iAtom1 /= iAtom2f) then
+            C(iB:jB, :) = C(iB:jB,:) + alphaTmp*matmul(transpose(sqrTmp(:nOrb2,:nOrb1)),B(iC:jC,:))
+          end if
+        end do
+      end do
+      !$OMP END PARALLEL DO
+
+    case ("R", "r")
+
+      !$OMP PARALLEL DO DEFAULT(SHARED) &
+      !$OMP &PRIVATE(iAtom1,nOrb1,iB,jB,iNeigh,sqrTmp,iAtom2,iAtom2f,nOrb2,iOrig,ii,iC,jC) &
+      !$OMP & REDUCTION(+:C) SCHEDULE(RUNTIME)
+      do iAtom1 = 1, nAtom
+        iB = iAtomStart(iAtom1)
+        jB = iAtomStart(iAtom1 + 1) - 1
+        nOrb1 = jB - iB + 1
+        do iNeigh = 0, nNeighbour(iAtom1)
+          iOrig = iSparseStart(iNeigh,iAtom1) + 1
+          sqrTmp(:,:) = 0.0_dp
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
+          iAtom2f = img2CentCell(iAtom2)
+          iC = iAtomStart(iAtom2f)
+          jC = iAtomStart(iAtom2f + 1) - 1
+          nOrb2 = jC - iC + 1
+          sqrTmp(:nOrb2,:nOrb1) = reshape(A(iOrig:iOrig+nOrb2*nOrb1-1), [nOrb2,nOrb1])
+          ! symmetrize on-diagonal blocks just in case
+          if (iAtom1 == iAtom2f) then
+            do ii = 1, nOrb1
+              sqrTmp(ii,ii+1:nOrb2) = sqrTmp(ii+1:nOrb2,ii)
+            end do
+          end if
+          C(:,iC:jC) = C(:,iC:jC) + alphaTmp*matmul(B(:,iB:jB),transpose(sqrTmp(:nOrb2,:nOrb1)))
+          ! other triangle due to symmetry of matrix
+          if (iAtom1 /= iAtom2f) then
+            C(:,iB:jB) = C(:,iB:jB) + alphaTmp*matmul(B(:,iC:jC),sqrTmp(:nOrb2,:nOrb1))
+          end if
+        end do
+      end do
+      !$OMP END PARALLEL DO
+
+    end select
+
+  end subroutine symm_${suffix}$_gamma
+
+
+  !> Sparse Gamma point matrix with dense ${typename}$ matrix as a symm operation, using specified
+  !> boundary conditions. Symmetric matrix on 'l'eft or 'r'ight , where A is symmetric and sparse
+  !> and B is general.
+  subroutine symm_bc_${suffix}$_gamma(C, side, A, B, bcs, iNeighbour, nNeighbour, img2CentCell,&
+      & iSparseStart, iAtomStart, coords, species, orb, alpha, beta)
+
+    !> Dense matrix on return
+    ${typename}$(dp), intent(inout):: C(:,:)
+
+    !> Sparse matrix
+    real(dp), intent(in) :: A(:)
+
+    !> Side which is the sparse matrix. SIDE = 'L' or 'l' C := alpha*A*B + beta*C; SIDE = 'R' or 'r'
+    !> C := alpha*B*A + beta*C
+    character, intent(in) :: side
+
+    !> Dense matrix on entry
+    ${typename}$(dp), intent(in) :: B(:,:)
+
+    !> Boundary conditions on the system
+    type(TBoundaryConditions), intent(in) :: bcs
+
+    !> Atom neighbour list
+    integer, intent(in) :: iNeighbour(0:,:)
+
+    !> Number of neighbours for atoms
+    integer, intent(in) :: nNeighbour(:)
+
+    !> Image to central cell mapping
+    integer, intent(in) :: img2CentCell(:)
+
+    !> Sparse indexing
+    integer, intent(in) :: iSparseStart(0:,:)
+
+    !> Dense indexing
+    integer, intent(in) :: iAtomStart(:)
+
+    !> Coordinates of all atoms
+    real(dp), intent(in) :: coords(:,:)
+
+    !> Species of each atom
+    integer, intent(in) :: species(:)
+
+    !> data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
+
+    !> Scaling factor for A * B
+    ${typename}$(dp), optional, intent(in) :: alpha
+
+    !> Scaling factor for incoming C
+    ${typename}$(dp), optional, intent(in) :: beta
+
+    integer :: iOrig, iB, iC, jB, jC, iNeigh, nAtom, iAtom1, iAtom2, iAtom2f, nOrb1, nOrb2, ii
+    real(dp) :: sqrTmp(orb%mOrb, orb%mOrb)
+    ${typename}$(dp) :: alphaTmp
+
+    @:ASSERT(all(shape(C) == shape(B)))
+    @:ASSERT(side == 'r' .or. side == 'R' .or. side == 'l' .or. side == 'L')
+
+    nAtom = size(iAtomStart)-1
+
+    if (present(alpha)) then
+      alphaTmp = alpha
+    else
+      alphaTmp = 1.0_dp
+    end if
+
+    if (present(beta)) then
+      C(:,:) = beta * C
+    else
+      C(:,:) = 0.0_dp
+    end if
+
+    select case(side)
+
+    case ("L", "l")
+
+      !$OMP PARALLEL DO DEFAULT(SHARED) &
+      !$OMP &PRIVATE(iAtom1,nOrb1,iB,jB,iNeigh,sqrTmp,iAtom2,iAtom2f,nOrb2,iOrig,ii,iC,jC) &
+      !$OMP & REDUCTION(+:C) SCHEDULE(RUNTIME)
+      do iAtom1 = 1, nAtom
+        iB = iAtomStart(iAtom1)
+        jB = iAtomStart(iAtom1 + 1) - 1
+        nOrb1 = jB - iB + 1
+        do iNeigh = 0, nNeighbour(iAtom1)
+          iOrig = iSparseStart(iNeigh,iAtom1) + 1
+          sqrTmp(:,:) = 0.0_dp
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
+          iAtom2f = img2CentCell(iAtom2)
+          iC = iAtomStart(iAtom2f)
+          jC = iAtomStart(iAtom2f + 1) - 1
+          nOrb2 = jC - iC + 1
+          sqrTmp(:nOrb2,:nOrb1) = reshape(A(iOrig:iOrig+nOrb2*nOrb1-1), [nOrb2,nOrb1])
+          call bcs%foldInDiatomicBlock(sqrTmp, iAtom1, iAtom2, coords, species, img2centCell, orb)
+          ! symmetrize on-diagonal blocks just in case
+          if (iAtom1 == iAtom2f) then
+            do ii = 1, nOrb1
+              sqrTmp(ii,ii+1:nOrb2) = sqrTmp(ii+1:nOrb2,ii)
+            end do
+          end if
+          C(iC:jC,:) = C(iC:jC,:) + alphaTmp*matmul(sqrTmp(:nOrb2,:nOrb1),B(iB:jB,:))
+          ! other triangle due to symmetry of matrix
+          if (iAtom1 /= iAtom2f) then
+            C(iB:jB, :) = C(iB:jB,:) + alphaTmp*matmul(transpose(sqrTmp(:nOrb2,:nOrb1)),B(iC:jC,:))
+          end if
+        end do
+      end do
+      !$OMP END PARALLEL DO
+
+    case ("R", "r")
+
+      !$OMP PARALLEL DO DEFAULT(SHARED) &
+      !$OMP &PRIVATE(iAtom1,nOrb1,iB,jB,iNeigh,sqrTmp,iAtom2,iAtom2f,nOrb2,iOrig,ii,iC,jC) &
+      !$OMP & REDUCTION(+:C) SCHEDULE(RUNTIME)
+      do iAtom1 = 1, nAtom
+        iB = iAtomStart(iAtom1)
+        jB = iAtomStart(iAtom1 + 1) - 1
+        nOrb1 = jB - iB + 1
+        do iNeigh = 0, nNeighbour(iAtom1)
+          iOrig = iSparseStart(iNeigh,iAtom1) + 1
+          sqrTmp(:,:) = 0.0_dp
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
+          iAtom2f = img2CentCell(iAtom2)
+          iC = iAtomStart(iAtom2f)
+          jC = iAtomStart(iAtom2f + 1) - 1
+          nOrb2 = jC - iC + 1
+          sqrTmp(:nOrb2,:nOrb1) = reshape(A(iOrig:iOrig+nOrb2*nOrb1-1), [nOrb2,nOrb1])
+          call bcs%foldInDiatomicBlock(sqrTmp, iAtom1, iAtom2, coords, species, img2centCell, orb)
+          ! symmetrize on-diagonal blocks just in case
+          if (iAtom1 == iAtom2f) then
+            do ii = 1, nOrb1
+              sqrTmp(ii,ii+1:nOrb2) = sqrTmp(ii+1:nOrb2,ii)
+            end do
+          end if
+          C(:,iC:jC) = C(:,iC:jC) + alphaTmp*matmul(B(:,iB:jB),transpose(sqrTmp(:nOrb2,:nOrb1)))
+          ! other triangle due to symmetry of matrix
+          if (iAtom1 /= iAtom2f) then
+            C(:,iB:jB) = C(:,iB:jB) + alphaTmp*matmul(B(:,iC:jC),sqrTmp(:nOrb2,:nOrb1))
+          end if
+        end do
+      end do
+      !$OMP END PARALLEL DO
+
+    end select
+
+  end subroutine symm_bc_${suffix}$_gamma
+
+#:endfor
+
+
+  !> Sparse matrix at specified k-point with dense ${typename}$ matrix as a symm operation,
+  !> symmetric matrix on 'l'eft or 'r'ight , where A is symmetric and sparse and B is general.
+  subroutine symm_kpt(C, side, A, B, iNeighbour, nNeighbour, kPoint, iCellVec, cellVec,&
+      & img2CentCell, iSparseStart, iAtomStart, orb, alpha, beta)
+
+    !> Dense matrix on return
+    complex(dp), intent(inout):: C(:,:)
+
+    !> Sparse matrix
+    real(dp), intent(in) :: A(:)
+
+    !> Side which is the sparse matrix. SIDE = 'L' or 'l' C := alpha*A*B + beta*C; SIDE = 'R' or 'r'
+    !> C := alpha*B*A + beta*C
+    character, intent(in) :: side
+
+    !> Dense matrix on entry
+    complex(dp), intent(in) :: B(:,:)
+
+    !> Atom neighbour list
+    integer, intent(in) :: iNeighbour(0:,:)
+
+    !> Number of neighbours for atoms
+    integer, intent(in) :: nNeighbour(:)
+
+    !> Relative coordinates of the k-point where the sparse matrix should be unfolded.
+    real(dp), intent(in) :: kPoint(:)
+
+    !> Index of the cell translation vector for each atom.
+    integer, intent(in) :: iCellVec(:)
+
+    !> Relative coordinates of the cell translation vectors.
+    real(dp), intent(in) :: cellVec(:, :)
+
+    !> Image to central cell mapping
+    integer, intent(in) :: img2CentCell(:)
+
+    !> Sparse indexing
+    integer, intent(in) :: iSparseStart(0:,:)
+
+    !> Dense indexing
+    integer, intent(in) :: iAtomStart(:)
+
+    !> data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
+
+    !> Scaling factor for A * B
+    complex(dp), optional, intent(in) :: alpha
+
+    !> Scaling factor for incoming C
+    complex(dp), optional, intent(in) :: beta
+
+    integer :: iOrig, iB, iC, jB, jC, iNeigh, nAtom, iAtom1, iAtom2, iAtom2f, nOrb1, nOrb2, ii, iVec
+    complex(dp) :: sqrTmp(orb%mOrb, orb%mOrb), alphaTmp, phase
+    real(dp) :: kPoint2p(3)
+
+    @:ASSERT(all(shape(C) == shape(B)))
+    @:ASSERT(side == 'r' .or. side == 'R' .or. side == 'l' .or. side == 'L')
+
+    nAtom = size(iAtomStart)-1
+
+    kPoint2p(:) = 2.0_dp * pi * kPoint
+
+    if (present(alpha)) then
+      alphaTmp = alpha
+    else
+      alphaTmp = 1.0_dp
+    end if
+
+    if (present(beta)) then
+      C(:,:) = beta * C
+    else
+      C(:,:) = 0.0_dp
+    end if
+
+    select case(side)
+
+    case ("L", "l")
+
+      !$OMP PARALLEL DO DEFAULT(SHARED) &
+      !$OMP &PRIVATE(nOrb1,iB,jB,iNeigh,sqrTmp,iAtom2,iAtom2f,nOrb2,iOrig,ii,iC,jC,iVec,&
+      !$OMP &phase) REDUCTION(+:C) SCHEDULE(RUNTIME)
+      do iAtom1 = 1, nAtom
+        iB = iAtomStart(iAtom1)
+        jB = iAtomStart(iAtom1 + 1) - 1
+        nOrb1 = jB - iB + 1
+        do iNeigh = 0, nNeighbour(iAtom1)
+          iOrig = iSparseStart(iNeigh,iAtom1) + 1
+          sqrTmp(:,:) = 0.0_dp
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
+          iAtom2f = img2CentCell(iAtom2)
+          iC = iAtomStart(iAtom2f)
+          jC = iAtomStart(iAtom2f + 1) - 1
+          nOrb2 = jC - iC + 1
+          iVec = iCellVec(iAtom2)
+          phase = exp(imag * dot_product(kPoint2p, cellVec(:, iVec)))
+          sqrTmp(:nOrb2,:nOrb1) = phase * reshape(A(iOrig:iOrig+nOrb2*nOrb1-1), [nOrb2,nOrb1])
+          ! Hermitian symmetry on-diagonal blocks just in case
+          if (iAtom1 == iAtom2f) then
+            do ii = 1, nOrb1
+              sqrTmp(ii,ii+1:nOrb2) = conjg(sqrTmp(ii+1:nOrb2,ii))
+            end do
+          end if
+          C(iC:jC,:) = C(iC:jC,:) + alphaTmp*matmul(sqrTmp(:nOrb2,:nOrb1),B(iB:jB,:))
+          ! other triangle due to symmetry of matrix
+          if (iAtom1 /= iAtom2f) then
+            C(iB:jB, :) = C(iB:jB,:)&
+                & + alphaTmp * matmul(transpose(conjg(sqrTmp(:nOrb2,:nOrb1))),B(iC:jC,:))
+          end if
+
+        end do
+      end do
+      !$OMP END PARALLEL DO
+
+    case ("R", "r")
+
+      !$OMP PARALLEL DO DEFAULT(SHARED) &
+      !$OMP &PRIVATE(nOrb1,iB,jB,iNeigh,sqrTmp,iAtom2,iAtom2f,nOrb2,iOrig,ii,iC,jC,iVec,&
+      !$OMP &phase) REDUCTION(+:C) SCHEDULE(RUNTIME)
+      do iAtom1 = 1, nAtom
+        iB = iAtomStart(iAtom1)
+        jB = iAtomStart(iAtom1 + 1) - 1
+        nOrb1 = jB - iB + 1
+        do iNeigh = 0, nNeighbour(iAtom1)
+          iOrig = iSparseStart(iNeigh,iAtom1) + 1
+          sqrTmp(:,:) = 0.0_dp
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
+          iAtom2f = img2CentCell(iAtom2)
+          iC = iAtomStart(iAtom2f)
+          jC = iAtomStart(iAtom2f + 1) - 1
+          nOrb2 = jC - iC + 1
+          iVec = iCellVec(iAtom2)
+          phase = exp(imag * dot_product(kPoint2p, cellVec(:, iVec)))
+          sqrTmp(:nOrb2,:nOrb1) = phase * reshape(A(iOrig:iOrig+nOrb2*nOrb1-1), [nOrb2,nOrb1])
+          ! Hermitian symmetry on-diagonal blocks just in case
+          if (iAtom1 == iAtom2f) then
+            do ii = 1, nOrb1
+              sqrTmp(ii,ii+1:nOrb2) = conjg(sqrTmp(ii+1:nOrb2,ii))
+            end do
+          end if
+          C(:,iC:jC) = C(:,iC:jC)&
+              & + alphaTmp * matmul(B(:,iB:jB),transpose(conjg(sqrTmp(:nOrb2,:nOrb1))))
+          ! other triangle due to symmetry of matrix
+          if (iAtom1 /= iAtom2f) then
+            C(:,iB:jB) = C(:,iB:jB) + alphaTmp*matmul(B(:,iC:jC),sqrTmp(:nOrb2,:nOrb1))
+          end if
+        end do
+      end do
+      !$OMP END PARALLEL DO
+
+    end select
+
+  end subroutine symm_kpt
+
+
+  !> Sparse matrix at specified k-point with dense ${typename}$ matrix as a symm operation, using
+  !> specified boundary conditions. symmetric matrix on 'l'eft or 'r'ight , where A is symmetric and
+  !> sparse and B is general.
+  subroutine symm_bc_kpt(C, side, A, B, bcs, iNeighbour, nNeighbour, kPoint, iCellVec, cellVec,&
+      & img2CentCell, iSparseStart, iAtomStart, coords, species, orb, alpha, beta)
+
+    !> Dense matrix on return
+    complex(dp), intent(inout):: C(:,:)
+
+    !> Sparse matrix
+    real(dp), intent(in) :: A(:)
+
+    !> Side which is the sparse matrix. SIDE = 'L' or 'l' C := alpha*A*B + beta*C; SIDE = 'R' or 'r'
+    !> C := alpha*B*A + beta*C
+    character, intent(in) :: side
+
+    !> Dense matrix on entry
+    complex(dp), intent(in) :: B(:,:)
+
+    !> Boundary conditions on the system
+    type(TBoundaryConditions), intent(in) :: bcs
+
+    !> Atom neighbour list
+    integer, intent(in) :: iNeighbour(0:,:)
+
+    !> Number of neighbours for atoms
+    integer, intent(in) :: nNeighbour(:)
+
+    !> Relative coordinates of the k-point where the sparse matrix should be unfolded.
+    real(dp), intent(in) :: kPoint(:)
+
+    !> Index of the cell translation vector for each atom.
+    integer, intent(in) :: iCellVec(:)
+
+    !> Relative coordinates of the cell translation vectors.
+    real(dp), intent(in) :: cellVec(:, :)
+
+    !> Image to central cell mapping
+    integer, intent(in) :: img2CentCell(:)
+
+    !> Sparse indexing
+    integer, intent(in) :: iSparseStart(0:,:)
+
+    !> Dense indexing
+    integer, intent(in) :: iAtomStart(:)
+
+    !> Coordinates of all atoms
+    real(dp), intent(in) :: coords(:,:)
+
+    !> Species of each atom
+    integer, intent(in) :: species(:)
+
+    !> data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
+
+    !> Scaling factor for A * B
+    complex(dp), optional, intent(in) :: alpha
+
+    !> Scaling factor for incoming C
+    complex(dp), optional, intent(in) :: beta
+
+    integer :: iOrig, iB, iC, jB, jC, iNeigh, nAtom, iAtom1, iAtom2, iAtom2f, nOrb1, nOrb2, ii, iVec
+    complex(dp) :: sqrTmp(orb%mOrb, orb%mOrb), alphaTmp, phase
+    real(dp) :: kPoint2p(2)
+
+    @:ASSERT(all(shape(C) == shape(B)))
+    @:ASSERT(side == 'r' .or. side == 'R' .or. side == 'l' .or. side == 'L')
+
+    nAtom = size(iAtomStart)-1
+
+    kPoint2p(:) = 2.0_dp * pi * kPoint
+
+    if (present(alpha)) then
+      alphaTmp = alpha
+    else
+      alphaTmp = 1.0_dp
+    end if
+
+    if (present(beta)) then
+      C(:,:) = beta * C
+    else
+      C(:,:) = 0.0_dp
+    end if
+
+    select case(side)
+
+    case ("L", "l")
+
+      !$OMP PARALLEL DO DEFAULT(SHARED) &
+      !$OMP &PRIVATE(nOrb1,iB,jB,iNeigh,sqrTmp,iAtom2,iAtom2f,nOrb2,iOrig,ii,iC,jC,iVec,&
+      !$OMP &phase) REDUCTION(+:C) SCHEDULE(RUNTIME)
+      do iAtom1 = 1, nAtom
+        iB = iAtomStart(iAtom1)
+        jB = iAtomStart(iAtom1 + 1) - 1
+        nOrb1 = jB - iB + 1
+        do iNeigh = 0, nNeighbour(iAtom1)
+          iOrig = iSparseStart(iNeigh,iAtom1) + 1
+          sqrTmp(:,:) = 0.0_dp
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
+          iAtom2f = img2CentCell(iAtom2)
+          iC = iAtomStart(iAtom2f)
+          jC = iAtomStart(iAtom2f + 1) - 1
+          nOrb2 = jC - iC + 1
+          iVec = iCellVec(iAtom2)
+          phase = exp(imag * dot_product(kPoint2p, cellVec(:, iVec)))
+          sqrTmp(:nOrb2,:nOrb1) = reshape(A(iOrig:iOrig+nOrb2*nOrb1-1), [nOrb2,nOrb1])
+          call bcs%foldInDiatomicBlock(sqrTmp, iAtom1, iAtom2, coords, species, img2centCell, orb)
+          sqrTmp(:nOrb2,:nOrb1) = phase * sqrTmp
+          ! Hermitian symmetry on-diagonal blocks just in case
+          if (iAtom1 == iAtom2f) then
+            do ii = 1, nOrb1
+              sqrTmp(ii,ii+1:nOrb2) = conjg(sqrTmp(ii+1:nOrb2,ii))
+            end do
+          end if
+          C(iC:jC,:) = C(iC:jC,:) + alphaTmp*matmul(sqrTmp(:nOrb2,:nOrb1),B(iB:jB,:))
+          ! other triangle due to symmetry of matrix
+          if (iAtom1 /= iAtom2f) then
+            C(iB:jB, :) = C(iB:jB,:)&
+                & + alphaTmp * matmul(transpose(conjg(sqrTmp(:nOrb2,:nOrb1))),B(iC:jC,:))
+          end if
+
+        end do
+      end do
+      !$OMP END PARALLEL DO
+
+    case ("R", "r")
+
+      !$OMP PARALLEL DO DEFAULT(SHARED) &
+      !$OMP &PRIVATE(nOrb1,iB,jB,iNeigh,sqrTmp,iAtom2,iAtom2f,nOrb2,iOrig,ii,iC,jC,iVec,&
+      !$OMP &phase) REDUCTION(+:C) SCHEDULE(RUNTIME)
+      do iAtom1 = 1, nAtom
+        iB = iAtomStart(iAtom1)
+        jB = iAtomStart(iAtom1 + 1) - 1
+        nOrb1 = jB - iB + 1
+        do iNeigh = 0, nNeighbour(iAtom1)
+          iOrig = iSparseStart(iNeigh,iAtom1) + 1
+          sqrTmp(:,:) = 0.0_dp
+          iAtom2 = iNeighbour(iNeigh, iAtom1)
+          iAtom2f = img2CentCell(iAtom2)
+          iC = iAtomStart(iAtom2f)
+          jC = iAtomStart(iAtom2f + 1) - 1
+          nOrb2 = jC - iC + 1
+          iVec = iCellVec(iAtom2)
+          phase = exp(imag * dot_product(kPoint2p, cellVec(:, iVec)))
+          sqrTmp(:nOrb2,:nOrb1) = reshape(A(iOrig:iOrig+nOrb2*nOrb1-1), [nOrb2,nOrb1])
+          sqrTmp(:nOrb2,:nOrb1) = phase * sqrTmp
+          call bcs%foldInDiatomicBlock(sqrTmp, iAtom1, iAtom2, coords, species, img2centCell, orb)
+          ! Hermitian symmetry on-diagonal blocks just in case
+          if (iAtom1 == iAtom2f) then
+            do ii = 1, nOrb1
+              sqrTmp(ii,ii+1:nOrb2) = conjg(sqrTmp(ii+1:nOrb2,ii))
+            end do
+          end if
+          C(:,iC:jC) = C(:,iC:jC)&
+              & + alphaTmp * matmul(B(:,iB:jB),transpose(conjg(sqrTmp(:nOrb2,:nOrb1))))
+          ! other triangle due to symmetry of matrix
+          if (iAtom1 /= iAtom2f) then
+            C(:,iB:jB) = C(:,iB:jB) + alphaTmp*matmul(B(:,iC:jC),sqrTmp(:nOrb2,:nOrb1))
+          end if
+        end do
+      end do
+      !$OMP END PARALLEL DO
+
+    end select
+
+  end subroutine symm_bc_kpt
+
+#:if WITH_SCALAPACK
+
+#:for VAR in [('real'),('complex')]
+
+  !> Re-distributes data for square matrices between BLACS block cyclic data and whole global rows
+  !> on each processor
+  subroutine sqr2rows_${VAR}$(square, row, denseDesc, blacsEnv)
+
+    !> Real matrix in block cyclic, last index over spin/kpts
+    ${VAR}$(dp), allocatable, intent(in) :: square(:,:,:)
+
+    !> Real matrix with individual rows on each processor, last index over spin/kpts
+    ${VAR}$(dp), allocatable, intent(inout) :: row(:,:,:)
+
+    !> Descriptors for dense matrices
+    type(TDenseDescr), intent(in) :: denseDesc
+
+    !> BLACS environment and information on grids
+    type(TBlacsEnv), intent(in) :: blacsEnv
+
+    integer :: iKS
+
+    @:ASSERT(allocated(square) .eqv. allocated(row))
+
+    if (.not.allocated(square)) then
+      return
+    end if
+
+    #! same group choices over spin/k for the two grids, so same size on last index
+    @:ASSERT(size(square, dim=3) == size(row, dim=3))
+
+    #! Ensure these are over the same contexts
+    @:ASSERT(blacsEnv%orbitalGrid%ctxt == blacsEnv%rowOrbitalGrid%ctxt)
+
+    do iKS = 1, size(square, dim=3)
+      call blacsfx_gemr2d(blacsEnv%nn, blacsEnv%nn, square(:,:,iKS), 1, 1,&
+          & denseDesc%blacsOrbSqr, row(:,:,iKS), 1, 1, denseDesc%blacsColumnSqr,&
+          & blacsEnv%orbitalGrid%ctxt)
+    end do
+
+  end subroutine sqr2rows_${VAR}$
+
+
+  !> Re-distributes data for square matrices between BLACS whole global rows on each processor and
+  !> block cyclic data
+  subroutine rows2sqr_${VAR}$(row, square, denseDesc, blacsEnv)
+
+    !> Real matrix with individual rows on each processor, last index over spin/kpts
+    ${VAR}$(dp), allocatable, intent(in) :: row(:,:,:)
+
+    !> Real matrix in block cyclic, last index over spin/kpts
+    ${VAR}$(dp), allocatable, intent(inout) :: square(:,:,:)
+
+    !> Descriptors for dense matrices
+    type(TDenseDescr), intent(in) :: denseDesc
+
+    !> BLACS environment and information on grids
+    type(TBlacsEnv), intent(in) :: blacsEnv
+
+    integer :: iKS
+
+    @:ASSERT(allocated(row) .eqv. allocated(square))
+
+    if (.not.allocated(row)) then
+      return
+    end if
+
+    #! same group choices over spin/k for the two grids, so same size on last index
+    @:ASSERT(size(row, dim=3) == size(square, dim=3))
+
+    #! Ensure these are over the same contexts
+    @:ASSERT(blacsEnv%orbitalGrid%ctxt == blacsEnv%rowOrbitalGrid%ctxt)
+
+    do iKS = 1, size(square, dim=3)
+      call blacsfx_gemr2d(blacsEnv%nn, blacsEnv%nn, row(:,:,iKS), 1, 1,&
+          & denseDesc%blacsColumnSqr, square(:,:,iKS), 1, 1, denseDesc%blacsOrbSqr,&
+          & blacsEnv%orbitalGrid%ctxt)
+    end do
+
+  end subroutine rows2sqr_${VAR}$
+
+#:endfor
+
+#:endif
+
+end module dftbp_math_sparseblas

--- a/src/dftbp/type/densedescr.F90
+++ b/src/dftbp/type/densedescr.F90
@@ -21,8 +21,12 @@ module dftbp_type_densedescr
   type :: TDenseDescr
 
   #:if WITH_SCALAPACK
-    !> BLACS specifier for the matrix
+    !> BLACS specifier for the orbital sized matrix
     integer :: blacsOrbSqr(DLEN_)
+
+    !> BLACS specifier for the reordered matrix
+    integer :: blacsColumnSqr(DLEN_)
+
   #:endif
 
     !> Dense matrix indexing by the start of orbitals for each atom.


### PR DESCRIPTION
Expanded boundary condition derived type, for use with helical transforms in sparse blas and for later PRs for sparse/dense transforms. Move rotation for vectors to type.

symv operations
Complex or real vector with real(/Gamma), k-points and helical sparse multiplications with vectors

symm operations
Complex, real or helical matrices with real and k-point sparse multiplications

Start of mpi parallel sparse with dense by reorganizing BLACS matrices to put entire rows on processors, then enabling distributed use of serial GEMM/GEMV

Note: coverage will reduce as most of the routines are not in use yet.