### PR TITLE
Check possible range-separated input against actual SK-files

### DIFF
--- a/src/dftbp/dftb/rangeseparated.F90
+++ b/src/dftbp/dftb/rangeseparated.F90
@@ -23,7 +23,8 @@ module dftbp_dftb_rangeseparated
   implicit none
 
   private
-  public :: TRangeSepSKTag, TRangeSepFunc, RangeSepFunc_init, getGammaPrimeValue, rangeSepTypes
+  public :: TRangeSepSKTag, TRangeSepFunc, RangeSepFunc_init, getGammaPrimeValue
+  public :: rangeSepTypes, rangeSepFunc
 
 
   type :: TRangeSepTypesEnum
@@ -40,8 +41,24 @@ module dftbp_dftb_rangeseparated
   end type TRangeSepTypesEnum
 
 
+  !> Enumerator for type of hybrid functional used.
+  !! (limited to purely long-range corrected for now)
+  type :: TRangeSepFuncEnum
+
+    !> (semi-)local
+    integer :: none = 0
+
+    !> Long-range corrected
+    integer :: lc = 1
+
+  end type TRangeSepFuncEnum
+
+
   !> Container for enumerated range separation types
   type(TRangeSepTypesEnum), parameter :: rangeSepTypes = TRangeSepTypesEnum()
+
+  !> Container for enumerated types of hybrid functionals.
+  type(TRangeSepFuncEnum), parameter :: rangeSepFunc = TRangeSepFuncEnum()
 
 
   !> Slater-Koster file RangeSep tag structure

--- a/src/dftbp/dftbplus/inputdata.F90
+++ b/src/dftbp/dftbplus/inputdata.F90
@@ -112,6 +112,9 @@ module dftbp_dftbplus_inputdata
     !> Choice of range separation method
     integer :: rangeSepAlg
 
+    !> Hybrid xc-functional type, as extracted from SK-file(s)
+    integer :: rangeSepType
+
   end type TRangeSepInp
 
 

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -29,7 +29,7 @@ module dftbp_dftbplus_parser
   use dftbp_dftb_halogenx, only : halogenXSpecies1, halogenXSpecies2
   use dftbp_dftb_periodic, only : TNeighbourList, TNeighbourlist_init, getSuperSampling, &
       & getCellTranslations, updateNeighbourList
-  use dftbp_dftb_rangeseparated, only : TRangeSepSKTag, rangeSepTypes
+  use dftbp_dftb_rangeseparated, only : TRangeSepSKTag, rangeSepTypes, rangeSepFunc
   use dftbp_dftb_repulsive_chimesrep, only : TChimesRepInp
   use dftbp_dftb_repulsive_polyrep, only : TPolyRepInp, TPolyRep
   use dftbp_dftb_repulsive_splinerep, only : TSplineRepInp, TSplineRep
@@ -73,7 +73,7 @@ module dftbp_dftbplus_parser
   use dftbp_type_commontypes, only : TOrbitals
   use dftbp_type_linkedlist, only : TListCharLc, TListInt, TListIntR1, TListReal, TListRealR1,&
       & TListRealR2, TListString, init, destruct, append, get, len, asArray, asVector, intoArray
-  use dftbp_type_oldskdata, only : TOldSKData, readFromFile
+  use dftbp_type_oldskdata, only : TOldSKData, readFromFile, inquireRangeSepTag
   use dftbp_type_orbitals, only : getShellnames
   use dftbp_type_typegeometry, only : TGeometry, reduce, setLattice
   use dftbp_type_typegeometryhsd, only : readTGeometryGen, readTGeometryHsd, readTGeometryXyz,&
@@ -1459,7 +1459,7 @@ contains
       skInterMeth = skEqGridNew
     end if
 
-    call parseRangeSeparated(node, ctrl%rangeSepInp)
+    call parseRangeSeparated(node, ctrl%rangeSepInp, skFiles)
 
     if (.not. allocated(ctrl%rangeSepInp)) then
       call getChild(node, "TruncateSKRange", child, requested=.false.)
@@ -7707,50 +7707,105 @@ contains
 
 
   !> Parse range separation input
-  subroutine parseRangeSeparated(node, input)
-    type(fnode), pointer, intent(in) :: node
-    type(TRangeSepInp), allocatable, intent(out) :: input
+  subroutine parseRangeSeparated(node, input, skFiles)
+    !> Node to parse
+    type(fnode), intent(in), pointer :: node
 
