### PR TITLE
Restrict file access type setting to binary I/O

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Changed
 -------
 
 - Binary output is done using stream I/O to enable processing of those files in
-  Python or C. The FileAccessTypes option can be used to restore the old
+  Python or C. The BinaryAccessTypes option can be used to restore the old
   (compiler dependent) sequential I/O.
 
 

--- a/app/waveplot/initwaveplot.F90
+++ b/app/waveplot/initwaveplot.F90
@@ -10,13 +10,13 @@
 !> Contains the routines for initialising waveplot.
 module waveplot_initwaveplot
   use dftbp_common_accuracy, only : dp
-  use dftbp_common_file, only : TFileDescr, openFile, closeFile, setDefaultFileAccess
+  use dftbp_common_file, only : TFileDescr, openFile, closeFile, setDefaultBinaryAccess
   use dftbp_common_globalenv, only : stdOut
   use dftbp_common_status, only : TStatus
   use dftbp_common_unitconversion, only : lengthUnits
   use dftbp_dftb_boundarycond, only : boundaryConditions, TBoundaryConditions,&
       & TBoundaryConditions_init
-  use dftbp_dftbplus_input_fileaccess, only : readFileAccessTypes
+  use dftbp_dftbplus_input_fileaccess, only : readBinaryAccessTypes
   use dftbp_extlibs_xmlf90, only : fnode, fNodeList, string, char, getLength, getItem1,&
       & getNodeName,destroyNode
   use dftbp_io_charmanip, only : i2c, unquote
@@ -128,7 +128,7 @@ module waveplot_initwaveplot
     integer, allocatable :: levelIndex(:,:)
 
     !> File access types
-    character(20) :: fileAccessTypes(2)
+    character(20) :: binaryAccessTypes(2)
 
   end type TOption
 
@@ -356,8 +356,8 @@ contains
     write(stdout, "(A)") "Doing initialisation"
 
     ! Set the same access for readwrite as for write (we do not open any files in readwrite mode)
-    call setDefaultFileAccess(this%opt%fileAccessTypes(1), this%opt%fileAccessTypes(2),&
-        & this%opt%fileAccessTypes(2))
+    call setDefaultBinaryAccess(this%opt%binaryAccessTypes(1), this%opt%binaryAccessTypes(2),&
+        & this%opt%binaryAccessTypes(2))
 
     ! Check eigenvector id
     call checkEigenvecs(eigVecBin, this%input%identity)
@@ -727,7 +727,7 @@ contains
 
     call getChildValue(node, "Verbose", this%opt%tVerbose, default=.false.)
 
-    call readFileAccessTypes(node, this%opt%fileAccessTypes)
+    call readBinaryAccessTypes(node, this%opt%binaryAccessTypes)
 
   end subroutine readOptions
 

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -4627,7 +4627,7 @@ This block collects some global options for the run.
   \kw{WriteCharges} &l & & Yes & \\
   \kwl{WriteChargesAsText}{kw:dftbp.WriteChargesAsText} & l & & No & \\
   \kw{SkipChargeTest} & l & ReadInitialCharges = Yes & No & \\
-  \kw{FileAccessTypes} & s | 2s & & "stream"  & \\
+  \kw{BinaryAccessTypes} & s | 2s & & "stream"  & \\
 \end{ptable}
 \begin{description}
 
@@ -4730,29 +4730,28 @@ This block collects some global options for the run.
   section~\ref{sec:charges.bin}), the check-sum this option removed the
   requirement that the checksum values in the file match the charges.
 
-\item[\is{FileAccessTypes}\label{sec:dftbp.Options.FileAccessTypes}] Specifies
-  the default file access types. It contains either one string specifying the
-  same access type for both reading and writing files, or two strings specifying
-  the access type separately for reading and writing. Each value must be either
-  \is{"sequential"} or \is{"stream"}. The default is \is{"stream"} for both
-  actions. It only affects the I/O of binary files.
+\item[\is{BinaryAccessTypes}\label{sec:dftbp.Options.BinaryAccessTypes}]
+  Specifies the default access format for binary (non-human-readable) files. It
+  contains either one string specifying the same type for both reading and
+  writing those files, or two strings specifying the types separately for
+  reading and writing. Each value must be either \is{"stream"} or
+  \is{"sequential"}. The default is \is{"stream"} for both actions.
 
