### PR TITLE
Blocks combination of xTB and XLBOMD together

### DIFF
--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -2561,6 +2561,9 @@ contains
       if (this%tExtChrg .or. this%isExtField) then
         call error("External fields currently disabled for XLBOMD calculations")
       end if
+      if (this%hamiltonianType /= hamiltonianTypes%dftb) then
+        call error("XLBOMD calculations currently only supported for the DFTB hamiltonian")
+      end if
       allocate(this%xlbomdIntegrator)
       call Xlbomd_init(this%xlbomdIntegrator, input%ctrl%xlbomd, this%nIneqOrb)
     end if

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -801,7 +801,9 @@ contains
         end if
       end if
 
-      call readXlbomdOptions(node, ctrl%xlbomd)
+      if (ctrl%hamiltonian == hamiltonianTypes%dftb) then
+        call readXlbomdOptions(node, ctrl%xlbomd)
+      end if
 
       call getInputMasses(node, geom, ctrl%masses)
 


### PR DESCRIPTION
Block in parser and init for this combination (the regular XLBOMD + gfn{1,2} seems superficially to run OK, but is probably not correct, while the fast version blows up after a few hundred steps).