### PR TITLE
Fix indentation errors and convert comments to uppercase

### DIFF
--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -184,28 +184,28 @@ module dftbp_dftbplus_initprogram
     !> SCC module internal variables
     type(TScc), allocatable :: scc
 
-    !> nr. of atoms
+    !> Nr. of atoms
     integer :: nAtom
 
-    !> nr. of all (boundary condition images and original) atoms
+    !> Nr. of all (boundary condition images and original) atoms
     integer :: nAllAtom
 
-    !> nr. of original atom in central cell
+    !> Nr. of original atom in central cell
     integer, allocatable :: img2CentCell(:)
 
-    !> nr of different types (nAtom)
+    !> Nr. of different types (nAtom)
     integer :: nType
 
-    !> data type for atomic orbital information
+    !> Data type for atomic orbital information
     type(TOrbitals), allocatable :: orb
 
-    !> nr. of orbitals in the system
+    !> Nr. of orbitals in the system
     integer :: nOrb
 
-    !> types of the atoms (nAllAtom)
+    !> Types of the atoms (nAllAtom)
     integer, allocatable :: species(:)
 
-    !> type of the atoms (nAtom)
+    !> Type of the atoms (nAtom)
     integer, allocatable :: species0(:)
 
     !> Coords of the atoms (3, nAllAtom)
@@ -214,7 +214,7 @@ module dftbp_dftbplus_initprogram
     !> Coords in central cell (3, nAtom)
     real(dp), allocatable :: coord0(:,:)
 
-    !> if calculation is periodic
+    !> If calculation is periodic
     logical :: tPeriodic
 
     !> If the calculation is helical geometry
@@ -226,50 +226,50 @@ module dftbp_dftbplus_initprogram
     !> How to calculate forces
     integer :: forceType
 
-    !> are atomic coordinates fractional?
+    !> Are atomic coordinates fractional?
     logical :: tFracCoord
 
     !> Tolerance for SCC cycle
     real(dp) :: sccTol
 
-    !> lattice vectors as columns
+    !> Lattice vectors as columns
     real(dp), allocatable :: latVec(:,:)
 
     !> Origin of coordinate system for periodic systems
     real(dp), allocatable :: origin(:)
 
-    !> reciprocal lattice vectors as columns
+    !> Reciprocal lattice vectors as columns
     real(dp), allocatable :: recVec(:,:)
 
-    !> original lattice vectors used for optimising
+    !> Original lattice vectors used for optimising
     real(dp) :: origLatVec(3,3)
 
-    !> normalized vectors in those directions
+    !> Normalized vectors in those directions
     real(dp) :: normOrigLatVec(3,3)
 
-    !> reciprocal vectors in 2 pi units
+    !> Reciprocal vectors in 2 pi units
     real(dp), allocatable :: invLatVec(:,:)
 
-    !> cell volume
+    !> Cell volume
     real(dp) :: CellVol
 
-    !> reciprocal cell volume
+    !> Reciprocal cell volume
     real(dp) :: recCellVol
 
-    !> translation vecs for interacting image cells (3, nImgCell + 1)
+    !> Translation vecs for interacting image cells (3, nImgCell + 1)
     real(dp), allocatable :: cellVec(:,:)
 
-    !> cell vectors in absolute units
+    !> Cell vectors in absolute units
     real(dp), allocatable :: rCellVec(:,:)
 
-    !> index in cellVec for each atom
+    !> Index in cellVec for each atom
     integer, allocatable :: iCellVec(:)
 
 
     !> ADT for neighbour parameters
     type(TNeighbourList), allocatable :: neighbourList
 
-    !> nr. of neighbours for atoms out to max interaction distance (excluding Ewald terms)
+    !> Nr. of neighbours for atoms out to max interaction distance (excluding Ewald terms)
     integer, allocatable :: nNeighbourSK(:)
 
     !> Number of neighbours for each of the atoms for the exchange contributions in the long range
@@ -279,16 +279,16 @@ module dftbp_dftbplus_initprogram
     !> H/S sparse matrices indexing array for atomic blocks
     integer, allocatable :: iSparseStart(:,:)
 
-    !> self energy (orbital, atom)
+    !> Self energy (orbital, atom)
     real(dp), allocatable :: atomEigVal(:,:)
 
-    !> reference n_0 charges for each atom
+    !> Reference n_0 charges for each atom
     real(dp), allocatable :: referenceN0(:,:)
 
-    !> list of atomic masses
+    !> List of atomic masses
     real(dp), allocatable :: mass(:)
 
-    !> list of atomic masses for each species
+    !> List of atomic masses for each species
     real(dp), allocatable :: speciesMass(:)
 
     !> Hamiltonian type
@@ -315,16 +315,16 @@ module dftbp_dftbplus_initprogram
     !> Integral container
     type(TIntegral) :: ints
 
-    !> nr. of K-points
+    !> Nr. of K-points
     integer :: nKPoint
 
     !> K-points
     real(dp), allocatable :: kPoint(:,:)
 
-    !> weight of the K-Points
+    !> Weight of the K-Points
     real(dp), allocatable :: kWeight(:)
 
-    !> external pressure if periodic
+    !> External pressure if periodic
     real(dp) :: extPressure
 
     !> Barostat used if MD and periodic
