### PR TITLE
Allocate linresp input only on demand

### DIFF
--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -1817,7 +1817,7 @@ contains
 
     this%tPrintForces = input%ctrl%tPrintForces
     this%tForces = input%ctrl%tForces .or. this%tPrintForces
-    this%isLinResp = input%ctrl%lrespini%tInit
+    this%isLinResp = allocated(input%ctrl%lrespini)
     if (this%isLinResp) then
       allocate(this%linearResponse)
     end if
@@ -5226,6 +5226,8 @@ contains
     type(TInputData), intent(in), target :: input
 
     character(lc) :: tmpStr
+
+    @:ASSERT(allocated(input%ctrl%lrespini))
 
     if (withMpi) then
       call error("Linear response calc. does not work with MPI yet")

--- a/src/dftbp/dftbplus/inputdata.F90
+++ b/src/dftbp/dftbplus/inputdata.F90
@@ -481,7 +481,7 @@ module dftbp_dftbplus_inputdata
     type(TXLBOMDInp), allocatable :: xlbomd
 
     !> TD Linear response input
-    type(TLinrespini) :: lrespini
+    type(TLinrespini), allocatable :: lrespini
 
     !> ElectronDynamics
     type(TElecDynamicsInp), allocatable :: elecDynInp

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -4664,12 +4664,10 @@ contains
           & response calculations (requires the ARPACK/ngARPACK libraries).')
     end if
 
-    ctrl%lrespini%tInit = .false.
-    ctrl%lrespini%tPrintEigVecs = .false.
-
     if (associated(child)) then
 
-      ctrl%lrespini%tInit = .true.
+      allocate(ctrl%lrespini)
+      ctrl%lrespini%tPrintEigVecs = .false.
 
       if (ctrl%tSpin) then
         ctrl%lrespini%sym = ' '
@@ -5037,7 +5035,12 @@ contains
     !> Control structure to fill
     type(TControl), intent(inout) :: ctrl
 
-    if (ctrl%tPrintEigVecs .or. ctrl%lrespini%tPrintEigVecs) then
+
+    logical :: tPrintEigVecs
+
+    tPrintEigVecs = ctrl%tPrintEigVecs
+    if (allocated(ctrl%lrespini)) tPrintEigvecs = tPrintEigvecs .or. ctrl%lrespini%tPrintEigVecs
+    if (tPrintEigVecs) then
       call getChildValue(node, "EigenvectorsAsText", ctrl%tPrintEigVecsTxt, .false.)
     end if
 
@@ -5177,7 +5180,7 @@ contains
 
     tLRNeedsSpinConstants = .false.
 
-    if (ctrl%lrespini%tInit) then
+    if (allocated(ctrl%lrespini)) then
       select case (ctrl%lrespini%sym)
       case ("T", "B", " ")
         tLRNeedsSpinConstants = .true.

--- a/src/dftbp/timedep/linresp.F90
+++ b/src/dftbp/timedep/linresp.F90
@@ -111,9 +111,6 @@ module dftbp_timedep_linresp
     !> diagnose output of Arnoldi solver
     logical :: tDiagnoseArnoldi
 
-    !> Initialised data structure?
-    logical :: tInit = .false.
-
   end type TLinrespini
 
 


### PR DESCRIPTION
Rationalize the usage of the linresp input type.

Closes #945 