### PR TITLE
Handling for perturbation SC failures

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -1397,7 +1397,10 @@ To select the DFTB Hamiltonian you must set \is{Hamiltonian =
   number of steps, the program stops. However in cases where the
   calculation is not for a static structure (so \is{Driver} $\neq$
   \cb), this behaviour can be overridden using
-  \kw{ConvergentSccOnly}.
+  \kw{ConvergentSccOnly}. {\bf Note:} For calculations using
+  $k$-points, the default number of SCC iterations will default to 1
+  in cases where a band structure is being plotted (see \iscb{KLines}
+  in section \ref{sec:dftbp.KLines}).
 
 \item[\is{ConvergentSccOnly}] If true, requires that the SCC cycle converges
   before proceeding to subsequent stages of the calculation (forces, analysis,
@@ -4959,16 +4962,35 @@ section~\ref{sec:dftbp.dEbandout}.
 There are common options for the perturbations, which appear outside
 their respective blocks in the \is{Analysis} environment:
 \begin{ptable}
-\kw{DegeneracyTolerance} & r & & 128\\
-\kw{eta} & r & & 1E-8\\
+  \kw{ConvergedPerturb} & l & SCC = Yes & Yes\\
+  \kw{MaxPerturbIter} & i & SCC = Yes & 100\\
+  \kw{PerturbDegenTol} & r & & 128\\
+  \kw{PerturbEta} & r & Dynamic Polarisation& 1E-8\\
+  \kw{PerturbSccTol} & r & SCC = Yes & 1e-5\\
 \end{ptable}
 \begin{description}
-\item[\is{DegeneracyTolerance}] In the case of degenerate systems,
+\item[\is{ConvergedPerturb}] If true, requires that the
+  perturbation self-consistently converges. If false, the code can
+  continue with a warning, but will return NaN for properties
+  evaluated at that stage.
+\item[\is{MaxPerturbIter}] Maximal number of self-consistent
+  cycles to reach convergence for perturbation evaluation of
+  properties. If convergence is not reached after the specified number
+  of steps, the program stops. This behaviour can be overridden using
+  \kw{ConvergedPerturb}, but will then produce Not a Number
+  (NaN) for non-convergent properties. {\bf Note:} For calculations
+  using $k$-points, the default number of self-consistent iterations
+  will default to 1 in cases where a band structure is being plotted
+  (see \iscb{KLines} in section \ref{sec:dftbp.KLines}).
+\item[\is{PerturbDegenTol}] In the case of degenerate systems,
   determines the number of times machine epsilon that separated
   eigenvalues are considered non-degenerate.
-\item[\is{eta}] In the case of finite frequency perturbations, a small
-  imaginary constant, of magnitude \is{eta} is used in the expression
+\item[\is{PerturbEta}] In the case of finite frequency perturbations, a small
+  imaginary constant, of magnitude \is{PerturbEta} is used in the expression
   to avoid divergences at resonant conditions.
+\item[\is{PerturbSccTol}] Stopping criteria for the perturbation
+  self-consistency.  Specifies the tolerance for the maximum
+  difference in any charge derivatives between two cycles.
 \end{description}
 
 
@@ -5008,7 +5030,7 @@ Static polarisability, with an adjusted degeneracy tolerance:
 \begin{verbatim}
 Analysis {
   Polarisability = {} # static enabled by default
-  DegeneracyTolerance = 1024 # levels within 1024 x machine tolerance
+  PerturbDegenTol = 1024 # levels within 1024 x machine tolerance
 }
 \end{verbatim}
 

--- a/doc/dftb+/manual/releases.tex
+++ b/doc/dftb+/manual/releases.tex
@@ -8,6 +8,7 @@ is listed below:
   \begin{tabular}{ccc}
     \is{InputVersion} / Release & \is{ParserVersion} & Date
     available\\ \hline
+    23.1 & 13 & ???\\
     22.2 & 12 & \DTMdate{2022-12-20}\\
     22.1 & 11 & \DTMdate{2022-05-25}\\
     21.2 & 10 & \DTMdate{2021-12-13}\\

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -504,6 +504,16 @@ module dftbp_dftbplus_initprogram
     !> Density functional tight binding perturbation theory
     logical :: doPerturbation = .false.
 
+    !> Self-consistency tolerance for perturbation (if SCC)
+    real(dp) :: perturbSccTol = 0.0_dp
+
+    !> Maximum iteration for self-consistency in the perturbation routines
+    integer :: maxPerturbIter = 0
+
+    !> Require converged perturbation (if true, terminate on failure, otherwise return NaN for
+    !> non-converged)
+    logical :: isPerturbConvRequired = .true.
+
     !> Density functional tight binding perturbation for each geometry step
     logical :: doPerturbEachGeom = .false.
 
@@ -1379,6 +1389,10 @@ contains
 
     ! Brillouin zone sampling
     if (this%tPeriodic .or. this%tHelical) then
+      if (input%ctrl%poorKSampling) then
+        call warning("The suplied k-points are probably not accurate for properties requiring&
+            & integration over the Brillouin zone")
+      end if
       this%nKPoint = input%ctrl%nKPoint
       allocate(this%kPoint(size(input%ctrl%KPoint,dim=1), this%nKPoint))
       allocate(this%kWeight(this%nKPoint))
@@ -1448,7 +1462,7 @@ contains
     this%isSccConvRequired = (input%ctrl%isSccConvRequired .and. this%tSccCalc)
 
     if (this%tSccCalc) then
-      this%maxSccIter = input%ctrl%maxIter
+      this%maxSccIter = input%ctrl%maxSccIter
     else
       this%maxSccIter = 1
     end if
@@ -2277,30 +2291,34 @@ contains
           & spin orbit calculations")
     end if
 
-    this%doPerturbation = input%ctrl%doPerturbation
+    this%doPerturbation = allocated(input%ctrl%perturbInp)
     this%doPerturbEachGeom = this%tDerivs .and. this%doPerturbation ! needs work
 
     if (this%doPerturbation .or. this%doPerturbEachGeom) then
 
+      this%perturbSccTol = input%ctrl%perturbInp%perturbSccTol
+      this%maxPerturbIter = input%ctrl%perturbInp%maxPerturbIter
+      this%isPerturbConvRequired = input%ctrl%perturbInp%isPerturbConvRequired
+
       allocate(this%response)
       call TResponse_init(this%response, responseSolverTypes%spectralSum, this%tFixEf,&
-          & input%ctrl%tolDegenDFTBPT, input%ctrl%etaFreq)
+          & input%ctrl%perturbInp%tolDegenDFTBPT, input%ctrl%perturbInp%etaFreq)
 
-      this%isEResp = allocated(input%ctrl%dynEFreq)
+      this%isEResp = allocated(input%ctrl%perturbInp%dynEFreq)
       if (this%isEResp) then
-        call move_alloc(input%ctrl%dynEFreq, this%dynRespEFreq)
+        call move_alloc(input%ctrl%perturbInp%dynEFreq, this%dynRespEFreq)
         if (this%isRangeSep .and. any(this%dynRespEFreq /= 0.0_dp)) then
           call error("Finite frequency range separated calculation not currently supported")
         end if
       end if
 
-      this%isKernelResp = allocated(input%ctrl%dynKernelFreq)
+      this%isKernelResp = allocated(input%ctrl%perturbInp%dynKernelFreq)
       if (this%isKernelResp) then
-        call move_alloc(input%ctrl%dynKernelFreq, this%dynKernelFreq)
+        call move_alloc(input%ctrl%perturbInp%dynKernelFreq, this%dynKernelFreq)
         if (this%isRangeSep .and. any(this%dynKernelFreq /= 0.0_dp)) then
           call error("Finite frequency range separated calculation not currently supported")
         end if
-        this%isRespKernelRPA = input%ctrl%isRespKernelRPA
+        this%isRespKernelRPA = input%ctrl%perturbInp%isRespKernelRPA
         if (.not.this%isRespKernelRPA .and. .not.this%tSccCalc) then
           call error("RPA option only relevant for SCC calculations of response kernel")
         end if
@@ -2315,8 +2333,7 @@ contains
         call error("Currently the perturbation expressions for NEGF are not implemented")
       end if
       if (.not. this%electronicSolver%providesEigenvals) then
-        call error("Perturbation expression for polarisability require eigenvalues and&
-            & eigenvectors")
+        call error("Perturbation expressions currently require eigenvalues and eigenvectors")
       end if
 
       if (this%t3rd) then

--- a/src/dftbp/dftbplus/inputdata.F90
+++ b/src/dftbp/dftbplus/inputdata.F90
@@ -11,6 +11,7 @@
 module dftbp_dftbplus_inputdata
   use dftbp_common_accuracy, only : dp, lc
   use dftbp_common_hamiltoniantypes, only : hamiltonianTypes
+  use dftbp_derivs_perturb, only : TPerturbInp
   use dftbp_dftb_dftbplusu, only : TDftbUInp
   use dftbp_dftb_dispersions, only : TDispersionInp
   use dftbp_dftb_elstatpot, only : TElStatPotentialsInp
@@ -212,32 +213,8 @@ module dftbp_dftbplus_inputdata
     !> Input data for Pipek-Mezey localisation
     type(TPipekMezeyInp), allocatable :: pipekMezeyInp
 
-    !> Is a perturbation expression in use
-    logical :: doPerturbation = .false.
-
-    !> Is a perturbation expression in use for each geometry step
-    logical :: doPerturbEachGeom = .false.
-
-    !> Tolerance for idenfifying need for degenerate perturbation theory
-    real(dp) :: tolDegenDFTBPT = 128.0_dp
-
-    !> Is this is a static electric field perturbation calculation
-    logical :: isEPerturb = .false.
-
-    !> Frequencies for perturbation (0 being static case)
-    real(dp), allocatable :: dynEFreq(:)
-
-    !> Frequency dependent perturbation eta
-    real(dp), allocatable :: etaFreq
-
-    !> Is the response kernel (and frontier eigenvalue derivatives) calculated by perturbation
-    logical :: isRespKernelPert = .false.
-
-    !> Is the response kernel evaluated at the RPA level, or (if SCC) self-consistent
-    logical :: isRespKernelRPA
-
-    !> Frequencies for perturbation (0 being static case)
-    real(dp), allocatable :: dynKernelFreq(:)
+    !> Perturbation theory input data
+    type(TPerturbInp), allocatable :: perturbInp
 
     !> Printing of atom resolved energies
     logical :: tAtomicEnergy = .false.
@@ -300,7 +277,10 @@ module dftbp_dftbplus_inputdata
     type(TElectronicSolverInp) :: solver
 
     integer :: iMixSwitch = 0
-    integer :: maxIter = 0
+
+    !> Maximum number of self-consitent iterations
+    integer :: maxSccIter = 0
+
     real(dp) :: almix = 0.0_dp
     integer :: iGenerations = 0
     logical :: tFromStart = .true.
@@ -367,10 +347,17 @@ module dftbp_dftbplus_inputdata
     !> Second derivative finite difference step
     real(dp) :: deriv2ndDelta = 0.0_dp
 
+    !> Number of k-points for the calculation
     integer :: nKPoint = 0
+
+    !> K-points for the system (= 0 for molecular in free space and no symmetries)
     real(dp), allocatable :: kPoint(:,:)
+
+    !> Weights for the k-points
     real(dp), allocatable :: kWeight(:)
 
+    !> Are the k-points not suitable for integrals over the Brillouin zone
+    logical :: poorKSampling = .false.
 
     !> Cell pressure if periodic
     real(dp) :: pressure = 0.0_dp

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -300,9 +300,9 @@ contains
               & this%eigVecsReal, this%eigvecsCplx, this%ints%hamiltonian, this%ints%overlap,&
               & this%orb, this%nAtom, this%species, this%neighbourList, this%nNeighbourSK,&
               & this%denseDesc, this%iSparseStart, this%img2CentCell, this%coord, this%scc,&
-              & this%maxSccIter, this%sccTol, this%isSccConvRequired, this%nMixElements,&
-              & this%nIneqOrb, this%iEqOrbitals, this%tempElec, this%Ef, this%spinW,&
-              & this%thirdOrd, this%dftbU, this%iEqBlockDftbu, this%onSiteElements,&
+              & this%maxPerturbIter, this%perturbSccTol, this%isPerturbConvRequired,&
+              & this%nMixElements, this%nIneqOrb, this%iEqOrbitals, this%tempElec, this%Ef,&
+              & this%spinW, this%thirdOrd, this%dftbU, this%iEqBlockDftbu, this%onSiteElements,&
               & this%iEqBlockOnSite, this%rangeSep, this%nNeighbourLC, this%pChrgMixer,&
               & this%kPoint, this%kWeight, this%iCellVec, this%cellVec, this%polarisability,&
               & this%dEidE, this%dqOut, this%neFermi, this%dEfdE, errStatus, this%dynRespEFreq)
@@ -475,9 +475,9 @@ contains
             & this%eigVecsReal, this%eigvecsCplx, this%ints%hamiltonian, this%ints%overlap,&
             & this%orb, this%nAtom, this%species, this%neighbourList, this%nNeighbourSK,&
             & this%denseDesc, this%iSparseStart, this%img2CentCell, this%coord, this%scc,&
-            & this%maxSccIter, this%sccTol, this%isSccConvRequired, this%nMixElements,&
-            & this%nIneqOrb, this%iEqOrbitals, this%tempElec, this%Ef, this%spinW,&
-            & this%thirdOrd, this%dftbU, this%iEqBlockDftbu, this%onSiteElements,&
+            & this%maxPerturbIter, this%perturbSccTol, this%isPerturbConvRequired,&
+            & this%nMixElements, this%nIneqOrb, this%iEqOrbitals, this%tempElec, this%Ef,&
+            & this%spinW, this%thirdOrd, this%dftbU, this%iEqBlockDftbu, this%onSiteElements,&
             & this%iEqBlockOnSite, this%rangeSep, this%nNeighbourLC, this%pChrgMixer, this%kPoint,&
             & this%kWeight, this%iCellVec, this%cellVec, this%polarisability, this%dEidE,&
             & this%dqOut, this%neFermi, this%dEfdE, errStatus, this%dynRespEFreq)
@@ -500,12 +500,12 @@ contains
             & this%fdDetailedOut, this%filling, this%eigen, this%eigVecsReal, this%eigvecsCplx,&
             & this%ints%hamiltonian, this%ints%overlap, this%orb, this%nAtom, this%species,&
             & this%neighbourList, this%nNeighbourSK, this%denseDesc, this%iSparseStart,&
-            & this%img2CentCell, this%isRespKernelRPA, this%scc, this%maxSccIter, this%sccTol,&
-            & this%isSccConvRequired, this%nMixElements, this%nIneqOrb, this%iEqOrbitals,&
-            & this%tempElec, this%Ef, this%spinW, this%thirdOrd, this%dftbU, this%iEqBlockDftbu,&
-            & this%onSiteElements, this%iEqBlockOnSite, this%rangeSep, this%nNeighbourLC,&
-            & this%pChrgMixer, this%kPoint, this%kWeight, this%iCellVec, this%cellVec,&
-            & this%neFermi, errStatus, this%dynKernelFreq, this%tHelical, this%coord)
+            & this%img2CentCell, this%isRespKernelRPA, this%scc, this%maxPerturbIter,&
+            & this%perturbSccTol, this%isPerturbConvRequired, this%nMixElements, this%nIneqOrb,&
+            & this%iEqOrbitals, this%tempElec, this%Ef, this%spinW, this%thirdOrd, this%dftbU,&
+            & this%iEqBlockDftbu, this%onSiteElements, this%iEqBlockOnSite, this%rangeSep,&
+            & this%nNeighbourLC, this%pChrgMixer, this%kPoint, this%kWeight, this%iCellVec,&
+            & this%cellVec, this%neFermi, errStatus, this%dynKernelFreq, this%tHelical, this%coord)
         if (errStatus%hasError()) then
           call error(errStatus%message)
         end if

