### PR TITLE
Use same default for ShellResolvedSCC for xTB as in DFTB

### DIFF
--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -1832,10 +1832,14 @@ contains
       end if
     end if
 
-    call getChildValue(node, "ShellResolvedSCC", ctrl%tShellResolved, .true.)
-
     ! SCC parameters
     call getChildValue(node, "SCC", ctrl%tSCC, .true.)
+    if (ctrl%tSCC) then
+      call getChildValue(node, "ShellResolvedSCC", ctrl%tShellResolved, .false.)
+    else
+      ctrl%tShellResolved = .false.
+    end if
+
     ifSCC: if (ctrl%tSCC) then
 
       ! get charge mixing options etc.

--- a/test/app/dftb+/spin/gfn1_Fe4/dftb_in.hsd
+++ b/test/app/dftb+/spin/gfn1_Fe4/dftb_in.hsd
@@ -13,6 +13,7 @@ Hamiltonian = xTB {
   MaxSCCIterations = 1000
   Mixer = Broyden {}
   Charge = 0.0
+  ShellResolvedSCC = yes
   SpinPolarisation = Colinear {
     UnpairedElectrons = 12
   }

--- a/test/app/dftb+/spin/ipea1_Fe4_noncolinear/dftb_in.hsd
+++ b/test/app/dftb+/spin/ipea1_Fe4_noncolinear/dftb_in.hsd
@@ -13,6 +13,7 @@ Hamiltonian = xTB {
   MaxSCCIterations = 1000
   Mixer = Broyden {}
   Charge = 0.0
+  ShellResolvedSCC = yes
   SpinPolarisation = NonColinear {
     InitialSpins = {
       AtomSpin = {


### PR DESCRIPTION
Setting `shellResolved` to `.true.` was an ad-hoc choice and maybe not a good one.