@@ -333,17 +333,14 @@ module dftbp_dftbplus_initprogram
     !> Barostat coupling strength
     real(dp) :: BarostatStrength
 
-
     !> H and S are real
     logical :: tRealHS
 
-
-    !> nr. of electrons
+    !> Nr. of electrons
     real(dp), allocatable :: nEl(:)
 
     !> Nr. of all electrons if neutral
     real(dp) :: nEl0
-
 
     !> Spin W values
     real(dp), allocatable :: spinW(:,:,:)
@@ -354,7 +351,7 @@ module dftbp_dftbplus_initprogram
     !> DFTB+U calculation, if relevant
     type(TDftbU), allocatable :: dftbU
 
-    !> electron temperature
+    !> Electron temperature
     real(dp) :: tempElec
 
     !> If K points should filled separately
@@ -372,25 +369,25 @@ module dftbp_dftbplus_initprogram
     !> Choice of electron distribution function, defaults to Fermi
     integer :: iDistribFn = fillingTypes%Fermi
 
-    !> atomic kinetic temperature
+    !> Atomic kinetic temperature
     real(dp) :: tempAtom
 
     !> MD stepsize
     real(dp) :: deltaT
 
-    !> maximal number of SCC iterations
+    !> Maximal number of SCC iterations
     integer :: maxSccIter
 
     !> Minimal number of SCC iterations
     integer :: minSccIter
 
-    !> is this a spin polarized calculation?
+    !> Is this a spin polarized calculation?
     logical :: tSpin
 
     !> Number of spin components, 1 is unpolarised, 2 is polarised, 4 is noncolinear / spin-orbit
     integer :: nSpin
 
-    !> is there spin-orbit coupling
+    !> Is there spin-orbit coupling
     logical :: tSpinOrbit
 
     !> Use block like dual representation for spin orbit
@@ -405,20 +402,19 @@ module dftbp_dftbplus_initprogram
     !> Is there a complex hamiltonian contribution in real space
     logical :: tImHam
 
-    !> is this a two component calculation (spin orbit or non-collinear spin)
+    !> Is this a two component calculation (spin orbit or non-collinear spin)
     logical :: t2Component
 
     !> Common Fermi level across spin channels
     logical :: tSpinSharedEf
 
-
     !> Geometry optimisation needed?
     logical :: isGeoOpt
 
-    !> optimise coordinates inside unit cell (periodic)?
+    !> Optimise coordinates inside unit cell (periodic)?
     logical :: tCoordOpt
 
-    !> optimise lattice constants?
+    !> Optimise lattice constants?
     logical :: tLatOpt
 
     !> Fix angles between lattice vectors when optimising?
@@ -457,7 +453,7 @@ module dftbp_dftbplus_initprogram
     !> Should the net charges be printed
     logical :: tPrintNetAtomCharges
 
-    !> calculate an electric dipole?
+    !> Calculate an electric dipole?
     logical :: tDipole
 
     !> Do we need atom resolved E?
@@ -478,7 +474,7 @@ module dftbp_dftbplus_initprogram
     !> Is the contribution from an excited state needed for the forces
     logical :: tCasidaForces
 
-    !> are forces being returned
+    !> Are forces being returned
     logical :: tPrintForces
 
     !> Number of moved atoms
@@ -544,10 +540,10 @@ module dftbp_dftbplus_initprogram
     !> Derivatives of Mulliken charges with respect to perturbation
     real(dp), allocatable :: dqOut(:,:,:,:)
 
-    !> use commands from socket communication to control the run
+    !> Use commands from socket communication to control the run
     logical :: tSocket
 
-    !> socket details
+    !> Socket details
   #:if WITH_SOCKETS
     type(ipiSocketComm), allocatable :: socket
   #:endif
@@ -561,7 +557,7 @@ module dftbp_dftbplus_initprogram
     !> Use converged SCC charges for properties like forces or charge dependent dispersion
     logical :: isSccConvRequired
 
-    !> labels of atomic species
+    !> Labels of atomic species
     character(mc), allocatable :: speciesName(:)
 
     !> General geometry optimiser
@@ -594,7 +590,7 @@ module dftbp_dftbplus_initprogram
     !> Temperature profile driver in MD
     type(TTempProfile), allocatable :: temperatureProfile
 
-    !> geometry optimiser
+    !> Geometry optimiser
     type(TNumDerivs), allocatable :: derivDriver
 
     !> Total charge
@@ -606,25 +602,25 @@ module dftbp_dftbplus_initprogram
     !> Is the check-sum for charges read externally to be used?
     logical :: tSkipChrgChecksum
 
-    !> reference neutral atomic occupations
+    !> Reference neutral atomic occupations
     real(dp), allocatable :: q0(:, :, :)
 
-    !> shell resolved neutral reference
+    !> Shell resolved neutral reference
     real(dp), allocatable :: qShell0(:,:)
 
-    !> input charges (for potentials)
+    !> Input charges (for potentials)
     real(dp), allocatable :: qInput(:, :, :)
 
-    !> output charges
+    !> Output charges
     real(dp), allocatable :: qOutput(:, :, :)
 
-    !> charge differences between input and output charges
+    !> Charge differences between input and output charges
     real(dp), allocatable :: qDiff(:, :, :)
 
