### PR TITLE
Ordering agnostic SK-parsing

### DIFF
--- a/src/dftbp/type/oldskdata.F90
+++ b/src/dftbp/type/oldskdata.F90
@@ -182,12 +182,9 @@ contains
       end if
     end do
 
-    if (.not. present(splineRepIn)) then
-      call closeFile(file)
-      return
+    if (present(splineRepIn)) then
+      call readSplineRep(file%unit, fileName, splineRepIn, iSp1, iSp2)
     end if
-
-    call readSplineRep(file%unit, fileName, splineRepIn, iSp1, iSp2)
 
     ! Read range-separated parameter(s)
     if (present(rangeSepSK)) then
@@ -276,6 +273,8 @@ contains
     logical :: hasspline
     real(dp), allocatable :: xend(:)
 
+    rewind(fp)
+
     ! Look for spline
     do
       read(fp, '(A)', iostat=iostat) chdummy
@@ -361,6 +360,8 @@ contains
       fd = file%unit
       call checkIoError(iErr, fname, "Unable to open file")
     end if
+
+    rewind(fd)
 
     ! Seek range-separated extra tag in SK-file
     do

--- a/utils/get_opt_externals
+++ b/utils/get_opt_externals
@@ -128,9 +128,9 @@ def set_status(destdir, status):
 def get_slakos(destdir):
     '''Downloads and extracts parametrizations for the tests.'''
 
-    url = 'https://github.com/aradi/testparams/archive/cd7536f659be2665cd78d0297f00d377544840aa.tar.gz'
+    url = 'https://github.com/dftbplus/testparams/archive/6165104e60efbdb3ad05d005c282ada50f12dfef.tar.gz'
     fname = os.path.join(destdir, 'testparams.tar.gz')
-    unpackname = os.path.join(destdir, 'testparams-cd7536f659be2665cd78d0297f00d377544840aa')
+    unpackname = os.path.join(destdir, 'testparams-6165104e60efbdb3ad05d005c282ada50f12dfef')
     targetname = os.path.join(destdir, 'origin')
     if os.path.exists(unpackname):
         shutil.rmtree(unpackname)


### PR DESCRIPTION
Fixes #1269.

Remark: While it seems like this fix is automatically tested by updating the testparams commit ID, it is not. I verified it by (manually) applying the patch to #1223, however, proper regression testing will only be in place as soon as #1223 is merged.