### PR TITLE
Append geometry option and device range trap

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -301,7 +301,7 @@ methods are available:
   \kw{Convergence} & m &  & & \pref{sec:dftbp.Convergence} \\
   \kw{MaxSteps} &i &  & 200 & \\
   \kw{OutputPrefix} &s &  & "geo\_end" & \\
-  %\kw{AppendGeometries} & l & & \is{No} & \\
+  \kw{AppendGeometries} & l & & \is{No} & \\
   %\kw{Constraints} & (1i3r)* & LatticeOpt = No & \cb            & \\
   %\kw{ConvergentForcesOnly} & l & SCC = Yes & \is{Yes} & \\
 \end{ptable}

--- a/src/dftbp/dftbplus/input/geoopt.F90
+++ b/src/dftbp/dftbplus/input/geoopt.F90
@@ -48,7 +48,7 @@ module dftbp_dftbplus_input_geoopt
 contains
 
   !> General entry point to read geometry optimization
-  subroutine readGeoOptInput(node, geom, input)
+  subroutine readGeoOptInput(node, geom, input, atomsRange)
 
     !> Node to get the information from
     type(fnode), pointer, intent(in) :: node
@@ -59,13 +59,17 @@ contains
     !> Control structure to be filled
     type(TGeoOptInput), intent(out) :: input
 
+    !> Default range of moving atoms (may be restricted for example by contacts in transport
+    !> calculations)
+    character(len=*), intent(in) :: atomsRange
+
     type(fnode), pointer :: child, value1
     type(string) :: buffer
 
     call getChildValue(node, "Optimizer", child, "Rational")
     call readOptimizerInput(child, input%optimizer)
 
-    call readFilterInput(node, geom, input%filter)
+    call readFilterInput(node, geom, input%filter, atomsRange)
 
     call getChildValue(node, "Convergence", value1, "", child=child, allowEmptyValue=.true.)
     call readOptTolerance(child, input%tolerance)
@@ -114,7 +118,7 @@ contains
 
 
   !> Entry point for reading input for cartesian geometry transformation filter
-  subroutine readFilterInput(node, geom, input)
+  subroutine readFilterInput(node, geom, input, atomsRange)
 
     !> Node to get the information from
     type(fnode), pointer, intent(in) :: node
@@ -124,6 +128,10 @@ contains
 
     !> Control structure to be filled
     type(TFilterInput), intent(out) :: input
+
+    !> Default range of moving atoms (may be restricted for example by contacts in transport
+    !> calculations)
+    character(len=*), intent(in) :: atomsRange
 
     type(fnode), pointer :: child
     type(string) :: buffer
@@ -137,7 +145,7 @@ contains
       end if
       call getChildValue(node, "Isotropic", input%isotropic, .false.)
     end if
-    call getChildValue(node, "MovedAtoms", buffer, "1:-1", multiple=.true., child=child)
+    call getChildValue(node, "MovedAtoms", buffer, trim(atomsRange), multiple=.true., child=child)
     call getSelectedAtomIndices(child, char(buffer), geom%speciesNames, geom%species, &
         & input%indMovedAtom)
 

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -1306,9 +1306,9 @@ contains
       if (.not. (this%deltaDftb%isSpinPurify .and.&
           & this%deltaDftb%iDeterminant == determinants%triplet)) then
         call writeCurrentGeometry(this%geoOutFile, this%pCoord0Out, this%tLatOpt, this%tMd,&
-            & this%tAppendGeo, this%tFracCoord, this%tPeriodic, this%tHelical, this%tPrintMulliken,&
-            & this%species0, this%speciesName, this%latVec, this%origin, iGeoStep, iLatGeoStep,&
-            & this%nSpin, this%qOutput, this%velocities)
+            & this%tAppendGeo.and.iGeoStep>0, this%tFracCoord, this%tPeriodic, this%tHelical,&
+            & this%tPrintMulliken, this%species0, this%speciesName, this%latVec, this%origin,&
+            & iGeoStep, iLatGeoStep, this%nSpin, this%qOutput, this%velocities)
       endif
     end if
 

--- a/test/app/dftb+/geoopt/H2O_rf/dftb_in.hsd
+++ b/test/app/dftb+/geoopt/H2O_rf/dftb_in.hsd
@@ -9,6 +9,7 @@ Geometry = GenFormat {
 Driver = GeometryOptimization {
   Optimizer = Rational {}
   MaxSteps = 100
+  AppendGeometries = Yes
   OutputPrefix = "geom.out"
 }
 


### PR DESCRIPTION
* GeometryOptimization environment with AppendGeometries flag
* Fix atom range default for transport calculations in
  GeometryOptimization
* Simplify atom range code for other drivers, reducing preprocessor
  use