### PR TITLE
Add input flag to (de)activate writing charges to disc

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -4599,6 +4599,7 @@ This block collects some global options for the run.
   \kwl{WriteRealHS}{kw:dftbp.WriteRealHS} & l & & No & \\
   \kwl{ReadChargesAsText}{kw:dftbp.ReadChargesAsText} & l &
   ReadInitialCharges = Yes & No & \\
+  \kw{WriteCharges} &l & & Yes & \\
   \kwl{WriteChargesAsText}{kw:dftbp.WriteChargesAsText} & l & & No & \\
   \kw{SkipChargeTest} & l & ReadInitialCharges = Yes & No & \\
 \end{ptable}
@@ -4682,6 +4683,11 @@ This block collects some global options for the run.
   \verb|charges.bin| to contain starting charges stored in binary. If \is{Yes},
   then \verb|charges.dat| should contain a text file of this data. See section
   \ref{sec:charges.bin}.
+
+\item[\is{WriteCharges}] Turns the creation of the
+  \verb|charges.bin| (or \verb|charges.dat|) file on and off. (This might e.g.\
+  prove to be useful to avoid unnecessary I/O load during geometry optimization or MD,
+  if a later restart of the calculation is not needed.)
 
 \item[\is{WriteChargesAsText}] If \is{No}, the program stores charges in the
   binary file \verb|charges.bin|, while if \is{Yes} then \verb|charges.dat|

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -780,10 +780,13 @@ module dftbp_dftbplus_initprogram
     !> Whether potential shifts are read from file
     logical :: tWriteShifts
 
-    !> should charges written to disc be in ascii or binary format?
+    !> Produce charges.bin
+    logical :: tWriteCharges
+
+    !> Should charges written to disc be in ascii or binary format?
     logical :: tWriteChrgAscii
 
-    !> produce tagged output?
+    !> Produce tagged output?
     logical :: tWriteAutotest
 
     !> Produce detailed.xml
@@ -810,7 +813,7 @@ module dftbp_dftbplus_initprogram
     !> Frequency for saving restart info
     integer :: restartFreq
 
-    !> dispersion data and calculations
+    !> Dispersion data and calculations
     class(TDispersionIface), allocatable :: dispersion
 
     !> Solvation data and calculations
@@ -2643,6 +2646,7 @@ contains
     this%tWriteAutotest = env%tGlobalLead .and. input%ctrl%tWriteTagged
     this%tWriteDetailedXML = env%tGlobalLead .and. input%ctrl%tWriteDetailedXML
     this%tWriteResultsTag = env%tGlobalLead .and. input%ctrl%tWriteResultsTag
+    this%tWriteCharges = env%tGlobalLead .and. input%ctrl%tWriteCharges
     this%tWriteDetailedOut = env%tGlobalLead .and. input%ctrl%tWriteDetailedOut .and.&
         & .not. this%tRestartNoSC
     this%tWriteBandDat = input%ctrl%tWriteBandDat .and. env%tGlobalLead&
@@ -4587,7 +4591,6 @@ contains
 
     !> Environment
     type(TEnvironment), intent(inout) :: env
-
 
     call TTaggedWriter_init(this%taggedWriter)
 

--- a/src/dftbp/dftbplus/inputdata.F90
+++ b/src/dftbp/dftbplus/inputdata.F90
@@ -143,6 +143,9 @@ module dftbp_dftbplus_inputdata
     !> Disc charges are stored as ascii or binary files
     logical :: tReadChrgAscii = .true.
 
+    !> Write charges to disc
+    logical :: tWriteCharges = .true.
+
     !> Disc charges should be written as ascii or binary files
     logical :: tWriteChrgAscii = .true.
 

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -279,9 +279,10 @@ contains
             & this%derivs, this%totalStress, this%cellVol)
       end if
     #:endif
-      tWriteCharges =  allocated(this%qInput) .and. tWriteRestart .and. this%tMulliken&
+      tWriteCharges = allocated(this%qInput) .and. tWriteRestart .and. this%tMulliken&
           & .and. this%tSccCalc .and. .not. this%tDerivs&
-          & .and. this%maxSccIter > 1 .and. this%deltaDftb%nDeterminant() == 1
+          & .and. this%maxSccIter > 1 .and. this%deltaDftb%nDeterminant() == 1&
+          & .and. this%tWriteCharges
       if (tWriteCharges) then
         call writeCharges(fCharges, this%tWriteChrgAscii, this%orb, this%qInput, this%qBlockIn,&
             & this%qiBlockIn, this%deltaRhoIn, size(this%iAtInCentralRegion), this%multipoleInp)
@@ -1179,7 +1180,7 @@ contains
           tWriteSccRestart = env%tGlobalLead .and. needsSccRestartWriting(this%restartFreq,&
               & iGeoStep, iSccIter, this%minSccIter, this%maxSccIter, this%tMd, &
               & this%isGeoOpt .or. allocated(this%geoOpt),&
-              & this%tDerivs, tConverged, this%tReadChrg, tStopScc)
+              & this%tDerivs, tConverged, this%tReadChrg, tStopScc) .and. this%tWriteCharges
           if (tWriteSccRestart) then
             call writeCharges(fCharges, this%tWriteChrgAscii, this%orb, this%qInput, this%qBlockIn,&
                 & this%qiBlockIn, this%deltaRhoIn, size(this%iAtInCentralRegion), this%multipoleInp)

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -3890,11 +3890,8 @@ contains
     call getChildValue(node, "WriteDetailedOut", ctrl%tWriteDetailedOut, tWriteDetailedOutDef)
 
     call getChildValue(node, "WriteAutotestTag", ctrl%tWriteTagged, .false.)
-    call getChildValue(node, "WriteDetailedXML", ctrl%tWriteDetailedXML, &
-        &.false.)
-    call getChildValue(node, "WriteResultsTag", ctrl%tWriteResultsTag, &
-        &.false.)
-
+    call getChildValue(node, "WriteDetailedXML", ctrl%tWriteDetailedXML, .false.)
+    call getChildValue(node, "WriteResultsTag", ctrl%tWriteResultsTag, .false.)
 
     if (.not.(ctrl%tMD.or.ctrl%isGeoOpt.or.allocated(ctrl%geoOpt))) then
       if (ctrl%tSCC) then
@@ -3925,7 +3922,11 @@ contains
     if (ctrl%tReadChrg) then
       call getChildValue(node, "ReadChargesAsText", ctrl%tReadChrgAscii, .false.)
     end if
-    call getChildValue(node, "WriteChargesAsText", ctrl%tWriteChrgAscii, .false.)
+
+    call getChildValue(node, "WriteCharges", ctrl%tWriteCharges, .true.)
+    if (ctrl%tWriteCharges) then
+      call getChildValue(node, "WriteChargesAsText", ctrl%tWriteChrgAscii, .false.)
+    end if
 
     ctrl%tSkipChrgChecksum = .false.
     if (.not. ctrl%tFixEf .and. ctrl%tReadChrg) then


### PR DESCRIPTION
Adds option to control whether restart file (charges.{bin|dat}) shall be written to disc:
`Options = {
  WriteCharges = Yes|No
}`

Tasks:
- [x]  add input flag to (de)activate writing charges to disc
- [x] documentation

:negative_squared_cross_mark: regression tests (charges.{bin|dat} not tested)

Presumably closes #1088.