### PR TITLE
Revise quantities printed in md.out

### DIFF
--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -1811,7 +1811,7 @@ contains
               & + this%extPressure * this%cellVol
         end if
         call writeMdOut2(this%fdMd%unit, this%tPeriodic, this%tPrintForces, this%tStress,&
-            & this%isLinResp, this%eField, this%tFixEf, this%tPrintMulliken,&
+            & this%tBarostat, this%isLinResp, this%eField, this%tFixEf, this%tPrintMulliken,&
             & this%dftbEnergy(this%deltaDftb%iDeterminant), this%energiesCasida, this%latVec,&
             & this%derivs, this%totalStress, this%cellVol, this%intPressure, this%extPressure,&
             & tempIon, this%qOutput, this%q0, this%dipoleMoment, this%eFieldScaling,&

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -1810,11 +1810,12 @@ contains
               & this%dftbEnergy(this%deltaDftb%iDeterminant)%EMermin&
               & + this%extPressure * this%cellVol
         end if
-        call writeMdOut2(this%fdMd%unit, this%tStress, this%tBarostat, this%tPeriodic,&
+        call writeMdOut2(this%fdMd%unit, this%tPeriodic, this%tPrintForces, this%tStress,&
             & this%isLinResp, this%eField, this%tFixEf, this%tPrintMulliken,&
             & this%dftbEnergy(this%deltaDftb%iDeterminant), this%energiesCasida, this%latVec,&
-            & this%cellVol, this%intPressure, this%extPressure, tempIon, this%qOutput, this%q0,&
-            & this%dipoleMoment, this%eFieldScaling, this%dipoleMessage)
+            & this%derivs, this%totalStress, this%cellVol, this%intPressure, this%extPressure,&
+            & tempIon, this%qOutput, this%q0, this%dipoleMoment, this%eFieldScaling,&
+            & this%dipoleMessage)
         call writeCurrentGeometry(this%geoOutFile, this%pCoord0Out, .false., .true., .true.,&
             & this%tFracCoord, this%tPeriodic, this%tHelical, this%tPrintMulliken, this%species0,&
             & this%speciesName, this%latVec, this%origin, iGeoStep, iLatGeoStep, this%nSpin,&

--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -4028,17 +4028,17 @@ contains
       do ii = 1, size(derivs, dim=2)
         write(fd, "(3E24.8)") -derivs(:, ii)
       end do
+      if (hasStress) then
+        write(fd, "(A)") "Total stress (au)"
+        do ii = 1, size(totalStress, dim=2)
+          write(fd, "(3E24.8)") totalStress(:,ii)
+        end do
+      end if
     end if
     if (withBarostat) then
       write(fd, "(A)") "Lattice vectors (A)"
       do ii = 1, size(latVec, dim=2)
         write(fd, "(3E24.8)") latVec(:,ii) * Bohr__AA
-      end do
-    end if
-    if (hasStress) then
-      write(fd, "(A)") "Total stress (au)"
-      do ii = 1, size(totalStress, dim=2)
-        write(fd, "(3E24.8)") totalStress(:,ii)
       end do
     end if
     if (isPeriodic) then

--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -4023,25 +4023,25 @@ contains
     integer :: ii
     character(lc) :: strTmp
 
+    if (printForces) then
+      write(fd, "(A)") "Forces (au)"
+      do ii = 1, size(derivs, dim=2)
+        write(fd, "(3E24.8)") -derivs(:, ii)
+      end do
+    end if
+    if (withBarostat) then
+      write(fd, "(A)") "Lattice vectors (A)"
+      do ii = 1, size(latVec, dim=2)
+        write(fd, "(3E24.8)") latVec(:,ii) * Bohr__AA
+      end do
+    end if
+    if (hasStress) then
+      write(fd, "(A)") "Total stress (au)"
+      do ii = 1, size(totalStress, dim=2)
+        write(fd, "(3E24.8)") totalStress(:,ii)
+      end do
+    end if
     if (isPeriodic) then
-      if (withBarostat) then
-        write(fd, "(A)") "Lattice vectors (A)"
-        do ii = 1, 3
-          write(fd, "(3E24.8)") latVec(:,ii) * Bohr__AA
-        end do
-      end if
-      if (printForces) then
-        write(fd, "(A)") "Forces (au)"
-        do ii = 1, size(derivs, dim=2)
-          write(fd, "(3E24.8)") -derivs(:, ii)
-        end do
-      end if
-      if (hasStress) then
-        write(fd, "(A)") "Total stress (au)"
-        do ii = 1, 3
-          write(fd, "(3E24.8)") totalStress(:,ii)
-        end do
-      end if
       write(fd, format2Ue) "Volume", cellVol, "au^3", Bohr__AA**3 * cellVol, "A^3"
       write(fd, format2Ue) "Pressure", cellPressure, "au", cellPressure * au__pascal, "Pa"
       if (abs(pressure) < 1.0e-16_dp) then

--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -3947,9 +3947,9 @@ contains
   end subroutine writeMdOut1
 
   !> Second group of output data during molecular dynamics
-  subroutine writeMdOut2(fd, isPeriodic, printForces, hasStress, isLinResp, eField, fixEf,&
-      & printMulliken, energy, energiesCasida, latVec, derivs, totalStress, cellVol, cellPressure,&
-      & pressure, tempIon, qOutput, q0, dipoleMoment, eFieldScaling, dipoleMessage)
+  subroutine writeMdOut2(fd, isPeriodic, printForces, hasStress, withBarostat, isLinResp, eField,&
+      & fixEf, printMulliken, energy, energiesCasida, latVec, derivs, totalStress, cellVol,&
+      & cellPressure, pressure, tempIon, qOutput, q0, dipoleMoment, eFieldScaling, dipoleMessage)
 
     !> File ID
     integer, intent(in) :: fd
@@ -3962,6 +3962,9 @@ contains
 
     !> Is the stress tensor to be printed?
     logical, intent(in) :: hasStress
+
+    !> Is a barostat in use?
+    logical, intent(in) :: withBarostat
 
     !> Is linear response excitation being used?
     logical, intent(in) :: isLinResp
@@ -4021,10 +4024,12 @@ contains
     character(lc) :: strTmp
 
     if (isPeriodic) then
-      write(fd, "(A)") "Lattice vectors (A)"
-      do ii = 1, 3
-        write(fd, "(3E24.8)") latVec(:,ii) * Bohr__AA
-      end do
+      if (withBarostat) then
+        write(fd, "(A)") "Lattice vectors (A)"
+        do ii = 1, 3
+          write(fd, "(3E24.8)") latVec(:,ii) * Bohr__AA
+        end do
+      end if
       if (printForces) then
         write(fd, "(A)") "Forces (au)"
         do ii = 1, size(derivs, dim=2)

--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -4035,13 +4035,13 @@ contains
         end do
       end if
     end if
-    if (withBarostat) then
-      write(fd, "(A)") "Lattice vectors (A)"
-      do ii = 1, size(latVec, dim=2)
-        write(fd, "(3E24.8)") latVec(:,ii) * Bohr__AA
-      end do
-    end if
     if (isPeriodic) then
+      if (withBarostat) then
+        write(fd, "(A)") "Lattice vectors (A)"
+        do ii = 1, size(latVec, dim=2)
+          write(fd, "(3E24.8)") latVec(:,ii) * Bohr__AA
+        end do
+      end if
       write(fd, format2Ue) "Volume", cellVol, "au^3", Bohr__AA**3 * cellVol, "A^3"
       write(fd, format2Ue) "Pressure", cellPressure, "au", cellPressure * au__pascal, "Pa"
       if (abs(pressure) < 1.0e-16_dp) then


### PR DESCRIPTION
Remark: In order to print atomic forces to `md.out`, the HSD block
```
Analysis {
  CalculateForces = Yes
}
```
needs to be set explicitly. Lattice vectors and the total stress tensor are printed as well, atomic positions however are only written to the `.xyz` trajectory file, not `md.out`.

- [x] documentation (does not seem to be affected)

Possibly closes #1272.