-    !> net (on-site only contributions) charge per atom
+    !> Net (on-site only contributions) charge per atom
     real(dp), allocatable :: qNetAtom(:)
 
-    !> input Mulliken block charges (diagonal part == Mulliken charges)
+    !> Input Mulliken block charges (diagonal part == Mulliken charges)
     real(dp), allocatable :: qBlockIn(:, :, :, :)
 
     !> Output Mulliken block charges
@@ -636,13 +632,13 @@ module dftbp_dftbplus_initprogram
     !> Imaginary part of output Mulliken block charges
     real(dp), allocatable :: qiBlockOut(:, :, :, :)
 
-    !> input charges packed into unique equivalence elements
+    !> Input charges packed into unique equivalence elements
     real(dp), allocatable :: qInpRed(:)
 
-    !> output charges packed into unique equivalence elements
+    !> Output charges packed into unique equivalence elements
     real(dp), allocatable :: qOutRed(:)
 
-    !> charge differences packed into unique equivalence elements
+    !> Charge differences packed into unique equivalence elements
     real(dp), allocatable :: qDiffRed(:)
 
     !> Orbital equivalence relations
@@ -654,13 +650,13 @@ module dftbp_dftbplus_initprogram
     !> Quadrupolar equivalence relations
     integer, allocatable :: iEqQuadrupole(:,:)
 
-    !> nr. of inequivalent orbitals
+    !> Nr. of inequivalent orbitals
     integer :: nIneqOrb
 
-    !> nr. of inequivalent dipoles
+    !> Nr. of inequivalent dipoles
     integer :: nIneqDip
 
-    !> nr. of inequivalent quadrupoles
+    !> Nr. of inequivalent quadrupoles
     integer :: nIneqQuad
 
     !> Multipole moments for the input charges
@@ -669,7 +665,7 @@ module dftbp_dftbplus_initprogram
     !> Multipole moments for the output charges
     type(TMultipole) :: multipoleOut
 
-    !> nr. of elements to go through the mixer - may contain reduced orbitals and also orbital
+    !> Nr. of elements to go through the mixer - may contain reduced orbitals and also orbital
     !> blocks (if tDFTBU or onsite corrections)
     integer :: nMixElements
 
@@ -687,7 +683,6 @@ module dftbp_dftbplus_initprogram
 
     !> Unique Hubbard U (needed for being able to calculate equivalency relations)
     type(TUniqueHubbard), allocatable :: uniqHubbU
-
 
     ! External charges
 
@@ -715,7 +710,7 @@ module dftbp_dftbplus_initprogram
     !> Full 3rd order or only atomic site
     logical :: t3rdFull = .false.
 
-    !> data structure for 3rd order
+    !> Data structure for 3rd order
     type(TThirdOrder), allocatable :: thirdOrd
 
     !> Correction to energy from on-site matrix elements
@@ -730,22 +725,22 @@ module dftbp_dftbplus_initprogram
     !> Calculate Casida linear response excitations
     logical :: isLinResp
 
-    !> calculate Z vector for excited properties
+    !> Calculate Z vector for excited properties
     logical :: tLinRespZVect
 
-    !> data type for pp-RPA
+    !> Data type for pp-RPA
     type(TppRPAcal), allocatable :: ppRPA
 
     !> Print eigenvectors
     logical :: tPrintExcitedEigVecs
 
-    !> data type for linear response
+    !> Data type for linear response
     type(TLinResp), allocatable :: linearResponse
 
     !> Whether to run a range separated calculation
     logical :: isRangeSep
 
-    !> Range Separation data
+    !> Range-separation data
     type(TRangeSepFunc), allocatable :: rangeSep
 
     !> DeltaRho input for calculation of range separated Hamiltonian
@@ -832,7 +827,7 @@ module dftbp_dftbplus_initprogram
     !> Can stress be calculated?
     logical :: tStress
 
-    !> should XLBOMD be used in MD
+    !> Should XLBOMD be used in MD
     logical :: isXlbomd
 
     !> XLBOMD related parameters
@@ -877,7 +872,7 @@ module dftbp_dftbplus_initprogram
     !> Non-SCC part of the hamiltonian in sparse storage
     real(dp), allocatable :: h0(:)
 
-    !> electronic filling
+    !> Electronic filling
     real(dp), allocatable :: filling(:,:,:)
 
     !> Square dense hamiltonian storage for cases with k-points
@@ -901,7 +896,7 @@ module dftbp_dftbplus_initprogram
     !> Eigenvalues
     real(dp), allocatable :: eigen(:,:,:)
 
-    !> density matrix
+    !> Density matrix
     real(dp), allocatable :: rhoSqrReal(:,:,:)
 
     !> Total energy components (potentially for multiple determinants)
@@ -931,10 +926,10 @@ module dftbp_dftbplus_initprogram
     !> Forces on any external charges
     real(dp), allocatable :: chrgForces(:,:)
 
-    !> excited state force addition
+    !> Excited state force addition
     real(dp), allocatable :: excitedDerivs(:,:)
 
-    !> dipole moments, when available, for whichever determinants are present
+    !> Dipole moments, when available, for whichever determinants are present
     real(dp), allocatable :: dipoleMoment(:, :)
 
     !> Additional dipole moment related message to write out
@@ -973,10 +968,10 @@ module dftbp_dftbplus_initprogram
     !> Are large dense matrices required?
     logical :: tLargeDenseMatrices
 
