### PR TITLE
Support for global Hybrids and CAM functionals

### DIFF
--- a/src/dftbp/common/environment.F90
+++ b/src/dftbp/common/environment.F90
@@ -107,7 +107,7 @@ module dftbp_common_environment
       & TTimerItem("Diagonalisation", 2),&
       & TTimerItem("Sparse to dense", 4),&
       & TTimerItem("Dense to sparse", 4),&
-      & TTimerItem("Range separated Hamiltonian", 4),&
+      & TTimerItem("Hybrid Hamiltonian", 4),&
       & TTimerItem("Density matrix creation", 2),&
       & TTimerItem("Energy evaluation", 2),&
       & TTimerItem("Post-SCC processing", 1),&

--- a/src/dftbp/derivs/linearresponse.F90
+++ b/src/dftbp/derivs/linearresponse.F90
@@ -299,8 +299,8 @@ contains
       end if
       call unpackHS(workLocal, over, neighbourList%iNeighbour, nNeighbourSK,&
           & denseDesc%iAtomStart, iSparseStart, img2CentCell)
-      call rangeSep%addLRHamiltonian(dRhoSqr(:,:,iS), over, neighbourList%iNeighbour, nNeighbourLC,&
-          & denseDesc%iAtomStart, iSparseStart, orb, dRho, workLocal)
+      call rangeSep%addCamHamiltonian(env, dRhoSqr(:,:,iS), over, neighbourList%iNeighbour,&
+          & nNeighbourLC, denseDesc%iAtomStart, iSparseStart, orb, dRho, workLocal)
     end if
 
     ! form |c> H' <c|

--- a/src/dftbp/derivs/linearresponse.F90
+++ b/src/dftbp/derivs/linearresponse.F90
@@ -299,8 +299,8 @@ contains
       end if
       call unpackHS(workLocal, over, neighbourList%iNeighbour, nNeighbourSK,&
           & denseDesc%iAtomStart, iSparseStart, img2CentCell)
-      call rangeSep%addLRHamiltonian(env, dRhoSqr(:,:,iS), over, neighbourList%iNeighbour,&
-          & nNeighbourLC, denseDesc%iAtomStart, iSparseStart, orb, dRho, workLocal)
+      call rangeSep%addLRHamiltonian(dRhoSqr(:,:,iS), over, neighbourList%iNeighbour, nNeighbourLC,&
+          & denseDesc%iAtomStart, iSparseStart, orb, dRho, workLocal)
     end if
 
     ! form |c> H' <c|

--- a/src/dftbp/dftb/getenergies.F90
+++ b/src/dftbp/dftb/getenergies.F90
@@ -260,7 +260,7 @@ contains
     ! Add exchange contribution for range separated calculations
     if (allocated(rangeSep) .and. .not. allocated(reks)) then
       energy%Efock = 0.0_dp
-      call rangeSep%addLREnergy(energy%Efock)
+      call rangeSep%addCamEnergy(energy%Efock)
     end if
 
     ! Free energy contribution if attached to an electron reservoir

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -3363,25 +3363,31 @@ contains
     end if
 
     if (this%isRangeSep) then
-      write(stdOut, "(A,':',T30,A)") "Range separated hybrid", "Yes"
-      write(stdOut, "(2X,A,':',T30,E14.6)") "Screening parameter omega",&
-          & input%ctrl%rangeSepInp%omega
-      write(stdOut, "(2X,A,':',T30,E14.6,E14.6)") "CAM parameters alpha/beta",&
-          & input%ctrl%rangeSepInp%camAlpha, input%ctrl%rangeSepInp%camBeta
+      if (input%ctrl%rangeSepInp%tHyb) then
+        write(stdOut, "(A,':',T30,A)") "Global hybrid", "Yes"
+        write(stdOut, "(2X,A,':',T30,E14.6)") "Fraction of HF",&
+            & input%ctrl%rangeSepInp%camAlpha
+      elseif (input%ctrl%rangeSepInp%tLc .or. input%ctrl%rangeSepInp%tCam) then
+        write(stdOut, "(A,':',T30,A)") "Range separated hybrid", "Yes"
+        write(stdOut, "(2X,A,':',T30,E14.6)") "Screening parameter omega",&
+            & input%ctrl%rangeSepInp%omega
+        write(stdOut, "(2X,A,':',T30,E14.6,E14.6)") "CAM parameters alpha/beta",&
+            & input%ctrl%rangeSepInp%camAlpha, input%ctrl%rangeSepInp%camBeta
+      end if
 
       select case(input%ctrl%rangeSepInp%rangeSepAlg)
       case (rangeSepTypes%neighbour)