--- a/src/dftbp/dftbplus/oldcompat.F90
+++ b/src/dftbp/dftbplus/oldcompat.F90
@@ -78,6 +78,9 @@ contains
       case (11)
         call convert_11_12(root)
         version = 12
+      case (12)
+        call convert_12_13(root)
+        version = 13
       end select
     end do
 
@@ -766,6 +769,67 @@ contains
     end if
 
   end subroutine convert_11_12
+
+
+  !> Converts input from version 12 to 13. (Version 13 introduced in February 2023)
+  subroutine convert_12_13(root)
+
+    !> Root tag of the HSD-tree
+    type(fnode), pointer :: root
+
+    type(fnode), pointer :: ch1, ch2, ch3, par1
+    integer :: maxIter
+    logical :: isPerturb, isConvRequired
+    real(dp) :: sccTol
+
+    call getDescendant(root, "Analysis/Polarisability", ch1)
+    isPerturb = associated(ch1)
+    if (.not.isPerturb) then
+      call getDescendant(root, "Analysis/ResponseKernel", ch1)
+      isPerturb = associated(ch1)
+    end if
+
+    if (isPerturb) then
+
+      call getDescendant(root, "Analysis/Eta", ch1)
+      if (associated(ch1)) then
+        call detailedWarning(ch1, "Keyword renamed to 'PerturbEta'.")
+        call setNodeName(ch1, "PerturbEta")
+      end if
+
+      call getDescendant(root, "Analysis/DegeneracyTolerance", ch1)
+      if (associated(ch1)) then
+        call detailedWarning(ch1, "Keyword renamed to 'PerturbDegenTol'.")
+        call setNodeName(ch1, "PertubDegenTol")
+      end if
+
+      call getDescendant(root, "Hamiltonian/DFTB/MaxSCCIterations", ch1, parent=par1)
+      if (associated(ch1)) then
+        call getChildValue(par1, "MaxSCCIterations", maxIter)
+        call getDescendant(root, "Analysis", ch1)
+        call setChildValue(ch1, "MaxPerturbIter", maxIter, child=ch2)
+        call setUnprocessed(ch2)
+      end if
+
+      call getDescendant(root, "Hamiltonian/DFTB/ConvergentSCCOnly", ch1, parent=par1)
+      if (associated(ch1)) then
+        call getChildValue(par1, "ConvergentSCCOnly", isConvRequired)
+        call getDescendant(root, "Analysis", ch1)
+        call setChildValue(ch1, "ConvergedPerturb", isConvRequired, child=ch2)
+        call setUnprocessed(ch2)
+      end if
+
+      call getDescendant(root, "Hamiltonian/DFTB/SccTolerance", ch1, parent=par1)
+      if (associated(ch1)) then
+        call getChildValue(par1, "SccTolerance", sccTol)
+        call getDescendant(root, "Analysis", ch1)
+        call setChildValue(ch1, "PerturbSccTol", sccTol, child=ch2)
+        call setUnprocessed(ch2)
+      end if
+
+    end if
+
+  end subroutine convert_12_13
 
 
   !> Update values in the DftD3 block to match behaviour of v6 parser

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -125,7 +125,7 @@ module dftbp_dftbplus_parser
 
   !> Actual input version <-> parser version maps (must be updated at every public release)
   type(TVersionMap), parameter :: versionMaps(*) = [&
-      & TVersionMap("22.2", 12),&
+      & TVersionMap("23.1", 13), TVersionMap("22.2", 12),&
       & TVersionMap("22.1", 11), TVersionMap("21.2", 10), TVersionMap("21.1", 9),&
       & TVersionMap("20.2", 9), TVersionMap("20.1", 8), TVersionMap("19.1", 7),&
       & TVersionMap("18.2", 6), TVersionMap("18.1", 5), TVersionMap("17.1", 5)]