-    type(fnode), pointer :: child1, value1, child2, value2, child3
+    !> Range separated data structure to fill
+    type(TRangeSepInp), intent(inout), allocatable :: input
+
+    !> List of SK file names to read in for every interaction
+    type(TListCharLc), intent(inout) :: skFiles(:,:)
+
+    !! File name of representative SK-file to read
+    character(lc) :: fileName
+
+    !! Range-separated extra tag in SK-files, if allocated
+    integer :: rangeSepSkTag
+
+    !! Range-separated functional type of user input
+    integer :: rangeSepInputTag
+
+    !! Auxiliary node pointers
+    type(fnode), pointer :: hybridChild, hybridValue, screeningChild, screeningValue, child1
+
+    !! True, if RangeSeparated input block present
+    logical :: isHybridInp
+
+    !! True, if range-separated extra tag found in SK-file(s)
+    logical :: isHybridSk
+
+    !! Temporary string buffers
     type(string) :: buffer, modifier
 
-    call getChildValue(node, "RangeSeparated", value1, "None", child=child1)
-    call getNodeName(value1, buffer)
+    @:ASSERT(size(skFiles, dim=1) == size(skFiles, dim=2))
+    @:ASSERT((size(skFiles, dim=1) > 0))
 
-    select case (char(buffer))
+    ! Extracting range-separated tag from first SK-file only is a workaround and assumes that a set
+    ! of given SK-files uses the same parameters (which should always be the case)!
+    call get(skFiles(1, 1), fileName, 1)
 
-    case ("none")
-      continue
+    ! Check if SK-files contain extra tag for range-separated functionals
+    call inquireRangeSepTag(fileName, rangeSepSkTag)
+    isHybridSk = rangeSepSkTag /= rangeSepFunc%none
 