-    !> derivative of cell volume wrt to lattice vectors, needed for pV term
+    !> Derivative of cell volume wrt to lattice vectors, needed for pV term
     real(dp) :: extLatDerivs(3,3)
 
-    !> internal pressure within the cell
+    !> Internal pressure within the cell
     real(dp) :: intPressure
 
     !> Derivative of total energy with respect to lattice vectors
@@ -1067,7 +1062,7 @@ module dftbp_dftbplus_initprogram
     !> Electrostatics type (either gammafunctional or poisson)
     integer :: electrostatics
 
-    !> list of atoms in the central cell (or device region if transport)
+    !> List of atoms in the central cell (or device region if transport)
     integer, allocatable :: iAtInCentralRegion(:)
 
     !> Correction for {O,N}-X bonds
@@ -1091,10 +1086,10 @@ module dftbp_dftbplus_initprogram
     !> Final density matrices if multiple determinants being used
     real(dp), allocatable :: deltaRhoDets(:,:)
 
-    !> data type for REKS
+    !> Data type for REKS
     type(TReksCalc), allocatable :: reks
 
-    !> atomic charge contribution in excited state
+    !> Atomic charge contribution in excited state
     real(dp), allocatable :: dQAtomEx(:)
 
     !> Boundary condition
@@ -1157,10 +1152,10 @@ contains
     integer :: nGeneration
     real(dp) :: mixParam
 
-    !> mixer number
+    !> Mixer number
     integer :: iMixer
 
-    !> simple mixer (if used)
+    !> Simple mixer (if used)
     type(TSimpleMixer), allocatable :: pSimpleMixer
 
     !> Anderson mixer (if used)
@@ -1186,13 +1181,13 @@ contains
     !> Steepest descent driver
     type(TSteepDesc), allocatable :: pSteepDescLat
 
-    !> gradient DIIS driver
+    !> Gradient DIIS driver
     type(TDIIS), allocatable :: pDIIS
 
-    !> lBFGS driver for geometry optimisation
+    !> LBFGS driver for geometry optimisation
     type(TLbfgs), allocatable :: pLbfgs
 
-    !> lBFGS driver for lattice optimisation
+    !> LBFGS driver for lattice optimisation
     type(TLbfgs), allocatable :: pLbfgsLat
 
     !> FIRE driver for geometry optimisation
@@ -1234,7 +1229,7 @@ contains
 
     character(lc) :: strTmp, strTmp2
 
-    !> flag to check for first cycle through a loop
+    !> Flag to check for first cycle through a loop
     logical :: tFirst
 
     !> Nr. of Hamiltonians to diagonalise independently
@@ -3711,7 +3706,7 @@ contains
     !> If periodic, are the atomic positions in fractional coordinates?
     logical, intent(in) :: tFracCoord
 
-    !> lattice vectors, stored columnwise
+    !> Lattice vectors, stored columnwise
     real(dp), intent(in) :: latVec(:,:)
 
     !> Origin of coordinate system for periodic systems
@@ -4457,13 +4452,13 @@ contains
     !> Holds the parsed input data.
     type(TInputData), intent(in) :: input
 
-    !> electronic solver for the system
+    !> Electronic solver for the system
     type(TElectronicSolver), intent(inout) :: electronicSolver
 
     !> Number of spin components, 1 is unpolarised, 2 is polarised, 4 is noncolinear / spin-orbit
     integer, intent(in) :: nSpin
 
-    !> electron temperature
+    !> Electron temperature
     real(dp), intent(in) :: tempElec
 
     !> Transport interface
@@ -4479,7 +4474,7 @@ contains
     !> Transport interface
     type(TNegfInt), intent(out) :: negfInt
 
-    !> container for data needed by libNEGF
+    !> Container for data needed by libNEGF
     type(TNegfInfo), intent(out) :: ginfo
 
     !> Transport calculation parameters
@@ -4942,7 +4937,7 @@ contains
   !>
   subroutine getDenseDescBlacs(env, rowBlock, colBlock, denseDesc, isSparseReorderRequired)
 
-    !> parallel environment
+    !> Parallel environment
     type(TEnvironment), intent(in) :: env
 
     !> Size of matrix row blocks
@@ -5289,13 +5284,13 @@ contains
     !> 3rd order hamiltonian contributions included
     logical, intent(in) :: t3rd
 
-    !> a real hamiltonian
+    !> A real hamiltonian
     logical, intent(in) :: tRealHs
 
-    !> periodic boundary conditions
+    !> Periodic boundary conditions
     logical, intent(in) :: tPeriodic
 
-    !> forces being evaluated in the excited state
+    !> Forces being evaluated in the excited state
     logical, intent(in) :: tCasidaForces
 
     !> Solvation data and calculations
@@ -5446,13 +5441,13 @@ contains
     !> Number of atoms in the system
     integer, intent(in) :: nAtom
 
-    !> species of atoms
+    !> Species of atoms
     integer, intent(in) :: species0(:)
 
     !> Hubbard values for species
     real(dp), intent(in) :: hubbU(:,:)
 
-    !> input for range separated calculation
+    !> Input for range separated calculation
     type(TRangeSepInp), intent(in) :: rangeSepInp
 
     !> Is this spin restricted (F) or unrestricted (T)
