### PR TITLE
Fix mpi-win finalization problem

### DIFF
--- a/app/dftb+/dftbplus.F90
+++ b/app/dftb+/dftbplus.F90
@@ -22,7 +22,7 @@ program dftbplus
 
   type(TEnvironment) :: env
   type(TInputData), allocatable :: input
-  type(TDftbPlusMain), allocatable :: main
+  type(TDftbPlusMain), allocatable, target :: main
 
   call initGlobalEnv()
   call printDftbHeader(releaseName, releaseYear)

--- a/app/dftb+/dftbplus.F90
+++ b/app/dftb+/dftbplus.F90
@@ -22,17 +22,19 @@ program dftbplus
 
   type(TEnvironment) :: env
   type(TInputData), allocatable :: input
-  type(TDftbPlusMain) :: main
+  type(TDftbPlusMain), allocatable :: main
 
   call initGlobalEnv()
   call printDftbHeader(releaseName, releaseYear)
   allocate(input)
   call parseHsdInput(input)
   call TEnvironment_init(env)
+  allocate(main)
   call main%initProgramVariables(input, env)
   deallocate(input)
   call runDftbPlus(main, env)
   call main%destructProgramVariables()
+  deallocate(main)
 #:if WITH_MAGMA
   call magmaf_finalize()
 #:endif

--- a/src/dftbp/api/mm/mmapi.F90
+++ b/src/dftbp/api/mm/mmapi.F90
@@ -375,7 +375,7 @@ contains
   subroutine TDftbPlus_setupCalculator(this, input)
 
     !> Instance.
-    class(TDftbPlus), intent(inout) :: this
+    class(TDftbPlus), target, intent(inout) :: this
 
     !> Representation of the DFTB+ input.
     type(TDftbPlusInput), intent(inout) :: input

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -1839,12 +1839,9 @@ contains
     else
       this%tCasidaForces = .false.
     end if
-    if (this%tSccCalc) then
-      this%forceType = input%ctrl%forceType
-    else
-      if (input%ctrl%forceType /= forceTypes%orig) then
-        call error("Invalid force evaluation method for non-SCC calculations.")
-      end if
+    this%forceType = input%ctrl%forceType
+    if (.not. this%tSccCalc .and. input%ctrl%forceType /= forceTypes%orig) then
+      call error("Invalid force evaluation method for non-SCC calculations.")
     end if
     if (this%forceType == forceTypes%dynamicT0 .and. this%tempElec > minTemp) then
        call error("This ForceEvaluation method requires the electron temperature to be zero")

--- a/src/dftbp/io/hsdparser.F90
+++ b/src/dftbp/io/hsdparser.F90
@@ -185,6 +185,7 @@ contains
     !> DOM-tree of the parsed input on exit
     type(fnode), pointer :: xmlDoc
 
+    logical, parameter :: parsedTypes(nSeparator) = .true.
     type(fnode), pointer :: rootNode, dummy
     logical :: tFinished
     integer :: curLine
@@ -204,7 +205,7 @@ contains
     curLine = 0
     lineReader = TLineReader(fd)
     tFinished = parse_recursive(rootNode, 0, residual, .false., lineReader, curFile, 0, curLine,&
-        & [.true., .true., .true., .true., .true., .true., .true.], .false.)
+        & parsedTypes, .false.)
 
   end subroutine parseHSD_opened
 


### PR DESCRIPTION
Seems to fix the error we get with the recent Intel compilers for MPI-applications, when `mpi_finalize()` is invoked: The mpi-windows will be freed explicitely before the call, allowing `mpi_finalize()` to run without any problems.

* [X] Test with buildbot (successful)