-    case ("lc")
-      allocate(input)
-      call getChildValue(value1, "Screening", value2, "Thresholded", child=child2)
-      call getNodeName(value2, buffer)
-      select case(char(buffer))
-      case ("neighbourbased")
-        input%rangeSepAlg = rangeSepTypes%neighbour
-        call getChildValue(value2, "CutoffReduction", input%cutoffRed, 0.0_dp,&
-            & modifier=modifier, child=child3)
-        call convertUnitHsd(char(modifier), lengthUnits, child3, input%cutoffRed)
-      case ("thresholded")
-        input%rangeSepAlg = rangeSepTypes%threshold
-        call getChildValue(value2, "Threshold", input%screeningThreshold, 1e-6_dp)
-        call getChildValue(value2, "CutoffReduction", input%cutoffRed, 0.0_dp,&
-            & modifier=modifier, child=child3)
-        call convertUnitHsd(char(modifier), lengthUnits, child3, input%cutoffRed)
-      case ("matrixbased")
-        input%rangeSepAlg = rangeSepTypes%matrixBased
-        ! In this case, CutoffRedunction is not used so it should be set to zero.
-        input%cutoffRed = 0.0_dp
+    call getChild(node, "RangeSeparated", child=hybridChild, requested=.false.)
+    isHybridInp = associated(hybridChild)
+
+    if (isHybridInp .and. .not. isHybridSk) then
+      call error("RangeSeparated input block present, but SK-file '" // trim(fileName)&
+          & // "' seems to be (semi-)local.")
+    elseif (isHybridSk .and. .not. isHybridInp) then
+      call error("Hybrid SK-file '" // trim(fileName) // "' present, but HSD input block missing.")
+    end if
+
+    if (isHybridInp) then
+      call getChildValue(node, "RangeSeparated", hybridValue, "None", child=hybridChild)
+      call getNodeName(hybridValue, buffer)
+      ! Convert hybrid functional type of user input to enumerator
+      select case(tolower(char(buffer)))
+      case ("lc")
+        rangeSepInputTag = rangeSepFunc%lc
       case default
-        call getNodeHSdName(value2, buffer)
-        call detailedError(child2, "Invalid screening method '" // char(buffer) // "'")
+        call detailedError(hybridChild, "Unknown hybrid xc-functional type '" // char(buffer)&
+            & // "' in input.")
       end select
-
-    case default
-      call getNodeHSDName(value1, buffer)
-      call detailedError(child1, "Invalid Algorithm '" // char(buffer) // "'")
-    end select
+      if (.not. rangeSepInputTag == rangeSepSkTag) then
+        ! Check if hybrid functional type is in line with SK-files
+        call detailedError(hybridChild, "Hybrid functional type conflict with SK-files.")
+      end if
+      select case (tolower(char(buffer)))
+      case ("none")
+        rangeSepInputTag = rangeSepFunc%none
+        continue
+      case ("lc")
+        allocate(input)
+        call getChildValue(hybridValue, "Screening", screeningValue, "Thresholded",&
+            & child=screeningChild)
+        call getNodeName(screeningValue, buffer)
+        select case(char(buffer))
+        case ("neighbourbased")
+          input%rangeSepAlg = rangeSepTypes%neighbour
+          call getChildValue(screeningValue, "CutoffReduction", input%cutoffRed, 0.0_dp,&
+              & modifier=modifier, child=child1)
+          call convertUnitHsd(char(modifier), lengthUnits, child1, input%cutoffRed)
+        case ("thresholded")
+          input%rangeSepAlg = rangeSepTypes%threshold
+          call getChildValue(screeningValue, "Threshold", input%screeningThreshold, 1e-6_dp)
+          call getChildValue(screeningValue, "CutoffReduction", input%cutoffRed, 0.0_dp,&
+              & modifier=modifier, child=child1)
+          call convertUnitHsd(char(modifier), lengthUnits, child1, input%cutoffRed)
+        case ("matrixbased")
+          input%rangeSepAlg = rangeSepTypes%matrixBased
+          ! In this case, CutoffRedunction is not used so it should be set to zero.
+          input%cutoffRed = 0.0_dp
+        case default
+          call getNodeHSdName(screeningValue, buffer)
+          call detailedError(screeningChild, "Invalid screening method '" // char(buffer) // "'.")
+        end select
+      end select
+      input%rangeSepType = rangeSepInputTag
+    end if
 
   end subroutine parseRangeSeparated
 

--- a/src/dftbp/type/oldskdata.F90
+++ b/src/dftbp/type/oldskdata.F90
@@ -13,14 +13,15 @@ module dftbp_type_oldskdata
   use dftbp_common_accuracy, only : dp, lc
   use dftbp_common_constants, only : amu__au
   use dftbp_common_file, only : TFileDescr, openFile, closeFile
-  use dftbp_dftb_rangeseparated, only : TRangeSepSKTag
+  use dftbp_dftb_rangeseparated, only : TRangeSepSKTag, rangeSepFunc
   use dftbp_dftb_repulsive_polyrep, only : TPolyRepInp
   use dftbp_dftb_repulsive_splinerep, only : TSplineRepInp
   use dftbp_io_message, only : error
+  use dftbp_io_charmanip, only : tolower
   implicit none
 
   private
-  public :: TOldSKData, readFromFile, readSplineRep
+  public :: TOldSKData, readFromFile, readSplineRep, inquireRangeSepTag
 
 
   !> Represents the Slater-Koster data in an SK file.
@@ -103,7 +104,7 @@ contains
     !> Repulsive polynomial part of the SK-file.
     type(TPolyRepInp), intent(out), optional :: polyRepIn
 
-    !> Reads rangeseparation parameter from SK file
+    !> Reads range-separated parameter(s) from SK file
     type(TRangeSepSKTag), intent(inout), optional :: rangeSepSK
 
     type(TFileDescr) :: file
@@ -151,7 +152,7 @@ contains
       read (file%unit,*, iostat=iostat) skData%mass, (coeffs(ii), ii = 2, 9), &
           &polyCutoff, rDummy, (rDummy, ii = 12, 20)
       call checkIoError(iostat, fileName, "Unable to read 3rd data line")
-      skData%mass = skData%mass * amu__au  !convert to atomic units
+      skData%mass = skData%mass * amu__au  ! convert to atomic units
     else
       read (file%unit,*, iostat=iostat) rDummy, (coeffs(ii), ii = 2, 9),&
           & polyCutoff, (rDummy, ii = 11, 20)
@@ -169,14 +170,14 @@ contains
     skData%skOver(:,:) = 0.0_dp
     do iGrid = 1, skData%nGrid
       if (tExtended) then
-        read (file%unit, *, iostat=iostat) &
-            &(skData%skHam(iGrid, ii), ii = 1, nSKInter), &
-            &(skData%skOver(iGrid, ii), ii = 1, nSKInter)
+        read (file%unit, *, iostat=iostat)&
+            & (skData%skHam(iGrid, ii), ii = 1, nSKInter),&
+            & (skData%skOver(iGrid, ii), ii = 1, nSKInter)
         call checkIoError(iostat, fileName, "Reading error for integrals")
       else
-        read(file%unit,*, iostat=iostat) &
-            &(skData%skHam(iGrid, iSKInterOld(ii)), ii = 1, nSKInterOld), &
-            &(skData%skOver(iGrid, iSKInterOld(ii)), ii = 1, nSKInterOld)
+        read(file%unit,*, iostat=iostat)&
+            & (skData%skHam(iGrid, iSKInterOld(ii)), ii = 1, nSKInterOld),&
+            & (skData%skOver(iGrid, iSKInterOld(ii)), ii = 1, nSKInterOld)
         call checkIoError(iostat, fileName, "Reading error for integrals")
       end if
     end do
@@ -188,14 +189,72 @@ contains
 
     call readSplineRep(file%unit, fileName, splineRepIn, iSp1, iSp2)
 
-    !> Read range separation parameter
+    ! Read range-separated parameter(s)
     if (present(rangeSepSK)) then
-       call readRangeSep(file%unit, fileName, rangeSepSK)
+      call readRangeSepParams(file%unit, fileName, rangeSepSK)
     end if
 
     call closeFile(file)
 
   end subroutine OldSKData_readFromFile
+
+
+  !> Reads range-separated parameter(s) from an open file.
+  subroutine readRangeSepParams(fp, fname, rangeSepSK)
+
+    !> File identifier
+    integer, intent(in) :: fp
+
+    !> File name
+    character(len=*), intent(in) :: fname
+
+    !> range-separated parameter(s)
+    type(TRangeSepSKTag), intent(inout) :: rangeSepSK
+
+    !! Error status
+    integer :: iErr
+
+    !! Temporary character storage
+    character(lc) :: strDummy
+
+    !! True, if range-separated extra tag was found in SK-file
+    logical :: isRangeSepTag
+
+    !! Extra tag in SK-files, defining the type of range-separated
+    integer :: rangeSepTag
+
+    call inquireRangeSepTag(fname, rangeSepTag, fp=fp)
+    rewind(fp)
+
+    ! Seek range-separated section in SK file
+    do
+      read(fp, '(A)', iostat=iErr) strDummy
+      if (iErr /= 0) then
+        isRangeSepTag = .false.
+        exit
+      elseif (strDummy == "RangeSep") then
+        isRangeSepTag = .true.
+        exit
+      end if
+    end do
+
+    if (.not. isRangeSepTag) then
+      write(strDummy, "(A,A,A)") "Range-separated calculation requested, but SK-file '",&
+          & trim(fname), "' is not a suitable parametrization."
+      call error(strDummy)
+    end if
+
+    if (rangeSepTag == rangeSepFunc%lc) then
+      read(fp, *, iostat=iErr) strDummy, rangeSepSK%omega
+      call checkioerror(iErr, fname, "Error in reading range-separated parameter(s)")
+    end if
+
+    if (rangeSepSK%omega < 0.0_dp) then
+      write(strDummy, "(A)") "Range-separation parameter is negative."
+      call error(strDummy)
+    end if
+
+  end subroutine readRangeSepParams
 
 
   !> Reads the repulsive from an open file.
@@ -268,64 +327,79 @@ contains
   end subroutine OldSKData_readsplinerep
 
 
-  !> Reads the RangeSep data from an open file.
-  subroutine readRangeSep(fp, fname, rangeSepSK)
-
-    !> File identifier
-    integer, intent(in) :: fp
+  !> Inquires range-separated extra tag of SK-file.
+  subroutine inquireRangeSepTag(fname, rangeSepTag, fp)
 
     !> File name
-    character(*), intent(in) :: fname
+    character(len=*), intent(in) :: fname
 
-    !> Rangesep data
-    type(TRangeSepSKTag), intent(inout) :: rangeSepSK
+    !> Range-separated extra tag, if allocated
+    integer, intent(out) :: rangeSepTag
 
-    integer :: iostat
-    character(lc) :: chdummy
-    real(dp) :: omega
-    logical :: hasRangeSep
+    !> File identifier, if file is already open
+    integer, intent(in), optional :: fp
 
-    !> Seek rangesep part in SK file
+    !! File descriptor
+    type(TFileDescr) :: file
+
+    !! Error status
+    integer :: iErr
+
+    !! Temporary character storage
+    character(lc) :: strDummy
+
+    !! True, if range-separated extra tag was found in SK-file
+    logical :: isRangeSepTag
+
+    !> File identifier
+    integer :: fd
+
+    if (present(fp)) then
+      fd = fp
+    else
+      call openFile(file, fname, mode="r", ioStat=iErr)
+      fd = file%unit
+      call checkIoError(iErr, fname, "Unable to open file")
+    end if
+
+    ! Seek range-separated extra tag in SK-file
     do
-      read(fp, '(A)', iostat=iostat) chdummy
-      if (iostat /= 0) then
-        hasRangeSep = .false.
+      read(fd, '(A)', iostat=iErr) strDummy
+      if (iErr /= 0) then
+        isRangeSepTag = .false.
         exit
-      elseif (chdummy == "RangeSep") then
-        hasRangeSep = .true.
+      elseif (strDummy == "RangeSep") then
+        isRangeSepTag = .true.
         exit
       end if
     end do
 
-    if ( .not. hasRangeSep) then
-      write(chdummy, "(A,A,A)") "RangeSep extension tag not found in file '",&
-          & trim(fname), "'"
-      call error(chdummy)
+    if (isRangeSepTag) then
+      read(fd, *, iostat=iErr) strDummy
+      call checkIoError(iErr, fname, "Error in reading range-separated extra tag and method")
+
+      select case(tolower(trim(strDummy)))
+      case ("lc")
+        rangeSepTag = rangeSepFunc%lc
+      case default
+        write(strDummy, "(A,A,A)") "Unknown range-separated method in SK-file '",&
+            & trim(fname), "'"
+        call error(strDummy)
+      end select
+    else
+      rangeSepTag = rangeSepFunc%none
     end if
 
-    read(fp, *, iostat=iostat) chdummy, omega
-    call checkioerror(iostat, fname, "Error in reading range-sep method and range-sep parameter")
+    if (.not. present(fp)) call closeFile(file)
 
-    if (chdummy /= "LC") then
-      write(chdummy, "(A,A,A)") "Unknown range-separation method in SK file '", trim(fname), "'"
-      call error(chdummy)
-    end if
-
-    if (omega < 0.0_dp) then
-      write(chdummy, "(A)") "Range-separation parameter is negative"
-      call error(chdummy)
-   end if
-
-   rangeSepSK%omega = omega
-
-  end subroutine ReadRangeSep
+  end subroutine inquireRangeSepTag
 
 
   !> Checks for IO errors and prints message.
-  subroutine checkIOError(iostat, fname, msg)
+  subroutine checkIOError(iErr, fname, msg)
 
     !> Flag of the IO operation.
-    integer, intent(in) :: iostat
+    integer, intent(in) :: iErr
 
     !> Name of the file.
     character(*), intent(in) :: fname
@@ -333,7 +407,7 @@ contains
     !> Message to print if IO operation flag is non-zero.
     character(*), intent(in) :: msg
 
-    if (iostat /= 0) then
+    if (iErr /= 0) then
       call error("IO error in file '" // trim(fname) // "': " // trim(msg))
     end if
 


### PR DESCRIPTION
Up to now it is possible to (unknowingly) run calculations based on long-range corrected SK-files like [ob2-1-1](https://dftb.org/parameters/download/ob2/ob2-1-1) without providing the corresponding `RangeSeparated {}` HSD input block, resulting in a completely inconsistent/wrong Hamiltonian, since the required Fock-like exchange contribution of second order is not constructed/added.

This PR blocks a calculation if either a hybrid-DFTB run is requested by the user but the SK-file is (semi-)local or the SK-file was created based on a range-separated hybrid xc-functional but the user did not add the associated HSD input block.

At some point the entire SK-file parser needs to be revamped, since the behavior should not depend on the user input, i.e. whether certain derived types are allocated or not.