### PR TITLE
Use workload-aware chunking according to num neighbors where possible

### DIFF
--- a/src/dftbp/common/schedule.F90
+++ b/src/dftbp/common/schedule.F90
@@ -23,14 +23,34 @@ module dftbp_common_schedule
   implicit none
 
   private
-  public :: distributeRangeInChunks, distributeRangeInChunks2
-  public :: assembleChunks, getChunkRanges
+  public :: distributeRangeInChunks, distributeRangeInChunks2,&
+      & distributeRangeWithWorkload
+  public :: assembleChunks, getChunkRanges, getChunkIterWithWorkload
+  public :: TChunkIterator
 
 #:for _, _, NAME in CHUNK_TYPES
   interface assembleChunks
     module procedure assemble${NAME}$Chunks
   end interface assembleChunks
 #:endfor
+
+
+  !> Iterator over chunks
+  type :: TChunkIterator
+    private
+
+    !> List of indices
+    integer, allocatable :: indices(:)
+
+    !> Current position in the index list
+    integer :: currentIndex
+
+  contains
+    procedure :: getNextIndex => TChunkIterator_getNextIndex
+    procedure :: getNumIndices => TChunkIterator_getNumIndices
+    procedure :: hasNextIndex => TChunkIterator_hasNextIndex
+    procedure :: resetIndex => TChunkIterator_resetIndex
+  end type TChunkIterator
 
 contains
 
@@ -120,6 +140,35 @@ contains
   end subroutine distributeRangeInChunks2
 
 
+  !> Distributes a range among processes within a process group
+  !> and take into account that each item may have a different workload
+  subroutine distributeRangeWithWorkload(env, globalFirst, globalLast, workload, chunkIter)
+
+    !> Computational environment settings
+    type(TEnvironment), intent(in) :: env
+
+    !> First element of the range
+    integer, intent(in) :: globalFirst
+
+    !> Last element of the range
+    integer, intent(in) :: globalLast
+
+    !> Number of elements each item has to process
+    integer, intent(in) :: workload(:)
+
+    !> Iterator with indices for the chunks
+    type(TChunkIterator), intent(out) :: chunkIter
+
+  #:if WITH_MPI
+    call getChunkIterWithWorkload(env%mpi%groupComm%size, env%mpi%groupComm%rank, globalFirst, globalLast,&
+        & workload, chunkIter)
+  #:else
+    call getChunkIterWithWorkload(1, 0, globalFirst, globalLast, workload, chunkIter)
+  #:endif
+
+  end subroutine distributeRangeWithWorkload
+
+
 #:for DTYPE, RANK, NAME in CHUNK_TYPES
 
   !> Assembles the chunks by summing up contributions within a process group.
@@ -176,5 +225,124 @@ contains
 
   end subroutine getChunkRanges
 
+
+  !> Calculate the chunk ranges for a given MPI-communicator considerung different workload
+  subroutine getChunkIterWithWorkload(groupSize, myRank, globalFirst, globalLast, workload, chunkIter)
+
+    !> Size of the group over which the chunks should be distributed
+    integer, intent(in) :: groupSize
+
+    !> Rank of the current process
+    integer, intent(in) :: myRank
+
+    !> First element of the range
+    integer, intent(in) :: globalFirst
+
+    !> Last element of the range
+    integer, intent(in) :: globalLast
+
+    !> Workload for each item
+    integer, intent(in) :: workload(:)
+
+    !> The chunk iterator
+    type(TChunkIterator), intent(out) :: chunkIter
+
+    integer :: numIndices, rank, i
+    integer, allocatable :: rankWorkload(:), indices(:)
+
+    allocate(rankWorkload(groupSize))
+    allocate(indices(globalLast - globalFirst + 1))
+
+    rankWorkload(:) = 0
+    indices(:) = 0
+    numIndices = 0
+
+    do i = globalFirst, globalLast
+      rank = minloc(rankWorkload, dim=1)
+      rankWorkload(rank) = rankWorkload(rank) + max(1, workload(i))
+      if (rank == myRank + 1) then
+        numIndices = numIndices + 1
+        indices(numIndices) = i
+      end if
+    end do
+
+    call TChunkIterator_init(chunkIter, indices(1:numIndices))
+
+  end subroutine getChunkIterWithWorkload
+
+
+  !> Initializes a new chunk iterator
+  subroutine TChunkIterator_init(this, indices)
+
+    !> Instance
+    class(TChunkIterator), intent(out) :: this
+
+    !> Index list
+    integer, intent(in) :: indices(:)
+
+    @:ASSERT(size(indices) > 0)
+    @:ASSERT(all(indices > 0))
+
+    allocate(this%indices(size(indices)))
+    this%indices = indices
+    this%currentIndex = 0
+
+  end subroutine TChunkIterator_init
+
+
+  !> Returns whether there is a next item available in the iterator
+  function TChunkIterator_hasNextIndex(this) result(hasNextIndex)
+
+    !> Instance
+    class(TChunkIterator), intent(inout) :: this
+
+    !> Whether there is a next index
+    logical :: hasNextIndex
+
+    hasNextIndex = this%currentIndex < size(this%indices)
+
+  end function TChunkIterator_hasNextIndex
+
+
+  !> Resets the iterator
+  subroutine TChunkIterator_resetIndex(this)
+
+    !> Instance
+    class(TChunkIterator), intent(inout) :: this
+
+    this%currentIndex = 0
+
+  end subroutine TChunkIterator_resetIndex
+
+
+  !> Returns the next item of the iterator
+  function TChunkIterator_getNumIndices(this) result(numIndices)
+
+    !> Instance
+    class(TChunkIterator), intent(inout) :: this
+
+    !> Number of indices in this iterator
+    integer :: numIndices
+
+    numIndices = size(this%indices)
+
+  end function TChunkIterator_getNumIndices
+
+
+  !> Returns the next item of the iterator
+  function TChunkIterator_getNextIndex(this) result(nextIndex)
+
+    !> Instance
+    class(TChunkIterator), intent(inout) :: this
+
+    !> The next index
+    integer :: nextIndex
+
+    @:ASSERT(this%currentIndex < size(this%indices))
+
+    this%currentIndex = this%currentIndex + 1
+    nextIndex = this%indices(this%currentIndex)
+
+  end function TChunkIterator_getNextIndex
 
 end module dftbp_common_schedule

--- a/src/dftbp/common/schedule.F90
+++ b/src/dftbp/common/schedule.F90
@@ -47,6 +47,7 @@ module dftbp_common_schedule
 
   contains
     procedure :: getNextIndex => TChunkIterator_getNextIndex
+    procedure :: getIndex => TChunkIterator_getIndex
     procedure :: getNumIndices => TChunkIterator_getNumIndices
     procedure :: hasNextIndex => TChunkIterator_hasNextIndex
     procedure :: resetIndex => TChunkIterator_resetIndex
@@ -344,5 +345,26 @@ contains
     nextIndex = this%indices(this%currentIndex)
 
   end function TChunkIterator_getNextIndex
+
+
+  !> Returns a certain item from the underlying index array.
+  !> This routine is thread safe and can be used in OpenMP-parallelized loops.
+  function TChunkIterator_getIndex(this, item) result(nextIndex)
+
+    !> Instance
+    class(TChunkIterator), intent(inout) :: this
+
+    !> The index of the array
+    integer, intent(in) :: item
+
+    !> The value of the array
+    integer :: nextIndex
+
+    @:ASSERT(item > 0)
+    @:ASSERT(item <= size(this%indices))
+
+    nextIndex = this%indices(item)
+
+  end function TChunkIterator_getIndex
 
 end module dftbp_common_schedule

--- a/src/dftbp/derivs/perturb.F90
+++ b/src/dftbp/derivs/perturb.F90
@@ -1146,8 +1146,8 @@ contains
       dPotential%intBlock(:,:,:,:) = dPotential%intBlock + dPotential%extBlock
 
       dHam(:,:) = 0.0_dp
-      call addShift(dHam, over, nNeighbourSK, neighbourList%iNeighbour, species, orb,&
-          & iSparseStart, nAtom, img2CentCell, dPotential%intBlock)
+      call addShift(env, dHam, over, nNeighbourSK, neighbourList%iNeighbour, species, orb,&
+          & iSparseStart, nAtom, img2CentCell, dPotential%intBlock, .true.)
 
       if (nSpin > 1) then
         dHam(:,:) = 2.0_dp * dHam
@@ -1252,7 +1252,7 @@ contains
           end if
 
           dqOut(:,:,iS) = 0.0_dp
