### PR TITLE
Handle JSON Fortran dependency in mctc-lib

### DIFF
--- a/external/mctc-lib/CMakeLists.txt
+++ b/external/mctc-lib/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 # Propagate OpenMP option correctly to subproject
 set(WITH_OpenMP ${WITH_OMP})
+# Disable JSON Fortran dependency in case of subproject include
+set(WITH_JSON FALSE)
 
 add_subdirectory(${MCTC-LIB_SOURCE_DIR} ${MCTC-LIB_BINARY_DIR})
 


### PR DESCRIPTION
- disable JSON Fortran dependency if mctc-lib is included as subproject
- JSON Fortran is only needed for IO interface, which is not used in DFTB+