-        write(stdOut, "(2X,A,':',T30,2X,A)") "Range separated algorithm", "NeighbourBased"
+        write(stdOut, "(2X,A,':',T30,2X,A)") "Screening algorithm", "NeighbourBased"
         write(stdOut, "(2X,A,':',T30,E14.6,A)") "Spatially cutoff at",&
             & input%ctrl%rangeSepInp%cutoffRed * Bohr__AA," A"
       case (rangeSepTypes%threshold)
-        write(stdOut, "(2X,A,':',T30,2X,A)") "Range separated algorithm", "Thresholded"
+        write(stdOut, "(2X,A,':',T30,2X,A)") "Screening algorithm", "Thresholded"
         write(stdOut, "(2X,A,':',T30,E14.6)") "Thresholded to",&
             & input%ctrl%rangeSepInp%screeningThreshold
       case (rangeSepTypes%matrixBased)
-        write(stdOut, "(2X,A,':',T30,2X,A)") "Range separated algorithm", "MatrixBased"
+        write(stdOut, "(2X,A,':',T30,2X,A)") "Screening algorithm", "MatrixBased"
       case default
-        call error("Unknown range separated hybrid method")
+        call error("Unknown (range-separated) hybrid screening algorithm")
       end select
     end if
 
@@ -5205,7 +5211,11 @@ contains
     end if
 
     if (this%isRS_LinResp .and. rangeSepInp%tCam) then
-        call error("General CAM functionals not currently implemented for range-separation.")
+      call error("General CAM functionals not currently implemented for linear response.")
+    end if
+
+    if (this%isRS_LinResp .and. rangeSepInp%tHyb) then
+      call error("Global hybrid functionals not currently implemented for linear response.")
     end if
 
   end subroutine ensureRangeSeparatedReqs

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -5212,7 +5212,7 @@ contains
 
 
   !> Stop if linear response module can not be invoked due to unimplemented combinations of
-  !> features.
+  !! features.
   subroutine ensureLinRespConditions(tSccCalc, t3rd, tRealHS, tPeriodic, tCasidaForces, solvation,&
       & isRS_LinResp, nSpin, tSpin, tHelical, tSpinOrbit, isDftbU, tempElec, isOnsiteCorrected,&
       & input)

--- a/src/dftbp/dftbplus/inputdata.F90
+++ b/src/dftbp/dftbplus/inputdata.F90
@@ -114,7 +114,13 @@ module dftbp_dftbplus_inputdata
     !> CAM beta parameter
     real(dp) :: camBeta
 
-    !> True, if a CAM-functional is requested, otherwise LC is assumed
+    !> True, for global hybrids
+    logical :: tHyb
+
+    !> True, for long-range corrected functionals
+    logical :: tLc
+
+    !> True, for general CAM range-separation
     logical :: tCam
 
     !> Choice of range separation method

--- a/src/dftbp/dftbplus/inputdata.F90
+++ b/src/dftbp/dftbplus/inputdata.F90
@@ -108,6 +108,15 @@ module dftbp_dftbplus_inputdata
     !> Separation parameter
     real(dp) :: omega
 
+    !> CAM alpha parameter
+    real(dp) :: camAlpha
+
+    !> CAM beta parameter
+    real(dp) :: camBeta
+
+    !> True, if a CAM-functional is requested, otherwise LC is assumed
+    logical :: tCam
+
     !> Choice of range separation method
     integer :: rangeSepAlg
 

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -2782,8 +2782,8 @@ contains
       ! Should this be used elsewhere, need to pass isRangeSep
       if (allocated(rangeSep)) then
         call denseMulliken(deltaRhoInSqr, SSqrReal, denseDesc%iAtomStart, qOutput)