-          call mulliken(dqOut(:,:,iS), over, drho(:,iS), orb, &
+          call mulliken(env, dqOut(:,:,iS), over, drho(:,iS), orb, &
               & neighbourList%iNeighbour, nNeighbourSK, img2CentCell, iSparseStart)
 
           dEf(iS) = -sum(dqOut(:, :, iS)) / neFermi(iS)
@@ -1320,11 +1320,11 @@ contains
 
       dqOut(:,:,:) = 0.0_dp
       do iS = 1, nSpin
-        call mulliken(dqOut(:,:,iS), over, drho(:,iS), orb, &
+        call mulliken(env, dqOut(:,:,iS), over, drho(:,iS), orb, &
             & neighbourList%iNeighbour, nNeighbourSK, img2CentCell, iSparseStart)
         if (allocated(dftbU) .or. allocated(onsMEs)) then
           dqBlockOut(:,:,:,iS) = 0.0_dp
-          call mulliken(dqBlockOut(:,:,:,iS), over, drho(:,iS), orb, neighbourList%iNeighbour,&
+          call mulliken(env, dqBlockOut(:,:,:,iS), over, drho(:,iS), orb, neighbourList%iNeighbour,&
               & nNeighbourSK, img2CentCell, iSparseStart)
         end if
       end do

--- a/src/dftbp/dftb/dispslaterkirkw.F90
+++ b/src/dftbp/dftb/dispslaterkirkw.F90
@@ -476,9 +476,10 @@ contains
     !$omp reduction(+:localEnergies, localDeriv, localSigma) &
     !$omp shared(nNeighbourSK, iNeighbour, img2CentCell, c6) &
     !$omp shared(neighDist2, rVdW2, coords, corr, chunkIter) &
-    !$omp private(iAt1, iNeigh, iAt2, iAt2f, dist2, dist, h0, h1, h2, rTmp, vec, gr, ii, iIter)
+    !$omp private(iIter, iAt1, iNeigh, iAt2, iAt2f, dist2, dist) &
+    !$omp private(h0, h1, h2, rTmp, vec, gr, ii)
     do iIter = 1, chunkIter%getNumIndices()
-      iAt1 = chunkIter%getNextIndex()
+      iAt1 = chunkIter%getIndex(iIter)
       do iNeigh = 1, nNeighbourSK(iAt1)
         iAt2 = iNeighbour(iNeigh, iAt1)
         iAt2f = img2CentCell(iAt2)

--- a/src/dftbp/dftb/dispuff.F90
+++ b/src/dftbp/dftb/dispuff.F90
@@ -20,7 +20,7 @@ module dftbp_dftb_dispuff
   use dftbp_common_accuracy, only : dp, tolDispersion
   use dftbp_common_constants, only: pi
   use dftbp_common_environment, only : TEnvironment
-  use dftbp_common_schedule, only : distributeRangeInChunks, assembleChunks
+  use dftbp_common_schedule, only : distributeRangeWithWorkload, TChunkIterator, assembleChunks
   use dftbp_common_status, only : TStatus
   use dftbp_dftb_dispcommon, only : getOptimalEta, getMaxGDispersion, getMaxRDispersion,&
       & addDispEGr_per_species
@@ -426,11 +426,11 @@ contains
     !> Volume of the unit cell
     real(dp), intent(in), optional :: vol
 
-    integer :: iAtFirst, iAtLast
-    integer :: iAt1, iAt2, iAt2f, iSp1, iSp2, iNeigh, ii
+    integer :: iIter, iAt1, iAt2, iAt2f, iSp1, iSp2, iNeigh, ii
     real(dp) :: rr, r2, r5, r6, r10, r12, k1, k2, dE, dGr, u0, u1, u2, f6
     real(dp) :: gr(3), vec(3)
     real(dp), allocatable :: localDeriv(:,:), localSigma(:, :), localEnergies(:)
+    type(TChunkIterator) :: chunkIter
 
   #:block DEBUG_CODE
     if (present(stress)) then
@@ -450,7 +450,7 @@ contains
       f6 = 1.0_dp
     end if
 
-    call distributeRangeInChunks(env, 1, nAtom, iAtFirst, iAtLast)
+    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
 
     allocate(localEnergies(nAtom), localDeriv(3, nAtom), localSigma(3, 3))
     localEnergies(:) = 0.0_dp
@@ -459,11 +459,12 @@ contains
 
     !$omp parallel do default(none) schedule(runtime) &
     !$omp reduction(+:localEnergies, localDeriv, localSigma) &
-    !$omp shared(iAtFirst, iAtLast, species, nNeighbourSK, iNeighbour, coords) &
+    !$omp shared(species, nNeighbourSK, iNeighbour, coords, chunkIter) &
     !$omp shared(img2CentCell, neighDist2, c6, r0, c12, cPoly, f6) &
     !$omp private(iAt1, iSp1, iNeigh, iAt2, vec, iAt2f, iSp2, r2, rr, k1, r6) &
-    !$omp private(r12, k2, dE, dGr, r10, r5, u0, u1, u2, gr, ii)
-    do iAt1 = iAtFirst, iAtLast
+    !$omp private(r12, k2, dE, dGr, r10, r5, u0, u1, u2, gr, ii, iIter)
+    do iIter = 1, chunkIter%getNumIndices()
+      iAt1 = chunkIter%getNextIndex()
       iSp1 = species(iAt1)
       do iNeigh = 1, nNeighbourSK(iAt1)
         iAt2 = iNeighbour(iNeigh, iAt1)

--- a/src/dftbp/dftb/dispuff.F90
+++ b/src/dftbp/dftb/dispuff.F90
@@ -461,10 +461,11 @@ contains
     !$omp reduction(+:localEnergies, localDeriv, localSigma) &
     !$omp shared(species, nNeighbourSK, iNeighbour, coords, chunkIter) &
     !$omp shared(img2CentCell, neighDist2, c6, r0, c12, cPoly, f6) &
-    !$omp private(iAt1, iSp1, iNeigh, iAt2, vec, iAt2f, iSp2, r2, rr, k1, r6) &
-    !$omp private(r12, k2, dE, dGr, r10, r5, u0, u1, u2, gr, ii, iIter)
+    !$omp private(iIter, iAt1, iSp1, iNeigh, iAt2, vec, iAt2f, iSp2) &
+    !$omp private(r2, rr, k1, r6, r12, k2, dE, dGr, r10, r5, u0, u1) &
+    !$omp private(u2, gr, ii)
     do iIter = 1, chunkIter%getNumIndices()
-      iAt1 = chunkIter%getNextIndex()
+      iAt1 = chunkIter%getIndex(iIter)
       iSp1 = species(iAt1)
       do iNeigh = 1, nNeighbourSK(iAt1)
         iAt2 = iNeighbour(iNeigh, iAt1)

--- a/src/dftbp/dftb/forces.F90
+++ b/src/dftbp/dftb/forces.F90
@@ -175,9 +175,10 @@ contains
     call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
 
     !$OMP PARALLEL DO PRIVATE(nOrb1, iNeigh, iAtom2, iAtom2f, nOrb2, iOrig, sqrDMTmp, sqrEDMTmp,&
-    !$OMP& hPrimeTmp, sPrimeTmp, ii, iAtom1) DEFAULT(SHARED) SCHEDULE(RUNTIME) REDUCTION(+:deriv)
+    !$OMP& hPrimeTmp, sPrimeTmp, ii, iIter, iAtom1) DEFAULT(SHARED) SCHEDULE(RUNTIME)&
+    !$OMP& REDUCTION(+:deriv)
     do iIter = 1, chunkIter%getNumIndices()
-      iAtom1 = chunkIter%getNextIndex()
+      iAtom1 = chunkIter%getIndex(iIter)
       nOrb1 = orb%nOrbAtom(iAtom1)
       !! loop from 1 as no contribution from the atom itself
       do iNeigh = 1, nNeighbourSK(iAtom1)
@@ -278,10 +279,10 @@ contains
     call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
 
     !$OMP PARALLEL DO PRIVATE(nOrb1, iNeigh, iAtom2, iAtom2f, nOrb2, iOrig, sqrDMTmp, sqrEDMTmp,&
-    !$OMP& hPrimeTmp, sPrimeTmp, ii, intermed, theta, iAtom1) DEFAULT(SHARED) SCHEDULE(RUNTIME)&
-    !$OMP& REDUCTION(+:deriv)
+    !$OMP& hPrimeTmp, sPrimeTmp, ii, intermed, theta, iIter, iAtom1) DEFAULT(SHARED)&
+    !$OMP& SCHEDULE(RUNTIME) REDUCTION(+:deriv)
     do iIter = 1, chunkIter%getNumIndices()
-      iAtom1 = chunkIter%getNextIndex()
+      iAtom1 = chunkIter%getIndex(iIter)
       nOrb1 = orb%nOrbAtom(iAtom1)
       !! loop from 1 as no contribution from the atom itself
       do iNeigh = 1, nNeighbourSK(iAtom1)
@@ -487,11 +488,11 @@ contains
 
     call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
 
-    !$OMP PARALLEL DO PRIVATE(iAtom1,iSp1,nOrb1,iNeigh,iAtom2,iAtom2f,iSp2,nOrb2,iOrig,sqrDMTmp, &
-    !$OMP& sqrEDMTmp,hPrimeTmp,sPrimeTmp,derivTmp,shiftSprime,iSpin,ii,theta,iIter)&
+    !$OMP PARALLEL DO PRIVATE(iIter,iAtom1,iSp1,nOrb1,iNeigh,iAtom2,iAtom2f,iSp2,nOrb2,iOrig,sqrDMTmp, &
+    !$OMP& sqrEDMTmp,hPrimeTmp,sPrimeTmp,derivTmp,shiftSprime,iSpin,ii,theta)&
     !$OMP& DEFAULT(SHARED) SCHEDULE(RUNTIME) REDUCTION(+:deriv)
     do iIter = 1, chunkIter%getNumIndices()
-      iAtom1 = chunkIter%getNextIndex()
+      iAtom1 = chunkIter%getIndex(iIter)
       iSp1 = species(iAtom1)
       nOrb1 = orb%nOrbSpecies(iSp1)
       do iNeigh = 1, nNeighbourSK(iAtom1)
@@ -625,7 +626,7 @@ contains
     !$OMP& sqrEDMTmp,hPrimeTmp,sPrimeTmp,derivTmp,shiftSprime,iSpin,ii) DEFAULT(SHARED) &
     !$OMP& SCHEDULE(RUNTIME) REDUCTION(+:deriv)
     do iIter = 1, chunkIter%getNumIndices()
