### PR TITLE
Remove functionality duplicates and clean up

### DIFF
--- a/app/waveplot/gridcache.F90
+++ b/app/waveplot/gridcache.F90
@@ -8,20 +8,21 @@
 #:include 'common.fypp'
 
 !> A cache for calculating molecule orbitals on a grid.
-!> This object is responsible for reading in the eigenvectors from a specified file and passing the
-!> appropriate eigenvectors to the molecule orbital calculator.
+!! This object is responsible for reading in the eigenvectors from a specified file and passing the
+!! appropriate eigenvectors to the molecule orbital calculator.
 module waveplot_gridcache
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : pi
   use dftbp_common_file, only : TFileDescr, openFile, closeFile
   use dftbp_common_globalenv, only : stdOut
   use dftbp_io_message, only : error
-  use waveplot_molorb, only : TMolecularOrbital, init, getValue
+  use waveplot_molorb, only : TMolecularOrbital, getValue
   implicit none
 
   private
+  public :: TGridCache, TGridCache_init, next
 
-  !> Contains the data for a grid cache
+  !> Contains the data for a grid cache.
   type TGridCache
 
     !> Molecular orbital calculator
@@ -93,33 +94,24 @@ module waveplot_gridcache
     !> Initialised?
     logical :: tInitialised = .false.
 
-  end type TgridCache
-
-
-  !> Initialises a GridCache instance.
-  interface init
-    module procedure GridCache_init
-  end interface
+  end type TGridCache
 
 
   !> Delivers the next molecular orbital grid from the cache
   interface next
-    module procedure GridCache_next_real
-    module procedure GridCache_next_cmpl
+    module procedure TGridCache_next_real
+    module procedure TGridCache_next_cmpl
   end interface
 
-  public :: TgridCache
-  public :: init, next
 
 contains
 
