### PR TITLE
Fixed window locks called unitialised

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Changed
 Fixed
 -----
 
+- Memory leak for MPI enabled code with many geometric steps.
+
 
 23.1 (2023-07-05)
 =================

--- a/src/dftbp/dftb/periodic.F90
+++ b/src/dftbp/dftb/periodic.F90
@@ -64,27 +64,33 @@ module dftbp_dftb_periodic
     !> whether the neighbour list has been set by an API call
     logical :: setExternally = .false.
 
-    ! Whether memory should be allocated via MPI-windows (or directly via allocate() otherwise)
+    !> Whether memory should be allocated via MPI-windows (or directly via allocate() otherwise)
+    !!
+    !! Note: this variable cannot be inside the MPI block below with current code, as the parser
+    !! uses this data structure before the MPI environment is set up (in addition to the main code
+    !! use). This leads to a fall back to the usual distributed case if MPI is enabled, instead of
+    !! the shared window in that case.
     logical, private :: useMpiWindows_ = .false.
 
-    ! memory allocated for the iNeighbour array
+  #:if WITH_MPI
+
+    !> memory allocated for the iNeighbour array
     integer, pointer, private :: iNeighbourMem_(:) => null()
 
-    ! memory allocated for the neighDist2 array
+    !> memory allocated for the neighDist2 array
     real(dp), pointer, private :: neighDist2Mem_(:) => null()
 
-  #:if WITH_MPI
-    ! MPI shared memory window handler for iNeighbour
+    !> MPI shared memory window handler for iNeighbour
     type(mpifx_win), private :: iNeighbourWin_
 
-    ! MPI shared memory window handler for neightDist2
+    !> MPI shared memory window handler for neightDist2
     type(mpifx_win), private :: neighDist2Win_
-
-  #:endif
 
   contains
 
     final :: TNeighbourList_final
+
+  #:endif
 
   end type TNeighbourList
 
@@ -116,6 +122,7 @@ contains
   end subroutine TNeighbourList_init
 
 
+#:if WITH_MPI
   !> Deallocates MPI shared memory if required
   subroutine TNeighbourList_final(this)
 
@@ -123,24 +130,16 @@ contains
     type(TNeighbourList), intent(inout) :: this
 
     if (this%useMpiWindows_) then
-    #:if WITH_MPI
       if (associated(this%iNeighbourMem_)) then
         call this%iNeighbourWin_%free()
       end if
       if (associated(this%neighDist2Mem_)) then
         call this%neighDist2Win_%free()
       end if
-    #:endif
-    else
-      if (associated(this%iNeighbourMem_)) then
-        deallocate(this%iNeighbourMem_)
-      end if
-      if (associated(this%neighDist2Mem_)) then
-        deallocate(this%neighDist2Mem_)
-      end if
     end if
 
   end subroutine TNeighbourList_final
+#:endif
 
 
   !> Calculates the translation vectors for cells, which could contain atoms interacting with any of
@@ -453,6 +452,8 @@ contains
           & isParallelSetupError)
       isParallel = .not. isParallelSetupError
     end if
+
+    neigh%useMpiWindows_ = isParallel
   #:endif
 
     if (.not. isParallel) then
@@ -557,7 +558,7 @@ contains
       isSetupError = .true.
     end if
   #:if WITH_MPI
-    if (isParallel) then
+    if (neigh%useMpiWindows_) then
       ! find if any of the processes in the node comm are in error state
       call mpifx_allreduceip(env%mpi%nodeComm, isSetupError, MPI_LOR)
       if (isSetupError) then
@@ -576,11 +577,11 @@ contains
 
     call reallocateArrays1(img2CentCell, iCellVec, coord, nAllAtom)
 
-    if (isParallel) then
     #:if WITH_MPI
+    if (neigh%useMpiWindows_) then
       call mpifx_allreduceip(env%mpi%nodeComm, neigh%nNeighbour, MPI_MAX)
-    #:endif
     end if
+    #:endif
 
     maxNeighbour = maxval(neigh%nNeighbour(1:nAtom))
     maxNeighbourLocal = min(ubound(iNeighbour, dim=1), maxNeighbour)
@@ -600,9 +601,9 @@ contains
 
     end do lpStoreAtoms
 
-    call allocateNeighbourArrays(neigh, maxNeighbour, nAtom, isParallel, env)
+    call allocateNeighbourArrays(neigh, maxNeighbour, nAtom, env)
     call fillNeighbourArrays(neigh, iNeighbour, neighDist2, startAtom, endAtom, maxNeighbour,&
-        & nAtom, isParallel)
+        & nAtom)
 
   end subroutine updateNeighbourList
 
@@ -671,12 +672,9 @@ contains
     nAtom = size(nNeighbour)
 
     neigh%setExternally = .true.
+    neigh%useMpiWindows_ = .true.
 