-  Starting with version 23.1, \dftbp{} consistently uses stream-I/O in order to
-  procude binary files (e.g.\ \verb|eigenvec.bin|, \verb|charges.bin|, etc.),
-  which can be processed by programs written in other languages (Python, C). In
-  earlier versions most binary files were written using sequential I/O, which
-  were not transferable between languages or even between Fortran compilers. You
-  can read in or write out files in this old format by setting the appropriate
-  action to \is{"sequential"}.
+  Starting with version 23.1, \dftbp{} consistently uses stream-I/O for binary
+  files in order to procude files (e.g.\ \verb|eigenvec.bin|,
+  \verb|charges.bin|, etc.), which can be processed by programs written in other
+  languages (Python, C). In earlier versions most binary files were written
+  using sequential I/O, which were not transferable between languages or even
+  between Fortran compilers. You can read in or write out files in this old
+  format by setting the appropriate action to \is{"sequential"}.
 
   Example:
 \begin{verbatim}
   # Use old sequential I/O for input and output of binary files
-  FileAccessTypes = "sequential"
+  BinaryAccessTypes = "sequential"
 
   # Use the old format when reading and the new format when writing binary files
-  FileAccessTypes = "sequential"  "stream"
-
+  BinaryAccessTypes = "sequential"  "stream"
 \end{verbatim}
 
 

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -4733,12 +4733,12 @@ This block collects some global options for the run.
 \item[\is{BinaryAccessTypes}\label{sec:dftbp.Options.BinaryAccessTypes}]
   Specifies the default access format for binary (non-human-readable) files. It
   contains either one string specifying the same type for both reading and
-  writing those files, or two strings specifying the types separately for
+  writing those files, or two strings separately specifying the types for
   reading and writing. Each value must be either \is{"stream"} or
   \is{"sequential"}. The default is \is{"stream"} for both actions.
 
   Starting with version 23.1, \dftbp{} consistently uses stream-I/O for binary
