### PR TITLE
Missing parser version in regression case

### DIFF
--- a/test/app/dftb+/dispersion/charged_dftd4/dftb_in.hsd
+++ b/test/app/dftb+/dispersion/charged_dftd4/dftb_in.hsd
@@ -22,7 +22,7 @@ Hamiltonian = DFTB {
   }
   MaxSCCIterations = 250
   SlaterKosterFiles = Type2FileNames {
-Prefix = {slakos/origin/mio-1-1/}
+    Prefix = {slakos/origin/mio-1-1/}
     Separator = "-"
     Suffix = ".skf"
   }
@@ -38,4 +38,8 @@ Parallel {
   # Allow OMP threads explicitely to test for hybrid parallelisation with
   # MPI-binary. (Check the manual before using this in production runs!)
   UseOmpThreads = Yes
+}
+
+ParserOptions {
+  ParserVersion = 12
 }


### PR DESCRIPTION
Minor change to add parser version to regression test (and slight formatting of input file).