### PR TITLE
Dipole and E fields for blocked cases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,12 @@ Added
 Changed
 -------
 
+- Allow electric fields in periodic systems even when interactions
+  cross the sawtooth in the field
+
+- Allow printing of dipole moments, even in cases where the absolute
+  value is ill-defined (charged systems or periodic cases), but its
+  derivative may be meaningful.
 
 
 Fixed

--- a/src/dftbp/dftb/extfields.F90
+++ b/src/dftbp/dftb/extfields.F90
@@ -10,7 +10,7 @@ module dftbp_dftb_extfields
   use dftbp_common_accuracy, only : dp, lc
   use dftbp_dftb_periodic, only : TNeighbourList
   use dftbp_dftb_potentials, only : TPotentials
-  use dftbp_io_message, only : error
+  use dftbp_io_message, only : warning
   implicit none
 
   public :: TEField, TElecFieldInput, addUpExternalField
@@ -122,6 +122,7 @@ contains
 
     integer :: nAtom, iAt1, iAt2, iNeigh, ii
     character(lc) :: tmpStr
+    logical :: isBoundaryCrossed
 
     if (allocated(eField)) then
       nAtom = size(nNeighbourSK)
@@ -134,6 +135,7 @@ contains
         end if
         eField%absEfield = sqrt(sum(eField%Efield**2))
         if (tPeriodic) then
+          isBoundaryCrossed = .false.
           do iAt1 = 1, nAtom
             do iNeigh = 1, nNeighbourSK(iAt1)
               iAt2 = neighbourList%iNeighbour(iNeigh, iAt1)
@@ -142,14 +144,15 @@ contains
                 ! component of electric field projects onto vector between cells
                 if (abs(dot_product(cellVec(:, iCellVec(iAt2)), eField%EfieldVector))&
                     & > epsilon(1.0_dp)) then
-                  write(tmpStr, "(A, I0, A, I0, A)") 'Interaction between atoms ', iAt1, ' and ',&
-                      & img2CentCell(iAt2), ' crosses the saw-tooth discontinuity in the electric&
-                      & field.'
-                  call error(tmpStr)
+                  isBoundaryCrossed = .true.
                 end if
               end if
             end do
           end do
+          if (isBoundaryCrossed) then
+            call warning("Interactions between atoms cross the saw-tooth discontinuity in the&
+                & electric field")
+          end if
           do iAt1 = 1, nAtom
             potential%extAtom(iAt1,1) = potential%extAtom(iAt1,1)&
                 & + dot_product(coord0Fold(:, iAt1), eField%Efield)

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -956,6 +956,9 @@ module dftbp_dftbplus_initprogram
     !> dipole moments, when available, for whichever determinants are present
     real(dp), allocatable :: dipoleMoment(:, :)
 
+    !> Additional dipole moment related message to write out
+    character(lc) :: dipoleMessage
+
     !> Coordinates to print out
     real(dp), pointer :: pCoord0Out(:,:)
 
@@ -2199,11 +2202,23 @@ contains
       this%cutOff%mCutOff = max(this%cutOff%mCutOff, this%halogenXCorrection%getRCutOff())
     end if
 
-    if (input%ctrl%nrChrg == 0.0_dp .and. .not.(this%tPeriodic.or.this%tHelical) .and.&
-        & this%tMulliken) then
-      this%tDipole = .true.
-    else
-      this%tDipole = .false.
+    this%tDipole = this%tMulliken
+    if (this%tDipole) then
+      block
+        logical :: isDipoleDefined
+        isDipoleDefined = .true.
+        if (abs(input%ctrl%nrChrg) > epsilon(0.0_dp)) then
+          call warning("Dipole printed for a charged system : origin dependent quantity")
+        end if
+        if (this%tPeriodic.or.this%tHelical) then
+          call warning("Dipole printed for extended system : value printed is not well defined")
+        end if
+        if (isDipoleDefined) then
+          write(this%dipoleMessage, "(A)")"Warning: dipole moment is not defined absolutely!"
+        else
+          write(this%dipoleMessage, "(A)")""
+        end if
+      end block
     end if
 
     if (this%tMulliken) then

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -323,7 +323,7 @@ contains
       if (this%tWriteDetailedOut) then
         call writeDetailedOut7(this%fdDetailedOut%unit,&
             & this%isGeoOpt .or. allocated(this%geoOpt), tGeomEnd, this%tMd, this%tDerivs,&
-            & this%eField, this%dipoleMoment, this%deltaDftb, this%solvation)
+            & this%eField, this%dipoleMoment, this%deltaDftb, this%solvation, this%dipoleMessage)
       end if
 
       call writeFinalDriverStatus(this%isGeoOpt .or. allocated(this%geoOpt), tGeomEnd, this%tMd,&
@@ -1567,7 +1567,7 @@ contains
             & this%isLinResp, this%eField, this%tFixEf, this%tPrintMulliken,&
             & this%dftbEnergy(this%deltaDftb%iDeterminant), this%energiesCasida, this%latVec,&
             & this%cellVol, this%intPressure, this%extPressure, tempIon, this%qOutput, this%q0,&
-            & this%dipoleMoment, this%solvation)
+            & this%dipoleMoment, this%solvation, this%dipoleMessage)
         call writeCurrentGeometry(this%geoOutFile, this%pCoord0Out, .false., .true., .true.,&
             & this%tFracCoord, this%tPeriodic, this%tHelical, this%tPrintMulliken, this%species0,&
             & this%speciesName, this%latVec, this%origin, iGeoStep, iLatGeoStep, this%nSpin,&
@@ -4551,7 +4551,7 @@ contains
       do iAt = 1, nAtom
         dipole(1, iAt) = dipole(1, iAt) + sum(q0(:, iAt, 1)) * coord0(ii, iAt)
       end do
-      write(stdOut, "(F12.8)", advance='no') sum(dipole)
+      write(stdOut, "(F16.8)", advance='no') sum(dipole)
     end do
     write(stdOut, *) " au"
     if (allocated(solvation)) then
@@ -7353,6 +7353,8 @@ contains
     end if
 
   end subroutine getReksNextInputDensity
+
+
   !> Set correct dipole moment according to type of REKS calculation
   subroutine assignDipoleMoment(dipoleTmp, dipoleMoment, iDet, tDipole, reks, isSingleState)
 

--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -3522,7 +3522,7 @@ contains
 
   !> Seventh group of data for detailed.out
   subroutine writeDetailedOut7(fd, tGeoOpt, tGeomEnd, tMd, tDerivs, eField, dipoleMoment,&
-      & deltaDftb, solvation)
+      & deltaDftb, solvation, dipoleMessage)
 
     !> File ID
     integer, intent(in) :: fd
