### PR TITLE
Fix for incorrect pointers

### DIFF
--- a/src/dftbp/dftb/periodic.F90
+++ b/src/dftbp/dftb/periodic.F90
@@ -898,16 +898,6 @@ contains
       call neigh%neighDist2Win_%unlock()
     #:endif
     else
-      if (associated(neigh%iNeighbourMem_)) then
-        deallocate(neigh%iNeighbourMem_)
-      end if
-      if (associated(neigh%neighDist2Mem_)) then
-        deallocate(neigh%neighDist2Mem_)
-      end if
-
-      allocate(neigh%iNeighbour(0:maxNeighbour, 1:nAtom))
-      allocate(neigh%neighDist2(0:maxNeighbour, 1:nAtom))
-
       neigh%iNeighbour(1:,:) = iNeighbour(1:maxNeighbour,:)
       neigh%neighDist2(1:,:) = neighDist2(1:maxNeighbour,:)
     end if


### PR DESCRIPTION
Note that other MPI-only parts of the window code probably should be inside pre-processor blocks, so probably need a further PR to refact that.

Closes #1266 