@@ -5561,7 +5556,7 @@ contains
       & tSccCalc, tSpin, tSpinOrbit, isDftbU, isExtField, isLinResp, tPeriodic, tLatOpt, tReadChrg,&
       & tPoisson, isShellResolved)
 
-    !> data type for REKS input
+    !> Data type for REKS input
     type(TReksInp), intent(in) :: reksInp
 
     !> Solvation data and calculations
@@ -5573,34 +5568,34 @@ contains
     !> K-points
     real(dp), intent(in) :: kPoint(:,:)
 
-    !> nr. of electrons
+    !> Nr. of electrons
     real(dp), intent(in) :: nEl(:)
 
-    !> nr. of K-points
+    !> Nr. of K-points
     integer, intent(in) :: nKPoint
 
     !> Is the calculation SCC?
     logical, intent(in) :: tSccCalc
 
-    !> is this a spin polarized calculation?
+    !> Is this a spin polarized calculation?
     logical, intent(in) :: tSpin
 
-    !> is there spin-orbit coupling
+    !> Is there spin-orbit coupling
     logical, intent(in) :: tSpinOrbit
 
-    !> is this a DFTB+U calculation?
+    !> Is this a DFTB+U calculation?
     logical, intent(in) :: isDftbU
 
-    !> external electric field
+    !> External electric field
     logical, intent(in) :: isExtField
 
     !> Calculate Casida linear response excitations
     logical, intent(in) :: isLinResp
 
-    !> if calculation is periodic
+    !> If calculation is periodic
     logical, intent(in) :: tPeriodic
 
-    !> optimise lattice constants?
+    !> Optimise lattice constants?
     logical, intent(in) :: tLatOpt
 
     !> If initial charges/dens mtx. from external file.
@@ -5671,13 +5666,13 @@ contains
       & hamiltonianType, nSpin, nExtChrg, is3rd, isRangeSep, isDispersion, isQNetAllocated,&
       & tForces, tPeriodic, tStress, tDipole)
 
-    !> data type for REKS
+    !> Data type for REKS
     type(TReksCalc), intent(out) :: reks
 
-    !> data type for REKS input
+    !> Data type for REKS input
     type(TReksInp), intent(inout) :: reksInp
 
-    !> electronic solver for the system
+    !> Electronic solver for the system
     type(TElectronicSolver), intent(in) :: electronicSolver
 
     !> Atomic orbital information
@@ -5686,10 +5681,10 @@ contains
     !> Spin W values
     real(dp), intent(inout) :: spinW(:,:,:)
 
-    !> nr. of electrons
+    !> Nr. of electrons
     real(dp), intent(in) :: nEl(:)
 
-    !> coordinates and charges of external point charges
+    !> Coordinates and charges of external point charges
     real(dp), allocatable, intent(in) :: extChrg(:,:)
 
     !> Width of the Gaussians if the charges are blurred
@@ -5719,13 +5714,13 @@ contains
     !> Do we need forces?
     logical, intent(in) :: tForces
 
-    !> if calculation is periodic
+    !> If calculation is periodic
     logical, intent(in) :: tPeriodic
 
     !> Can stress be calculated?
     logical, intent(in) :: tStress
 
-    !> calculate an electric dipole?
+    !> Calculate an electric dipole?
     logical, intent(inout) :: tDipole
 
     ! Condition for Hamiltonian types
@@ -5761,16 +5756,16 @@ contains
 
   subroutine printReksInitInfo(reks, orb, speciesName, nType)
 
-    !> data type for REKS
+    !> Data type for REKS
     type(TReksCalc), intent(in) :: reks
 
-    !> data structure with atomic orbital information
+    !> Data structure with atomic orbital information
     type(TOrbitals), intent(in) :: orb
 
-    !> labels of atomic species
+    !> Labels of atomic species
     character(mc), intent(in) :: speciesName(:)
 
-    !> nr of different types (nAtom)
+    !> Nr of different types (nAtom)
     integer, intent(in) :: nType
 
     integer :: ii, iType
@@ -6178,19 +6173,19 @@ contains
   !> Replace charges with those from the stored contact values
   subroutine overrideContactCharges(qOrb, qOrbUp, transpar, qBlock, qBlockUp)
 
-    !> input charges
+    !> Input charges
     real(dp), intent(inout) :: qOrb(:,:,:)
 
-    !> uploaded charges
+    !> Uploaded charges
     real(dp), intent(in) :: qOrbUp(:,:,:)
 
     !> Transport parameters
     type(TTransPar), intent(in) :: transpar
 
-    !> block charges, for example from DFTB+U
+    !> Block charges, for example from DFTB+U
     real(dp), allocatable, intent(inout) :: qBlock(:,:,:,:)
 
-    !> uploaded block charges
+    !> Uploaded block charges
     real(dp), allocatable, intent(in) :: qBlockUp(:,:,:,:)
 
     integer :: ii, iStart, iEnd

--- a/src/dftbp/dftbplus/inputdata.F90
+++ b/src/dftbp/dftbplus/inputdata.F90
@@ -7,7 +7,7 @@
 
 #:include 'common.fypp'
 
