### PR TITLE
Added missing import in fermihelper

### DIFF
--- a/src/dftbp/derivs/fermihelper.F90
+++ b/src/dftbp/derivs/fermihelper.F90
@@ -10,7 +10,7 @@
 !> Module containing finite temperature function distributions and derivatives for the Fermi-Dirac
 !> distribution
 module dftbp_derivs_fermihelper
-  use dftbp_common_accuracy, only : dp
+  use dftbp_common_accuracy, only : dp, mExpArg
   implicit none
 
   private


### PR DESCRIPTION
If EXP_TRAP is defined, the variable mExpArg is missing.