-  files in order to procude files (e.g.\ \verb|eigenvec.bin|,
+  files in order to produce files (e.g.\ \verb|eigenvec.bin|,
   \verb|charges.bin|, etc.), which can be processed by programs written in other
   languages (Python, C). In earlier versions most binary files were written
   using sequential I/O, which were not transferable between languages or even

--- a/doc/dftb+/manual/waveplot.tex
+++ b/doc/dftb+/manual/waveplot.tex
@@ -89,7 +89,7 @@ The following properties can be specified:
   \kw{Verbose} & l & & No &  \\
   \kw{RepeatBox} & 3i & & \{1 1 1\} & \\
   \kw{ShiftGrid} & l & & Yes & \\
-  \kw{FileAccessTypes} & 2s & & "stream" "stream"  & \\
+  \kw{BinaryAccessTypes} & 2s & & "stream" "stream"  & \\
   \hline
 \end{ptable}
 \begin{description}
@@ -212,8 +212,9 @@ Example:
 \item[\is{Verbose}] If true, some extra messages are printed out
   during the calculation.
 
-\item[\is{FileAccessTypes}] Sets the file access type for binary I/O. See the
-  keyword description in Sec.~\ref{sec:dftbp.Options.FileAccessTypes} on page \pref{sec:dftbp.Options.FileAccessTypes}.
+\item[\is{BinaryAccessTypes}] Sets the file access type for binary I/O. See the
+  keyword description in Sec.~\ref{sec:dftbp.Options.BinaryAccessTypes} on page
+  \pref{sec:dftbp.Options.BinaryAccessTypes}.
 
 \end{description}
 

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -17,7 +17,7 @@ module dftbp_dftbplus_initprogram
       & Bohr__nm, Hartree__kJ_mol, Boltzmann
   use dftbp_common_envcheck, only : checkStackSize
   use dftbp_common_environment, only : TEnvironment, globalTimers
-  use dftbp_common_file, only : TFileDescr, setDefaultFileAccess, clearFile
+  use dftbp_common_file, only : TFileDescr, setDefaultBinaryAccess, clearFile
   use dftbp_common_globalenv, only : stdOut, withMpi
   use dftbp_common_hamiltoniantypes, only : hamiltonianTypes
   use dftbp_common_status, only : TStatus
@@ -1294,8 +1294,8 @@ contains
     call env%globalTimer%startTimer(globalTimers%globalInit)
 
     ! Set the same access for readwrite as for write (we do not open any files in readwrite mode)
-    call setDefaultFileAccess(input%ctrl%fileAccessTypes(1), input%ctrl%fileAccessTypes(2),&
-        & input%ctrl%fileAccessTypes(2))
+    call setDefaultBinaryAccess(input%ctrl%binaryAccessTypes(1), input%ctrl%binaryAccessTypes(2),&
+        & input%ctrl%binaryAccessTypes(2))
 
     ! Basic variables
     this%hamiltonianType = input%ctrl%hamiltonian

--- a/src/dftbp/dftbplus/input/fileaccess.F90
+++ b/src/dftbp/dftbplus/input/fileaccess.F90
@@ -16,15 +16,15 @@ module dftbp_dftbplus_input_fileaccess
   implicit none
 
   private
-  public :: readFileAccessTypes
+  public :: readBinaryAccessTypes
 
 contains
 
 
   !> Reads in the file acess types
-  subroutine readFileAccessTypes(node, accessTypes)
+  subroutine readBinaryAccessTypes(node, accessTypes)
 
-    !> Parent note which should contain the "FileAccessTypes" subnode
+    !> Parent note which should contain the "BinaryAccessTypes" subnode
     type(fnode), pointer, intent(in) :: node
 
     !> Read and write access types on exit (defaulting to ["stream", "stream"])
@@ -36,14 +36,14 @@ contains
 
     @:ASSERT(size(accessTypes) == 2)
 
-    call getChild(node, "FileAccessTypes", child, requested=.false.)
+    call getChild(node, "BinaryAccessTypes", child, requested=.false.)
     if (.not. associated(child)) then
-      call setChildValue(node, "FileAccessTypes", ["stream"], child=child)
+      call setChildValue(node, "BinaryAccessTypes", ["stream"], child=child)
     end if
     call init(stringList)
     call getChildValue(child, "", stringList)
     if (len(stringList) < 1 .or. len(stringList) > 2) then
-      call detailedError(child, "FileAccessTypes needs one or two arguments")
+      call detailedError(child, "BinaryAccessTypes needs one or two arguments")
     end if
     call asArray(stringList, accessTypes(1 : len(stringList)))
     if (len(stringList) == 1) then
@@ -57,6 +57,6 @@ contains
       end if
     end do
 
-  end subroutine readFileAccessTypes
+  end subroutine readBinaryAccessTypes
 
 end module dftbp_dftbplus_input_fileaccess

--- a/src/dftbp/dftbplus/inputdata.F90
+++ b/src/dftbp/dftbplus/inputdata.F90
@@ -541,8 +541,8 @@ module dftbp_dftbplus_inputdata
     !> Whether ChIMES correction for repulsives should be applied.
     type(TChimesRepInp), allocatable :: chimesRepInput
 
-    !> File access type to use when opening files for reading and writing
-    character(20) :: fileAccessTypes(2)
+    !> File access type to use when opening binary files for reading and writing
+    character(20) :: binaryAccessTypes(2)
 
   end type TControl
 

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -36,7 +36,7 @@ module dftbp_dftbplus_parser
   use dftbp_dftb_slakocont, only : init, addTable
   use dftbp_dftb_slakoeqgrid, only : skEqGridNew, skEqGridOld, TSlakoEqGrid, init
   use dftbp_dftbplus_forcetypes, only : forceTypes
-  use dftbp_dftbplus_input_fileaccess, only : readFileAccessTypes
+  use dftbp_dftbplus_input_fileaccess, only : readBinaryAccessTypes
   use dftbp_dftbplus_inputconversion, only : transformpdosregioninfo
   use dftbp_dftbplus_inputdata, only :TInputData, TControl, TSlater, TBlacsOpts, TRangeSepInp
   use dftbp_dftbplus_oldcompat, only : convertOldHSD
@@ -3963,7 +3963,7 @@ contains
       call getChildValue(node, "SkipChargeTest", ctrl%tSkipChrgChecksum, .false.)
     end if
 
-    call readFileAccessTypes(node, ctrl%fileAccessTypes)
+    call readBinaryAccessTypes(node, ctrl%binaryAccessTypes)
 
   end subroutine readOptions
 

--- a/test/app/dftb+/legacy/file_access/dftb_in.hsd.all
+++ b/test/app/dftb+/legacy/file_access/dftb_in.hsd.all
@@ -11,7 +11,7 @@
 }
 
 +Options {
-  FileAccessTypes = "stream"
+  BinaryAccessTypes = "stream"
 }
 
 %
