### PR TITLE
Implement alternative AE/BE keywords spelling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ Added
 
 - Spin-orbit coupling for xTB
 
+- Dual American and British English spelling for various input keywords
+
+
 Fixed
 -----
 
@@ -27,6 +30,7 @@ Fixed
 - Corrected units for electrostatic gate potentials in transport
 
 - Stratmann solver available without ARPACK
+
 
 22.1 (2022-05-25)
 =================

--- a/app/waveplot/initwaveplot.F90
+++ b/app/waveplot/initwaveplot.F90
@@ -21,7 +21,7 @@ module waveplot_initwaveplot
   use dftbp_io_hsdparser, only : parseHSD, dumpHSD
   use dftbp_io_hsdutils, only : getChildValue, setChildValue, getChild, setChild, getChildren,&
       & getSelectedIndices, detailedError, detailedWarning
-  use dftbp_io_hsdutils2, only : convertUnitHsd, readHSDAsXML, warnUnprocessedNodes
+  use dftbp_io_hsdutils2, only : convertUnitHsd, readHSDAsXML, warnUnprocessedNodes, renameChildren
   use dftbp_io_message, only : warning, error
   use dftbp_io_xmlutils, only : removeChildNodes
   use dftbp_type_linkedlist, only : TListIntR1, TListReal, init, destruct, len, append, asArray
@@ -537,6 +537,7 @@ contains
     call getChildValue(node, "TotalChargeDensity", this%opt%tPlotTotChrg, .false.)
 
     if (nSpin == 2) then
+      call renameChildren(node, "TotalSpinPolarization", "TotalSpinPolarisation")
       call getChildValue(node, "TotalSpinPolarisation", this%opt%tPlotTotSpin, .false.)
     else
       this%opt%tPlotTotSpin = .false.

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -266,8 +266,9 @@ structure during the calculation.\\ \bigskip Currently the following
 methods are available:
 \begin{description}
 \item[\iscb{}] Static calculation with the input geometry.
-\item[\iscb{GeometryOptimisation}] Geometry optimisation of the input geometry.
-  See p.~\pref{sec:dftbp.GeometryOptimisation}.
+\item[\iscb{GeometryOptimisation} / \iscb{GeometryOptimization}] Geometry
+  optimisation of the input geometry.  See
+  p.~\pref{sec:dftbp.GeometryOptimisation}.
 \item[\iscb{SteepestDescent}] (\textbf{deprecated}) Geometry optimisation by moving atoms
   along the acting forces. See p.~\pref{sec:dftbp.SteepestDescent}.
 \item[\iscb{ConjugateGradient}] (\textbf{deprecated}) Geometry optimisation using the
@@ -308,8 +309,49 @@ methods are available:
   %\kw{Constraints} & (1i3r)* & LatticeOpt = No & \cb            & \\
   %\kw{ConvergentForcesOnly} & l & SCC = Yes & \is{Yes} & \\
 \end{ptable}
+\begin{description}
+\item[\is{Optimiser} / \is{Optimizer}] Type of the geometry optimiser to use. (See following sections for possible optimiser types.)
 
-Example for performing a full lattice optimisation using the rational function optimiser:
+\item[\is{MovedAtoms}] Indices of the atoms which should be moved. The
+  atoms can be specified via index selection expressions, as described
+  in appendix \ref{sec:index_selection}.
+
+\item[\is{LatticeOpt}] Allow the lattice vectors to change during
+  optimisation. \is{MovedAtoms} can be optionally used with lattice
+  optimisation if the atomic coordinates are to be co-optimised with
+  the lattice.\footnote{This is functional but not very efficient at
+    the moment.}
+
+\item[\is{FixAngles}] If optimising the lattice, allow only the
+  lengths of lattice vectors to vary, not the angles between them. For
+  example if your lattice is orthorhombic, this option will maintain
+  that symmetry during optimisation.
+
+\item[\is{FixLengths}] If optimising the lattice with \is{FixAngles} =
+  \is{Yes}, allow only the lengths of the specified lattice vectors to
+  vary.
+
+\item[\is{Isotropic}] If optimising the lattice, allow only uniform
+  scaling of the unit cell. This option is incompatible with
+  \is{FixAngles}.
+
+\item[\is{Convergence}] Convergence criteria. See section
+  \ref{sec:dftbp.Convergence}.
+
+\item[\is{MaxSteps}] Maximum number of steps after which the optimisation should
+  stop (unless already stopped by achieving convergence). Setting this value as
+  -1 runs a huge() number of iterations.
+
+\item[\is{OutputPrefix}] Prefix of the geometry files containing the
+  final structure.
+
+\item[\is{AppendGeometries}] If set to \is{Yes}, the geometry file in
+  the XYZ-format will contain all the geometries obtained during the
+  optimisation (instead of containing only the last geometry).
+
+\end{description}
+
+Example for performing a full lattice optimisation using the rational function optimiser.
 
 \begin{verbatim}
 Driver = GeometryOptimisation {
@@ -1466,7 +1508,7 @@ To select the DFTB Hamiltonian you must set \is{Hamiltonian =
   \is{FixedFermiLevel} is present (see section \ref{sec:dftbp.Filling}), then value
   specified here will be ignored.
 
-\item[\is{SpinPolarisation}] Specifies if and how the system is spin
+\item[\is{SpinPolarisation} / \is{SpinPolarization}] Specifies if and how the system is spin
   polarised. See p.~\pref{sec:dftbp.SpinPolarisation}.
 
 \item[\is{SpinConstants}] Specifies the atom type specific constants needed for
@@ -1608,11 +1650,12 @@ expressions, as described in appendix \ref{sec:index_selection}.):
   forces when the charges are well converged. For non-converged charges however the resulting forces
   can differ considerably between methods.
 
-\item[\is{CustomisedHubbards}] Enables overriding of the Hubbard U values for given species. If the
-  option \is{ShellResolvedScc} has been set to \is{Yes}, you need to specify one Hubbard U value
-  for each atomic shell in the basis of the given atom type, otherwise only one atomic value is
-  required. For all species not specified in this block, the value(s) found in their respective
-  Slater-Koster files will be used.
+\item[\is{CustomisedHubbards} / \is{CustomizedHubbards}] Enables overriding of
+  the Hubbard U values for given species. If the option \is{ShellResolvedScc}
+  has been set to \is{Yes}, you need to specify one Hubbard U value for each
+  atomic shell in the basis of the given atom type, otherwise only one atomic
+  value is required. For all species not specified in this block, the value(s)
+  found in their respective Slater-Koster files will be used.
 
   \textbf{Warning:} This option is for experts only! Overriding values stored in the SK-files may
   result in \textbf{inconsistent results}. Make sure you understand the consequences when using this
@@ -1625,11 +1668,12 @@ expressions, as described in appendix \ref{sec:index_selection}.):
   }
   \end{verbatim}
 
