### PR TITLE
Add X+Y data for NrOfExcitations to autotest.tag

### DIFF
--- a/src/dftbp/io/taggedoutput.F90
+++ b/src/dftbp/io/taggedoutput.F90
@@ -212,6 +212,9 @@ module dftbp_io_taggedoutput
     !> Atomic dipole moments
     character(lenLabel) :: dipoleAtom = 'atomic_dipole_moments'
 
+    !> Casida X+Y eigenvector for target state
+    character(lenLabel) :: casidaEigenV = 'casida_eigenvector'
+
   end type TTagLabelsEnum
 
 

--- a/src/dftbp/timedep/linrespgrad.F90
+++ b/src/dftbp/timedep/linrespgrad.F90
@@ -3171,6 +3171,9 @@ contains
         end if
       end if
 
+      ! X+Y eigenvector of target state
+      call taggedWriter%write(fdTagged, tagLabels%casidaEigenV, xpy)
+
     end if
 
   end subroutine writeExcitations


### PR DESCRIPTION
PR to allow for overlapping atoms upon user request and write sensible overlap data. 
Necessary for interface with Newton-X.
Here: Implemented writing of X+Y data to autotest.tag, in this way only one file needs to be parsed by Newton-X. 
ToDo (?) Writing to results.tag instead of autotest.tag, but currently all excited state info is in autotest.tag. 
           (?) Remove writing to X+Y.DAT. The tag file can become quite large, redundant info.
