### PR TITLE
Fix for repeating allocation of array

### DIFF
--- a/src/dftbp/derivs/perturb.F90
+++ b/src/dftbp/derivs/perturb.F90
@@ -269,7 +269,7 @@ contains
     real(dp), allocatable, intent(inout) :: neFermi(:)
 
     !> Derivative of the Fermi energy (if metallic)
-    real(dp), allocatable, intent(inout) :: dEfdE(:,:)
+    real(dp), allocatable, intent(out) :: dEfdE(:,:)
 
     !> Status of routine
     type(TStatus), intent(out) :: errStatus


### PR DESCRIPTION
Wasn't taking the array out of scope when calling the routine multiple times (as happens with finite difference driver).