### PR TITLE
Fix undefined pointer in TAlignArray

### DIFF
--- a/src/dftbp/common/memman.F90
+++ b/src/dftbp/common/memman.F90
@@ -127,7 +127,11 @@ contains
     !> Pointer to the array data
     real(dp), pointer, intent(out) :: array(:)
 
-    call c_f_pointer(this%memoryPointer_, array, [this%size])
+    if (c_associated(this%memoryPointer_)) then
+      call c_f_pointer(this%memoryPointer_, array, [this%size])
+    else
+      array => null()
+    end if
 
   end subroutine TAlignedArray_getArray
 


### PR DESCRIPTION
As far as I understand the standard, the result of of `c_f_pointer` is undefined if the C-pointer going in is not associated. The corresponding memman unit test (`deallocate`)  failed with a few compilers, but not with all. This simple fix should make it deterministic.