### PR TITLE
Work around intel 2021.7 compiler bug

### DIFF
--- a/cmake/DftbPlusUtils.cmake
+++ b/cmake/DftbPlusUtils.cmake
@@ -437,7 +437,8 @@ function(dftbp_guess_toolchain toolchain)
 
   if("${CMAKE_Fortran_COMPILER_ID}|${CMAKE_C_COMPILER_ID}" STREQUAL "GNU|GNU")
     set(_toolchain "gnu")
-  elseif("${CMAKE_Fortran_COMPILER_ID}|${CMAKE_C_COMPILER_ID}" STREQUAL "Intel|Intel")
+  elseif("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel|IntelLLVM"
+      AND "${CMAKE_C_COMPILER_ID}" MATCHES "Intel|IntelLLVM")
     set(_toolchain "intel")
   elseif("${CMAKE_Fortran_COMPILER_ID}|${CMAKE_C_COMPILER_ID}" STREQUAL "NAG|GNU")
     set(_toolchain "nag")

--- a/src/dftbp/include/common.fypp
+++ b/src/dftbp/include/common.fypp
@@ -119,5 +119,15 @@ block
 end block
 #:enddef
 
+
+#! Simple macro printing out the position of a line
+#:def PRINT_POSITION()
+block
+  use iso_fortran_env, only : output_unit
+  write(output_unit, "(a)") "Reached line ${_LINE_}$ in ${_FILE_}$"
+  flush(output_unit)
+end block
+#:enddef
+
 #:endif
 #:endmute


### PR DESCRIPTION
Not sure, where the bug comes from, a simple assignment between two derived type fails without any obvious reason. Turning the LHS into allocatable and use `move_alloc()` instead seems to fix it. The scenario is too involved to reduce it for compiler error reporting. 

Also, the `polyRep` test failures seem to come from missing compiler flags (the toolchain selection has chosen `general` instead of `intel`, when one of the Intel compilers was IntelLLVM (which is default for the C compiler in CMake now...). I've fixed the toolchain selection.

Closes #1154 #1155