### PR TITLE
Initialise missed variables used by Poisson solver

### DIFF
--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -6305,6 +6305,8 @@ contains
     call getChildValue(pNode,"Gate",pTmp2,"none",child=pChild)
     call getNodeName(pTmp2, buffer)
 
+    poisson%insLength = 0.0_dp
+    poisson%insRad = 0.0_dp
     select case(char(buffer))
     case ("none")
       poisson%gateType = "N"


### PR DESCRIPTION
Note, not documented what they are doing or correct values. Missed by parser initialisation.