-        call rangeSep%addLRHamiltonian(env, deltaRhoInSqr(:,:,iSpin), ints%overlap,&
-            & neighbourList%iNeighbour,  nNeighbourLC, denseDesc%iAtomStart, iSparseStart,&
+        call rangeSep%addCamHamiltonian(env, deltaRhoInSqr(:,:,iSpin), ints%overlap,&
+            & neighbourList%iNeighbour, nNeighbourLC, denseDesc%iAtomStart, iSparseStart,&
             & orb, HSqrReal, SSqrReal)
       end if
 
@@ -5504,7 +5504,7 @@ contains
     !> Integral container
     type(TIntegral), intent(in) :: ints
 
-    !> Dense matrix descriptor,required for rangeSep
+    !> Dense matrix descriptor, required for rangeSep
     type(TDenseDescr), intent(in) :: denseDesc
 
     !> Change in density matrix during this SCC step for rangesep
@@ -5647,7 +5647,7 @@ contains
       if (size(deltaRhoOutSqr, dim=3) > 2) then
         call error("Range separated forces do not support non-colinear spin")
       else
-        call rangeSep%addLRGradients(derivs, nonSccDeriv, deltaRhoOutSqr, skOverCont, coord,&
+        call rangeSep%addCamGradients(derivs, nonSccDeriv, deltaRhoOutSqr, skOverCont, coord,&
             & species, orb, denseDesc%iAtomStart, SSqrReal, neighbourList%iNeighbour, nNeighbourSK)
       end if
     end if
@@ -7181,12 +7181,12 @@ contains
       call qm2udL(reks%hamSqrL, reks%Lpaired)
       tmpEn(:) = 0.0_dp
       do iL = 1, reks%Lmax
-        ! Add rangeseparated contribution
-        call rangeSep%addLRHamiltonian(env, reks%deltaRhoSqrL(:,:,1,iL), ints%overlap, &
+        ! Add range-separated contribution to Hamiltonian
+        call rangeSep%addCamHamiltonian(env, reks%deltaRhoSqrL(:,:,1,iL), ints%overlap, &
             & neighbourList%iNeighbour, nNeighbourLC, denseDesc%iAtomStart, &
             & iSparseStart, orb, reks%hamSqrL(:,:,1,iL), reks%overSqr)
-        ! Calculate the long-range exchange energy for up spin
-        call rangeSep%addLREnergy(tmpEn(iL))
+        ! Calculate range-separated exchange energy for spin up
+        call rangeSep%addCamEnergy(tmpEn(iL))
       end do
     end if
 

--- a/src/dftbp/reks/reksinterface.F90
+++ b/src/dftbp/reks/reksinterface.F90
@@ -904,7 +904,7 @@ module dftbp_reks_reksinterface
       if (this%isRangeSep) then
         ! deltaRhoSqrL has (my_ud) component
         lcDerivs(:,:,iL) = 0.0_dp
-        call rangeSep%addLRGradients(lcDerivs(:,:,iL), nonSccDeriv, this%deltaRhoSqrL(:,:,:,iL),&
+        call rangeSep%addCamGradients(lcDerivs(:,:,iL), nonSccDeriv, this%deltaRhoSqrL(:,:,:,iL),&
             & skOverCont, coord, species, orb, denseDesc%iAtomStart, this%overSqr,&
             & neighbourList%iNeighbour, nNeighbourSK)
       end if


### PR DESCRIPTION
Accounts for recently introduced features in SkProgs (cf. corresponding [PR](https://github.com/dftbplus/skprogs/pull/30)). For now only basic functionality is provided (single-point, analytic forces, probably MD, ...).

Done/remaining tasks:
- [x] extend range-separated type by more general CAM functionals (alpha, beta, omega)
- [x] global hybrids (parse SK extra tag, only full-range Hartree-Fock evaluation)
- [x] check analytical forces against finite differences (global hybrids|CAM)
- [ ] documentation
- [ ] regression tests

Later PR's would have to address:
- periodic boundary conditions (+ eventually k-points)
- (real-time) TD-CAM-DFTB
- xTB
- ...