### PR TITLE
Fix for uninitialised stress in sockets

### DIFF
--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -991,7 +991,7 @@ module dftbp_dftbplus_initprogram
 
     !> Stress tensors for various contribution in periodic calculations
     !> Sign convention: Positive diagonal elements expand the supercell
-    real(dp) :: totalStress(3,3)
+    real(dp) :: totalStress(3,3) = 0.0_dp
 
     !> Stress tensors for determinants if using TI-DFTB
     real(dp), allocatable :: mixedStress(:,:), tripletStress(:,:)

--- a/test/app/dftb+/sockets/H2O_cluster/prerun.py
+++ b/test/app/dftb+/sockets/H2O_cluster/prerun.py
@@ -92,7 +92,10 @@ def main():
         # stress x lattive volume
         buf = receive_all(connection, 9*8)
         unpacked_data = struct.unpack('9d', buf)
-        print(unpacked_data)
+        if tPeriodic:
+            print(unpacked_data)
+            # contains numerical junk if not peridic, so do nothing
+            # otherwise
 
         # dummy '0' at the end of the data
         buf = receive_all(connection, 4)


### PR DESCRIPTION
If boundary conditions don't support stress tensor, init to 0 in DFTB+ and skip printing in regression test.