@@ -21,7 +21,7 @@
 }
 
 +Options {
-  FileAccessTypes = "stream" "stream"
+  BinaryAccessTypes = "stream" "stream"
 }
 
 %
@@ -31,7 +31,7 @@
 }
 
 +Options {
-  FileAccessTypes = "stream" "sequential"
+  BinaryAccessTypes = "stream" "sequential"
 }
 
 %
@@ -41,7 +41,7 @@
 }
 
 +Options {
-  FileAccessTypes = "sequential"
+  BinaryAccessTypes = "sequential"
 }
 
 %
@@ -51,7 +51,7 @@
 }
 
 +Options {
-  FileAccessTypes = "sequential" "sequential"
+  BinaryAccessTypes = "sequential" "sequential"
 }
 
 %
@@ -61,7 +61,7 @@
 }
 
 +Options {
-  FileAccessTypes = "sequential" "stream"
+  BinaryAccessTypes = "sequential" "stream"
 }
 
 %

--- a/test/src/dftbp/unittests/common/file.F90
+++ b/test/src/dftbp/unittests/common/file.F90
@@ -9,7 +9,7 @@
 
 #:block TEST_SUITE("file")
   use dftbp_common_file, only : TFileDescr, TOpenOptions, fileExists, openFile, closeFile,&
-      & clearFile, defaultFileAccess
+      & clearFile, defaultBinaryAccess, defaultTextAccess
   use dftbp_io_charmanip, only : tolower
   implicit none
 
@@ -476,19 +476,35 @@
 
   #:contains
 
-    #:block TEST("default_access")
-      character(*), parameter :: fname = "default_access"
+    #:block TEST("default_text_access")
+      character(*), parameter :: fname = "default_text_access"
 
       ! Note: openFile() closes the file connected to the descriptor (if any)
       call openFile(fd, fname, mode="w", ioStat=ioStat)
       @:ASSERT(ioStat == 0)
-      @:ASSERT(checkUnitProperties_(fd%unit, access=defaultFileAccess(2)))
+      @:ASSERT(checkUnitProperties_(fd%unit, access=defaultTextAccess(2)))
       call openFile(fd, fname, mode="r", ioStat=ioStat)
       @:ASSERT(ioStat == 0)
-      @:ASSERT(checkUnitProperties_(fd%unit, access=defaultFileAccess(1)))
+      @:ASSERT(checkUnitProperties_(fd%unit, access=defaultTextAccess(1)))
       call openFile(fd, fname, mode="r+", ioStat=ioStat)
       @:ASSERT(ioStat == 0)
-      @:ASSERT(checkUnitProperties_(fd%unit, access=defaultFileAccess(3)))
+      @:ASSERT(checkUnitProperties_(fd%unit, access=defaultTextAccess(3)))
+    #:endblock
+
+
+    #:block TEST("default_binary_access")
+      character(*), parameter :: fname = "default_binary_access"
+
+      ! Note: openFile() closes the file connected to the descriptor (if any)
+      call openFile(fd, fname, mode="wb", ioStat=ioStat)
+      @:ASSERT(ioStat == 0)
+      @:ASSERT(checkUnitProperties_(fd%unit, access=defaultBinaryAccess(2)))
+      call openFile(fd, fname, mode="rb", ioStat=ioStat)
+      @:ASSERT(ioStat == 0)
+      @:ASSERT(checkUnitProperties_(fd%unit, access=defaultBinaryAccess(1)))
+      call openFile(fd, fname, mode="r+b", ioStat=ioStat)
+      @:ASSERT(ioStat == 0)
+      @:ASSERT(checkUnitProperties_(fd%unit, access=defaultBinaryAccess(3)))
     #:endblock
 
 


### PR DESCRIPTION
Text I/O is done with sequential I/O by default now to avoid issues with T-formatting.

Renames keyword `FileAccessType` into more specific `BinaryAccessType`. No parser version dumping necessary, as the previous keyword was not part of any official release so far.
