### PR TITLE
Make sure ParserVersion appears in dftb_in.hsd

### DIFF
--- a/src/dftbp/io/hsdutils.F90
+++ b/src/dftbp/io/hsdutils.F90
@@ -3079,7 +3079,7 @@ contains
 
     type(string) :: str
 
-    str = msg
+    str = trim(msg)
     call appendPathAndLine(node, str)
     call error(char(str) // newline)
 


### PR DESCRIPTION
Was missing if InputVersion was set and no conversion was necessary.