-\item[\kw{CustomisedOccupations}] Enables overriding the reference neutral atom
-  electronic occupations of the shells. Note that the atom remains neutral since
-  a corresponding ionic counter charge is implicitly added to its core. This
-  option can be used, for example, to simulate effective doping by setting a
-  slightly larger or smaller number of electrons on certain atoms.
+\item[\kw{CustomisedOccupations} / \is{CustomizedOccupations}] Enables
+  overriding the reference neutral atom electronic occupations of the
+  shells. Note that the atom remains neutral since a corresponding ionic counter
+  charge is implicitly added to its core. This option can be used, for example,
+  to simulate effective doping by setting a slightly larger or smaller number of
+  electrons on certain atoms.
 
   Example:
   \begin{verbatim}
@@ -1749,8 +1793,8 @@ library.
   \is{FixedFermiLevel} is present (see section \ref{sec:dftbp.Filling}), then value
   specified here will be ignored.
 
-\item[\is{SpinPolarisation}] Specifies if and how the system is spin
-  polarised. See p.~\pref{sec:dftbp.SpinPolarisation}.
+\item[\is{SpinPolarisation} / \is{SpinPolarization}] Specifies if and how the
+    system is spin polarised. See p.~\pref{sec:dftbp.SpinPolarisation}.
 
 \item[\is{SpinConstants}] Specifies the atom type specific constants needed for
   the spin polarised calculations, in units of Hartree.  See
@@ -3095,20 +3139,18 @@ Example:\invparskip
   }
 \end{verbatim}
 
-Alternatively you can provide values for each atomic species in your
-system, but must supply different values for different coordination
-numbers using the \kwcb{HybridDependentPol} keyword. The code needs
-specific parameters for each type of atom in environments with 0, 1,
-2, 3, 4 or $\geqslant$5 neighbours. \dftbp{} then picks the
-appropriate values for each atom based on their coordination in the
-\emph{starting} geometry.  Two atoms are considered to be neighbours
-if their distance is less than the sum of their covalent radii, hence
-you need to supply the covalent radii for each atomic species using
-the \kw{CovalentRadius} keyword. This is then followed by a
-\kw{HybridPolarisations} block containing a list of six values for
-atomic polarisabilities then six van der Waals radii and finally a
-single hybridisation independent effective charge for that atomic
-species.
+Alternatively you can provide values for each atomic species in your system, but
+must supply different values for different coordination numbers using the
+\kwcb{HybridDependentPol} keyword. The code needs specific parameters for each
+type of atom in environments with 0, 1, 2, 3, 4 or $\geqslant$5
+neighbours. \dftbp{} then picks the appropriate values for each atom based on
+their coordination in the \emph{starting} geometry.  Two atoms are considered to
+be neighbours if their distance is less than the sum of their covalent radii,
+hence you need to supply the covalent radii for each atomic species using the
+\kw{CovalentRadius} keyword. This is then followed by a \kw{HybridPolarisations}
+/ \kw{HybridPolarization} block containing a list of six values for atomic
+polarisabilities then six van der Waals radii and finally a single hybridisation
+independent effective charge for that atomic species.
 
 Example:\invparskip
 \begin{verbatim}
