### PR TITLE
Add init check for XLBOMD+solvent

### DIFF
--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -2564,6 +2564,9 @@ contains
       if (this%hamiltonianType /= hamiltonianTypes%dftb) then
         call error("XLBOMD calculations currently only supported for the DFTB hamiltonian")
       end if
+      if (allocated(this%solvation)) then
+        call error("XLBOMD does not work with solvation models yet!")
+      end if
       allocate(this%xlbomdIntegrator)
       call Xlbomd_init(this%xlbomdIntegrator, input%ctrl%xlbomd, this%nIneqOrb)
     end if


### PR DESCRIPTION
Avoids a ground state SCC calculation before the code would stop
with an error due to missing functionality.