### PR TITLE
Fixes and generalises header print

### DIFF
--- a/app/dftb+/dftbplus.F90
+++ b/app/dftb+/dftbplus.F90
@@ -10,15 +10,13 @@
 program dftbplus
   use dftbp_common_environment, only : TEnvironment, TEnvironment_init
   use dftbp_common_globalenv, only : initGlobalEnv, destructGlobalEnv
+  use dftbp_common_release, only : releaseName, releaseYear
   use dftbp_dftbplus_hsdhelpers, only : parseHsdInput
   use dftbp_dftbplus_initprogram, only : TDftbPlusMain
   use dftbp_dftbplus_inputdata, only : TInputData
   use dftbp_dftbplus_main, only : runDftbPlus
   use dftbp_io_formatout, only : printDftbHeader
   implicit none
-
-  character(len=*), parameter :: releaseName = '${RELEASE}$'
-  integer, parameter :: releaseYear = 2023
 
   type(TEnvironment) :: env
   type(TInputData), allocatable :: input

--- a/app/transporttools/setupgeom.F90
+++ b/app/transporttools/setupgeom.F90
@@ -9,6 +9,7 @@
 
 program setupgeom
   use dftbp_common_globalenv
+  use dftbp_common_release, only : releaseYear
   use dftbp_io_formatout, only : printDftbHeader
   use transporttools_inputdata, only : TInputData
   use transporttools_parser, only : parseHsdInput
@@ -18,9 +19,6 @@ program setupgeom
   use dftbp_extlibs_mpifx, only : mpifx_init_thread, mpifx_finalize
 #:endif
   implicit none
-
-  character(len=*), parameter :: releaseName = ''
-  integer, parameter :: releaseYear = 2020
 
   type(TInputData), allocatable :: input
 
@@ -37,7 +35,7 @@ program setupgeom
 #:else
   call initGlobalEnv()
 #:endif
-  call printDftbHeader(releaseName, releaseYear)
+  call printDftbHeader('(setupgeom)', releaseYear)
   allocate(input)
   call parseHsdInput(input)
   deallocate(input)

--- a/src/dftbp/common/CMakeLists.txt
+++ b/src/dftbp/common/CMakeLists.txt
@@ -15,6 +15,7 @@ set(sources-fpp
   ${curdir}/hamiltoniantypes.F90
   ${curdir}/memman.F90
   ${curdir}/optarg.F90
+  ${curdir}/release.F90
   ${curdir}/schedule.F90
   ${curdir}/status.F90
   ${curdir}/timer.F90

--- a/src/dftbp/common/release.F90
+++ b/src/dftbp/common/release.F90
@@ -1,0 +1,30 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2023  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+#:include 'common.fypp'
+
+!> Release of code constants and types
+module dftbp_common_release
+  implicit none
+
+  public
+
+  !> Release name of the code
+  character(len=*), parameter :: releaseName = '${RELEASE}$'
+
+  !> Year of release
+  integer, parameter :: releaseYear = 2023
+
+  !> Mapping between input version and parser version
+  type :: TVersionMap
+    !> named version of parser input
+    character(10) :: inputVersion
+    !> Corresponding numerical version of parser input
+    integer :: parserVersion
+  end type TVersionMap
+
+end module dftbp_common_release

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -15,6 +15,7 @@ module dftbp_dftbplus_parser
   use dftbp_common_filesystem, only : findFile, getParamSearchPath
   use dftbp_common_globalenv, only : stdout, withMpi, withScalapack, abortProgram
   use dftbp_common_hamiltoniantypes, only : hamiltonianTypes
+  use dftbp_common_release, only : TVersionMap
   use dftbp_common_status, only : TStatus
   use dftbp_common_unitconversion, only : lengthUnits, energyUnits, forceUnits, pressureUnits,&
       & timeUnits, EFieldUnits, freqUnits, massUnits, VelocityUnits, dipoleUnits, chargeUnits,&
@@ -114,15 +115,6 @@ module dftbp_dftbplus_parser
     !> HSD output?
     logical :: tWriteHSD
   end type TParserFlags
-
-
-  !> Mapping between input version and parser version
-  type :: TVersionMap
-    !> named version of parser input
-    character(10) :: inputVersion
-    !> Corresponding numerical version of parser input
-    integer :: parserVersion
-  end type TVersionMap
 
   !> Actual input version <-> parser version maps (must be updated at every public release)
   type(TVersionMap), parameter :: versionMaps(*) = [&

--- a/src/dftbp/io/formatout.F90
+++ b/src/dftbp/io/formatout.F90
@@ -350,13 +350,13 @@ contains
   end subroutine writeXYZFormat_fid
 
 
-  !> Writes the greeting message of dftb+ on stdout
-  subroutine printDFTBHeader(release, year)
+  !> Writes the greeting message of dftb+ code(s) on stdout
+  subroutine printDFTBHeader(text, year)
 
-    !> release version of the code
-    character(len=*), intent(in) :: release
+    !> Additional text to print next to project name
+    character(len=*), intent(in) :: text
 
-    !> release year
+    !> Release year
     integer, intent(in) :: year
 
     character, parameter :: verticalBar = '|'
@@ -364,7 +364,7 @@ contains
     integer, parameter :: headerWidth = 80
 
     write(stdOut, '(2A,/,A)') verticalBar, repeat(horizontalBar, headerWidth - 1), verticalBar
-    write(stdOut, '(3A)') verticalBar, '  DFTB+ ', trim(release)
+    write(stdOut, '(3A)') verticalBar, '  DFTB+ ', trim(text)
     write(stdOut, '(A)') verticalBar
     write(stdOut, '(2A,I0,A)') verticalBar, '  Copyright (C) 2006 - ', year,&
         & '  DFTB+ developers group'


### PR DESCRIPTION
The setupgeom code also uses this and was outdated. Mechanism ready for other codes (waveplot, modes) for a future PR.  Also moved type for release map used in parser calls to a global location, so can be used by other Fortran tools in the future.