@@ -3718,7 +3760,7 @@ to compensate the systematic overestimation of the volume by this
 approach.
 
 To use the generalised Born model in the SCC procedure use the
-\is{GeneralisedBorn\cb} method in the input to \kw{Solvation}.
+\iscb{GeneralisedBorn} / \iscb{GeneralizedBorn} method in the input to \kw{Solvation}.
 The non-polar solvent area model can be combinded with the GB model
 enabling to additionally correct for hydrogen bonding, the resulting
 model is called GBSA.
@@ -4058,7 +4100,7 @@ where $\Psi^j_n$ is the solute's potential at the $n$-th grid point.
       \item[\is{MaxMoment}]
         Maximum moment for spherical harmonic expansion in the ddCOSMO equations.
         Moments of 6 and higher are recommended.
-      \item[\is{Regularisation}]
+      \item[\is{Regularisation} / \is{Regularization}]
         Regularisation factor for the ddCOSMO equation. A value of 0.2 is recommended
       \item[\is{Accuracy}]
         Convergence criteria for the ddCOSMO equations, this value effects the cost
@@ -4592,7 +4634,7 @@ This block collects some global options for the run.
   value can be used to reproduce earlier MD calculations by setting
   the initial seed to the same value.)
 
-\item[\is{MinimiseMemoryUsage}] Tries to minimise memory usage by
+\item[\is{MinimiseMemoryUsage} / \is{MinimizeMemoryUsage}] Tries to minimise memory usage by
   storing various matrices on disc instead of keeping them in memory.
   Set it to \is{Yes} to reduce the memory requirement for calculations
   with many k-points or spin polarisation. Note: Currently this option has no
@@ -4770,7 +4812,7 @@ Example:
   }
 \end{verbatim}
 
-\subsection{Localise}
+\subsection{Localise / Localize}
 \label{sec:dftbp.Localise} Convert the single particle states of the calculation
 to localised orbitals via a unitary transformation. Localised orbitals span the
 same states as the occupied orbitals, so are equivalent to the usual valence
@@ -5149,7 +5191,7 @@ available for range separated calculations.
 
   \end{description}
 
-  \subsubsection{Diagonaliser}
+  \subsubsection{Diagonaliser / Diagonalizer}
   \label{sec:dftbp.casdiag}
   Specifies which iterative diagonaliser should be used to solve the Casida
   equations. The keyword expects either a \iscb{Arpack} or \iscb{Stratmann}
@@ -5442,7 +5484,7 @@ Perform Dirac-delta perturbation (or a \textit{kick}) to the density matrix.
 \end{ptable}
 
 \begin{description}
- \item[\is{PolarisationDirection}] The cartesian axis for the kick:
+ \item[\is{PolarisationDirection} / \is{PolarizationDirection}] The cartesian axis for the kick:
    \verb|"x"|, \verb|"y"| or \verb|"z"|. If set to \verb|"all"|,
    calculates the three directions $x,y,z$ consecutively. For
    polarisation direction \verb|x,y,z| the dipole moment output file
@@ -5467,10 +5509,10 @@ Apply time-dependent sinusoidal perturbation to the system.
 \end{ptable}
 
 \begin{description}
- \item[\is{PolarisationDirection}] Vector along which the electric
+ \item[\is{PolarisationDirection} / \is{PolarizationDirection}] Vector along which the electric
    field is polarised.
 
- \item[\is{ImagPolarisationDirection}] Imaginary part of the
+ \item[\is{ImagPolarisationDirection} / \is{ImagPolarizationDirection}] Imaginary part of the
    polarisation vector. Useful for circularly polarised fields.
 
  \item[\is{LaserEnergy }] \modif{\modtype{energy}} Energy $\hbar

--- a/doc/dftb+/manual/waveplot.tex
+++ b/doc/dftb+/manual/waveplot.tex
@@ -156,10 +156,11 @@ PlottedSpins =  1 2      # Both spin-up and spin-down plotted
 \item[\is{TotalChargeDensity}] If true, the total charge density of
   the system is plotted.
 
-\item[\is{TotalSpinPolarisation}] If true, the total spin polarisation of
-  the system (difference of the spin up and spin down densities) is
-  plotted. This option is only interpreted if the processed \dftbp{}
-  calculation was spin polarised.
+\item[\is{TotalSpinPolarisation} / \kw{TotalSpinPolarization}] If
+  true, the total spin polarisation of the system (difference of the
+  spin up and spin down densities) is plotted. This option is only
+  interpreted if the processed \dftbp{} calculation was spin
+  polarised.
 
 \item[\is{TotalChargeDifference}] If true, the difference between the
   total charge density and the charge density obtained by superposing

--- a/src/dftbp/dftbplus/input/geoopt.F90
+++ b/src/dftbp/dftbplus/input/geoopt.F90
@@ -16,7 +16,7 @@ module dftbp_dftbplus_input_geoopt
   use dftbp_io_charmanip, only : unquote
   use dftbp_io_hsdutils, only : getChild, getChildValue, setChild, detailedError, &
       & detailedWarning, getSelectedAtomIndices
