### PR TITLE
Change ELPA mode to 2 to fix test

### DIFF
--- a/test/app/dftb+/solvers/Si384_ELPA2/dftb_in.hsd
+++ b/test/app/dftb+/solvers/Si384_ELPA2/dftb_in.hsd
@@ -399,7 +399,7 @@ Hamiltonian = DFTB {
     Si = "p"
   }
   EigenSolver = ELPA {
-    Mode = 1
+    Mode = 2
   }
   Filling = Fermi {
     Temperature [Kelvin] = 0.0


### PR DESCRIPTION
The mode should be 2, otherwise the test is exactly equal to `Si384_ELPA1`.