### PR TITLE
Proper cmake processing of dftbplus.h file

### DIFF
--- a/src/dftbp/CMakeLists.txt
+++ b/src/dftbp/CMakeLists.txt
@@ -155,15 +155,18 @@ endif()
 
 if(INSTALL_INCLUDE_FILES)
   install(DIRECTORY ${includedir}/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${INSTALL_MODULEDIR}")
-  CONFIGURE_FILE(
-    "${CMAKE_CURRENT_SOURCE_DIR}/api/mm/dftbplus.h"
-    "${CMAKE_CURRENT_BINARY_DIR}/dftbplus.h"
-    @ONLY
-  )
-  install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/dftbplus.h"
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-  )
+
+  if(WITH_API OR BUILD_SHARED_LIBS)
+    CONFIGURE_FILE(
+      "${CMAKE_CURRENT_SOURCE_DIR}/api/mm/dftbplus.h"
+      "${CMAKE_CURRENT_BINARY_DIR}/dftbplus.h"
+      @ONLY
+      )
+    install(
+      FILES "${CMAKE_CURRENT_BINARY_DIR}/dftbplus.h"
+      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+      )
+  endif()
 
   get_target_property(moddirs xmlf90_objlib INTERFACE_INCLUDE_DIRECTORIES)
   foreach(moddir IN LISTS moddirs)

--- a/src/dftbp/api/mm/dftbplus.h
+++ b/src/dftbp/api/mm/dftbplus.h
@@ -8,7 +8,7 @@
 #define __DFTBPLUS_H__
 
 #define __DFTBPLUS_RELEASE__ "@RELEASE@"
-#define __DFTBPLUS_API__ "@API_RELEASE@"
+#define __DFTBPLUS_API__ "@API_VERSION@"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Only generated in build when WITH_API.
Contains correctly expanded API version macro.
Fixes bug introduced in c0f2a7dce

Closes #1095 