-      iAtom1 = chunkIter%getNextIndex()
+      iAtom1 = chunkIter%getIndex(iIter)
       iSp1 = species(iAtom1)
       nOrb1 = orb%nOrbSpecies(iSp1)
       do iNeigh = 1, nNeighbourSK(iAtom1)
@@ -760,11 +761,11 @@ contains
 
     call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
 
-    !$OMP PARALLEL DO PRIVATE(iAtom1,iSp1,nOrb1,iNeigh,iAtom2,iAtom2f,iSp2,nOrb2,iOrig,sqrDMTmp, &
-    !$OMP& sqrEDMTmp,hPrimeTmp,sPrimeTmp,derivTmp,shiftSprime,iSpin,ii,iIter) DEFAULT(SHARED) &
+    !$OMP PARALLEL DO PRIVATE(iIter,iAtom1,iSp1,nOrb1,iNeigh,iAtom2,iAtom2f,iSp2,nOrb2,iOrig,sqrDMTmp, &
+    !$OMP& sqrEDMTmp,hPrimeTmp,sPrimeTmp,derivTmp,shiftSprime,iSpin,ii) DEFAULT(SHARED) &
     !$OMP& SCHEDULE(RUNTIME) REDUCTION(+:deriv)
     do iIter = 1, chunkIter%getNumIndices()
-      iAtom1 = chunkIter%getNextIndex()
+      iAtom1 = chunkIter%getIndex(iIter)
       iSp1 = species(iAtom1)
       nOrb1 = orb%nOrbSpecies(iSp1)
       do iNeigh = 1, nNeighbourSK(iAtom1)

--- a/src/dftbp/dftb/getenergies.F90
+++ b/src/dftbp/dftb/getenergies.F90
@@ -43,12 +43,15 @@ contains
 
 
   !> Calculates various energy contribution that can potentially update for the same geometry
-  subroutine calcEnergies(sccCalc, tblite, qOrb, q0, chargePerShell, multipole, species,&
+  subroutine calcEnergies(env, sccCalc, tblite, qOrb, q0, chargePerShell, multipole, species,&
       & isExtField, isXlbomd, dftbU, tDualSpinOrbit, rhoPrim, H0, orb, neighbourList,&
       & nNeighbourSK, img2CentCell, iSparseStart, cellVol, extPressure, TS, potential, &
       & energy, thirdOrd, solvation, rangeSep, reks, qDepExtPot, qBlock, qiBlock, xi,&
       & iAtInCentralRegion, tFixEf, Ef, onSiteElements, qNetAtom, vOnSiteAtomInt,&
       & vOnSiteAtomExt)
+
+    !> Environment settings
+    type(TEnvironment), intent(in) :: env
 
     !> SCC module internal variables
     type(TScc), allocatable, intent(in) :: sccCalc
@@ -172,7 +175,7 @@ contains
 
     ! Tr[H0 * Rho] can be done with the same algorithm as Mulliken-analysis
     energy%atomNonSCC(:) = 0.0_dp
-    call mulliken(energy%atomNonSCC, rhoPrim(:,1), H0, orb, neighbourList%iNeighbour, nNeighbourSK,&
+    call mulliken(env, energy%atomNonSCC, rhoPrim(:,1), H0, orb, neighbourList%iNeighbour, nNeighbourSK,&
         & img2CentCell, iSparseStart)
     energy%EnonSCC = sum(energy%atomNonSCC(iAtInCentralRegion))
 

--- a/src/dftbp/dftb/populations.F90
+++ b/src/dftbp/dftb/populations.F90
@@ -13,7 +13,7 @@ module dftbp_dftb_populations
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : pi
   use dftbp_common_environment, only : TEnvironment
-  use dftbp_common_schedule, only : distributeRangeWithWorkload, TChunkIterator, assembleChunks
+  use dftbp_common_schedule, only : distributeRangeWithWorkload, assembleChunks
   use dftbp_type_commontypes, only : TOrbitals
   implicit none
 
@@ -134,22 +134,22 @@ contains
     integer, intent(in) :: iPair(0:,:)
 
     integer :: iOrig
-    integer :: iNeigh
+    integer :: iIter, iNeigh
     integer :: nAtom, iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2
     real(dp) :: sqrTmp(orb%mOrb,orb%mOrb)
     real(dp) :: mulTmp(orb%mOrb**2)
-    type(TChunkIterator) :: chunkIter
+    integer, allocatable :: iterIndices(:)
 
     nAtom = size(orb%nOrbAtom)
 
     @:ASSERT(all(shape(qq) == (/orb%mOrb, nAtom/)))
     @:ASSERT(size(over) == size(rho))
 
-    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
+    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, iterIndices)
 
-    do while (chunkIter%hasNextIndex())
-      iAtom1 = chunkIter%getNextIndex()
+    do iIter = 1, size(iterIndices)
+      iAtom1 = iterIndices(iIter)
       nOrb1 = orb%nOrbAtom(iAtom1)
       do iNeigh = 0, nNeighbourSK(iAtom1)
         sqrTmp(:,:) = 0.0_dp
@@ -208,22 +208,22 @@ contains
     integer, intent(in) :: iPair(0:,:)
 
     integer :: iOrig
-    integer :: iNeigh
+    integer :: iIter, iNeigh
     integer :: nAtom, iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2
     real(dp) :: STmp(orb%mOrb,orb%mOrb)
     real(dp) :: rhoTmp(orb%mOrb,orb%mOrb)
-    type(TChunkIterator) :: chunkIter
+    integer, allocatable :: iterIndices(:)
 
     nAtom = size(orb%nOrbAtom)
 
     @:ASSERT(all(shape(qq) == (/orb%mOrb,orb%mOrb,nAtom/)))
     @:ASSERT(size(over) == size(rho))
 
-    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
+    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, iterIndices)
 
-    do while (chunkIter%hasNextIndex())
-      iAtom1 = chunkIter%getNextIndex()
+    do iIter = 1, size(iterIndices)
+      iAtom1 = iterIndices(iIter)
       nOrb1 = orb%nOrbAtom(iAtom1)
       do iNeigh = 0, nNeighbourSK(iAtom1)
         iAtom2 = iNeighbour(iNeigh, iAtom1)
@@ -283,22 +283,22 @@ contains
     integer, intent(in) :: iPair(0:,:)
 
     integer :: iOrig
-    integer :: iNeigh
+    integer :: iIter, iNeigh
     integer :: nAtom, iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2
     real(dp) :: STmp(orb%mOrb,orb%mOrb)
     real(dp) :: rhoTmp(orb%mOrb,orb%mOrb)
-    type(TChunkIterator) :: chunkIter
+    integer, allocatable :: iterIndices(:)
 
     nAtom = size(orb%nOrbAtom)
 
     @:ASSERT(all(shape(qq) == (/orb%mOrb,orb%mOrb,nAtom/)))
     @:ASSERT(size(over) == size(rho))
 
-    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
+    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, iterIndices)
 
-    do while (chunkIter%hasNextIndex())
-      iAtom1 = chunkIter%getNextIndex()
+    do iIter = 1, size(iterIndices)
+      iAtom1 = iterIndices(iIter)
       nOrb1 = orb%nOrbAtom(iAtom1)
       do iNeigh = 0, nNeighbourSK(iAtom1)
         iAtom2 = iNeighbour(iNeigh, iAtom1)

--- a/src/dftbp/dftb/shift.F90
+++ b/src/dftbp/dftb/shift.F90
@@ -11,6 +11,9 @@
 !> generalisations of H_mu,nu = 0.5*S_mu,nu*(V_mu + V_nu)
 module dftbp_dftb_shift
   use dftbp_common_accuracy, only : dp
+  use dftbp_common_environment, only : TEnvironment
+  use dftbp_common_schedule, only : distributeRangeWithWorkload, TChunkIterator,&
+      & getChunkIterWithWorkload, assembleChunks
   use dftbp_type_commontypes, only : TOrbitals
 
   implicit none
@@ -37,8 +40,11 @@ contains
 
 
   !> Regular atomic shift (potential is only dependent on number of atom)