-!> Contains data type representing the input data for DFTB
+!> Contains data type representing the input data for DFTB.
 module dftbp_dftbplus_inputdata
   use dftbp_common_accuracy, only : dp, lc
   use dftbp_common_hamiltoniantypes, only : hamiltonianTypes
@@ -120,14 +120,14 @@ module dftbp_dftbplus_inputdata
     !> Choice of electronic hamiltonian
     integer :: hamiltonian = hamiltonianTypes%none
 
-    !> random number generator seed
-    integer :: iSeed       = 0
+    !> Random number generator seed
+    integer :: iSeed = 0
 
-    !> maximum force for geometry convergence
-    real(dp) :: maxForce    = 0.0_dp
+    !> Maximum force for geometry convergence
+    real(dp) :: maxForce = 0.0_dp
 
     !> SCC calculation?
-    logical :: tScc        = .false.
+    logical :: tScc = .false.
 
     !> l-shell resolved SCC
     logical :: tShellResolved = .false.
@@ -149,17 +149,17 @@ module dftbp_dftbplus_inputdata
     !> Disc charges should be written as ascii or binary files
     logical :: tWriteChrgAscii = .true.
 
-    !> should probably be packaged
+    !> Should probably be packaged
     logical :: isGeoOpt = .false.
 
-    !> coordinate optimisation
-    logical :: tCoordOpt   = .false.
+    !> Coordinate optimisation
+    logical :: tCoordOpt = .false.
 
-    !> maximum line search step for atoms
+    !> Maximum line search step for atoms
     real(dp) :: maxAtomDisp = 0.2_dp
 
-    !> should probably be packaged
-    logical :: tLatOpt     = .false.
+    !> Should probably be packaged
+    logical :: tLatOpt = .false.
 
     !> Fix angles during lattice optimisation
     logical :: tLatOptFixAng = .false.
@@ -170,28 +170,28 @@ module dftbp_dftbplus_inputdata
     !> Isotropically scale instead
     logical :: tLatOptIsotropic = .false.
 
-    !> maximum possible linesearch step
+    !> Maximum possible linesearch step
     real(dp) :: maxLatDisp = 0.2_dp
 
-    !> add new geometries at the end of files
-    logical :: tAppendGeo  = .false.
+    !> Add new geometries at the end of files
+    logical :: tAppendGeo = .false.
 
-    !> use converged SCC charges for properties like forces or charge dependent dispersion
+    !> Use converged SCC charges for properties like forces or charge dependent dispersion
     logical :: isSccConvRequired = .true.
 
-    !> geometry step
-    integer :: iGeoOpt     = 0
+    !> Geometry step
+    integer :: iGeoOpt = 0
 
-    !> used for gDIIS
+    !> Used for gDIIS
     real(dp) :: deltaGeoOpt = 0.0_dp
 
-    !> used for gDIIS
+    !> Used for gDIIS
     integer :: iGenGeoOpt = 0
 
-    !> internal variable for requirement of Mulliken analysis
+    !> Internal variable for requirement of Mulliken analysis
     logical :: tMulliken = .false.
 
-    !> printout of Mulliken
+    !> Printout of Mulliken
     logical :: tPrintMulliken = .false.
 
     !> Net atomic charges (i.e. on-site only part of Mulliken charges)
@@ -203,11 +203,11 @@ module dftbp_dftbplus_inputdata
     !> Input for CM5 corrected Mulliken charges
     type(TCM5Input), allocatable :: cm5Input
 
-    !> electrostatic potential evaluation and printing
+    !> Electrostatic potential evaluation and printing
     type(TElStatPotentialsInp), allocatable :: elStatPotentialsInp
 
     !> Localise electronic states
-    logical :: tLocalise   = .false.
+    logical :: tLocalise = .false.
 
     !> Input data for Pipek-Mezey localisation
     type(TPipekMezeyInp), allocatable :: pipekMezeyInp
@@ -239,16 +239,16 @@ module dftbp_dftbplus_inputdata
     !> Frequencies for perturbation (0 being static case)
     real(dp), allocatable :: dynKernelFreq(:)
 
-    !> printing of atom resolved energies
+    !> Printing of atom resolved energies
     logical :: tAtomicEnergy = .false.
 
-    !> print eigenvectors to disc
-    logical :: tPrintEigVecs  = .false.
+    !> Print eigenvectors to disc
+    logical :: tPrintEigVecs = .false.
 
-    !> text file of eigenvectors?
+    !> Text file of eigenvectors?
     logical :: tPrintEigVecsTxt = .false.
 
-    !> project eigenvectors spatially
+    !> Project eigenvectors spatially
     logical :: tProjEigenvecs = .false.
 
     !> Evaluate forces
@@ -257,13 +257,13 @@ module dftbp_dftbplus_inputdata
     !> Evaluate force contributions from the excited state if required and (tForces)
     logical :: tCasidaForces = .false.
 
-    !> force evaluation method
+    !> Force evaluation method
     integer :: forceType
 
     !> Output forces
     logical :: tPrintForces = .false.
 
-    !> method for calculating derivatives
+    !> Method for calculating derivatives
     integer :: iDerivMethod = 0
 
     !> 1st derivative finite difference step
@@ -271,39 +271,39 @@ module dftbp_dftbplus_inputdata
 
 
     !> Molecular dynamics
