### PR TITLE
Implement dampingVer2 for new LC-DFTB variant

### DIFF
--- a/src/dftbp/dftb/shortgamma.F90
+++ b/src/dftbp/dftb/shortgamma.F90
@@ -14,7 +14,7 @@ module dftbp_dftb_shortgamma
   use dftbp_dftb_h5correction, only : TH5CorrectionInput, TH5Correction, TH5Correction_init
   use dftbp_dftb_periodic, only : TNeighbourList, getNrOfNeighbours
   use dftbp_dftb_shortgammafuncs, only : expGammaCutOff, expGamma, expGammaPrime, expGammaDamped,&
-      & expGammaDampedPrime
+      & expGammaDampedPrime, expGammaHQ, expGammaHQPrime
   use dftbp_dftb_uniquehubbard, only : TUniqueHubbard
   use dftbp_type_commontypes, only : TOrbitals
 #:if WITH_SCALAPACK
@@ -31,6 +31,9 @@ module dftbp_dftb_shortgamma
 
     !> Flag for each species, whether damping should be applied to it. Shape: [nSpecies]
     logical, allocatable :: isDamped(:)
+
+    !> Damping parameter for each species. Shape: [nSpecies]
+    real(dp), allocatable :: dampingFactor(:)
 
     !> Damping exponent
     real(dp) :: exponent
@@ -371,7 +374,12 @@ contains
             u2 = this%hubbU_%uniqHubbU(iU2, species(iAt2f))
             if (iNeigh <= this%nNeigh_(iU2,iU1,species(iAt2f),iAt1)) then
               if (this%damping_%isDamped(iSp1) .or. this%damping_%isDamped(iSp2)) then
-                tmpGammaPrime = expGammaDampedPrime(rab, u2, u1, this%damping_%exponent)
+                if (allocated(this%damping_%dampingFactor)) then
+                  tmpGammaPrime = expGammaHQPrime(rab, u2, u1, this%damping_%exponent, &
+                      & this%damping_%dampingFactor(iSp2), this%damping_%dampingFactor(iSp1))
+                else
+                  tmpGammaPrime = expGammaDampedPrime(rab, u2, u1, this%damping_%exponent)
+                end if
               else
                 tmpGammaPrime = expGammaPrime(rab, u2, u1)
                 if (allocated(this%h5Correction_)) then
@@ -445,7 +453,12 @@ contains
             u2 = this%hubbU_%uniqHubbU(iU2, species(iAt2f))
             if (iNeigh <= this%nNeigh_(iU2,iU1,species(iAt2f),iAt1)) then
               if (this%damping_%isDamped(iSp1) .or. this%damping_%isDamped(iSp2)) then
-                tmpGammaPrime = expGammaDampedPrime(rab, u2, u1, this%damping_%exponent)
+                if (allocated(this%damping_%dampingFactor)) then
+                  tmpGammaPrime = expGammaHQPrime(rab, u2, u1, this%damping_%exponent, &
+                      & this%damping_%dampingFactor(iSp2), this%damping_%dampingFactor(iSp1))
+                else
+                  tmpGammaPrime = expGammaDampedPrime(rab, u2, u1, this%damping_%exponent)
+                end if
               else
                 tmpGammaPrime = expGammaPrime(rab, u2, u1)
                 if (allocated(this%h5Correction_)) then
@@ -539,7 +552,12 @@ contains
             u2 = this%hubbU_%uniqHubbU(iU2, species(iAt2f))
             if (iNeigh <= this%nNeigh_(iU2,iU1,species(iAt2f),iAt1)) then
               if (this%damping_%isDamped(iSp1) .or. this%damping_%isDamped(iSp2)) then
-                tmpGammaPrime = expGammaDampedPrime(rab, u2, u1, this%damping_%exponent)
+                if (allocated(this%damping_%dampingFactor)) then
+                  tmpGammaPrime = expGammaHQPrime(rab, u2, u1, this%damping_%exponent, &
+                      & this%damping_%dampingFactor(iSp2), this%damping_%dampingFactor(iSp1))
+                else
+                  tmpGammaPrime = expGammaDampedPrime(rab, u2, u1, this%damping_%exponent)
+                end if
               else
                 tmpGammaPrime = expGammaPrime(rab, u2, u1)
               end if
