### PR TITLE
Fix backward compatibility of argparse

### DIFF
--- a/test/app/dftb+/bin/tagdiff
+++ b/test/app/dftb+/bin/tagdiff
@@ -325,7 +325,7 @@ def zOpen(filename, mode):
 def parseOptions():
     """Parses script's options"""
 
-    parser = ArgumentParser(usage="usage: %(prog)s [ options ] orig new",
+    parser = ArgumentParser(usage="%(prog)s [ options ] orig new",
                             description=DESCRIPTION)
     parser.add_argument('--version', action='version',
                         version=("%%(prog)s %s" % VERSION))

--- a/tools/misc/calc_timeprop_maxpoldir
+++ b/tools/misc/calc_timeprop_maxpoldir
@@ -16,30 +16,29 @@ from scipy import linalg, constants
 import sys
 hplanck = constants.physical_constants['Planck constant in eV s'][0] * 1.0E15
 
-USAGE = """Reads output from TD calculation (after kick) and excitation energy
+DESCRIPTION = """Reads output from TD calculation (after kick) and excitation energy
 (or wavelength) of interest and diagonalizes polarizability tensor, to
 calculate direction of maximum polarizability of that particular excitation.
-
 Needs mux.dat, muy.dat and muz.dat files in working directory."""
 
 def main():
-    parser = argparse.ArgumentParser(description=USAGE)
-    parser.add_argument("tau", metavar="DAMPING",
-                        help="damping constant in fs")
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument("-d", "--damping", dest="tau", required=True,
+                        type=float, help="damping constant in fs")
 
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("-e", "--energy", dest="energy",
-                        help="excitation energy in eV")
-    group.add_argument("-w", "--wavelength", dest="wvlength",
-                        help="wavelength of excitation in nm")
+    group.add_argument("-e", "--energy", dest="energy", type=float,
+                       help="excitation energy in eV")
+    group.add_argument("-w", "--wavelength", dest="wvlength", type=float,
+                       help="wavelength of excitation in nm")
 
     args = parser.parse_args()
 
     if args.energy is not None:
-        energy = float(args.energy)
+        energy = args.energy
     elif args.wvlength is not None:
         cspeednm = constants.speed_of_light * 1.0e9 / 1.0e15
-        energy = hplanck * cspeednm / float(args.wvlength)
+        energy = hplanck * cspeednm / args.wvlength
 
     mux = np.loadtxt('mux.dat')
     muy = np.loadtxt('muy.dat')
@@ -87,7 +86,7 @@ def main():
         mu[2,1] += factor * muz[:,5]
         mu[2,2] += factor * muz[:,6]
 
-    damp = np.exp(-time/float(args.tau))
+    damp = np.exp(-time/ args.tau)
     energsev = np.fft.rfftfreq(10*time.shape[0],time[1]-time[0]) * hplanck
     idx = (np.abs(energsev-energy)).argmin()
 

--- a/tools/misc/calc_timeprop_spectrum
+++ b/tools/misc/calc_timeprop_spectrum
@@ -15,15 +15,15 @@ import argparse
 import numpy as np
 from scipy import constants
 
-USAGE = """Reads output from TD calculation (after kick) and produces
-absorption spectra. Needs mux.dat, muy.dat and muz.dat files in working directory."""
+DESCRIPTION = """Reads output from TD calculation (after kick) and produces absorption spectra.
+Needs mux.dat, muy.dat and muz.dat files in working directory."""
 
 def main():
-    parser = argparse.ArgumentParser(description=USAGE)
-    parser.add_argument("tau", metavar="DAMPING",
-                        help="damping constant in fs")
-    parser.add_argument("field", metavar="FIELD",
-                        help="field intensity in volts/angstrom")
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument("-d", "--damping", dest="tau", required=True,
+                        type=float, help="damping constant in fs")
+    parser.add_argument("-f", "--field", dest="field", required=True,
+                        type=float, help="field intensity in volts/angstrom")
 
     args = parser.parse_args()
 
@@ -38,7 +38,7 @@ def main():
     else:
         spinpol = False
 
-    damp = np.exp(-mux[:,0]/float(args.tau))
+    damp = np.exp(-mux[:,0]/ args.tau)
     if not spinpol:
         average = ((mux[:,1]-mux[0,1]) + (muy[:,2]-muy[0,2]) + (muz[:,3]-muz[0,3]))/3.0
     elif (spintype == 's'):
@@ -54,7 +54,7 @@ def main():
     cspeednm = constants.speed_of_light * 1.0e9 / 1.0e15
     energsev = np.fft.rfftfreq(10*mux.shape[0], mux[1,0]-mux[0,0]) * hplanck
     frec = np.fft.rfftfreq(10*mux.shape[0], (mux[1,0] - mux[0,0]) * 1.0E-15 )
-    absorption = -2.0 * energsev * spec.imag / np.pi / float(args.field)
+    absorption = -2.0 * energsev * spec.imag / np.pi / args.field
     energsnm = constants.nu2lambda(frec[1:]) * 1.0E9
 
     emin = 0.5

--- a/tools/misc/convolve.py
+++ b/tools/misc/convolve.py
@@ -18,9 +18,9 @@ import sys
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument("infile", metavar="INPUT",
+parser.add_argument("-i", "--input", dest="infile", required=True,
                     help="input file name")
-parser.add_argument("outfile", metavar="OUTPUT",
+parser.add_argument("-o", "--output", dest="outfile", required=True,
                     help="output file name")
 parser.add_argument("-b", "--broaden", dest="sigma", type=float, default=0.1,
                     help="broadening width")


### PR DESCRIPTION
This should fix the backward compatibility problems when switching from optparse to argparse (#1081).

I would suggest inserting a test in `calc_timeprop_maxpoldir` so that at least two parameters (either -d and -w or -d and -e) are set before the files (mux.dat, muy.dat and muz.dat) are imported.