-  use dftbp_io_hsdutils2, only : convertUnitHsd
+  use dftbp_io_hsdutils2, only : convertUnitHsd, renameChildren
   use dftbp_type_typegeometry, only : TGeometry
   implicit none
 
@@ -66,6 +66,7 @@ contains
     type(fnode), pointer :: child, value1
     type(string) :: buffer
 
+    call renameChildren(node, "Optimizer", "Optimiser")
     call getChildValue(node, "Optimiser", child, "Rational")
     call readOptimizerInput(child, input%optimiser)
 

--- a/src/dftbp/dftbplus/oldcompat.F90
+++ b/src/dftbp/dftbplus/oldcompat.F90
@@ -749,31 +749,6 @@ contains
     type(fnode), pointer :: ch1, ch2
     type(string) :: buffer
 
-    call getDescendant(root, "Driver/GeometryOptimization", ch1)
-    if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword renamed to 'GeometryOptimisation'.")
-      call setNodeName(ch1, "GeometryOptimisation")
-      call getDescendant(root, "Driver/GeometryOptimisation/Optimizer", ch2)
-      if (associated(ch2)) then
-        call detailedWarning(ch2, "Keyword renamed to 'Optimiser'.")
-        call setNodeName(ch2, "Optimiser")
-      end if
-    end if
-
-  #:for LABEL in [("Kick"), ("Laser")]
-    call getDescendant(root, "ElectronDynamics/Perturbation/${LABEL}$/PolarizationDirection", ch1)
-    if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword renamed to 'PolarisationDirection'.")
-      call setNodeName(ch1, "PolarisationDirection")
-    end if
-    call getDescendant(root, "ElectronDynamics/Perturbation/${LABEL}$/ImagPolarizationDirection",&
-        & ch1)
-    if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword renamed to 'ImagPolarisationDirection'.")
-      call setNodeName(ch1, "ImagPolarisationDirection")
-    end if
-  #:endfor
-
     call getDescendant(root, "Transport", ch1)
     if (associated(ch1)) then
       call getChildValue(root, "Transport/Task", ch1, child=ch2, default='uploadcontacts')

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -1192,6 +1192,7 @@ contains
     ! Read individual atom specifications
     call getChildren(child, "Mass", children)
     if (getLength(children) == 0) then
+      call destroyNodeList(children)
       return
     end if
 
@@ -1612,6 +1613,7 @@ contains
           end if
           call append(lrN(iSp1),rTmp)
         end do
+        call destroyNodeList(children)
       end do
 
       do iSp1 = 1, geo%nSpecies
@@ -4989,6 +4991,7 @@ contains
           ctrl%RegionLabel(iReg) = unquote(char(buffer))
         end do
       end if
+      call destroyNodeList(children)
 
       call getChild(node, "Localise", child=val, requested=.false.)
       if (associated(val)) then
@@ -5891,8 +5894,8 @@ contains
     call getChildren(root, "Contact", pNodeList)
     transpar%ncont = getLength(pNodeList)
     allocate(transpar%contacts(transpar%ncont))
-
     call readContacts(pNodeList, transpar%contacts, geom, char(buffer), transpar%contactLayerTol)
+    call destroyNodeList(pNodeList)
 
     transpar%taskUpload = .false.
 
@@ -6808,8 +6811,10 @@ contains
                 &for atom" // i2c(iAt) // " has been overwritten")
           end if
           atmCoupling(iAt) = rTmp
-        enddo
-      enddo
+        end do
+      end do
+      call destroyNodeList(children)
+
       ! Transform atom coupling in orbital coupling
       norbs = 0
       do ii=atm_range(1), atm_range(2)
@@ -7231,6 +7236,7 @@ contains
         call setChild(node, "Region", child)
         call setChildValue(child, "Atoms", trim(strTmp))
         call setChildValue(child, "Label", "localDOS")
+        call destroyNodeList(children)
         call getChildren(node, "Region", children)
         nReg = getLength(children)
       else
@@ -7390,9 +7396,7 @@ contains
       end do
       deallocate(shellNamesTmp)
     end do
-    if (associated(nodes)) then
-      call destroyNodeList(nodes)
-    end if
+    call destroyNodeList(nodes)
 
   end subroutine readCustomReferenceOcc
 

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -54,7 +54,8 @@ module dftbp_dftbplus_parser
   use dftbp_io_hsdparser, only : getNodeHSdName, parseHsd
   use dftbp_io_hsdutils, only : detailedError, detailedWarning, getChild, getChildValue,&
       & getChildren, getSelectedAtomIndices, setChild, setChildValue
-  use dftbp_io_hsdutils2, only : convertUnitHsd, getNodeName2, setUnprocessed, splitModifier
+  use dftbp_io_hsdutils2, only : convertUnitHsd, getNodeName2, setUnprocessed, splitModifier,&
+      & renameChildren
   use dftbp_io_message, only : error, warning
   use dftbp_io_xmlutils, only : removeChildNodes
   use dftbp_math_lapackroutines, only : matinv
@@ -463,6 +464,7 @@ contains
     end if
   #:endif
 