-  subroutine add_shift_atom(ham,over,nNeighbour,iNeighbour,species,orb,iPair, nAtom,img2CentCell, &
-      & shift)
+  subroutine add_shift_atom(env,ham,over,nNeighbour,iNeighbour,species,orb,iPair, nAtom,img2CentCell, &
+      & shift,isInputZero)
+
+    !> Computational environment settings
+    type(TEnvironment), intent(in) :: env
 
     !> The resulting Hamiltonian contribution.
     real(dp), intent(inout) :: ham(:,:)
@@ -64,13 +70,18 @@ contains
     !> Index mapping atoms onto the central cell atoms.
     integer, intent(in) :: nAtom
 
-    !> Shift to add at atom sites
+    !> Mapping from image atom to central cell
     integer, intent(in) :: img2CentCell(:)
 
+    !> Shift to add at atom sites
     real(dp), intent(in) :: shift(:,:)
+
+    !> Whether array 'ham' is zero everywhere on input
+    logical, intent(in) :: isInputZero
 
     integer :: iAt1, iAt2, iAt2f, iOrig, iSp1, iSp2, nOrb1, nOrb2
     integer :: iNeigh, iSpin, nSpin
+    type(TChunkIterator) :: chunkIter
 
     @:ASSERT(size(ham,dim=1)==size(over))
     @:ASSERT(size(ham,dim=2)==size(shift,dim=2))
@@ -81,12 +92,17 @@ contains
     @:ASSERT(size(iPair,dim=1)>=(maxval(nNeighbour)+1))
     @:ASSERT(size(iPair,dim=2)==nAtom)
     @:ASSERT(size(shift,dim=1)==nAtom)
+    @:ASSERT(isInputZero)
 
     nSpin = size(ham,dim=2)
     @:ASSERT(nSpin == 1 .or. nSpin == 2 .or. nSpin == 4)
 
+    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbour, chunkIter)
+
     do iSpin = 1, nSpin
-      do iAt1 = 1, nAtom
+      call chunkIter%resetIndex()
+      do while (chunkIter%hasNextIndex())
+        iAt1 = chunkIter%getNextIndex()
         iSp1 = species(iAt1)
         nOrb1 = orb%nOrbSpecies(iSp1)
         do iNeigh = 0, nNeighbour(iAt1)
@@ -103,12 +119,17 @@ contains
       end do
     end do
 
+    call assembleChunks(env, ham)
+
   end subroutine add_shift_atom
 
 
   !> l-dependent shift (potential is dependent on number of atom and l-shell)
-  subroutine add_shift_lshell( ham,over,nNeighbour,iNeighbour,species,orb,iPair,nAtom,img2CentCell,&
-      & shift )
+  subroutine add_shift_lshell(env,ham,over,nNeighbour,iNeighbour,species,orb,iPair,nAtom,img2CentCell,&
+      & shift,isInputZero)
+
+    !> Computational environment settings
+    type(TEnvironment), intent(in) :: env
 
     !> The resulting Hamiltonian contribution.
     real(dp), intent(inout) :: ham(:,:)
@@ -134,14 +155,19 @@ contains
     !> Index mapping atoms onto the central cell atoms.
     integer, intent(in) :: nAtom
 
-    !> Shift to add for each l-shell on all atom sites, (0:lmax,1:nAtom)
+    !> Mapping from image atom to central cell
     integer, intent(in) :: img2CentCell(:)
 
+    !> Shift to add for each l-shell on all atom sites, (0:lmax,1:nAtom)
     real(dp), intent(in) :: shift(:,:,:)
+
+    !> Whether array 'ham' is zero everywhere on input
+    logical, intent(in) :: isInputZero
 
     integer :: iAt1, iAt2f, iOrig, iSp1, iSp2, nOrb1, nOrb2
     integer :: iSh1, iSh2, iNeigh, iSpin, nSpin
     real(dp) :: tmpH(orb%mOrb,orb%mOrb), rTmp
+    type(TChunkIterator) :: chunkIter
 
     @:ASSERT(size(ham,dim=1)==size(over))
     @:ASSERT(size(nNeighbour)==nAtom)
@@ -152,11 +178,16 @@ contains
     @:ASSERT(size(iPair,dim=2)==nAtom)
     @:ASSERT(size(shift,dim=1)==orb%mShell)
     @:ASSERT(size(shift,dim=2)==nAtom)
+    @:ASSERT(isInputZero)
 
     nSpin = size(ham,dim=2)
 
+    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbour, chunkIter)
+
     do iSpin = 1, nSpin
-      do iAt1= 1, nAtom
+      call chunkIter%resetIndex()
+      do while (chunkIter%hasNextIndex())
+        iAt1 = chunkIter%getNextIndex()
         iSp1 = species(iAt1)
         nOrb1 = orb%nOrbSpecies(iSp1)
         do iNeigh = 0, nNeighbour(iAt1)
@@ -180,13 +211,18 @@ contains
       end do
     end do
 
+    call assembleChunks(env, ham)
+
   end subroutine add_shift_lshell
 
 
   !> shift depending on occupation-matrix like potentials. To use this for lm-dependent potentials,
   !> use a diagonal shift matrix
-  subroutine add_shift_block( ham,over,nNeighbour,iNeighbour,species,orb,iPair,nAtom,img2CentCell, &
-      & shift )
+  subroutine add_shift_block(env,ham,over,nNeighbour,iNeighbour,species,orb,iPair,nAtom,img2CentCell, &
+      & shift,isInputZero)
+
+    !> Computational environment settings
+    type(TEnvironment), intent(in) :: env
 
     !> The resulting Hamiltonian contribution.
     real(dp), intent(inout) :: ham(:,:)
@@ -212,14 +248,19 @@ contains
     !> Index mapping atoms onto the central cell atoms.
     integer, intent(in) :: nAtom
 
-    !> Shift to add at atom sites, listed as (0:nOrb,0:nOrb,1:nAtom)
+    !> Mapping from image atom to central cell
     integer, intent(in) :: img2CentCell(:)
 
+    !> Shift to add at atom sites, listed as (0:nOrb,0:nOrb,1:nAtom)
     real(dp), intent(in) :: shift(:,:,:,:)
+
+    !> Whether array 'ham' is zero everywhere on input
+    logical, intent(in) :: isInputZero
 
     integer :: iAt1, iAt2, iAt2f, iOrig, iSp1, iSp2, nOrb1, nOrb2
     integer :: iNeigh, iSpin, nSpin
     real(dp) :: tmpH(orb%mOrb,orb%mOrb), tmpS(orb%mOrb,orb%mOrb)
+    type(TChunkIterator) :: chunkIter
 
     @:ASSERT(size(ham,dim=1)==size(over))
     @:ASSERT(size(nNeighbour)==nAtom)
@@ -234,8 +275,18 @@ contains
 
     nSpin = size(ham,dim=2)
 
+    if (isInputZero) then
+      call distributeRangeWithWorkload(env, 1, nAtom, nNeighbour, chunkIter)
+    else
+      !> If input is not zero everywhere, we have to compute in serial here, otherwise
+      !> the call of 'assembleChunks' will mess up the array.
+      call getChunkIterWithWorkload(1, 0, 1, nAtom, nNeighbour, chunkIter)
+    end if
+
     do iSpin = 1, nSpin
-      do iAt1 = 1, nAtom
+      call chunkIter%resetIndex()
+      do while (chunkIter%hasNextIndex())
+        iAt1 = chunkIter%getNextIndex()
         iSp1 = species(iAt1)
         nOrb1 = orb%nOrbSpecies(iSp1)
         do iNeigh = 0, nNeighbour(iAt1)
@@ -257,6 +308,10 @@ contains
         end do
       end do
     end do
+
+    if (isInputZero) then
+      call assembleChunks(env, ham)
+    end if
 
   end subroutine add_shift_block
 

--- a/src/dftbp/dftb/shortgamma.F90
+++ b/src/dftbp/dftb/shortgamma.F90
@@ -746,7 +746,7 @@ contains
     integer :: iAt1, iAt2f, iSp1, iSp2, iSh1, iSh2, iU1, iU2, iNeigh, iAt1Start, iAt1End
     integer :: nAtom, maxShell1, maxShell2
     integer, allocatable :: maxNeigh(:)
-    real(dp) :: shortGammaValue, deltaQShellValue, shiftShellSum
+    real(dp) :: shortGammaValue, deltaQShellValue
     type(TChunkIterator) :: chunkIter
     logical :: skipLoop
 
@@ -777,30 +777,23 @@ contains
         iAt1 = chunkIter%getNextIndex()
         iSp1 = species(iAt1)
         maxShell1 = orb%nShell(iSp1)
-
-        do iNeigh = 0, maxNeigh(iAt1)
-          iAt2f = img2CentCell(iNeighbours(iNeigh, iAt1))
-          iSp2 = species(iAt2f)
-          maxShell2 = orb%nShell(iSp2)
-
-          do iSh1 = 1, maxShell1
-            iU1 = hubb%iHubbU(iSh1, iSp1)
-            deltaQShellValue = deltaQShell(iSh1, iAt1)
-
+        do iSh1 = 1, maxShell1
+          iU1 = hubb%iHubbU(iSh1, iSp1)
+          deltaQShellValue = deltaQShell(iSh1, iAt1)
+          do iNeigh = 0, maxNeigh(iAt1)
+            iAt2f = img2CentCell(iNeighbours(iNeigh, iAt1))
+            iSp2 = species(iAt2f)
+            maxShell2 = orb%nShell(iSp2)
             do iSh2 = 1, maxShell2
               iU2 = hubb%iHubbU(iSh2, iSp2)
               shortGammaValue = shortGamma(iU2, iU1, iNeigh, iAt1)
