### PR TITLE
Align Fortran arrays by calling posix_memalign

### DIFF
--- a/src/dftbp/common/memman.F90
+++ b/src/dftbp/common/memman.F90
@@ -5,14 +5,64 @@
 !  See the LICENSE file for terms of usage and distribution.                                       !
 !--------------------------------------------------------------------------------------------------!
 
+#:include 'common.fypp'
+
 !> Contains various constants for memory management
 module dftbp_common_memman
   use dftbp_common_accuracy, only : dp
+  use dftbp_io_message, only : error, warning
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_null_ptr, c_f_pointer,&
+      & c_int, c_intptr_t, c_size_t
 
   implicit none
 
   private
-  public :: incrmntOfArray
+  public :: incrmntOfArray, TAlignedArray
+
+  !> Holds an allocated array being aligned in memory
+  type TAlignedArray
+
+    !> Actual array data
+    real(dp), pointer :: array(:)
+
+    !> Number of array elements
+    integer :: size = 0
+
+    !> Chosen alignment in bytes (default: 64 byted)
+    integer :: alignment = 64
+
+    !> Whether the array is allocated
+    logical :: isAllocated = .false.
+
+    !> Pointer to the allocated memory
+    type(c_ptr) :: memoryPointer = c_null_ptr
+
+  contains
+
+    procedure :: allocateAligned => TAlignedArray_allocateAligned
+    final :: TAlignedArray_finalize
+
+  end type TAlignedArray
+
+
+  !> Bound to 'posix_memalign' to allocate aligned memory
+  interface
+    function posixMemalign(ptr, alignment, size) result(error) bind(C, name="posix_memalign")
+      import c_ptr, c_intptr_t, c_int
+      type(c_ptr), intent(inout) :: ptr
+      integer(c_intptr_t), intent(in), value :: alignment, size
+      integer(c_int) :: error
+    end function
+  end interface
+
+
+  !> Bound to 'free' to deallocate memory again being previously allocated using 'posix_memalign'
+  interface
+    subroutine free(ptr) bind(C, name="free")
+      import c_ptr
+      type(c_ptr), value :: ptr
+    end subroutine
+  end interface
 
 
 contains
@@ -29,5 +79,60 @@ contains
     incrmntOfArray = currentSize + currentSize  / 2 + 1
 
   end function incrmntOfArray
+
+
+  !> Allocate an array aligned to the n byte boundary (typically used for aligning to 64 byte)
+  subroutine TAlignedArray_allocateAligned(this, size, alignment)
+
+    !> Instance of the aligned array type
+    class(TAlignedArray), intent(inout) :: this
+
+    !> Lower and upper bound for alignment
+    integer, intent(in) :: size
+
+    !> Alignment (default: 64 bytes)
+    integer, intent(in), optional :: alignment
+
+    if (this%isAllocated) then
+      call error("Aligned array is already allocated")
+    end if
+
+    @:ASSERT(size > 0)
+
+    if (present(alignment)) then
+      @:ASSERT(alignment >= dp)
+      @:ASSERT(mod(alignment, dp) == 0)
+
+      this%alignment = alignment
+    end if
+
+    if (posixMemalign(this%memoryPointer, int(this%alignment, kind=c_size_t),&
+          & int(size * dp, kind=c_size_t)) /= 0) then
+      call error("Error during allocation of aligned array")
+    end if
+
+    this%size = size
+    call c_f_pointer(this%memoryPointer, this%array, [size])
+
+    this%isAllocated = .true.
+
+  end subroutine TAlignedArray_allocateAligned
+
+
+  !> Clean-up an aligned array by deallocating it
+  subroutine TAlignedArray_finalize(this)
+
+    !> Instance of the aligned array type
+    type(TAlignedArray), intent(inout) :: this
+
+    if (this%isAllocated) then
+      nullify(this%array)
+      call free(this%memoryPointer)
+      this%memoryPointer = c_null_ptr
+      this%isAllocated = .false.
+    end if
+
+  end subroutine TAlignedArray_finalize
+
 
 end module dftbp_common_memman

--- a/src/dftbp/common/memman.F90
+++ b/src/dftbp/common/memman.F90
@@ -29,7 +29,7 @@ module dftbp_common_memman
     integer :: alignment = 64
 
     !> Pointer to the allocated memory
-    type(c_ptr), private :: memoryPointer = c_null_ptr
+    type(c_ptr), private :: memoryPointer_ = c_null_ptr
 
   contains
 
@@ -92,7 +92,7 @@ contains
 
     integer :: dp_size
 
-    if (c_associated(this%memoryPointer)) then
+    if (c_associated(this%memoryPointer_)) then
       call error("Aligned array is already allocated")
     end if
 
@@ -106,12 +106,12 @@ contains
       this%alignment = alignment
     end if
 
