### PR TITLE
add include directory of ELSI to elsi target in CMake

### DIFF
--- a/cmake/Modules/Findelsi.cmake
+++ b/cmake/Modules/Findelsi.cmake
@@ -15,6 +15,11 @@ if(NOT TARGET elsi::elsi)
       INTERFACE
       "${ELSI_INCLUDE_DIRS}"
     )
+    target_include_directories(
+      elsi::elsi
+      INTERFACE
+      "${ELSI_INCLUDEDIR}"
+    )
 
     foreach(_lib IN LISTS ELSI_LINK_LIBRARIES)
       if(_lib MATCHES "pexsi")


### PR DESCRIPTION
Fixes #1147

`ELSI_INCLUDE_DIRS` does not have the path to the include folder of ELSI itself, only paths to those packages that are dependencies of ELSI. The path to the include folder of ELSI is returned by `pkg_check_modules` in `ELSI_INCLUDEDIR`