-              if (iSh2 > 1) then
-                shiftShellSum = shiftShellSum + shortGammaValue * deltaQShell(iSh2, iAt2f)
-              else
-                shiftShellSum = shortGammaValue * deltaQShell(iSh2, iAt2f)
-              end if
+              shiftShell(iSh1, iAt1) = shiftShell(iSh1, iAt1)&
+                    & - shortGammaValue * deltaQShell(iSh2, iAt2f)
               if (iAt2f /= iAt1) then
                 shiftShell(iSh2, iAt2f) = shiftShell(iSh2, iAt2f)&
                     & - shortGammaValue * deltaQShellValue
               end if
             end do
-            shiftShell(iSh1, iAt1) = shiftShell(iSh1, iAt1) - shiftShellSum
           end do
         end do
       end do

--- a/src/dftbp/dftb/shortgamma.F90
+++ b/src/dftbp/dftb/shortgamma.F90
@@ -11,6 +11,7 @@
 module dftbp_dftb_shortgamma
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : TEnvironment
+  use dftbp_common_schedule, only : getChunkIterWithWorkload, TChunkIterator
   use dftbp_dftb_h5correction, only : TH5CorrectionInput, TH5Correction, TH5Correction_init
   use dftbp_dftb_periodic, only : TNeighbourList, getNrOfNeighbours
   use dftbp_dftb_shortgammafuncs, only : expGammaCutOff, expGamma, expGammaPrime, expGammaDamped,&
@@ -743,45 +744,67 @@ contains
     real(dp), intent(out) :: shiftShell(:,:)
 
     integer :: iAt1, iAt2f, iSp1, iSp2, iSh1, iSh2, iU1, iU2, iNeigh, iAt1Start, iAt1End
-
-    integer :: nAtom
+    integer :: nAtom, maxShell1, maxShell2
+    integer, allocatable :: maxNeigh(:)
+    real(dp) :: shortGammaValue, deltaQShellValue, shiftShellSum
+    type(TChunkIterator) :: chunkIter
+    logical :: skipLoop
 
     nAtom = size(nNeigh, dim=4)
 
+    allocate(maxNeigh(nAtom))
+    do iAt1 = 1, nAtom
+      maxNeigh(iAt1) = maxval(nNeigh(:,:,:,iAt1))
+    end do
+
+    skipLoop = .false.
     #:if WITH_SCALAPACK
       if (env%blacs%atomGrid%iProc /= -1) then
-        iAt1Start = env%blacs%atomGrid%iproc * nAtom / env%blacs%atomGrid%nproc + 1
-        iAt1End = (env%blacs%atomGrid%iproc + 1) * nAtom / env%blacs%atomGrid%nproc
+        call getChunkIterWithWorkload(env%blacs%atomGrid%nproc, env%blacs%atomGrid%iproc,&
+            & 1, nAtom, maxNeigh, chunkIter)
       else
         ! Do not calculate anything if process is not part of the atomic grid
-        iAt1Start = 0
-        iAt1End = -1
+        skipLoop = .true.
       end if
     #:else
-      iAt1Start = 1
-      iAt1End = nAtom
+      call getChunkIterWithWorkload(1, 0, 1, nAtom, maxNeigh, chunkIter)
     #:endif
 
     shiftShell(:,:) = 0.0_dp
-    do iAt1 = iAt1Start, iAt1End
-      iSp1 = species(iAt1)
-      do iSh1 = 1, orb%nShell(iSp1)
-        iU1 = hubb%iHubbU(iSh1, iSp1)
-        do iNeigh = 0, maxval(nNeigh(:,:,:,iAt1))
+
+    if (.not. skipLoop) then
+      do while (chunkIter%hasNextIndex())
+        iAt1 = chunkIter%getNextIndex()
+        iSp1 = species(iAt1)
+        maxShell1 = orb%nShell(iSp1)
+
+        do iNeigh = 0, maxNeigh(iAt1)
           iAt2f = img2CentCell(iNeighbours(iNeigh, iAt1))
           iSp2 = species(iAt2f)
-          do iSh2 = 1, orb%nShell(iSp2)
-            iU2 = hubb%iHubbU(iSh2, iSp2)
-            shiftShell(iSh1, iAt1) = shiftShell(iSh1, iAt1)&
-                & - shortGamma(iU2, iU1, iNeigh, iAt1) * deltaQShell(iSh2, iAt2f)
-            if (iAt2f /= iAt1) then
-              shiftShell(iSh2, iAt2f) = shiftShell(iSh2, iAt2f)&
-                  & - shortGamma(iU2, iU1, iNeigh, iAt1) * deltaQShell(iSh1, iAt1)
-            end if
+          maxShell2 = orb%nShell(iSp2)
+
+          do iSh1 = 1, maxShell1
+            iU1 = hubb%iHubbU(iSh1, iSp1)
+            deltaQShellValue = deltaQShell(iSh1, iAt1)
+
+            do iSh2 = 1, maxShell2
+              iU2 = hubb%iHubbU(iSh2, iSp2)
+              shortGammaValue = shortGamma(iU2, iU1, iNeigh, iAt1)
+              if (iSh2 > 1) then
+                shiftShellSum = shiftShellSum + shortGammaValue * deltaQShell(iSh2, iAt2f)
+              else
+                shiftShellSum = shortGammaValue * deltaQShell(iSh2, iAt2f)
+              end if
+              if (iAt2f /= iAt1) then
+                shiftShell(iSh2, iAt2f) = shiftShell(iSh2, iAt2f)&
+                    & - shortGammaValue * deltaQShellValue
+              end if
+            end do
+            shiftShell(iSh1, iAt1) = shiftShell(iSh1, iAt1) - shiftShellSum
           end do
         end do
       end do
-    end do
+    end if
 
     #:if WITH_SCALAPACK
       call mpifx_allreduceip(env%mpi%groupComm, shiftShell, MPI_SUM)

--- a/src/dftbp/dftb/stress.F90
+++ b/src/dftbp/dftb/stress.F90
@@ -11,7 +11,7 @@
 module dftbp_dftb_stress
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : TEnvironment
-  use dftbp_common_schedule, only : distributeRangeWithWorkload, TChunkIterator, assembleChunks
+  use dftbp_common_schedule, only : distributeRangeWithWorkload, assembleChunks
   use dftbp_dftb_nonscc, only : TNonSccDiff
   use dftbp_dftb_slakocont, only : TSlakoCont
   use dftbp_type_commontypes, only : TOrbitals
@@ -111,12 +111,12 @@ contains
     real(dp), intent(in) :: cellVol
 
     integer :: iOrig, ii, jj
-    integer :: nAtom, iNeigh, iAtom1, iAtom2, iAtom2f
+    integer :: nAtom, iIter, iNeigh, iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2
     real(dp) :: sqrDMTmp(orb%mOrb,orb%mOrb), sqrEDMTmp(orb%mOrb,orb%mOrb)
     real(dp) :: hPrimeTmp(orb%mOrb,orb%mOrb,3), sPrimeTmp(orb%mOrb,orb%mOrb,3)
     real(dp) :: vect(3), intermed(3)
-    type(TChunkIterator) :: chunkIter
+    integer, allocatable :: iterIndices(:)
 
     @:ASSERT(all(shape(st) == [3, 3]))
     @:ASSERT(size(DM,dim=1)==size(EDM,dim=1))
@@ -124,10 +124,10 @@ contains
     nAtom = size(orb%nOrbAtom)
     st(:,:) = 0.0_dp
 
-    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
+    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, iterIndices)
 
-    do while (chunkIter%hasNextIndex())
-      iAtom1 = chunkIter%getNextIndex()
+    do iIter = 1, size(iterIndices)
+      iAtom1 = iterIndices(iIter)
       nOrb1 = orb%nOrbAtom(iAtom1)
       ! loop from 1 as no contribution from the atom itself
       do iNeigh = 1, nNeighbourSK(iAtom1)
@@ -225,13 +225,13 @@ contains
     real(dp), intent(in) :: cellVol
 
     integer :: iOrig, iSpin, nSpin, ii, jj
-    integer :: nAtom, iNeigh, iAtom1, iAtom2, iAtom2f
+    integer :: nAtom, iIter, iNeigh, iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2, iSp1, iSp2
     real(dp) :: sqrDMTmp(orb%mOrb,orb%mOrb), sqrEDMTmp(orb%mOrb,orb%mOrb)
     real(dp) :: hPrimeTmp(orb%mOrb,orb%mOrb,3), sPrimeTmp(orb%mOrb,orb%mOrb,3)
     real(dp) :: shiftSprime(orb%mOrb,orb%mOrb)
     real(dp) :: vect(3), intermed(3)