+    call renameChildren(parent, "GeometryOptimization", "GeometryOptimisation")
     call getNodeName2(node, buffer)
     driver: select case (char(buffer))
     case ("")
@@ -2258,6 +2260,7 @@ contains
     type(fnode), pointer :: value1, child
     type(string) :: buffer
 
+    call renameChildren(node, "SpinPolarization", "SpinPolarisation")
     call getChildValue(node, "SpinPolarisation", value1, "", child=child, &
         &allowEmptyValue=.true.)
     call getNodeName2(value1, buffer)
@@ -3905,6 +3908,7 @@ contains
     end if
     call getChildValue(node, "WriteHS", ctrl%tWriteHS, .false.)
     call getChildValue(node, "WriteRealHS", ctrl%tWriteRealHS, .false.)
+    call renameChildren(node, "MinimizeMemoryUsage", "MinimiseMemoryUsage")
     call getChildValue(node, "MinimiseMemoryUsage", ctrl%tMinMemory, .false., child=child)
     if (ctrl%tMinMemory) then
       call detailedWarning(child, "Memory minimisation is not working currently, normal calculation&
@@ -4048,6 +4052,7 @@ contains
             &modifier=modifier2, child=child3)
         call convertUnitHsd(char(modifier2), lengthUnits, child3, &
             &rCutoffs(iSp1))
+        call renameChildren(child2, "HybridPolarizations", "HybridPolarisations")
         call getChildValue(child2, "HybridPolarisations", tmp2R2(:, iSp1), &
             &modifier=modifier2, child=child3)
         if (len(modifier2) > 0) then
@@ -4834,6 +4839,7 @@ contains
       end if
       ctrl%lrespini%iLinRespSolver = linRespSolverTypes%None
 
+      call renameChildren(child, "Diagonalizer", "Diagonaliser")
       call getChildValue(child, "Diagonaliser", child2)
       call getNodeName(child2, buffer)
       select case(char(buffer))
@@ -4993,6 +4999,7 @@ contains
       end if
       call destroyNodeList(children)
 
+      call renameChildren(node, "Localize", "Localise")
       call getChild(node, "Localise", child=val, requested=.false.)
       if (associated(val)) then
         ctrl%tLocalise = .true.
@@ -5503,6 +5510,7 @@ contains
     type(fnode), pointer :: child, child2
     integer :: iSp1
 
+    call renameChildren(node, "CustomizedHubbards", "CustomisedHubbards")
     call getChild(node, "CustomisedHubbards", child, requested=.false.)
     if (associated(child)) then
       allocate(hubbU(orb%mShell, geo%nSpecies))
@@ -5617,6 +5625,7 @@ contains
 
     case ("kick")
       input%pertType = pertTypes%kick
+      call renameChildren(value1, "PolarizationDirection", "PolarisationDirection")
       call getChildValue(value1, "PolarisationDirection", buffer2)
       input%polDir = directionConversion(unquote(char(buffer2)), value1)
 
@@ -5634,7 +5643,9 @@ contains
 
     case ("laser")
       input%pertType = pertTypes%laser
+      call renameChildren(value1, "PolarizationDirection", "PolarisationDirection")
       call getChildValue(value1, "PolarisationDirection", input%reFieldPolVec)
+      call renameChildren(value1, "ImagPolarizationDirection", "ImagPolarisationDirection")
       call getChildValue(value1, "ImagPolarisationDirection", input%imFieldPolVec, &
           & [0.0_dp, 0.0_dp, 0.0_dp])
       call getChildValue(value1, "LaserEnergy", input%omega, modifier=modifier, child=child)
@@ -7360,6 +7371,7 @@ contains
     character(sc), allocatable :: shellNamesTmp(:)
     logical, allocatable :: atomOverriden(:)
 
+    call renameChildren(root, "CustomizedOccupations", "CustomisedOccupations")
     call getChild(root, "CustomisedOccupations", container, requested=.false.)
     if (.not. associated(container)) then
       return

--- a/src/dftbp/io/hsdutils2.F90
+++ b/src/dftbp/io/hsdutils2.F90
@@ -16,13 +16,14 @@ module dftbp_io_hsdutils2
   use dftbp_common_unitconversion, only : TUnit, unitConvStat => statusCodes, convertUnit
   use dftbp_extlibs_xmlf90, only : fnode, fnodeList, string, trim, len, assignment(=), parsefile,&
       & getLength, item, char, removeAttribute, getAttribute, setAttribute, setTagName,&
-      & normalize, append_to_string, destroyNodeList, removeAttribute
+      & normalize, append_to_string, destroyNodeList, removeAttribute, getItem1
   use dftbp_io_charmanip, only : newline, tolower, i2c
   use dftbp_io_hsdparser, only : attrName, attrModifier
   use dftbp_io_hsdutils, only : attrProcessed, getChild, setChildValue, detailedError,&
       & appendPathAndLine
   use dftbp_io_message, only : error, warning