@@ -595,7 +613,12 @@ contains
             u2 = this%hubbU_%uniqHubbU(iU2, species(iAt2f))
             if (iNeigh <= this%nNeigh_(iU2,iU1,species(iAt2f),iAt1)) then
               if (this%damping_%isDamped(iSp1) .or. this%damping_%isDamped(iSp2)) then
-                tmpGammaPrime = expGammaDampedPrime(rab, u2, u1, this%damping_%exponent)
+                if (allocated(this%damping_%dampingFactor)) then
+                  tmpGammaPrime = expGammaHQPrime(rab, u2, u1, this%damping_%exponent, &
+                      & this%damping_%dampingFactor(iSp2), this%damping_%dampingFactor(iSp1))
+                else
+                  tmpGammaPrime = expGammaDampedPrime(rab, u2, u1, this%damping_%exponent)
+                end if
               else
                 tmpGammaPrime = expGammaPrime(rab, u2, u1)
                 if (allocated(this%h5Correction_)) then
@@ -712,7 +735,12 @@ contains
             u2 = hubb%uniqHubbU(iU2, iSp2)
             if (iNeigh <= nNeigh(iU2, iU1, iSp2, iAt1)) then
               if (damping%isDamped(iSp1) .or. damping%isDamped(iSp2)) then
-                shortGamma(iU2 ,iU1, iNeigh, iAt1) = expGammaDamped(rab, u2, u1, damping%exponent)
+                if (allocated(damping%dampingFactor)) then
+                  shortGamma(iU2 ,iU1, iNeigh, iAt1) = expGammaHQ(rab, u2, u1, damping%exponent, &
+                      & damping%dampingFactor(iSp2), damping%dampingFactor(iSp1))
+                else
+                  shortGamma(iU2 ,iU1, iNeigh, iAt1) = expGammaDamped(rab, u2, u1, damping%exponent)
+                end if
               else
                 shortGamma(iU2, iU1, iNeigh, iAt1) = expGamma(rab, u2, u1)
                 if (present(h5Correction)) then

--- a/src/dftbp/dftb/shortgammafuncs.F90
+++ b/src/dftbp/dftb/shortgammafuncs.F90
@@ -15,6 +15,7 @@ module dftbp_dftb_shortgammafuncs
 
   private
   public :: expGammaCutoff, expGamma, expGammaPrime, expGammaDamped, expGammaDampedPrime
+  public :: expGammaHQ, expGammaHQPrime
 
 
 contains
@@ -263,6 +264,73 @@ contains
         &+ 2.0_dp * expGamma(rab, Ua, Ub) * exp(rTmp * rab**2) * rab * rTmp
 
   end function expGammaDampedPrime
+
+
+  !> Determines the value of the short range contribution to gamma with the exponential form with
+  !> damping.
+  function expGammaHQ(rab, Ua, Ub, dampExp, ka, kb)
+
+    !> separation of sites a and b
+    real(dp), intent(in) :: rab
+
+    !> Hubbard U for site a
+    real(dp), intent(in) :: Ua
+
+    !> Hubbard U for site b
+    real(dp), intent(in) :: Ub
+
+    !> Damping exponent
+    real(dp), intent(in) :: dampExp
+
+    !> HQ parameter for site a
+    real(dp), intent(in) :: ka
+
+    !> HQ parameter for site b
+    real(dp), intent(in) :: kb
+
+    !> returned contribution
+    real(dp) :: expGammaHQ
+
+    real(dp) :: rTmp
+
+    rTmp = -1.0_dp * (0.5_dp * (ka + kb))**dampExp
+    expGammaHQ = expGamma(rab, Ua, Ub) * exp(rTmp * rab**4)
+
+  end function expGammaHQ
+
+
+  !> Determines the value of the derivative of the short range contribution to gamma with the
+  !> exponential form with damping
+  function expGammaHQPrime(rab, Ua, Ub, dampExp, ka, kb)
+
+    !> separation of sites a and b
+    real(dp), intent(in) :: rab
+
+    !> Hubbard U for site a
+    real(dp), intent(in) :: Ua
+
+    !> Hubbard U for site b
+    real(dp), intent(in) :: Ub
+
+    !> Damping exponent
+    real(dp), intent(in) :: dampExp
+
+    !> HQ parameter for site a
+    real(dp), intent(in) :: ka
+
+    !> HQ parameter for site b
+    real(dp), intent(in) :: kb
+
+    !> returned contribution
+    real(dp) :: expGammaHQPrime
+
+    real(dp) :: rTmp
+
+    rTmp = -1.0_dp * (0.5_dp *(ka + kb))**dampExp
+    expGammaHQPrime = expGammaPrime(rab, Ua, Ub) * exp(rTmp * rab**4) &
+        &+ 4.0_dp * expGamma(rab, Ua, Ub) * exp(rTmp * rab**4) * rab * rTmp
+
+  end function expGammaHQPrime
 
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -5859,6 +5859,9 @@ contains
       ! Damping species: only H or any isotopes of it, but not He or anything heavier
       damping%isDamped = (speciesMass < 3.5_dp * amu__au)
       damping%exponent = ctrl%dampExp