-    type(TChunkIterator) :: chunkIter
+    integer, allocatable :: iterIndices(:)
 
     nAtom = size(orb%nOrbAtom)
     nSpin = size(shift,dim=4)
@@ -246,10 +246,10 @@ contains
 
     st(:,:) = 0.0_dp
 
-    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
+    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, iterIndices)
 
-    do while (chunkIter%hasNextIndex())
-      iAtom1 = chunkIter%getNextIndex()
+    do iIter = 1, size(iterIndices)
+      iAtom1 = iterIndices(iIter)
       iSp1 = species(iAtom1)
       nOrb1 = orb%nOrbSpecies(iSp1)
       do iNeigh = 1, nNeighbourSK(iAtom1)
@@ -367,13 +367,13 @@ contains
     real(dp), intent(in) :: cellVol
 
     integer :: iOrig, iSpin, nSpin, ii, jj
-    integer :: nAtom, iNeigh, iAtom1, iAtom2, iAtom2f
+    integer :: nAtom, iIter, iNeigh, iAtom1, iAtom2, iAtom2f
     integer :: nOrb1, nOrb2, iSp1, iSp2
     real(dp) :: sqrDMTmp(orb%mOrb,orb%mOrb), sqrEDMTmp(orb%mOrb,orb%mOrb)
     real(dp) :: hPrimeTmp(orb%mOrb,orb%mOrb,3), sPrimeTmp(orb%mOrb,orb%mOrb,3)
     real(dp) :: shiftSprime(orb%mOrb,orb%mOrb)
     real(dp) :: vect(3), intermed(3)
-    type(TChunkIterator) :: chunkIter
+    integer, allocatable :: iterIndices(:)
 
     nAtom = size(orb%nOrbAtom)
     nSpin = size(shift,dim=4)
@@ -388,10 +388,10 @@ contains
 
     st = 0.0_dp
 
-    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
+    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, iterIndices)
 
-    do while (chunkIter%hasNextIndex())
-      iAtom1 = chunkIter%getNextIndex()
+    do iIter = 1, size(iterIndices)
+      iAtom1 = iterIndices(iIter)
       iSp1 = species(iAtom1)
       nOrb1 = orb%nOrbSpecies(iSp1)
       do iNeigh = 1, nNeighbourSK(iAtom1)

--- a/src/dftbp/dftb/stress.F90
+++ b/src/dftbp/dftb/stress.F90
@@ -11,7 +11,7 @@
 module dftbp_dftb_stress
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : TEnvironment
-  use dftbp_common_schedule, only : distributeRangeInChunks, assembleChunks
+  use dftbp_common_schedule, only : distributeRangeWithWorkload, TChunkIterator, assembleChunks
   use dftbp_dftb_nonscc, only : TNonSccDiff
   use dftbp_dftb_slakocont, only : TSlakoCont
   use dftbp_type_commontypes, only : TOrbitals
@@ -116,7 +116,7 @@ contains
     real(dp) :: sqrDMTmp(orb%mOrb,orb%mOrb), sqrEDMTmp(orb%mOrb,orb%mOrb)
     real(dp) :: hPrimeTmp(orb%mOrb,orb%mOrb,3), sPrimeTmp(orb%mOrb,orb%mOrb,3)
     real(dp) :: vect(3), intermed(3)
-    integer :: iAtFirst, iAtLast
+    type(TChunkIterator) :: chunkIter
 
     @:ASSERT(all(shape(st) == [3, 3]))
     @:ASSERT(size(DM,dim=1)==size(EDM,dim=1))
@@ -124,9 +124,10 @@ contains
     nAtom = size(orb%nOrbAtom)
     st(:,:) = 0.0_dp
 
-    call distributeRangeInChunks(env, 1, nAtom, iAtFirst, iAtLast)
+    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
 
-    do iAtom1 = iAtFirst, iAtLast
+    do while (chunkIter%hasNextIndex())
+      iAtom1 = chunkIter%getNextIndex()
       nOrb1 = orb%nOrbAtom(iAtom1)
       ! loop from 1 as no contribution from the atom itself
       do iNeigh = 1, nNeighbourSK(iAtom1)
@@ -230,7 +231,7 @@ contains
     real(dp) :: hPrimeTmp(orb%mOrb,orb%mOrb,3), sPrimeTmp(orb%mOrb,orb%mOrb,3)
     real(dp) :: shiftSprime(orb%mOrb,orb%mOrb)
     real(dp) :: vect(3), intermed(3)
-    integer :: iAtFirst, iAtLast
+    type(TChunkIterator) :: chunkIter
 
     nAtom = size(orb%nOrbAtom)
     nSpin = size(shift,dim=4)
@@ -245,9 +246,10 @@ contains
 
     st(:,:) = 0.0_dp
 
-    call distributeRangeInChunks(env, 1, nAtom, iAtFirst, iAtLast)
+    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
 
-    do iAtom1 = iAtFirst, iAtLast
+    do while (chunkIter%hasNextIndex())
+      iAtom1 = chunkIter%getNextIndex()
       iSp1 = species(iAtom1)
       nOrb1 = orb%nOrbSpecies(iSp1)
       do iNeigh = 1, nNeighbourSK(iAtom1)
@@ -371,7 +373,7 @@ contains
     real(dp) :: hPrimeTmp(orb%mOrb,orb%mOrb,3), sPrimeTmp(orb%mOrb,orb%mOrb,3)
     real(dp) :: shiftSprime(orb%mOrb,orb%mOrb)
     real(dp) :: vect(3), intermed(3)
-    integer :: iAtFirst, iAtLast
+    type(TChunkIterator) :: chunkIter
 
     nAtom = size(orb%nOrbAtom)
     nSpin = size(shift,dim=4)
@@ -386,9 +388,10 @@ contains
 
     st = 0.0_dp
 
-    call distributeRangeInChunks(env, 1, nAtom, iAtFirst, iAtLast)
+    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
 
-    do iAtom1 = iAtFirst, iAtLast
+    do while (chunkIter%hasNextIndex())
+      iAtom1 = chunkIter%getNextIndex()
       iSp1 = species(iAtom1)
       nOrb1 = orb%nOrbSpecies(iSp1)
       do iNeigh = 1, nNeighbourSK(iAtom1)

--- a/src/dftbp/reks/reksgrad.F90
+++ b/src/dftbp/reks/reksgrad.F90
@@ -293,11 +293,11 @@ contains
 
       call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
 
-      !$OMP PARALLEL DO PRIVATE(iAtom1,iSp1,nOrb1,iNeigh,iAtom2,iAtom2f,iSp2,nOrb2,iOrig,sqrDMTmp, &
-      !$OMP& sqrEDMTmp,hPrimeTmp,sPrimeTmp,derivTmp,shiftSprime,iSpin,ii,iIter) DEFAULT(SHARED) &
+      !$OMP PARALLEL DO PRIVATE(iIter,iAtom1,iSp1,nOrb1,iNeigh,iAtom2,iAtom2f,iSp2,nOrb2,iOrig,sqrDMTmp, &
+      !$OMP& sqrEDMTmp,hPrimeTmp,sPrimeTmp,derivTmp,shiftSprime,iSpin,ii) DEFAULT(SHARED) &
       !$OMP& SCHEDULE(RUNTIME) REDUCTION(+:deriv)
       do iIter = 1, chunkIter%getNumIndices()
-        iAtom1 = chunkIter%getNextIndex()
+        iAtom1 = chunkIter%getIndex(iIter)
         iSp1 = species(iAtom1)
         nOrb1 = orb%nOrbSpecies(iSp1)
         do iNeigh = 1, nNeighbourSK(iAtom1)

--- a/src/dftbp/reks/reksgrad.F90
+++ b/src/dftbp/reks/reksgrad.F90
@@ -19,7 +19,7 @@ module dftbp_reks_reksgrad
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : TEnvironment, globalTimers
   use dftbp_common_globalenv, only : stdOut
-  use dftbp_common_schedule, only : distributeRangeWithWorkload, TChunkIterator, assembleChunks
+  use dftbp_common_schedule, only : distributeRangeWithWorkload, assembleChunks
   use dftbp_dftb_coulomb, only : addInvRPrime
   use dftbp_dftb_nonscc, only : TNonSccDiff
   use dftbp_dftb_periodic, only : TNeighbourList
@@ -263,7 +263,7 @@ contains
     real(dp) :: fac
     integer :: iIter
     integer :: tmpL, tmpLs, iL, Lmax
-    type(TChunkIterator) :: chunkIter
+    integer, allocatable :: iterIndices(:)
 
     nAtom = size(orb%nOrbAtom)
     nSpin = size(shift,dim=4)
@@ -291,13 +291,13 @@ contains
         end if
       end if
 
-      call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, chunkIter)
+      call distributeRangeWithWorkload(env, 1, nAtom, nNeighbourSK, iterIndices)
 
       !$OMP PARALLEL DO PRIVATE(iIter,iAtom1,iSp1,nOrb1,iNeigh,iAtom2,iAtom2f,iSp2,nOrb2,iOrig,sqrDMTmp, &
       !$OMP& sqrEDMTmp,hPrimeTmp,sPrimeTmp,derivTmp,shiftSprime,iSpin,ii) DEFAULT(SHARED) &
       !$OMP& SCHEDULE(RUNTIME) REDUCTION(+:deriv)