-
-  !> Initialises a GridCache instance
-  !> Caveat: Level index is not allowed to contain duplicate entries!
-  subroutine GridCache_init(sf, levelIndex, nOrb, nAllLevel, nAllKPoint, nAllSpin, nCached,&
+  !> Initialises a GridCache instance.
+  !! Caveat: Level index is not allowed to contain duplicate entries!
+  subroutine TGridCache_init(sf, levelIndex, nOrb, nAllLevel, nAllKPoint, nAllSpin, nCached,&
       & nPoints, tVerbose, eigvecbin, gridVec, origin, kPointCoords, tReal, molorb)
 
-    !> The structure to initialise
+    !> Structure to initialise
     type(TgridCache), intent(inout) :: sf
 
     !> Contains indexes (spin, kpoint, state) of the levels which must be calculated
@@ -183,15 +175,15 @@ contains
     @:ASSERT(all(shape(kPointCoords) == [3, nAllKPoint]))
 
     sf%molorb => molorb
-    sf%gridVec(:,:) = gridVec(:,:)
-    sf%origin = origin(:)
+    sf%gridVec(:,:) = gridVec
+    sf%origin = origin
     sf%nOrb = nOrb
     sf%nAllLevel = nAllLevel
     sf%nAllKPoint = nAllKPoint
     sf%nAllSpin = nAllSpin
     sf%tVerbose = tVerbose
     allocate(sf%kPoints(3, nAllKPoint))
-    sf%kPoints(:,:) = 2.0_dp * pi * kPointCoords(:,:)
+    sf%kPoints(:,:) = 2.0_dp * pi * kPointCoords
     sf%nCached = nCached
     sf%tReal = tReal
     if (sf%tReal) then
@@ -218,7 +210,7 @@ contains
             end if
           end do lpLevelIndex
           if (tFound) then
-            sf%levelIndex(:, ind) = curVec(:)
+            sf%levelIndex(:, ind) = curVec
             ind = ind +1
           end if
         end do
@@ -237,11 +229,11 @@ contains
     read(sf%fdEigVec%unit) ii
     sf%tInitialised = .true.
 
-  end subroutine GridCache_init
+  end subroutine TGridCache_init
 
 
-  !> Returns the next entry from the cache
-  subroutine GridCache_next_real(sf, gridValReal, levelIndex, tFinished)
+  !> Returns the next entry from the cache (real version).
+  subroutine TGridCache_next_real(sf, gridValReal, levelIndex, tFinished)
 
     !> Gridcache instance
     type(TgridCache), intent(inout) :: sf
@@ -259,11 +251,11 @@ contains
 
     call local_next(sf, gridValReal, gridValCmpl, levelIndex, tFinished)
 
-  end subroutine GridCache_next_real
+  end subroutine TGridCache_next_real
 
 
-  !> Returns the next entry from the cache
-  subroutine GridCache_next_cmpl(sf, gridValCmpl, levelIndex, tFinished)
+  !> Returns the next entry from the cache (complex version).
+  subroutine TGridCache_next_cmpl(sf, gridValCmpl, levelIndex, tFinished)
 
     !> Gridcache instance
     type(TgridCache), intent(inout) :: sf
@@ -281,10 +273,10 @@ contains
 
     call local_next(sf, gridValReal, gridValCmpl, levelIndex, tFinished)
 
-  end subroutine GridCache_next_cmpl
+  end subroutine TGridCache_next_cmpl
 
 
-  !> Working subroutine for the GridCache_next_* subroutines
+  !> Working subroutine for the TGridCache_next_* subroutines.
   subroutine local_next(sf, gridValReal, gridValCmpl, levelIndex, tFinished)
 
     !> Gridcache instance

--- a/app/waveplot/initwaveplot.F90
+++ b/app/waveplot/initwaveplot.F90
@@ -377,7 +377,7 @@ contains
   end subroutine TProgramVariables_init
 
 
-  !> Interprets the information stored in detailed.xml.
+  !> Interpret the information stored in detailed.xml.
   subroutine readDetailed(this, detailed, tGroundState, kPointsWeights)
 
     !> Container of program variables
@@ -451,7 +451,7 @@ contains
   end subroutine readDetailed
 
 
-  !> Reads in the geometry stored as .xml in internal or .gen format.
+  !> Read in the geometry stored as .xml in internal or .gen format.
   subroutine readGeometry(geo, geonode)
 
     !> Geometry instance
@@ -489,7 +489,7 @@ contains
   end subroutine readGeometry
 
 
-  !> Interprets the options.
+  !> Interpret the options.
   subroutine readOptions(this, node, nLevel, nKPoint, nSpin, nCached, tShiftGrid)
 
     !> Container of program variables
@@ -776,7 +776,7 @@ contains
   end subroutine readBasis
 
 
-  !> Reads in basis function for a species.
+  !> Read in basis function for a species.
   subroutine readSpeciesBasis(node, basisResolution, spBasis)
 
     !> Node containing the basis definition for a species

--- a/app/waveplot/slater.F90
+++ b/app/waveplot/slater.F90
@@ -7,55 +7,66 @@
 
 #:include 'common.fypp'
 
-!> Routines to calculate a Slater type orbital (STO)
+!> Routines to calculate a Slater type orbital (STO).
 module waveplot_slater
-  use dftbp_common_accuracy, only :dp
+  use dftbp_common_accuracy, only : dp
   implicit none
 
   private
   save
 
+  public :: realTessY
+  public :: TSlaterOrbital, TSlaterOrbital_init, getValue, assignment(=)
 
-  !> Data for STOs
+
+  !> Data type for STOs.
   type TSlaterOrbital
     private
+
+    !> Maximal power of the distance
     integer :: nPow
+
+    !> Number of exponential coefficients
     integer :: nAlpha
+
+    !> Angular momentum
     integer :: ll
+
+    !> Summation coefficients. Shape: [nPow, nAlpha]
     real(dp), allocatable :: aa(:,:)
+
+    !> Exponential coefficients
     real(dp), allocatable :: alpha(:)
+
+    !> STO values on the distance grid
     real(dp), allocatable :: gridValue(:)
+
+    !> Grid distance (resolution)
     real(dp) :: gridDist
+
+    !> Number of grid points
     integer :: nGrid
+
   end type TSlaterOrbital
 
 
-  !> Initialises a SlaterOrbital
-  interface init
-    module procedure SlaterOrbital_init
-  end interface
-
-
-  !> Returns the value of a Slater orbital in a given point
+  !> Returns the value of a Slater orbital in a given point.
   interface getValue
-    module procedure SlaterOrbital_getValue
+    module procedure TSlaterOrbital_getValue
   end interface
 
 
-  !> Assignment operator for SlaterOrbital to assure proper allocation
+  !> Assignment operator for SlaterOrbital to assure proper allocation.
   interface assignment(=)
-    module procedure SlaterOrbital_assign
+    module procedure TSlaterOrbital_assign
   end interface
-
-  public :: RealTessY
-  public :: TSlaterOrbital, init, getValue, assignment(=)
 
 contains
 
 
-  !> Returns the real tesseral spherical harmonics in a given point
-  !> This function only work for angular momenta between 0 and 3 (s-f).
-  function RealTessY(ll, mm, coord, rrOpt) result (rty)
+  !> Returns the real tesseral spherical harmonics in a given point.
+  !! This function only work for angular momenta between 0 and 3 (s-f).
+  function realTessY(ll, mm, coord, rrOpt) result(rty)
 
     !> Angular momentum of the spherical harmonics (0 <= ll <= 3)
     integer, intent(in) :: ll
@@ -156,11 +167,11 @@ contains
       end select
     end select
 
-  end function RealTessY
+  end function realTessY
 
 
   !> Initialises a SlaterOrbital.
-  subroutine SlaterOrbital_init(this, aa, alpha, ll, resolution, cutoff)
+  subroutine TSlaterOrbital_init(this, aa, alpha, ll, resolution, cutoff)
 
     !> SlaterOrbital instance to initialise
     type(TSlaterOrbital), intent(inout) :: this
@@ -209,15 +220,15 @@ contains
     allocate(this%gridValue(this%nGrid))
     do iGrid = 1, this%nGrid
       rr = real(iGrid - 1, dp) * resolution
-      call SlaterOrbital_getValue_explicit(ll, nPow, nAlpha, aa, this%alpha, rr,&
+      call TSlaterOrbital_getValue_explicit(ll, nPow, nAlpha, aa, this%alpha, rr,&
           & this%gridValue(iGrid))
     end do
 
-  end subroutine SlaterOrbital_init
+  end subroutine TSlaterOrbital_init
 
 
-  !> Retunrns the value of the SlaterOrbital in a given point
-  subroutine SlaterOrbital_getValue(this, rr, sto)
+  !> Returns the value of the SlaterOrbital in a given point.
+  subroutine TSlaterOrbital_getValue(this, rr, sto)
 
     !> SlaterOrbital instance
     type(TSlaterOrbital), intent(in) :: this
@@ -242,11 +253,11 @@ contains
       sto = 0.0_dp
     end if
 
-  end subroutine SlaterOrbital_getValue
+  end subroutine TSlaterOrbital_getValue
 
 
-  !> Calculates the value of an STO analytically
-  subroutine SlaterOrbital_getValue_explicit(ll, nPow, nAlpha, aa, alpha, rr, sto)
+  !> Calculates the value of an STO analytically.
+  subroutine TSlaterOrbital_getValue_explicit(ll, nPow, nAlpha, aa, alpha, rr, sto)
 
     !> Angular momentum of the STO
     integer, intent(in) :: ll
@@ -292,11 +303,11 @@ contains
       sto = sto + rTmp * exp(alpha(ii) * rr)
     end do
 
-  end subroutine SlaterOrbital_getValue_explicit
+  end subroutine TSlaterOrbital_getValue_explicit
 
 
-  !> An STO assignment with proper memory allocation (deep copy)
-  elemental subroutine SlaterOrbital_assign(left, right)
+  !> An STO assignment with proper memory allocation (deep copy).
+  elemental subroutine TSlaterOrbital_assign(left, right)
 
     !> Left value of the assignment
     type(TSlaterOrbital), intent(inout) :: left
@@ -305,8 +316,7 @@ contains
     type(TSlaterOrbital), intent(in) :: right
 
     if (allocated(left%aa)) then
-      deallocate(left%aa)
-      deallocate(left%alpha)
+      deallocate(left%aa, left%alpha)
     end if
 
     allocate(left%aa(size(right%aa, dim=1), size(right%aa, dim=2)))
@@ -316,12 +326,12 @@ contains
     left%nPow = right%nPow
     left%nAlpha = right%nAlpha
     left%ll = right%ll
-    left%aa(:,:) = right%aa(:,:)
-    left%alpha(:) = right%alpha(:)
-    left%gridValue(:) = right%gridValue(:)
+    left%aa(:,:) = right%aa
+    left%alpha(:) = right%alpha
+    left%gridValue(:) = right%gridValue
     left%gridDist = right%gridDist
     left%nGrid = right%nGrid
 
-  end subroutine SlaterOrbital_assign
+  end subroutine TSlaterOrbital_assign
 
 end module waveplot_slater

--- a/app/waveplot/slater.F90
+++ b/app/waveplot/slater.F90
@@ -16,7 +16,7 @@ module waveplot_slater
   save
 
   public :: realTessY
-  public :: TSlaterOrbital, TSlaterOrbital_init, getValue, assignment(=)
+  public :: TSlaterOrbital, TSlaterOrbital_init, getValue
 
 
   !> Data type for STOs.
@@ -56,13 +56,7 @@ module waveplot_slater
   end interface
 
 
-  !> Assignment operator for SlaterOrbital to assure proper allocation.
-  interface assignment(=)
-    module procedure TSlaterOrbital_assign
-  end interface
-
 contains
-
 
   !> Returns the real tesseral spherical harmonics in a given point.
   !! This function only work for angular momenta between 0 and 3 (s-f).
@@ -304,34 +298,5 @@ contains
     end do
 
   end subroutine TSlaterOrbital_getValue_explicit
-
-
-  !> An STO assignment with proper memory allocation (deep copy).
-  elemental subroutine TSlaterOrbital_assign(left, right)
-
-    !> Left value of the assignment
-    type(TSlaterOrbital), intent(inout) :: left
-
-    !> Right value of the assignment
-    type(TSlaterOrbital), intent(in) :: right
-
-    if (allocated(left%aa)) then
-      deallocate(left%aa, left%alpha)
-    end if
-
-    allocate(left%aa(size(right%aa, dim=1), size(right%aa, dim=2)))
-    allocate(left%alpha(size(right%alpha)))
-    allocate(left%gridValue(size(right%gridValue)))
-
-    left%nPow = right%nPow
-    left%nAlpha = right%nAlpha
-    left%ll = right%ll
-    left%aa(:,:) = right%aa
-    left%alpha(:) = right%alpha
-    left%gridValue(:) = right%gridValue
-    left%gridDist = right%gridDist
-    left%nGrid = right%nGrid
-
-  end subroutine TSlaterOrbital_assign
 
 end module waveplot_slater

--- a/app/waveplot/waveplot.F90
+++ b/app/waveplot/waveplot.F90
@@ -75,8 +75,7 @@ program waveplot
   !> MPI environment
   type(TMpiEnv) :: mpiEnv
 
-  ! As this is serial code, trap for run time execution on more than 1 processor with an mpi enabled
-  ! build
+  ! As this is serial code, trap for run time execution on more than 1 processor with MPI enabled
   call mpifx_init_thread(requiredThreading=MPI_THREAD_FUNNELED)
   call TMpiEnv_init(mpiEnv)
   call mpiEnv%mpiSerialEnv()
@@ -398,7 +397,6 @@ contains
 
     !> How often the grid should be repeated along the direction of the grid vectors
     integer, intent(in), optional :: repeatBox(:)
-
 
     integer, parameter :: bufferSize = 6
     real(dp) :: buffer(bufferSize)

--- a/src/dftbp/math/simplealgebra.F90
+++ b/src/dftbp/math/simplealgebra.F90
@@ -37,7 +37,7 @@ contains
 
 
   !> Signed determinant of a 3x3 matrix
-  function  determinant33(matrix)
+  function determinant33(matrix)
 
     !> The matrix for which to calculate the determinant.
     real(dp), intent(in) :: matrix(:,:)
@@ -62,7 +62,7 @@ contains
 
 
   !> Derivative of determinant of a 3x3 matrix
-  subroutine  derivDeterminant33(deriv,matrix)
+  subroutine derivDeterminant33(deriv,matrix)
 
     !> derivative of the determinant
     real(dp), intent(out) :: deriv(:, :)


### PR DESCRIPTION
Minor (cosmetic) changes to the Waveplot code-base + duplicate determinant routine removed + a question:
Is the `TSlaterOrbital_assign` subroutine still relevant or an artifact of a formerly required workaround that may be removed now?