### PR TITLE
Make building and linking of MUDPACK optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,10 @@ if(WITH_TRANSPORT)
     external/libnegf "${exclude}" "${LIBNEGF_GIT_REPOSITORY}" "${LIBNEGF_GIT_TAG}")
   #list(APPEND PKG_CONFIG_REQUIRES negf)
 endif()
-add_subdirectory(external/mudpack)
+
+if(WITH_POISSON)
+    add_subdirectory(external/mudpack)
+endif()
 
 if(WITH_TBLITE OR WITH_SDFTD3)
   set(MCTC_LIB_GIT_REPOSITORY "https://github.com/grimme-lab/mctc-lib.git")

--- a/src/dftbp/CMakeLists.txt
+++ b/src/dftbp/CMakeLists.txt
@@ -93,7 +93,10 @@ endif()
 if(WITH_TRANSPORT)
   target_link_libraries(dftbplus PUBLIC Negf::Negf)
 endif()
-target_link_libraries(dftbplus PUBLIC mudpack)
+
+if(WITH_POISSON)
+  target_link_libraries(dftbplus PUBLIC mudpack)
+endif()
 
 if(WITH_SDFTD3)
   target_link_libraries(dftbplus PUBLIC s-dftd3::s-dftd3)


### PR DESCRIPTION
Due to bugs, MUDPACK was build and linked, even with WITH_POISSON=0