### PR TITLE
Add stacksize information/recommendation to standard output

### DIFF
--- a/src/dftbp/common/CMakeLists.txt
+++ b/src/dftbp/common/CMakeLists.txt
@@ -7,6 +7,7 @@ set(sources-fpp
   ${curdir}/atomicmass.F90
   ${curdir}/coherence.F90
   ${curdir}/constants.F90
+  ${curdir}/envcheck.F90
   ${curdir}/environment.F90
   ${curdir}/file.F90
   ${curdir}/filesystem.F90
@@ -21,6 +22,9 @@ set(sources-fpp
   ${curdir}/unitconversion.F90
   ${curdir}/version.F90)
 
+list(APPEND sources-c
+  ${curdir}/envcheck.c)
+
 if(WITH_MPI)
   list(APPEND sources-fpp
     ${curdir}/blacsenv.F90
@@ -34,3 +38,4 @@ endif()
 
 
 set(ALL-SOURCES-FPP ${ALL-SOURCES-FPP} ${sources-fpp} PARENT_SCOPE)
+set(ALL-SOURCES-C ${ALL-SOURCES-C} ${sources-c} PARENT_SCOPE)

--- a/src/dftbp/common/envcheck.F90
+++ b/src/dftbp/common/envcheck.F90
@@ -1,0 +1,76 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2023  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+#:include 'common.fypp'
+#:include 'error.fypp'
+
+!> Contains functionality to check environment settings.
+module dftbp_common_envcheck
+
+  use, intrinsic :: iso_c_binding, only : c_char, c_int
+  use dftbp_common_accuracy, only : dp
+  use dftbp_common_environment, only : TEnvironment
+  use dftbp_common_globalenv, only : stdOut
+  use dftbp_io_message, only : warning
+  implicit none
+
+  private
+  public :: checkStackSize
+
+
+  interface
+    ! Interface for checking stacksize through C-routine.
+    subroutine get_stacksize(cStack, iErr) bind(C, name="get_stacksize_c")
+
+      import :: c_char, c_int
+      implicit none
+
+      !> Current stacksize
+      integer(kind=c_int), intent(out) :: cStack
+
+      !> Error status
+      integer(kind=c_int), intent(out) :: iErr
+
+    end subroutine get_stacksize
+  end interface
+
+
+contains
+
+  !> Checks stacksize settings for optimal user experience/performance.
+  subroutine checkStackSize(env)
+
+    !> Environment settings
+    type(TEnvironment), intent(in) :: env
+
+    !! Current stacksize
+    integer :: cStack
+
+    !! Error status
+    integer :: iErr
+
+    call get_stacksize(cStack, iErr)
+
+    if (iErr /= 0) then
+      write(stdOut, "(A,':',T30,A,I0,A)") "Current stacksize", "N/A (error code: ", iErr, ")"
+    else
+      if (cStack == -1 .or. cStack == 0) then
+        write(stdOut, "(A,':',T30,A)") "Current stacksize", "unlimited"
+      else
+        write(stdOut, "(A,':',T30,I0,A)") "Current stacksize",&
+            & nint(real(cStack, dp) / 1024.0_dp**2), " [Mb] (recommended: unlimited)"
+        call warning("Current stacksize not set to unlimited or hard limit, which might cause"&
+            & // new_line("A") // "   random crashes (e.g. segmentation faults). It is advised to&
+            & unlimit the" // new_line("A") // "   stacksize by issuing 'ulimit -s unlimited'&
+            & (Linux) or setting it to the " // new_line("A") // "   hard limit by 'ulimit -s hard'&
+            & (Mac) in advance.")
+      end if
+    end if
+
+  end subroutine checkStackSize
+
+end module dftbp_common_envcheck

--- a/src/dftbp/common/envcheck.c
+++ b/src/dftbp/common/envcheck.c
@@ -1,0 +1,24 @@
+/*------------------------------------------------------------------------------------------------*/
+/*  DFTB+: general package for performing fast atomistic simulations                              */
+/*  Copyright (C) 2006 - 2023  DFTB+ developers group                                             */
+/*                                                                                                */
+/*  See the LICENSE file for terms of usage and distribution.                                     */
+/*------------------------------------------------------------------------------------------------*/
+
+#include <sys/resource.h>
+
+/**
+ * Queries current stacksize.
+ *
+ * \param[out] cstack Current stacksize of task.
+ *
+ * \param[out] ierr Error status.
+ */
+void get_stacksize_c(int *cstack, int *ierr) {
+
+  struct rlimit rlim;
+  *ierr = getrlimit(RLIMIT_STACK, &rlim);
+
+  *cstack = rlim.rlim_cur;
+
+}

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -15,6 +15,7 @@ module dftbp_dftbplus_initprogram
   use dftbp_common_coherence, only : checkToleranceCoherence, checkExactCoherence
   use dftbp_common_constants, only : shellNames, Hartree__eV, Bohr__AA, amu__au, pi, au__ps,&
       & Bohr__nm, Hartree__kJ_mol, Boltzmann
+  use dftbp_common_envcheck, only : checkStackSize
   use dftbp_common_environment, only : TEnvironment, globalTimers
   use dftbp_common_file, only : TFile
   use dftbp_common_globalenv, only : stdOut, withMpi
@@ -2921,6 +2922,8 @@ contains
     else
       write(stdOut, "(A,':',T30,I0)") "Specified random seed", iSeed
     end if
+
+    call checkStackSize(env)
 
     if (input%ctrl%tMD) then
       select case(input%ctrl%iThermostat)


### PR DESCRIPTION
Inspired by the FHIaims code and our discussion during the developers meeting a while ago, I've added stacksize information to the standard output. Let's hope that this facilitates using the DFTB+ code and helps to avoid requests like [this](https://github.com/dftbplus/dftbplus/discussions/1092) one. However, undercutting the recommended stacksize does not stop the code, it solely prints a warning for now.

We might want to discuss if putting C sources into the same folder as Fortran files is a good idea.