### PR TITLE
Unused variables for spin-resolved energy

### DIFF
--- a/src/dftbp/dftb/rangeseparated.F90
+++ b/src/dftbp/dftb/rangeseparated.F90
@@ -86,12 +86,6 @@ module dftbp_dftb_rangeseparated
     !> total long range energy
     real(dp) :: lrEnergy
 
-    !> spin up part of energy
-    real(dp) :: lrEnergyUp
-
-    !> spin down part of energy
-    real(dp) :: lrEnergyDn
-
     !> Is this spin restricted (F) or unrestricted (T)
     logical :: tSpin
 


### PR DESCRIPTION
Note that the current energy structure for RS will break for MPI parallelism (it's a bit of a hack at the moment).