-  use dftbp_io_xmlutils, only : getTagsWithoutAttribute, removeNodes, removeSpace
+  use dftbp_io_xmlutils, only : getChildrenByName, getTagsWithoutAttribute, removeNodes,&
+      & removeSpace
   implicit none
 
   private
@@ -31,6 +32,7 @@ module dftbp_io_hsdutils2
   public :: getNodeName2, setNodeName, removeModifier, splitModifier
   public :: setUnprocessed, getDescendant
   public :: convertUnitHsd
+  public :: renameChildren
 
 
   !> Converts according to passed modifier and array of possible units by multplicating the provided
@@ -165,9 +167,7 @@ contains
 
 
   !> Changes the name of a given node.
-  !>
-  !> Returns if node is not associated.
-  subroutine setNodeName(node, name)
+  subroutine setNodeName(node, name, updateHsdName)
 
     !> Node to change.
     type(fnode), pointer :: node
@@ -175,16 +175,27 @@ contains
     !> New name of the node.
     character(len=*), intent(in) :: name
 
+    !> Whether the original HSD-name should be also updated (default: .false.)
+    !>
+    !> If set to .true., the attribute storing the original capitalized HSD-name will also be
+    !> updated if present. Otherwise, it is kept at its original value.
+    !>
+    logical, optional, intent(in) :: updateHsdName
+
     type(string) :: buffer
+    logical :: updateHsdName_
 
     @:ASSERT(associated(node))
 
+    updateHsdName_ = .false.
+    if (present(updateHsdName)) updateHsdName_ = updateHsdName
+
+    call setTagName(node, tolower(name))
     call getAttribute(node, attrName, buffer)
-    if (len(buffer) > 0) then
+    if (len(buffer) > 0 .and. updateHsdName_) then
       call removeAttribute(node, attrName)
       call setAttribute(node, attrName, name)
     end if
-    call setTagName(node, tolower(name))
 
   end subroutine setNodeName
 
@@ -366,5 +377,39 @@ contains
     end if
 
   end subroutine getDescendant
+
+
+  !> Renames children
+  subroutine renameChildren(node, oldName, newName, updateHsdNames)
+
+    !> Root node containing the children
+    type(fnode), pointer, intent(in) :: node
+
+    !> Old name of the children
+    character(*), intent(in) :: oldName
+
+    !> New name of the children
+    character(*), intent(in) :: newName
+
+    !> Whether the original HSD-name should be also updated (default: .false.)
+    !>
+    !> If set to .true., the attribute storing the original capitalized HSD-name will also be
+    !> updated if present. Otherwise, it is kept at its original value (e.g. error messages will
+    !> display the original name, not the renamed one).
+    !>
+    logical, optional, intent(in) :: updateHsdNames
+
+    type(fnodeList), pointer :: children
+    type(fnode), pointer :: child
+    integer :: iChild
+
+    children => getChildrenByName(node, tolower(oldname))
+    do iChild = 1, getLength(children)
+      call getItem1(children, iChild, child)
+      call setNodeName(child, newName, updateHsdNames)
+    end do
+    call destroyNodeList(children)
+
+  end subroutine renameChildren
 
 end module dftbp_io_hsdutils2

--- a/src/dftbp/solvation/solvparser.F90
+++ b/src/dftbp/solvation/solvparser.F90
@@ -23,7 +23,7 @@ module dftbp_solvation_solvparser
   use dftbp_io_charmanip, only : tolower, unquote
   use dftbp_io_hsdutils, only : getChild, getChildValue, setChild, detailedError, &
       & detailedWarning
-  use dftbp_io_hsdutils2, only : convertUnitHsd
+  use dftbp_io_hsdutils2, only : convertUnitHsd, renameChildren
   use dftbp_math_bisect, only : bisection
   use dftbp_solvation_born, only : TGBInput, fgbKernel
   use dftbp_solvation_cm5, only : TCM5Input
@@ -63,13 +63,14 @@ contains
     type(fnode), pointer :: solvModel
     type(string) :: buffer
 
+    call renameChildren(node, "GeneralizedBorn", "GeneralisedBorn")
     call getChildValue(node, "", solvModel)
     call getNodeName(solvModel, buffer)
 
     select case (char(buffer))
     case default
       call detailedError(node, "Invalid solvation model name.")
-    case ("generalizedborn")
+    case ("generalisedborn")
       allocate(input%GBInp)
       call readSolvGB(solvModel, geo, input%GBInp)
     case ("cosmo")
@@ -105,7 +106,7 @@ contains
     character(len=:), allocatable :: paramFile, paramTmp
 
     if (geo%tPeriodic .or. geo%tHelical) then