@@ -1329,7 +1329,6 @@ contains
     real(dp) :: rTmp
     integer, allocatable :: iTmpN(:)
     integer :: nShell, skInterMeth
-    logical :: tBadIntegratingKPoints
     real(dp) :: rSKCutOff
     type(string), allocatable :: searchPath(:)
     character(len=:), allocatable :: strOut
@@ -1564,7 +1563,7 @@ contains
   #:endif
 
     ! K-Points
-    call readKPoints(node, ctrl, geo, tBadIntegratingKPoints)
+    call readKPoints(node, ctrl, geo, ctrl%poorKSampling)
 
     call getChild(node, "OrbitalPotential", child, requested=.false.)
     if (associated(child)) then
@@ -1824,7 +1823,6 @@ contains
     type(fnode), pointer :: value1, child, child2
     type(string) :: buffer, modifier
     type(string), allocatable :: searchPath(:)
-    logical :: tBadIntegratingKPoints
     integer :: method, iSp1
     character(len=:), allocatable :: paramFile, paramTmp
     type(TOrbitals) :: orb
@@ -1934,7 +1932,7 @@ contains
   #:endif
 
     ! K-Points
-    call readKPoints(node, ctrl, geo, tBadIntegratingKPoints)
+    call readKPoints(node, ctrl, geo, ctrl%poorKSampling)
 
     ! Dispersion
     call getChildValue(node, "Dispersion", value1, "", child=child, &
@@ -2750,7 +2748,7 @@ contains
 
 
   !> K-Points
-  subroutine readKPoints(node, ctrl, geo, tBadIntegratingKPoints)
+  subroutine readKPoints(node, ctrl, geo, poorKSampling)
 
     !> Relevant node in input tree
     type(fnode), pointer :: node
@@ -2762,52 +2760,79 @@ contains
     type(TGeometry), intent(in) :: geo
 
     !> Is this k-point grid usable to integrate properties like the energy, charges, ...?
-    logical, intent(out) :: tBadIntegratingKPoints
+    logical, intent(out) :: poorKSampling
 
     integer :: ii
     character(lc) :: errorStr
 
     ! Assume SCC can has usual default number of steps if needed
-    tBadIntegratingKPoints = .false.
+    poorKSampling = .false.
 
     ! K-Points
     if (geo%tPeriodic) then
 
-      call getEuclideanKSampling(tBadIntegratingKPoints, ctrl, node, geo)
+      call getEuclideanKSampling(poorKSampling, ctrl, node, geo)
 
     else if (geo%tHelical) then
 
-      call getHelicalKSampling(tBadIntegratingKPoints, ctrl, node, geo)
+      call getHelicalKSampling(poorKSampling, ctrl, node, geo)
 
     end if
 
-    if (ctrl%tSCC) then
-      if (tBadIntegratingKPoints) then
-        ! prevent full SCC with these points
-        ii = 1
-      else
-        ii = 100
-      end if
-      call getChildValue(node, "MaxSCCIterations", ctrl%maxIter, ii)
-    end if
-
-    if (tBadIntegratingKPoints .and. ctrl%tSCC .and. ctrl%maxIter /= 1) then
-      write(errorStr, "(A,I3)") "SCC cycle with these k-points probably will&
-          & not correctly calculate many properties, SCC iterations set to:", ctrl%maxIter
-      call warning(errorStr)
-    end if
-    if (tBadIntegratingKPoints .and. ctrl%tSCC .and. .not.ctrl%tReadChrg) then
+    call maxSelfConsIterations(node, ctrl, "MaxSCCIterations", ctrl%maxSccIter)
+    ! Eventually, perturbation routines should also have restart reads:
+    if (ctrl%poorKSampling .and. ctrl%tSCC .and. .not.ctrl%tReadChrg) then
       call warning("It is strongly suggested you use the ReadInitialCharges option.")
     end if
 
   end subroutine readKPoints
 
 
+  !> Set the maximum number of SCC cycles, depending on k-point behaviour
+  subroutine maxSelfConsIterations(node, ctrl, label, maxSccIter)
+
+    !> Relevant node in input tree
+    type(fnode), pointer :: node
+
+    !> Control structure to be filled
+    type(TControl), intent(inout) :: ctrl
+
+    !> Name of the tag
+    character(*), intent(in) :: label
+
+    !> Number of self-consistent iterations
+    integer, intent(out) :: maxSccIter
+
+    ! string for error return
+    character(lc) :: warningStr
+
+    integer :: ii
+
+    maxSccIter = 1
+    if (ctrl%tSCC) then
+      if (ctrl%poorKSampling) then
+        ! prevent full SCC with these points
+        ii = 1
+      else
+        ii = 100
+      end if
+      call getChildValue(node, trim(label), maxSccIter, ii)
+    end if
+
+    if (ctrl%poorKSampling .and. maxSccIter /= 1) then
+      write(warningStr, "(A,I3)") "A self-consistent cycle with these k-points probably will&
+          & not correctly calculate many properties, maximum iterations set to:", maxSccIter
+      call warning(warningStr)
+    end if
+
+  end subroutine maxSelfConsIterations
+
+
   !> K-points in Euclidean space
-  subroutine getEuclideanKSampling(tBadIntegratingKPoints, ctrl, node, geo)
+  subroutine getEuclideanKSampling(poorKSampling, ctrl, node, geo)
 
     !> Is this k-point grid usable to integrate properties like the energy, charges, ...?
-    logical, intent(out) :: tBadIntegratingKPoints
+    logical, intent(out) :: poorKSampling
 
     !> Relevant node in input tree
     type(fnode), pointer :: node
@@ -2834,7 +2859,7 @@ contains
     select case(char(buffer))
 
     case ("supercellfolding")
-      tBadIntegratingKPoints = .false.
+      poorKSampling = .false.
       if (len(modifier) > 0) then
         call detailedError(child, "No modifier is allowed, if the &
             &SupercellFolding scheme is used.")
@@ -2860,7 +2885,7 @@ contains
 
     case ("klines")
       ! probably unable to integrate charge for SCC
-      tBadIntegratingKPoints = .true.
+      poorKSampling = .true.
       call init(li1)
       call init(lr1)
       call getChildValue(value1, "", 1, li1, 3, lr1)
@@ -2918,7 +2943,7 @@ contains
     case (textNodeName)
 
       ! no idea, but assume user knows what they are doing
-      tBadIntegratingKPoints = .false.
+      poorKSampling = .false.
 
       call init(lr1)
       call getChildValue(child, "", 4, lr1, modifier=modifier)
@@ -2953,10 +2978,10 @@ contains
 
 
   !> K-points for helical boundaries
-  subroutine getHelicalKSampling(tBadIntegratingKPoints, ctrl, node, geo)
+  subroutine getHelicalKSampling(poorKSampling, ctrl, node, geo)
 
     !> Is this k-point grid usable to integrate properties like the energy, charges, ...?
-    logical, intent(out) :: tBadIntegratingKPoints
+    logical, intent(out) :: poorKSampling
 
     !> Relevant node in input tree
     type(fnode), pointer :: node
@@ -2976,7 +3001,7 @@ contains
     character(lc) :: errorStr
 
     ! assume the user knows what they are doing
-    tBadIntegratingKPoints = .false.
+    poorKSampling = .false.
 
     call getChildValue(node, "KPointsAndWeights", value1, child=child)
     call getNodeName(value1, buffer)
@@ -5057,53 +5082,65 @@ contains
 
       call getChildValue(node, "WriteBandOut", ctrl%tWriteBandDat, tWriteBandDatDef)
 
-      ctrl%doPerturbation = .false.
+      call getChild(node, "Polarisability", child=child, requested=.false.)
+      call getChild(node, "ResponseKernel", child=child2, requested=.false.)
+      if (associated(child) .or. associated(child2)) then
+        allocate(ctrl%perturbInp)
+      end if
 
       ! electric field polarisability of system
       call getChild(node, "Polarisability", child=child, requested=.false.)
       if (associated(child)) then
-        ctrl%doPerturbation = .true.
-        ctrl%isEPerturb = .true.
-        call freqRanges(child, ctrl%dynEFreq)
+        ctrl%perturbInp%isEPerturb = .true.
+        call freqRanges(child, ctrl%perturbInp%dynEFreq)
       end if
 
       call getChild(node, "ResponseKernel", child=child, requested=.false.)
       if (associated(child)) then
-        ctrl%doPerturbation = .true.
-        ctrl%isRespKernelPert = .true.
+        ctrl%perturbInp%isRespKernelPert = .true.
         if (ctrl%tSCC) then
-          call getChildValue(child, "RPA", ctrl%isRespKernelRPA, .false.)
+          call getChildValue(child, "RPA", ctrl%perturbInp%isRespKernelRPA, .false.)
         else
-          ctrl%isRespKernelRPA = .true.
+          ctrl%perturbInp%isRespKernelRPA = .true.
         end if
-        call freqRanges(child, ctrl%dynKernelFreq)
+        call freqRanges(child, ctrl%perturbInp%dynKernelFreq)
       end if
 
-      if (ctrl%doPerturbation) then
-        call getChildValue(node, "DegeneracyTolerance", ctrl%tolDegenDFTBPT, 128.0_dp,&
+      if (allocated(ctrl%perturbInp)) then
+        call getChildValue(node, "PertubDegenTol", ctrl%perturbInp%tolDegenDFTBPT, 128.0_dp,&
             & child=child)
-        if (ctrl%tolDegenDFTBPT < 1.0_dp) then
-          call detailedError(child, "Degeneracy tolerance must be above 1x")
+        if (ctrl%perturbInp%tolDegenDFTBPT < 1.0_dp) then
+          call detailedError(child, "Perturbation degeneracy tolerance must be above 1x")
         end if
-        ctrl%tolDegenDFTBPT = ctrl%tolDegenDFTBPT * epsilon(0.0_dp)
+        ctrl%perturbInp%tolDegenDFTBPT = ctrl%perturbInp%tolDegenDFTBPT * epsilon(0.0_dp)
         isEtaNeeded = .false.
-        if (allocated(ctrl%dynEFreq)) then
-          if (any(ctrl%dynEFreq /= 0.0_dp)) then
+        if (allocated(ctrl%perturbInp%dynEFreq)) then
+          if (any(ctrl%perturbInp%dynEFreq /= 0.0_dp)) then
             isEtaNeeded = .true.
           end if
         end if
-        if (allocated(ctrl%dynKernelFreq)) then
-          if (any(ctrl%dynKernelFreq /= 0.0_dp)) then
+        if (allocated(ctrl%perturbInp%dynKernelFreq)) then
+          if (any(ctrl%perturbInp%dynKernelFreq /= 0.0_dp)) then
             isEtaNeeded = .true.
           end if
         end if
         if (isEtaNeeded) then
-          allocate(ctrl%etaFreq)
-          call getChildValue(node, "eta", ctrl%etaFreq, 1.0E-8_dp, child=child)
-          if (ctrl%etaFreq < epsilon(0.0_dp)) then
+          allocate(ctrl%perturbInp%etaFreq)
+          call getChildValue(node, "PerturbEta", ctrl%perturbInp%etaFreq, 1.0E-8_dp, child=child)
+          if (ctrl%perturbInp%etaFreq < epsilon(0.0_dp)) then
             call detailedError(child, "Imaginary constant for finite frequency perturbation too&
                 & small")
           end if
+        end if
+      end if
+
+      if (allocated(ctrl%perturbInp)) then
+        call maxSelfConsIterations(node, ctrl, "MaxPerturbIter", ctrl%perturbInp%maxPerturbIter)
+        if (ctrl%tScc) then
+          call getChildValue(node, "PerturbSccTol", ctrl%perturbInp%perturbSccTol, 1.0e-5_dp)
+          ! self consistency required, or not, to proceed with perturbation
+          call getChildValue(node, "ConvergedPerturb", ctrl%perturbInp%isPerturbConvRequired,&
+              & .true.)
         end if
       end if
 


### PR DESCRIPTION
If ConvergentPerturbationOnly = No then will return NaN for properties, but otherwise continue (for example if used for multiple frequencies, different directions for perturbation or other perturbations).

* Makes keywords around perturbation more explict and introduces parser v13 for compatibility update
* Sets tolerances/iterations/convergence for perturbation explicitly
* Fix some broken/missing comments
* Macros for NaN handling