@@ -3551,7 +3551,13 @@ contains
     !> Instance of the solvation model
     class(TSolvation), intent(in), allocatable :: solvation
 
+    !> Optional extra message about dipole moments
+    character(*), intent(in) :: dipoleMessage
+
     if (allocated(dipoleMoment)) then
+      if (len(trim(dipoleMessage))>0) then
+        write(fd, "(A)")trim(dipoleMessage)
+      end if
       if (deltaDftb%isNonAufbau) then
         if (deltaDftb%iGround > 0) then
           write(fd, "(A, 3F14.8, A)")'S0 Dipole moment:', dipoleMoment(:,deltaDftb%iGround), ' au'
@@ -3743,7 +3749,7 @@ contains
   !> Second group of output data during molecular dynamics
   subroutine writeMdOut2(fd, tStress, tPeriodic, tBarostat, isLinResp, eField, tFixEf,&
       & tPrintMulliken, energy, energiesCasida, latVec, cellVol, cellPressure, pressure, tempIon,&
-      & qOutput, q0, dipoleMoment, solvation)
+      & qOutput, q0, dipoleMoment, solvation, dipoleMessage)
 
     !> File ID
     integer, intent(in) :: fd
@@ -3802,6 +3808,9 @@ contains
     !> Instance of the solvation model
     class(TSolvation), intent(in), allocatable :: solvation
 
+    !> Optional extra message about dipole moments
+    character(*), intent(in) :: dipoleMessage
+
     integer :: ii
     character(lc) :: strTmp
 
@@ -3851,6 +3860,9 @@ contains
       write(fd, "(A, F14.8)") 'Net charge: ', sum(q0(:, :, 1) - qOutput(:, :, 1))
     end if
     if (allocated(dipoleMoment)) then
+      if (len(trim(dipoleMessage))>0) then
+        write(fd, "(A)")trim(dipoleMessage)
+      end if
       ii = size(dipoleMoment, dim=2)
       write(fd, "(A, 3F14.8, A)") 'Dipole moment:', dipoleMoment(:,ii),  'au'
       write(fd, "(A, 3F14.8, A)") 'Dipole moment:', dipoleMoment(:,ii) * au__Debye,  'Debye'


### PR DESCRIPTION
Calculate dipoles for periodic cases and when there is a net charge. The absolute value is undefined, but changes can be used, for example to evaluate Born charges or piezoelectric tensors as a derivative of forces/stress with respect to field or dipole with distortions.

Likewise, allow electric fields for periodic systems, even if interactions cross the saw-tooth discontinuity.