-    if (posixMemalign(this%memoryPointer, int(this%alignment, kind=c_size_t),&
+    if (posixMemalign(this%memoryPointer_, int(this%alignment, kind=c_size_t),&
           & int(size * dp_size, kind=c_size_t)) /= 0) then
       call error("Error during allocation of aligned array")
     end if
 
-    @:ASSERT(c_associated(this%memoryPointer))
+    @:ASSERT(c_associated(this%memoryPointer_))
 
     this%size = size
 
@@ -127,13 +127,13 @@ contains
     !> Pointer to the array data
     real(dp), pointer, intent(out) :: array(:)
 
-    call c_f_pointer(this%memoryPointer, array, [this%size])
+    call c_f_pointer(this%memoryPointer_, array, [this%size])
 
   end subroutine TAlignedArray_getArray
 
 
   !> On Assignment, deallocate, allocate, and copy array data
-  subroutine TAlignedArray_assign(this, other)
+  elemental impure subroutine TAlignedArray_assign(this, other)
 
     !> Instance of the lhs of the assignment
     class(TAlignedArray), intent(out) :: this
@@ -157,9 +157,9 @@ contains
     !> Instance of the aligned array type
     type(TAlignedArray), intent(inout) :: this
 
-    if (c_associated(this%memoryPointer)) then
-      call free(this%memoryPointer)
-      this%memoryPointer = c_null_ptr
+    if (c_associated(this%memoryPointer_)) then
+      call free(this%memoryPointer_)
+      this%memoryPointer_ = c_null_ptr
     end if
 
   end subroutine TAlignedArray_finalize

--- a/src/dftbp/common/memman.F90
+++ b/src/dftbp/common/memman.F90
@@ -28,7 +28,7 @@ module dftbp_common_memman
     !> Number of array elements
     integer :: size = 0
 
-    !> Chosen alignment in bytes (default: 64 byted)
+    !> Chosen alignment in bytes (default: 64 bytes)
     integer :: alignment = 64
 
     !> Whether the array is allocated
@@ -81,7 +81,7 @@ contains
   end function incrmntOfArray
 
 
-  !> Allocate an array aligned to the n byte boundary (typically used for aligning to 64 byte)
+  !> Allocate an array aligned to the n byte boundary (typically used for aligning to 64 bytes)
   subroutine TAlignedArray_allocateAligned(this, size, alignment)
 
     !> Instance of the aligned array type

--- a/test/src/dftbp/unittests/common/CMakeLists.txt
+++ b/test/src/dftbp/unittests/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(unit-test-prefix "${unit-test-prefix}/common")
 
 set(tests
+  memman
   schedule)
 
 foreach(test IN LISTS tests)

--- a/test/src/dftbp/unittests/common/memman.F90
+++ b/test/src/dftbp/unittests/common/memman.F90
@@ -1,0 +1,73 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2022  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+#:include "fytest.fypp"
+
+#:block TEST_SUITE("memman")
+  use dftbp_common_accuracy, only : dp
+  use dftbp_common_memman, only : TAlignedArray
+  use, intrinsic :: iso_c_binding, only : c_associated
+  implicit none
+
+#:contains
+
+  #:block TEST_FIXTURE("allocateAligned")
+
+    type(TAlignedArray) :: aligned
+
+  #:contains
+
+    #:block TEST("allocate32Bytes")
+      call aligned%allocateAligned(7, 32)
+
+      @:ASSERT(aligned%isAllocated)
+      @:ASSERT(aligned%alignment == 32)
+
+      @:ASSERT(aligned%size == 7)
+      @:ASSERT(size(aligned%array, dim=1) == 7)
+      @:ASSERT(lbound(aligned%array, dim=1) == 1)
+      @:ASSERT(ubound(aligned%array, dim=1) == 7)
+
+      aligned%array(:) = 1.0_dp
+      aligned%array(7) = 42.0_dp
+      @:ASSERT(aligned%array(7) == 42.0_dp)
+    #:endblock
+
+    #:block TEST("allocateDefault64Bytes")
+      call aligned%allocateAligned(7)
+
+      @:ASSERT(c_associated(aligned%memoryPointer))
+      @:ASSERT(aligned%isAllocated)
+      @:ASSERT(aligned%alignment == 64)
+    #:endblock
+
+    #:block TEST("deallocate")
+      @:ASSERT(.not. c_associated(aligned%memoryPointer))
+      @:ASSERT(.not. aligned%isAllocated)
+
+      call aligned%allocateAligned(7)
+      @:ASSERT(c_associated(aligned%memoryPointer))
+      @:ASSERT(aligned%isAllocated)
+
+      call triggerDeallocation(aligned)
+      @:ASSERT(.not. c_associated(aligned%memoryPointer))
+      @:ASSERT(.not. aligned%isAllocated)
+    #:endblock
+
+
+  #:endblock TEST_FIXTURE
+
+  subroutine triggerDeallocation(instance)
+
+    type(TAlignedArray), intent(out) :: instance
+
+  end subroutine triggerDeallocation
+
+#:endblock TEST_SUITE
+
+
+@:TEST_DRIVER()

--- a/test/src/dftbp/unittests/common/memman.F90
+++ b/test/src/dftbp/unittests/common/memman.F90
@@ -1,6 +1,6 @@
 !--------------------------------------------------------------------------------------------------!
 !  DFTB+: general package for performing fast atomistic simulations                                !
-!  Copyright (C) 2006 - 2022  DFTB+ developers group                                               !
+!  Copyright (C) 2006 - 2023  DFTB+ developers group                                               !
 !                                                                                                  !
 !  See the LICENSE file for terms of usage and distribution.                                       !
 !--------------------------------------------------------------------------------------------------!


### PR DESCRIPTION
Call `posix_memalign` to align arrays to the `n` byte boundary (usually used as 64 bytes on x86-64). Although the Intel Fortran compiler has a flag `-align array64byte`, which forces this alignment globally, nothing like this exists for the GNU compiler (and others). This implementation allows alignment independent of the compiler.