### PR TITLE
Performance coulomb

### DIFF
--- a/src/dftbp/dftb/coulomb.F90
+++ b/src/dftbp/dftb/coulomb.F90
@@ -2226,7 +2226,7 @@ contains
     real(dp) :: dewr(3)
 
     real(dp) :: rNew(3)
-    real(dp) :: rr
+    real(dp) :: rr, factor
     integer :: iR
 
     dewr = 0.0_dp
@@ -2239,12 +2239,14 @@ contains
           cycle
         end if
         ! derivative of -erf(alpha*r)/r
-        dewr(:) = dewr + rNew(:) * (-2.0_dp/sqrt(pi)*exp(-alpha*alpha*rr*rr)* alpha*rr&
-            & - erfcwrap(alpha*rr))/(rr*rr*rr)
+        factor = alpha*rr
+        dewr(:) = dewr + rNew(:) * (-2.0_dp/sqrt(pi) * exp(-factor*factor) * factor&
+            & - erfcwrap(factor))/(rr*rr*rr)
         ! deriv of erf(r/blur)/r
         if (rr < erfArgLimit_ * blurWidth) then
-          dewr(:) = dewr + rNew(:) * (2.0_dp/sqrt(pi)*exp(-rr*rr/(blurWidth**2))*rr/blurWidth&
-              & + erfcwrap(rr/blurWidth))/(rr*rr*rr)
+          factor = rr/blurWidth
+          dewr(:) = dewr + rNew(:) * (2.0_dp/sqrt(pi) * exp(-factor*factor) * factor&
+              & + erfcwrap(factor))/(rr*rr*rr)
         end if
       end do
     else
@@ -2254,8 +2256,9 @@ contains
         if (rr < tolSameDist2) then
           cycle
         end if
-        dewr(:) = dewr + rNew(:) * (-2.0_dp/sqrt(pi)*exp(-alpha*alpha*rr*rr)* alpha*rr&
-            & - erfcwrap(alpha*rr))/(rr*rr*rr)
+        factor = alpha*rr
+        dewr(:) = dewr + rNew(:) * (-2.0_dp/sqrt(pi) * exp(-factor*factor) * factor&
+            & - erfcwrap(factor))/(rr*rr*rr)
       end do
     end if
 
@@ -2345,13 +2348,14 @@ contains
     !> real space derivative term
     real(dp) :: derivRTerm(3)
 
-    real(dp) :: rr
+    real(dp) :: rr, factor
     rr = sqrt(sum(r(:)**2))
 
     @:ASSERT(rr >= epsilon(1.0_dp))
 
-    derivRTerm (:) = r(:)*(-2.0_dp/sqrt(pi)*exp(-alpha*alpha*rr*rr)* &
-        & alpha*rr - erfcwrap(alpha*rr))/(rr*rr*rr)
+    factor = alpha*rr
+    derivRTerm (:) = r(:)*(-2.0_dp/sqrt(pi)*exp(-factor*factor)* &
+        & factor - erfcwrap(factor))/(rr*rr*rr)
 
   end function derivRTerm
 

--- a/src/dftbp/math/errorfunction.F90
+++ b/src/dftbp/math/errorfunction.F90
@@ -31,6 +31,7 @@ contains
 
   !> Calculates the value of the error function.
   elemental function erfwrap(xx) result(res)
+    !$OMP DECLARE SIMD(erfwrap)
 
     !> Function argument.
     real(dp), intent(in) :: xx
@@ -45,6 +46,7 @@ contains
 
   !> Calculates the value of the complementary error function.
   elemental function erfcwrap(xx) result(res)
+    !$OMP DECLARE SIMD(erfcwrap)
 
     !> Function argument.
     real(dp), intent(in) :: xx


### PR DESCRIPTION
We can enhance the performance of the erf(c)wrap calls in the coulomb module. These are hotspots, so that we want the compiler to vectorize the expressions. To guide that, a temporary variable was introduced and SIMD directives were added.