-    logical :: tMD         = .false.
+    logical :: tMD = .false.
 
     !> Use Plumed
     logical :: tPlumed = .false.
 
     !> Finite difference derivatives calculation?
-    logical :: tDerivs     = .false.
+    logical :: tDerivs = .false.
 
     !> Should central cell coordinates be output?
     logical :: tShowFoldedCoord
 
-    real(dp) :: nrChrg        = 0.0_dp
-    real(dp) :: nrSpinPol     = 0.0_dp
-    logical :: tSpin         = .false.
+    real(dp) :: nrChrg = 0.0_dp
+    real(dp) :: nrSpinPol = 0.0_dp
+    logical :: tSpin = .false.
     logical :: tSpinSharedEf = .false.
-    logical :: tSpinOrbit    = .false.
+    logical :: tSpinOrbit = .false.
     logical :: tDualSpinOrbit = .false.
-    logical :: t2Component   = .false.
+    logical :: t2Component = .false.
 
-    !> initial spin pattern
+    !> Initial spin pattern
     real(dp), allocatable :: initialSpins(:,:)
 
-    !> initial charges
+    !> Initial charges
     real(dp), allocatable :: initialCharges(:)
 
     !> Electronic/eigenvalue solver options
     type(TElectronicSolverInp) :: solver
 
-    integer :: iMixSwitch    = 0
-    integer :: maxIter       = 0
-    real(dp) :: almix         = 0.0_dp
-    integer :: iGenerations  = 0
-    logical :: tFromStart    = .true.
+    integer :: iMixSwitch = 0
+    integer :: maxIter = 0
+    real(dp) :: almix = 0.0_dp
+    integer :: iGenerations = 0
+    logical :: tFromStart = .true.
     real(dp) :: broydenOmega0 = 0.01_dp
     real(dp) :: broydenMinWeight = 1.0_dp
     real(dp) :: broydenMaxWeight = 1.0e5_dp
@@ -312,32 +312,32 @@ module dftbp_dftbplus_inputdata
     integer :: andersonNrDynMix = 0
     real(dp), allocatable :: andersonDynMixParams(:,:)
     real(dp) :: andersonOmega0 = 1.0e-2_dp
-    integer :: nrMoved       = 0
+    integer :: nrMoved = 0
     integer, allocatable :: indMovedAtom(:)
     integer, allocatable :: indDerivAtom(:)
-    integer :: nrConstr      = 0
+    integer :: nrConstr = 0
     integer, allocatable :: conAtom(:)
     real(dp), allocatable :: conVec(:,:)
-    character(lc) :: outFile       = ''
+    character(lc) :: outFile = ''
 
-    !> do we have MD velocities
+    !> Do we have MD velocities
     logical :: tReadMDVelocities = .false.
 
-    !> initial MD velocities
+    !> Initial MD velocities
     real(dp), allocatable :: initialVelocities(:,:)
-    real(dp) :: deltaT        = 0.0_dp
+    real(dp) :: deltaT = 0.0_dp
 
-    real(dp) :: tempAtom      = 0.0_dp
-    integer :: iThermostat   = 0
+    real(dp) :: tempAtom = 0.0_dp
+    integer :: iThermostat = 0
 
-    !> whether to initialize internal state of the Nose-Hoover thermostat from input
+    !> Whether to initialize internal state of the Nose-Hoover thermostat from input
     logical :: tInitNHC = .false.
     real(dp), allocatable :: xnose(:)
     real(dp), allocatable :: vnose(:)
     real(dp), allocatable :: gnose(:)
 
 
-    !> whether to shift to a co-moving frame for MD
+    !> Whether to shift to a co-moving frame for MD
     logical :: tMDstill
     logical :: tRescale = .false.
     integer, allocatable :: tempMethods(:)
@@ -345,53 +345,53 @@ module dftbp_dftbplus_inputdata
     real(dp), allocatable :: tempValues(:)
     logical :: tSetFillingTemp = .false.
 
-    real(dp) :: tempElec      = 0.0_dp
-    logical :: tFixEf        = .false.
+    real(dp) :: tempElec = 0.0_dp
+    logical :: tFixEf = .false.
     real(dp), allocatable :: Ef(:)
-    logical :: tFillKSep     = .false.
-    integer :: iDistribFn    = fillingTypes%Fermi
-    real(dp) :: wvScale       = 0.0_dp
+    logical :: tFillKSep = .false.
+    integer :: iDistribFn = fillingTypes%Fermi
+    real(dp) :: wvScale = 0.0_dp
 
-    !> default chain length for Nose-Hoover
-    integer :: nh_npart      = 3
+    !> Default chain length for Nose-Hoover
+    integer :: nh_npart = 3
 
-    !> default order of NH integration
-    integer :: nh_nys        = 3
+    !> Default order of NH integration
+    integer :: nh_nys = 3
 
-    !> default multiple time steps for N-H propagation
-    integer :: nh_nc         = 1
+    !> Default multiple time steps for N-H propagation
+    integer :: nh_nc = 1
 
-    integer :: maxRun        = -2
+    integer :: maxRun = -2
 
 
-    !> second derivative finite difference step
-    real(dp) :: deriv2ndDelta    = 0.0_dp
+    !> Second derivative finite difference step
+    real(dp) :: deriv2ndDelta = 0.0_dp
 
