### PR TITLE
Ensure error returns for atoms too close

### DIFF
--- a/app/phonons/initphonons.F90
+++ b/app/phonons/initphonons.F90
@@ -13,6 +13,7 @@ module phonons_initphonons
   use dftbp_common_constants
   use dftbp_common_environment
   use dftbp_common_globalenv
+  use dftbp_common_status, only : TStatus
   use dftbp_common_unitconversion
   use dftbp_dftb_periodic
   use dftbp_io_charmanip
@@ -1468,6 +1469,7 @@ contains
     real(dp) :: mCutoff
     real(dp), allocatable :: coords(:,:), cellVec(:,:), rCellVec(:,:)
     integer, allocatable :: iCellVec(:)
+    type(TStatus) :: errStatus
 
     call TNeighbourlist_init(neighbourList, geo%nAtom, nInitNeighbours)
 
@@ -1489,7 +1491,10 @@ contains
     allocate(iCellVec(nAllAtom))
 
     call updateNeighbourList(coords, img2CentCell, iCellVec, neighbourList, &
-          &nAllAtom, geo%coords, mCutoff, rCellVec, symmetric=.false.)
+        &nAllAtom, geo%coords, mCutoff, rCellVec, errStatus, symmetric=.false.)
+    if (errStatus%hasError()) then
+      call error(errStatus%message)
+    end if
 
     deallocate(coords)
     deallocate(iCellVec)

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -382,7 +382,10 @@ contains
           & this%ints%overlap, this%neighbourList, this%nNeighbourSK, this%cutOff%skCutoff,&
           & this%denseDesc%iAtomStart, this%iSparseStart, this%img2CentCell, this%iCellVec,&
           & this%cellVec, this%rCellVec, this%orb, this%kPoint, this%kWeight, this%coord0Fold,&
-          & this%species0, this%speciesName, this%mu, this%lCurrArray)
+          & this%species0, this%speciesName, this%mu, this%lCurrArray, errStatus)
+      if (errStatus%hasError()) then
+        call error(errStatus%message)
+      end if
     end if
 
     if (this%tTunn) then
@@ -1931,11 +1934,12 @@ contains
     if (tHelical) then
       call updateNeighbourListAndSpecies(env, coord, species, img2CentCell, iCellVec,&
           & neighbourList, nAllAtom, coord0Fold, species0, cutoff%mCutoff, rCellVec,&
-          & helicalBoundConds=latVec)
+          & errStatus, helicalBoundConds=latVec)
     else
       call updateNeighbourListAndSpecies(env, coord, species, img2CentCell, iCellVec,&
-          & neighbourList, nAllAtom, coord0Fold, species0, cutoff%mCutOff, rCellVec)
+          & neighbourList, nAllAtom, coord0Fold, species0, cutoff%mCutOff, rCellVec, errStatus)
     end if
+    @:PROPAGATE_ERROR(errStatus)
 
     call getNrOfNeighboursForAll(nNeighbourSK, neighbourList, cutoff%skCutOff)
 

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -14,6 +14,7 @@ module dftbp_dftbplus_parser
   use dftbp_common_filesystem, only : findFile, getParamSearchPath
   use dftbp_common_globalenv, only : stdout, withMpi, withScalapack, abortProgram
   use dftbp_common_hamiltoniantypes, only : hamiltonianTypes
+  use dftbp_common_status, only : TStatus
   use dftbp_common_unitconversion, only : lengthUnits, energyUnits, forceUnits, pressureUnits,&
       & timeUnits, EFieldUnits, freqUnits, massUnits, VelocityUnits, dipoleUnits, chargeUnits,&
       & volumeUnits, angularUnits
@@ -3963,6 +3964,7 @@ contains
     integer, allocatable :: img2CentCell(:), iCellVec(:)
     integer :: nAllAtom
     type(TNeighbourList) :: neighs
+    type(TStatus) :: errStatus
 
     allocate(tmpR2(3, geo%nAtom))
     allocate(input%polar(geo%nAtom))
@@ -4028,8 +4030,11 @@ contains
       allocate(coords(3, nAllAtom))
       allocate(img2CentCell(nAllAtom))
       allocate(iCellVec(nAllAtom))
-      call updateNeighbourList(coords, img2CentCell, iCellVec, neighs, &
-          &nAllAtom, geo%coords, mCutoff, rCellVec)
+      call updateNeighbourList(coords, img2CentCell, iCellVec, neighs, nAllAtom, geo%coords,&
+          & mCutoff, rCellVec, errStatus)
+      if (errStatus%hasError()) then
+        call error(errStatus%message)
+      end if
       allocate(nNeighs(geo%nAtom))
       nNeighs(:) = 0
       do iAt1 = 1, geo%nAtom

--- a/src/dftbp/timedep/timeprop.F90
+++ b/src/dftbp/timedep/timeprop.F90
@@ -2830,7 +2830,8 @@ contains
     call boundaryCond%foldCoordsToCell(coord0Fold, this%latVec)
 
     call updateNeighbourListAndSpecies(env, coordAll, this%speciesAll, img2CentCell, this%iCellVec,&
-        & neighbourList, nAllAtom, coord0Fold, this%species, this%mCutoff, this%rCellVec)
+        & neighbourList, nAllAtom, coord0Fold, this%species, this%mCutoff, this%rCellVec, errStatus)
+    @:PROPAGATE_ERROR(errStatus)
     call getNrOfNeighboursForAll(nNeighbourSK, neighbourList, this%skCutoff)
     call getSparseDescriptor(neighbourList%iNeighbour, nNeighbourSK, img2CentCell, orb,&
         & iSparseStart, sparseSize)


### PR DESCRIPTION
Covers serial and MPI (both with and without node comm).

- [x] errStatus returned
- [x] synchronised error halt with consistent message if with node comm
- [x] unit testing