+      if (allocated(ctrl%hqDampingFactor)) then
+        damping%dampingFactor = ctrl%hqDampingFactor
+      end if
     else
       allocate(damping%isDamped(nSpecies))
       damping%isDamped(:) = .false.

--- a/src/dftbp/dftbplus/inputdata.F90
+++ b/src/dftbp/dftbplus/inputdata.F90
@@ -412,6 +412,7 @@ module dftbp_dftbplus_inputdata
     !> H short range damping
     logical :: tDampH = .false.
     real(dp) :: dampExp = 0.0_dp
+    real(dp), allocatable :: hqDampingFactor(:)
 
     type(TH5CorrectionInput), allocatable :: h5Input
 

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -3262,6 +3262,13 @@ contains
       ctrl%tDampH = .true.
       call getChildValue(value1, "Exponent", ctrl%dampExp)
 
+    case ("dampingver2")
+      ! Switch the correction on
+      ctrl%tDampH = .true.
+      call getChildValue(value1, "Exponent", ctrl%dampExp)
+      allocate(ctrl%hqDampingFactor(size(geo%speciesNames)))
+      call readSpeciesList(value1, geo%speciesNames, ctrl%hqDampingFactor)
+
     case ("h5")
       allocate(ctrl%h5Input)
       associate (h5Input => ctrl%h5Input)


### PR DESCRIPTION
See supporting information of https://doi.org/10.1021/acs.jpcc.0c10762

```cson
Geometry = GenFormat {
8 C
 N H
    1    1   -1.57871880113021E+00   -4.66110252218987E-02    0.00000000000000E+00
    2    1    1.57871880113021E+00    4.66110252218987E-02    0.00000000000000E+00
    3    2   -2.15862205948644E+00    1.36396073436068E-01    8.09565406182244E-01
    4    2   -8.49471429851224E-01    6.58193305695666E-01    0.00000000000000E+00
    5    2   -2.15862205948644E+00    1.36396073436068E-01   -8.09565406182244E-01
    6    2    2.15862205948644E+00   -1.36396073436068E-01   -8.09565406182244E-01
    7    2    8.49471429851224E-01   -6.58193305695666E-01    0.00000000000000E+00
    8    2    2.15862205948644E+00   -1.36396073436068E-01    8.09565406182244E-01
}

Hamiltonian = DFTB {
  HCorrection = DampingVer2{
    Exponent = 2.0
    H = 0.07
    C = 0.06
    N = 0.05
    O = 0.05
    S = -0.06
  }
  Solver = RelativelyRobust{}
  Charge = 0
  SCC = Yes
  Mixer = DIIS{}
  SCCTolerance = 1e-6
  MaxSCCIterations = 500
  MaxAngularMomentum = {
    H  = "s"
    #C  = "p"
    N  = "p"
    #O  = "p"
    #S  = "d"
  }
  SlaterKosterFiles = Type2Filenames{
    Prefix = "sk-ob2/w0.3/"
    Suffix = ".skf"
    Separator = "-" 
    LowerCaseTypeName = No
  }
  RangeSeparated = LC {
    Screening = Thresholded {
      Threshold = 1e-9
    }
  }
}

ParserOptions { ParserVersion = 10 }

```

<details><summary>Test run</summary>