-    integer :: nKPoint       = 0
+    integer :: nKPoint = 0
     real(dp), allocatable :: kPoint(:,:)
     real(dp), allocatable :: kWeight(:)
 
 
-    !> cell pressure if periodic
-    real(dp) :: pressure       = 0.0_dp
+    !> Cell pressure if periodic
+    real(dp) :: pressure = 0.0_dp
     logical :: tBarostat = .false.
 
-    !> use isotropic scaling if barostatting
+    !> Use isotropic scaling if barostatting
     logical :: tIsotropic = .true.
     real(dp) :: BarostatStrength = 0.0_dp
 
 
-    !> read atomic masses from the input not the SK data
+    !> Read atomic masses from the input not the SK data
     real(dp), allocatable :: masses(:)
 
 
-    !> spin constants
+    !> Spin constants
     real(dp), allocatable :: spinW(:,:,:)
 
-    !> customised Hubbard U values
+    !> Customised Hubbard U values
     real(dp), allocatable :: hubbU(:,:)
 
-    !> spin-orbit constants
+    !> Spin-orbit constants
     real(dp), allocatable :: xi(:,:)
 
     !> DFTB+U input, if present
@@ -406,10 +406,10 @@ module dftbp_dftbplus_inputdata
     !> Number of external charges
     integer :: nExtChrg = 0
 
-    !> external charge values and locations
+    !> External charge values and locations
     real(dp), allocatable :: extChrg(:,:)
 
-    !> finite charge width if needed
+    !> Finite charge width if needed
     real(dp), allocatable :: extChrgBlurWidth(:)
 
     !> Homogeneous external electric field
@@ -423,7 +423,6 @@ module dftbp_dftbplus_inputdata
     logical, allocatable :: tShellResInRegion(:)
     logical, allocatable :: tOrbResInRegion(:)
     character(lc), allocatable :: RegionLabel(:)
-
 
     !> H short range damping
     logical :: tDampH = .false.
@@ -440,7 +439,6 @@ module dftbp_dftbplus_inputdata
 
     !> Old kinetic energy stress contribution in MD
     logical :: useBuggyKEStress = .false.
-
 
     !> Ewald alpha
     real(dp) :: ewaldAlpha = 0.0_dp
@@ -462,14 +460,13 @@ module dftbp_dftbplus_inputdata
     logical :: tWriteRealHS = .false.
     logical :: tMinMemory = .false.
 
-    !> potential shifts are read from file
+    !> Potential shifts are read from file
     logical :: tReadShifts = .false.
-    !> potential shifts are written on file
+    !> Potential shifts are written on file
     logical :: tWriteShifts = .false.
 
-    !> use Poisson solver for electrostatics
+    !> Use Poisson solver for electrostatics
     logical :: tPoisson = .false.
-
 
     !> Dispersion related stuff
     type(TDispersionInp), allocatable :: dispInp
@@ -504,7 +501,7 @@ module dftbp_dftbplus_inputdata
     !> ElectronDynamics
     type(TElecDynamicsInp), allocatable :: elecDynInp
 
-    !> input for particle-particle RPA
+    !> Input for particle-particle RPA
     type(TppRPAcal), allocatable :: ppRPA
 
     !> LBFGS input
@@ -517,7 +514,7 @@ module dftbp_dftbplus_inputdata
     type(TRangeSepInp), allocatable :: rangeSepInp
 
   #:if WITH_SOCKETS
-    !> socket communication
+    !> Socket communication
     type(ipiSocketCommInp), allocatable :: socketInput
   #:endif
 
@@ -576,7 +573,7 @@ module dftbp_dftbplus_inputdata
 
 #:if WITH_TRANSPORT
 
-  !> container for data needed by libNEGF
+  !> Container for data needed by libNEGF
   type TNEGFInfo
     !> Transport section informations
     type(TNEGFTunDos) :: tundos
@@ -593,7 +590,7 @@ module dftbp_dftbplus_inputdata
 #:endif
 
 
-  !> container for input data constituents
+  !> Container for input data constituents
   type TInputData
     logical :: tInitialized = .false.
     type(TControl) :: ctrl
@@ -613,7 +610,7 @@ module dftbp_dftbplus_inputdata
   end interface init
 
 
-  !> destroy input data for variables that do not go out of scope
+  !> Destroy input data for variables that do not go out of scope
   interface destruct
     module procedure InputData_destruct
   end interface destruct
@@ -632,7 +629,7 @@ contains
   end subroutine InputData_init
 
 
-  !> destructor for parts that are not cleaned up when going out of scope
+  !> Destructor for parts that are not cleaned up when going out of scope
   subroutine InputData_destruct(this)
 
     !> Instance
@@ -643,7 +640,7 @@ contains
   end subroutine InputData_destruct
 
 
-  !> destructor for parts that are not cleaned up when going out of scope
+  !> Destructor for parts that are not cleaned up when going out of scope
   subroutine Control_destruct(this)
 
     !> Instance


### PR DESCRIPTION
Had some idle time and wrote a script that fixes some style related things. While white spaces for visual alignment are discouraged in the style guide, having FORD comments start with upper case characters is more of an undocumented convention I guess (and not even close to being consistently implemented).

The script is not yet robust enough to apply it to the whole code base, but I might work on improving it so that it could potentially end up supplementing the tools of srcmanip at some point.