-      do iIter = 1, chunkIter%getNumIndices()
-        iAtom1 = chunkIter%getIndex(iIter)
+      do iIter = 1, size(iterIndices)
+        iAtom1 = iterIndices(iIter)
         iSp1 = species(iAtom1)
         nOrb1 = orb%nOrbSpecies(iSp1)
         do iNeigh = 1, nNeighbourSK(iAtom1)

--- a/src/dftbp/reks/reksinterface.F90
+++ b/src/dftbp/reks/reksinterface.F90
@@ -1375,7 +1375,7 @@ module dftbp_reks_reksinterface
     call env%globalTimer%stopTimer(globalTimers%denseToSparse)
 
     qOutput(:,:,:) = 0.0_dp
-    call mulliken(qOutput(:,:,1), over, rhoPrim(:,1), orb, &
+    call mulliken(env, qOutput(:,:,1), over, rhoPrim(:,1), orb, &
         & neighbourList%iNeighbour, nNeighbourSK, img2CentCell, iSparseStart)
 
   end subroutine getMullikenPopFromRelaxedDensity_

--- a/src/dftbp/solvation/born.F90
+++ b/src/dftbp/solvation/born.F90
@@ -823,12 +823,12 @@ contains
 
     !$omp parallel do default(none) schedule(runtime) &
     !$omp reduction(+:psi, dpsidr, dpsitr) shared(species) &
-    !$omp shared(nNeighbour, iNeighbour, img2CentCell, coords, neighDist2, rho, chunkIter) &
-    !$omp shared(vdwRad) private(iAt1, iSp1, iNeigh, iAt2, iAt2f, iSp2, dist, iIter) &
-    !$omp private(tOvij, tOvji, vec, rhoi, rhoj, gi, gj, ap, am, lnab, rhab) &
+    !$omp shared(nNeighbour, iNeighbour, img2CentCell, coords, neighDist2, rho) &
+    !$omp shared(vdwRad, chunkIter) private(iAt1, iSp1, iNeigh, iAt2, iAt2f, iSp2, dist) &
+    !$omp private(iIter, tOvij, tOvji, vec, rhoi, rhoj, gi, gj, ap, am, lnab, rhab) &
     !$omp private(ab, dgi, dgj, dGr, rh1, rhr1, r24, r1, aprh1, r12, rvdwi, rvdwj)
     do iIter = 1, chunkIter%getNumIndices()
-      iAt1 = chunkIter%getNextIndex()
+      iAt1 = chunkIter%getIndex(iIter)
       iSp1 = species(iAt1)
       do iNeigh = 1, nNeighbour(iAt1)
         iAt2 = iNeighbour(iNeigh, iAt1)

--- a/src/dftbp/solvation/born.F90
+++ b/src/dftbp/solvation/born.F90
@@ -12,7 +12,8 @@ module dftbp_solvation_born
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : Hartree__eV
   use dftbp_common_environment, only : TEnvironment
-  use dftbp_common_schedule, only : distributeRangeInChunks, assembleChunks
+  use dftbp_common_schedule, only : distributeRangeInChunks, distributeRangeWithWorkload,&
+      & TChunkIterator, assembleChunks
   use dftbp_dftb_charges, only : getSummedCharges
   use dftbp_dftb_periodic, only : TNeighbourList, getNrOfNeighboursForAll
   use dftbp_math_blasroutines, only : hemv, gemv
@@ -801,7 +802,7 @@ contains
     !> Derivative of atomic volumes
     real(dp), intent(out) :: dpsidr(:,:,:)
 
-    integer :: nAtom, iAtFirst, iAtLast, iAt1, iNeigh, iAt2, iAt2f, iSp1, iSp2
+    integer :: nAtom, iIter, iAt1, iNeigh, iAt2, iAt2f, iSp1, iSp2
     logical :: tOvij, tOvji
     real(dp) :: vec(3), dist, rhoi, rhoj
     real(dp) :: gi, gj, ap, am, lnab, rhab, ab, dgi, dgj
@@ -809,10 +810,11 @@ contains
     real(dp) :: rh1, rhr1, r24, r1, aprh1, r12
     real(dp) :: rvdwi, rvdwj
     real(dp), allocatable :: dpsitr(:,:)
+    type(TChunkIterator) :: chunkIter
 
     nAtom = size(nNeighbour)
 
-    call distributeRangeInChunks(env, 1, nAtom, iAtFirst, iAtLast)
+    call distributeRangeWithWorkload(env, 1, nAtom, nNeighbour, chunkIter)
 
     allocate(dpsitr(3, nAtom))
     psi(:) = 0.0_dp
@@ -820,12 +822,13 @@ contains
     dpsitr(:, :) = 0.0_dp
 
     !$omp parallel do default(none) schedule(runtime) &
-    !$omp reduction(+:psi, dpsidr, dpsitr) shared(iAtFirst, iAtLast, species) &
-    !$omp shared(nNeighbour, iNeighbour, img2CentCell, coords, neighDist2, rho) &
-    !$omp shared(vdwRad) private(iAt1, iSp1, iNeigh, iAt2, iAt2f, iSp2, dist) &
+    !$omp reduction(+:psi, dpsidr, dpsitr) shared(species) &
+    !$omp shared(nNeighbour, iNeighbour, img2CentCell, coords, neighDist2, rho, chunkIter) &
+    !$omp shared(vdwRad) private(iAt1, iSp1, iNeigh, iAt2, iAt2f, iSp2, dist, iIter) &
     !$omp private(tOvij, tOvji, vec, rhoi, rhoj, gi, gj, ap, am, lnab, rhab) &
     !$omp private(ab, dgi, dgj, dGr, rh1, rhr1, r24, r1, aprh1, r12, rvdwi, rvdwj)
-    do iAt1 = iAtFirst, iAtLast
+    do iIter = 1, chunkIter%getNumIndices()
+      iAt1 = chunkIter%getNextIndex()
       iSp1 = species(iAt1)
       do iNeigh = 1, nNeighbour(iAt1)
         iAt2 = iNeighbour(iNeigh, iAt1)

--- a/src/dftbp/timedep/timeprop.F90
+++ b/src/dftbp/timedep/timeprop.F90
@@ -1174,7 +1174,7 @@ contains
     potential%intBlock = potential%intBlock + potential%extBlock
     potential%intShell = potential%intShell + potential%extShell
 
-    call getSccHamiltonian(H0, ints, nNeighbourSK, neighbourList, speciesAll, orb,&
+    call getSccHamiltonian(env, H0, ints, nNeighbourSK, neighbourList, speciesAll, orb,&
         & iSparseStart, img2CentCell, potential, .false., ints%hamiltonian, iHam)
 
     ! Hack due to not using Pauli-type structure outside of this part of the routine
@@ -1560,13 +1560,16 @@ contains
 
   !> Calculate energy - modify to include new way to calculate energy
   !> Repulsive energy and dispersion energies must be calculated before calling this subroutine
-  subroutine getTDEnergy(this, energy, rhoPrim, rho, neighbourList, nNeighbourSK, orb, iSquare,&
+  subroutine getTDEnergy(this, env, energy, rhoPrim, rho, neighbourList, nNeighbourSK, orb, iSquare,&
       & iSparseStart, img2CentCell, ham0, qq, q0, potential, chargePerShell, energyKin,&
       & tDualSpinOrbit, thirdOrd, solvation, rangeSep, qDepExtPot, qBlock, dftbU, xi,&
       & iAtInCentralRegion, tFixEf, Ef, onSiteElements)
 
     !> ElecDynamics instance
     type(TElecDynamics), intent(inout) :: this
+
+    !> Environment settings
+    type(TEnvironment), intent(in) :: env
 
     !> data type for energy components and total
     type(TEnergies), intent(inout) :: energy
@@ -1675,7 +1678,7 @@ contains
     call ud2qm(rhoPrim)
 
     TS = 0.0_dp
-    call calcEnergies(this%sccCalc, this%tblite, qq, q0, chargePerShell, this%multipole,&
+    call calcEnergies(env, this%sccCalc, this%tblite, qq, q0, chargePerShell, this%multipole,&
         & this%speciesAll, this%tLaser, .false., dftbU, tDualSpinOrbit, rhoPrim, ham0, orb,&
         & neighbourList, nNeighbourSK, img2CentCell, iSparseStart, 0.0_dp, 0.0_dp, TS,&
         & potential, energy, thirdOrd, solvation, rangeSep, reks, qDepExtPot, qBlock,&
@@ -3854,7 +3857,7 @@ contains
     call getPositionDependentEnergy(this, this%energy, coordAll, img2CentCell, nNeighbourSK,&
         & neighbourList, repulsive, iAtInCentralRegion, rangeSep)
 
-    call getTDEnergy(this, this%energy, this%rhoPrim, this%trho, neighbourList, nNeighbourSK, orb,&
+    call getTDEnergy(this, env, this%energy, this%rhoPrim, this%trho, neighbourList, nNeighbourSK, orb,&
         & iSquare, iSparseStart, img2CentCell, this%ham0, this%qq, q0, this%potential,&
         & this%chargePerShell, this%energyKin, tDualSpinOrbit, thirdOrd, solvation, rangeSep,&
         & qDepExtPot, this%qBlock, dftbu, xi, iAtInCentralRegion, tFixEf, Ef, onSiteElements)
@@ -4072,7 +4075,7 @@ contains
           & neighbourList, repulsive, iAtInCentralRegion, rangeSep)
     end if
 
-    call getTDEnergy(this, this%energy, this%rhoPrim, this%rho, neighbourList, nNeighbourSK, orb,&
+    call getTDEnergy(this, env, this%energy, this%rhoPrim, this%rho, neighbourList, nNeighbourSK, orb,&
         & iSquare, iSparseStart, img2CentCell, this%ham0, this%qq, q0, this%potential,&
         & this%chargePerShell, this%energyKin, tDualSpinOrbit, thirdOrd, solvation, rangeSep,&
         & qDepExtPot, this%qBlock, dftbU, xi, iAtInCentralRegion, tFixEf, Ef, onSiteElements)

--- a/test/src/dftbp/unittests/common/schedule.F90
+++ b/test/src/dftbp/unittests/common/schedule.F90
@@ -8,7 +8,7 @@
 #:include "fytest.fypp"
 
 #:block TEST_SUITE("schedule")
-  use dftbp_common_schedule, only : getChunkRanges
+  use dftbp_common_schedule, only : getChunkRanges, getChunkIterWithWorkload, TChunkIterator
   implicit none
 
 #:contains
@@ -57,6 +57,179 @@
       call getChunkRanges(3, 2, 3, 20, localFirst, localLast)
       @:ASSERT(localFirst == 15)
       @:ASSERT(localLast == 20)
+    #:endblock
+
+  #:endblock TEST_FIXTURE
+
+  #:block TEST_FIXTURE("getChunkIterWithWorkload")
+
+    integer :: workload(10), i
+    type(TChunkIterator) :: iter
+
+  #:contains
+
+    #:block TEST("singleRankEqualWorkload")
+      workload(:) = 1
+      call getChunkIterWithWorkload(1, 0, 1, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 10)
+      do i = 1, 10
+        @:ASSERT(iter%getNextIndex() == i)
+      end do
+      @:ASSERT(.not. iter%hasNextIndex())
+
+      workload(:) = 5
+      call getChunkIterWithWorkload(1, 0, 1, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 10)
+      do i = 1, 10
+        @:ASSERT(iter%getNextIndex() == i)
+      end do
+      @:ASSERT(.not. iter%hasNextIndex())
+    #:endblock
+
+    #:block TEST("singleRankZeroWorkload")
+      workload(1:5) = 0
+      workload(6:10) = 1
+      call getChunkIterWithWorkload(1, 0, 1, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 10)
+      do i = 1, 10
+        @:ASSERT(iter%getNextIndex() == i)
+      end do
+      @:ASSERT(.not. iter%hasNextIndex())
+
+      workload(:) = 0
+      call getChunkIterWithWorkload(1, 0, 1, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 10)
+      do i = 1, 10
+        @:ASSERT(iter%getNextIndex() == i)
+      end do
+      @:ASSERT(.not. iter%hasNextIndex())
+    #:endblock
+
+    #:block TEST("singleRankOffsetEqualWorkload")
+      workload(:) = -100
+      workload(7:10) = 1
+      call getChunkIterWithWorkload(1, 0, 7, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 4)
+      do i = 7, 10
+        @:ASSERT(iter%getNextIndex() == i)
+      end do
+      @:ASSERT(.not. iter%hasNextIndex())
+
+      workload(7:10) = 5
+      call getChunkIterWithWorkload(1, 0, 7, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 4)
+      do i = 7, 10
+        @:ASSERT(iter%getNextIndex() == i)
+      end do
+      @:ASSERT(.not. iter%hasNextIndex())
+    #:endblock
+
+    #:block TEST("twoRanksDifferentWorkload")
+      workload(1:2) = 1
+      workload(3) = 5
+      workload(4:5) = 0
+      workload(6:8) = 1
+      workload(9) = 10
+      workload(10) = 2
+
+      call getChunkIterWithWorkload(2, 0, 1, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 3)
+      @:ASSERT(iter%getNextIndex() == 1)
+      @:ASSERT(iter%getNextIndex() == 3)
+      @:ASSERT(iter%getNextIndex() == 9)
+      @:ASSERT(.not. iter%hasNextIndex())
+
+      call getChunkIterWithWorkload(2, 1, 1, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 7)
+      @:ASSERT(iter%getNextIndex() == 2)
+      @:ASSERT(iter%getNextIndex() == 4)
+      @:ASSERT(iter%getNextIndex() == 5)
+      @:ASSERT(iter%getNextIndex() == 6)
+      @:ASSERT(iter%getNextIndex() == 7)
+      @:ASSERT(iter%getNextIndex() == 8)
+      @:ASSERT(iter%getNextIndex() == 10)
+      @:ASSERT(.not. iter%hasNextIndex())
+    #:endblock
+
+    #:block TEST("threeRanksDifferentWorkload")
+      workload(1) = 10
+      workload(2) = 2
+      workload(3) = 3
+      workload(4) = 0
+      workload(5) = 10
+      workload(6) = 1
+      workload(7) = 1
+      workload(8) = 1
+      workload(9) = 10
+      workload(10) = 1
+
+      call getChunkIterWithWorkload(3, 0, 1, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 2)
+      @:ASSERT(iter%getNextIndex() == 1)
+      @:ASSERT(iter%getNextIndex() == 10)
+      @:ASSERT(.not. iter%hasNextIndex())
+
+      call getChunkIterWithWorkload(3, 1, 1, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 3)
+      @:ASSERT(iter%getNextIndex() == 2)
+      @:ASSERT(iter%getNextIndex() == 4)
+      @:ASSERT(iter%getNextIndex() == 5)
+      @:ASSERT(.not. iter%hasNextIndex())
+
+      call getChunkIterWithWorkload(3, 2, 1, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 5)
+      @:ASSERT(iter%getNextIndex() == 3)
+      @:ASSERT(iter%getNextIndex() == 6)
+      @:ASSERT(iter%getNextIndex() == 7)
+      @:ASSERT(iter%getNextIndex() == 8)
+      @:ASSERT(iter%getNextIndex() == 9)
+      @:ASSERT(.not. iter%hasNextIndex())
+    #:endblock
+
+    #:block TEST("threeRanksUnbalancedWorkload")
+      workload(:) = 1
+      workload(1) = 100
+      call getChunkIterWithWorkload(3, 0, 1, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 1)
+      @:ASSERT(iter%getNextIndex() == 1)
+      @:ASSERT(.not. iter%hasNextIndex())
+      call getChunkIterWithWorkload(3, 1, 1, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 5)
+      @:ASSERT(iter%getNextIndex() == 2)
+      @:ASSERT(iter%getNextIndex() == 4)
+      @:ASSERT(iter%getNextIndex() == 6)
+      @:ASSERT(iter%getNextIndex() == 8)
+      @:ASSERT(iter%getNextIndex() == 10)
+      @:ASSERT(.not. iter%hasNextIndex())
+      call getChunkIterWithWorkload(3, 2, 1, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 4)
+      @:ASSERT(iter%getNextIndex() == 3)
+      @:ASSERT(iter%getNextIndex() == 5)
+      @:ASSERT(iter%getNextIndex() == 7)
+      @:ASSERT(iter%getNextIndex() == 9)
+      @:ASSERT(.not. iter%hasNextIndex())
+
+      workload(:) = 1
+      workload(10) = 100
+      call getChunkIterWithWorkload(3, 0, 1, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 4)
+      @:ASSERT(iter%getNextIndex() == 1)
+      @:ASSERT(iter%getNextIndex() == 4)
+      @:ASSERT(iter%getNextIndex() == 7)
+      @:ASSERT(iter%getNextIndex() == 10)
+      @:ASSERT(.not. iter%hasNextIndex())
+      call getChunkIterWithWorkload(3, 1, 1, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 3)
+      @:ASSERT(iter%getNextIndex() == 2)
+      @:ASSERT(iter%getNextIndex() == 5)
+      @:ASSERT(iter%getNextIndex() == 8)
+      @:ASSERT(.not. iter%hasNextIndex())
+      call getChunkIterWithWorkload(3, 2, 1, 10, workload, iter)
+      @:ASSERT(iter%getNumIndices() == 3)
+      @:ASSERT(iter%getNextIndex() == 3)
+      @:ASSERT(iter%getNextIndex() == 6)
+      @:ASSERT(iter%getNextIndex() == 9)
+      @:ASSERT(.not. iter%hasNextIndex())
     #:endblock
 
   #:endblock TEST_FIXTURE


### PR DESCRIPTION
Enhance chunking by considering that every MPI rank has a different workload due to the number of neighbours. Also try to use this chunking, where it is applicable.