```
❯ DFTBPLUS_PARAM_DIR=external/slakos/origin ./_build_intel/app/dftb+/dftb+
|===============================================================================
|
|  DFTB+ development version (commit: 1087dcc9, base: 21.2)
|
|  Copyright (C) 2006 - 2022  DFTB+ developers group
|
|===============================================================================
|
|  When publishing results obtained with DFTB+, please cite the following
|  reference:
|
|  * DFTB+, a software package for efficient approximate density functional
|    theory based atomistic simulations, J. Chem. Phys. 152, 124101 (2020).
|    [doi: 10.1063/1.5143190]
|
|  You should also cite additional publications crediting the parametrization
|  data you use. Please consult the documentation of the SK-files for the
|  references.
|
|===============================================================================

Reading input file 'dftb_in.hsd'
forrtl: warning (406): fort: (1): In call to PARSE_RECURSIVE, an array temporary was created for argument #9

Image              PC                Routine            Line        Source             
dftb+              000000000246788F  Unknown               Unknown  Unknown
dftb+              0000000000C9C17C  dftbp_io_hsdparse         211  hsdparser.f90
dftb+              0000000000C9BA2A  dftbp_io_hsdparse         173  hsdparser.f90
dftb+              0000000000AB62D7  dftbp_dftbplus_pa         131  parser.f90
dftb+              000000000079DD9B  dftbp_dftbplus_hs          44  hsdhelpers.f90
dftb+              0000000000414EE2  MAIN__                     29  dftbplus.f90
dftb+              00000000004073A2  Unknown               Unknown  Unknown
libc-2.33.so       00007FB91B9F3B25  __libc_start_main     Unknown  Unknown
dftb+              00000000004072AE  Unknown               Unknown  Unknown
Parser version: 10

--------------------------------------------------------------------------------
Reading SK-files:
external/slakos/origin/sk-ob2/w0.3/N-N.skf
external/slakos/origin/sk-ob2/w0.3/N-H.skf
external/slakos/origin/sk-ob2/w0.3/H-H.skf
Done.


Processed input in HSD format written to 'dftb_pin.hsd'

Starting initialization...
--------------------------------------------------------------------------------
OpenMP threads:              4
Chosen random seed:          37178640
Mode:                        Static calculation
Self consistent charges:     Yes
SCC-tolerance:                 0.100000E-05
Max. scc iterations:                    500
Shell resolved Hubbard:      No
Spin polarisation:           No
Nr. of up electrons:             8.000000
Nr. of down electrons:           8.000000
Periodic boundaries:         No
Electronic solver:           Relatively robust
Mixer:                       DIIS mixer
Mixing parameter:                  0.200000
Maximal SCC-cycles:                     500
Nr. of chrg. vectors to mix:              6
Electronic temperature:        0.100000E-07 H      0.272114E-06 eV
Initial charges:             Set automatically (system chrg:   0.000E+00)
Included shells:             N:  s, p
                             H:  s
Damped SCC                   Yes
Damped species(s):           H                                                 
Range separated hybrid:      Yes
  Screening parameter omega:   0.300000E+00
  Range separated algorithm:   Thresholded
  Thresholded to:              0.100000E-08
Extra options:
                             Mulliken analysis

--------------------------------------------------------------------------------

***  Geometry step: 0

 iSCC Total electronic   Diff electronic      SCC error    
    1    0.00000000E+00    0.00000000E+00    0.69570067E+00
    2   -0.80864701E+01   -0.80864701E+01    0.14916924E+00
    3   -0.84887010E+01   -0.40223088E+00    0.30070950E-01
    4   -0.83439084E+01    0.14479260E+00    0.64430501E-02
    5   -0.83702975E+01   -0.26389087E-01    0.13420982E-02
    6   -0.83649096E+01    0.53878560E-02    0.27904608E-03
    7   -0.83659846E+01   -0.10749440E-02    0.18470542E-06
>> Charges saved for restart in charges.bin
 
Hellmann Feynman dipole:  0.00000000  0.00000000 -0.00000000  au
 
Total Energy:                       -8.2592087385 H         -224.7445 eV
Extrapolated to 0K:                 -8.2592087385 H         -224.7445 eV
Total Mermin free energy:           -8.2592087385 H         -224.7445 eV
Force related energy:               -8.2592087385 H         -224.7445 eV
 
 
--------------------------------------------------------------------------------
DFTB+ running times                          cpu [s]             wall clock [s]
--------------------------------------------------------------------------------
SCC                                    +       0.13 ( 93.4%)       0.04 ( 91.1%)
  Diagonalisation                              0.09 ( 64.5%)       0.03 ( 65.4%)
      Range separated Hamiltonian              0.04 ( 26.2%)       0.01 ( 22.6%)
--------------------------------------------------------------------------------
Missing                                +       0.01 (  6.6%)       0.00 (  8.9%)
Total                                  =       0.14 (100.0%)       0.04 (100.0%)
--------------------------------------------------------------------------------
```
</details>