### PR TITLE
build manual.pdf in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: CI
+name: DFTB+
 on: [push, pull_request]
 
 env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,19 @@
+name: Documentation
+on:
+  push:
+    branches: [ main ]
+jobs:
+  build-manual:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.gitlab.com/islandoftex/images/texlive:TL2023-2023-06-18-full
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Build DFTB+ manual
+        run: make -C doc/dftb+/manual
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: DFTB+ Manual
+          path: doc/dftb+/manual/manual.pdf


### PR DESCRIPTION
... and save it as an artifact. See the new workflow in action [here](https://github.com/MFTabriz/dftbplus/actions/runs/5361615944)!

This can be adapted later for continuous deployment.