-      call detailedError(node, "Generalized Born model currently not available with the&
+      call detailedError(node, "Generalised Born model currently not available with the&
          & selected boundary conditions")
     end if
 
@@ -329,6 +330,7 @@ contains
     type(fnode), pointer :: child
 
     call getChildValue(node, "MaxMoment", input%lmax, child=child)
+    call renameChildren(node, "Regularization", "Regularisation")
     call getChildValue(node, "Regularisation", input%eta, 0.2_dp, child=child)
     call getChildValue(node, "Accuracy", input%conv, child=child)
 

--- a/test/app/dftb+/derivatives/gfn2_c6h6_dipole/dftb_in.hsd
+++ b/test/app/dftb+/derivatives/gfn2_c6h6_dipole/dftb_in.hsd
@@ -20,7 +20,7 @@ Driver = SecondDerivatives {}
 Hamiltonian = xtb {
   Method = "GFN2-xTB"
   SCCTolerance = 1.0E-10
-  Solvation = GeneralizedBorn {
+  Solvation = GeneralisedBorn {
     ParamFile = "param_gbsa_benzene.txt"
   }
   Filling = Fermi {

--- a/test/app/dftb+/solvation/H2O_gb_rescale/dftb_in.hsd
+++ b/test/app/dftb+/solvation/H2O_gb_rescale/dftb_in.hsd
@@ -26,7 +26,7 @@ Hamiltonian = DFTB {
         Huu = {0}
         Hud = {0}
     }
-    Solvation = GeneralizedBorn { # GFN2-xTB/GBSA(water)
+    Solvation = GeneralisedBorn { # GFN2-xTB/GBSA(water)
         Solvent = fromConstants {
             Epsilon =   80.20000000
             MolecularMass [amu] = 18.00000000

--- a/test/app/dftb+/solvation/alpb_anion/dftb_in.hsd
+++ b/test/app/dftb+/solvation/alpb_anion/dftb_in.hsd
@@ -5,7 +5,7 @@ Geometry = xyzFormat {
 Driver {}
 
 Hamiltonian = DFTB {
-  Solvation = GeneralizedBorn { # GFN1-xTB/GBSA(CS2)
+  Solvation = GeneralisedBorn { # GFN1-xTB/GBSA(CS2)
     Solvent = fromConstants {
       Epsilon = 2.64  # Dielectric constant of the solvent
       MolecularMass = 76.14  # mass of the solvent molecule

--- a/test/app/dftb+/solvation/alpb_cation/dftb_in.hsd
+++ b/test/app/dftb+/solvation/alpb_cation/dftb_in.hsd
@@ -5,7 +5,7 @@ Geometry = xyzFormat {
 Driver {}
 
 Hamiltonian = DFTB {
-  Solvation = GeneralizedBorn { # GFN2-xTB/GBSA(CS2)
+  Solvation = GeneralisedBorn { # GFN2-xTB/GBSA(CS2)
     Solvent = fromConstants {
       Epsilon = 2.64  # Dielectric constant of the solvent
       MolecularMass [amu] = 76.14  # mass of the solvent molecule

--- a/test/app/dftb+/solvation/alpb_p16/dftb_in.hsd
+++ b/test/app/dftb+/solvation/alpb_p16/dftb_in.hsd
@@ -5,7 +5,7 @@ Geometry = xyzFormat {
 Driver {}
 
 Hamiltonian = DFTB {
-  Solvation = GeneralizedBorn { # GFN2-xTB/GBSA(CS2)
+  Solvation = GeneralisedBorn { # GFN2-xTB/GBSA(CS2)
     Solvent = fromConstants {
       Epsilon = 2.64  # Dielectric constant of the solvent
       MolecularMass [amu] = 76.14  # mass of the solvent molecule

--- a/test/app/dftb+/solvation/gb_cm5/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gb_cm5/dftb_in.hsd
@@ -5,7 +5,7 @@ Geometry = xyzFormat {
 Driver {}
 
 Hamiltonian = DFTB {
-  Solvation = GeneralizedBorn { # GFN1-xTB/GBSA(CS2)
+  Solvation = GeneralisedBorn { # GFN1-xTB/GBSA(CS2)
     Solvent = fromConstants {
       Epsilon = 2.64  # Dielectric constant of the solvent
       MolecularMass = 76.14  # mass of the solvent molecule

--- a/test/app/dftb+/solvation/gb_inf/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gb_inf/dftb_in.hsd
@@ -5,7 +5,7 @@ Geometry = xyzFormat {
 Driver {}
 
 Hamiltonian = DFTB {
-  Solvation = GeneralizedBorn {
+  Solvation = GeneralisedBorn {
     Solvent = fromConstants {
       Epsilon = Inf
       MolecularMass = 1.0

--- a/test/app/dftb+/solvation/gb_mol1bar/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gb_mol1bar/dftb_in.hsd
@@ -5,7 +5,7 @@ Geometry = xyzFormat {
 Driver {}
 
 Hamiltonian = DFTB {
-  Solvation = GeneralizedBorn { # GFN2-xTB/GBSA(CS2)
+  Solvation = GeneralisedBorn { # GFN2-xTB/GBSA(CS2)
     Solvent = fromConstants {
       Epsilon = 2.64  # Dielectric constant of the solvent
       MolecularMass [amu] = 76.14  # mass of the solvent molecule

--- a/test/app/dftb+/solvation/gb_p16/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gb_p16/dftb_in.hsd
@@ -5,7 +5,7 @@ Geometry = xyzFormat {
 Driver {}
 
 Hamiltonian = DFTB {
-  Solvation = GeneralizedBorn { # GFN1-xTB/GBSA(CS2)
+  Solvation = GeneralisedBorn { # GFN1-xTB/GBSA(CS2)
     Solvent = fromConstants {
       Epsilon = 2.64  # Dielectric constant of the solvent
       MolecularMass = 76.14  # mass of the solvent molecule

--- a/test/app/dftb+/solvation/gb_reference/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gb_reference/dftb_in.hsd
@@ -5,7 +5,7 @@ Geometry = xyzFormat {
 Driver {}
 
 Hamiltonian = DFTB {
-  Solvation = GeneralizedBorn { # GFN2-xTB/GBSA(CS2)
+  Solvation = GeneralisedBorn { # GFN2-xTB/GBSA(CS2)
     Solvent = fromConstants {
       Epsilon = 2.64  # Dielectric constant of the solvent
       MolecularMass [amu] = 76.14  # mass of the solvent molecule

--- a/test/app/dftb+/solvation/gb_specieslist/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gb_specieslist/dftb_in.hsd
@@ -12,7 +12,7 @@ Geometry = GenFormat {
 Driver = {}
 
 Hamiltonian = DFTB {
-  Solvation = GeneralizedBorn { # GFN2-xTB/GBSA(Toluene)
+  Solvation = GeneralisedBorn { # GFN2-xTB/GBSA(Toluene)
     Solvent = fromConstants {
       Epsilon =    7.00000000
       MolecularMass [amu] =   92.14000000
@@ -130,4 +130,3 @@ Parallel {
   # MPI-binary. (Check the manual before using this in production runs!)
   UseOmpThreads = Yes
 }
-

--- a/test/app/dftb+/solvation/gbsa_caffeine/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gbsa_caffeine/dftb_in.hsd
@@ -23,7 +23,7 @@ Geometry = genFormat {
 Driver {}
 
 Hamiltonian = DFTB {
-  Solvation = GeneralizedBorn { # GFN2-xTB/GBSA(water)
+  Solvation = GeneralisedBorn { # GFN2-xTB/GBSA(water)
     Solvent = fromConstants {
       Epsilon =   80.20000000
       MolecularMass [amu] =   18.00000000

--- a/test/app/dftb+/solvation/gbsa_e35/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gbsa_e35/dftb_in.hsd
@@ -5,7 +5,7 @@ Geometry = xyzFormat {
 Driver {}
 
 Hamiltonian = DFTB {
-  Solvation = GeneralizedBorn { # GFN2-xTB/GBSA(benzene)
+  Solvation = GeneralisedBorn { # GFN2-xTB/GBSA(benzene)
     Solvent = fromConstants {
       Epsilon = 7.00
       MolecularMass [amu] = 78.11

--- a/test/app/dftb+/solvation/gbsa_p16/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gbsa_p16/dftb_in.hsd
@@ -23,7 +23,7 @@ Geometry = genFormat {
 Driver {}
 
 Hamiltonian = DFTB {
-  Solvation = GeneralizedBorn { # GFN2-xTB/GBSA(water)
+  Solvation = GeneralisedBorn { # GFN2-xTB/GBSA(water)
     Solvent = fromConstants {
       Epsilon =   80.20000000
       MolecularMass [amu] =   18.00000000

--- a/test/app/dftb+/solvation/gbsa_param1/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gbsa_param1/dftb_in.hsd
@@ -5,7 +5,7 @@ Geometry = xyzFormat {
 Driver {}
 
 Hamiltonian = DFTB {
-  Solvation = GeneralizedBorn { # GFN2-xTB/GBSA(methanole)
+  Solvation = GeneralisedBorn { # GFN2-xTB/GBSA(methanole)
     ParamFile = "param_gbsa_methanol.txt"
   }
   SCC = Yes

--- a/test/app/dftb+/solvation/gbsa_param2/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gbsa_param2/dftb_in.hsd
@@ -5,7 +5,7 @@ Geometry = xyzFormat {
 Driver {}
 
 Hamiltonian = DFTB {
-  Solvation = GeneralizedBorn { # GFN1-xTB/GBSA(ch2cl2)
+  Solvation = GeneralisedBorn { # GFN1-xTB/GBSA(ch2cl2)
     ParamFile = "param_gbsa_ch2cl2.txt"
     State = "mol1bar"
     CM5 {}

--- a/test/app/dftb+/solvation/gbsa_param3/dftb_in.hsd
+++ b/test/app/dftb+/solvation/gbsa_param3/dftb_in.hsd
@@ -5,7 +5,7 @@ Geometry = xyzFormat {
 Driver {}
 
 Hamiltonian = DFTB {
-  Solvation = GeneralizedBorn { # GFN2-xTB/GBSA(dmso)
+  Solvation = GeneralisedBorn { # GFN2-xTB/GBSA(dmso)
     ParamFile = "param_gbsa_dmso.txt"
     State = "reference"
     Temperature [K] = 273.15


### PR DESCRIPTION
Node names, where American and British English versions differ, are converted internally to BE, allowing for both versions in the input independent of the InputVersion/ParserVersion settings.