-    #:if WITH_MPI
-      call allocateNeighbourArrays(neigh, nMaxNeighbours, nAtom, .true., env)
-    #:else
-      call allocateNeighbourArrays(neigh, nMaxNeighbours, nAtom, .false.)
-    #:endif
+    call allocateNeighbourArrays(neigh, nMaxNeighbours, nAtom, env)
 
     neigh%nNeighbour(:) = nNeighbour(:)
     neigh%cutoff = cutOff
@@ -731,13 +729,14 @@ contains
     end if
     species(1:nAllAtom) = species0(img2CentCell(1:nAllAtom))
 
-    #:if WITH_MPI
+    copyData = .true.
+  #:if WITH_MPI
+    if (neigh%useMpiWindows_) then
       call neigh%iNeighbourWin_%lock()
       call neigh%neighDist2Win_%lock()
       copyData = env%mpi%nodeComm%lead
-    #:else
-      copyData = .true.
-    #:endif
+    end if
+  #:endif
 
     !> This is done only for task 0 on the node due to MPI shared memory: Copy to the actual
     !> neighbour arrays.
@@ -776,20 +775,21 @@ contains
       end do
     end if
 
-    #:if WITH_MPI
+  #:if WITH_MPI
+    if (neigh%useMpiWindows_) then
       call neigh%iNeighbourWin_%sync()
       call neigh%neighDist2Win_%sync()
 
       call neigh%iNeighbourWin_%unlock()
       call neigh%neighDist2Win_%unlock()
-    #:endif
+    end if
+  #:endif
 
   end subroutine setNeighbourList
 
 
-
   !> Allocate arrays for type 'neigh'
-  subroutine allocateNeighbourArrays(neigh, maxNeighbour, nAtom, isParallel, env)
+  subroutine allocateNeighbourArrays(neigh, maxNeighbour, nAtom, env)
 
     !> Contains all neighbour information
     type(TNeighbourList), intent(inout) :: neigh
@@ -800,9 +800,6 @@ contains
     !> Number of atoms
     integer, intent(in) :: nAtom
 
-    !> Whether computation is done in parallel
-    logical, intent(in) :: isParallel
-
     !> Environment settings
     type(TEnvironment), intent(in), optional :: env
 
@@ -810,7 +807,6 @@ contains
     integer :: dataLength
   #:endif
 
-    neigh%useMpiWindows_ = isParallel
     if (neigh%useMpiWindows_) then
     #:if WITH_MPI
       if (associated(neigh%iNeighbourMem_)) then
@@ -845,7 +841,7 @@ contains
 
   !> Collect all neighbour data and copy to neighbour arrays
   subroutine fillNeighbourArrays(neigh, iNeighbour, neighDist2, startAtom, endAtom, maxNeighbour,&
-      & nAtom, isParallel)
+      & nAtom)
 
     !> Contains all neighbour information
     type(TNeighbourList), intent(inout) :: neigh
@@ -865,16 +861,13 @@ contains
     !> Number of atoms
     integer, intent(in) :: nAtom
 
-    !> Whether computation is done in parallel
-    logical, intent(in) :: isParallel
-
     integer :: ii
 
   #:if WITH_MPI
     integer :: maxNeighbourLocal
   #:endif
 
-    if (isParallel) then
+    if (neigh%useMpiWindows_) then
     #:if WITH_MPI
       maxNeighbourLocal = min(ubound(iNeighbour, dim=1), maxNeighbour)
 

--- a/src/dftbp/dftb/periodic.F90
+++ b/src/dftbp/dftb/periodic.F90
@@ -672,7 +672,9 @@ contains
     nAtom = size(nNeighbour)
 
     neigh%setExternally = .true.
+  #:if WITH_MPI
     neigh%useMpiWindows_ = .true.
+  #:endif
 
     call allocateNeighbourArrays(neigh, nMaxNeighbours, nAtom, env)
 

--- a/test/src/dftbp/unittests/dftb/period.F90
+++ b/test/src/dftbp/unittests/dftb/period.F90
@@ -139,10 +139,10 @@
 
       call createTestArray(neighDist2)
 
-      call allocateNeighbourArrays(neigh, maxNeighbour, nAtom, .false.)
+      call allocateNeighbourArrays(neigh, maxNeighbour, nAtom)
 
       call fillNeighbourArrays(neigh, iNeighbour, neighDist2, startAtom, endAtom, maxNeighbour,&
-          & nAtom, .false.)
+          & nAtom)
 
       @:ASSERT(lbound(neigh%iNeighbour, dim=1) == 0)
       @:ASSERT(ubound(neigh%iNeighbour, dim=1) == maxNeighbour)


### PR DESCRIPTION
Also moved more of type inside of MPI conditional block and commented up why the logical has to be available in serial, despite referring to MPI. This variable could be factored out of the serial path, but would need a duplicate non-windowed neighbor case for MPI, since the parser calls this as well for Slater-Kirkwood dispersion before the computational enviroment is setup for MPI.

Also changed isParallel use in relevant if() blocks over to the type's MPI window variable, just in case that ever becomes an optional switch.