### PR TITLE
Fix further leak in neighbour list memory handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,6 +305,9 @@ add_subdirectory(tools)
 #
 # Testing
 #
+if(TEST_WITH_VALGRIND)
+  find_program(VALGRIND valgrind REQUIRED)
+endif()
 string(CONFIGURE "${TEST_RUNNER_TEMPLATE}" TEST_RUNNER)
 if(NOT WITH_MPI)
   string(CONFIGURE "${MODES_RUNNER_TEMPLATE}" MODES_RUNNER)

--- a/config.cmake
+++ b/config.cmake
@@ -87,9 +87,9 @@ set(TEST_MPI_PROCS "1" CACHE STRING "Nr. of MPI processes used for testing")
 set(TEST_OMP_THREADS "1" CACHE STRING "Nr. of OpenMP-threads used for testing")
 
 option(TEST_WITH_VALGRIND "Whether valgrind should be invoked when testing binaries" FALSE)
-# Turn this on, when VALGRIND should invoked when testing binaries. Note, that this is currently
-# only active when testing serial (non-mpi) binaries. You also should consider to set OMP-threads
-# to 1 above to avoid false positives triggered by the threading library.
+# Turn this on, then VALGRIND should be invoked when testing binaries. Note, that this is currently
+# only active when testing serial (non-mpi) binaries. You also should consider setting OMP-threads
+# to 1 (see above) to avoid false positives triggered by the threading library.
 
 # Command line used to launch the test code.
 # The escaped variables (\${VARIABLE}) will be substituted by the corresponding CMake variables.

--- a/config.cmake
+++ b/config.cmake
@@ -86,11 +86,25 @@ set(TEST_MPI_PROCS "1" CACHE STRING "Nr. of MPI processes used for testing")
 
 set(TEST_OMP_THREADS "1" CACHE STRING "Nr. of OpenMP-threads used for testing")
 
+option(TEST_WITH_VALGRIND "Whether valgrind should be invoked when testing binaries" FALSE)
+# Turn this on, when VALGRIND should invoked when testing binaries. Note, that this is currently
+# only active when testing serial (non-mpi) binaries. You also should consider to set OMP-threads
+# to 1 above to avoid false positives triggered by the threading library.
+
 # Command line used to launch the test code.
 # The escaped variables (\${VARIABLE}) will be substituted by the corresponding CMake variables.
 if(WITH_MPI)
   set(TEST_RUNNER_TEMPLATE "env OMP_NUM_THREADS=\${TEST_OMP_THREADS} mpiexec -n \${TEST_MPI_PROCS}"
     CACHE STRING "How to run the tests")
+elseif(TEST_WITH_VALGRIND)
+  set(VALGRIND_OPTIONS
+    "--exit-on-first-error=yes --error-exitcode=1 --leak-check=full --show-leak-kinds=definite,possible --errors-for-leak-kinds=definite,possible"
+    CACHE STRING "Options to use for the valgrind wrapper"
+  )
+  set(TEST_RUNNER_TEMPLATE "env OMP_NUM_THREADS=\${TEST_OMP_THREADS} \${VALGRIND} \${VALGRIND_OPTIONS}" CACHE STRING
+    "How to run the tests")
+  set(MODES_RUNNER_TEMPLATE "env OMP_NUM_THREADS=\${TEST_OMP_THREADS} \${VALGRIND} \${VALGRIND_OPTIONS}" CACHE STRING
+    "How to run the modes code for tests")
 else()
   set(TEST_RUNNER_TEMPLATE "env OMP_NUM_THREADS=\${TEST_OMP_THREADS}" CACHE STRING
     "How to run the tests")

--- a/external/xmlf90/dom_element.f90
+++ b/external/xmlf90/dom_element.f90
@@ -12,9 +12,9 @@ implicit none
 
 private
 
-  !-------------------------------------------------------   
+  !-------------------------------------------------------
   ! METHODS FOR ELEMENT NODES
-  !-------------------------------------------------------   
+  !-------------------------------------------------------
   public :: getTagName
   public :: getElementsByTagName
   public :: getAttribute
@@ -31,11 +31,11 @@ CONTAINS
   !  METHODS FOR ELEMENT NODES
   !-----------------------------------------------------------
   subroutine getTagName(element, tagName)
-    type(fnode), intent(in) :: element   
+    type(fnode), intent(in) :: element
     type(string), intent(inout) :: tagName
 
     if (element % nodeType == ELEMENT_NODE) then
-      tagName = element % nodeName 
+      tagName = element % nodeName
     else
       tagName = ''
     endif
@@ -46,7 +46,7 @@ CONTAINS
   function getElementsByTagName(element, tag) result(nodelist)
     type(fnode), pointer         :: element
     character(len=*), intent(in) :: tag
-    type(fnodeList), pointer     :: nodelist 
+    type(fnodeList), pointer     :: nodelist
 
     type(fnode), pointer        :: np
 
@@ -64,15 +64,15 @@ CONTAINS
     type(string)                :: name
 
     !
-    ! Could replace the calls to helper methods by direct lookups of node 
+    ! Could replace the calls to helper methods by direct lookups of node
     ! components to make it faster.
-    ! 
+    !
     do
        if (.not. associated(np)) exit
        select case(np%nodeType)
 
-          case(DOCUMENT_NODE) 
-             ! special case ... search its children 
+          case(DOCUMENT_NODE)
+             ! special case ... search its children
              if (hasChildNodes(np)) call search(getFirstChild(np))
              ! will exit for lack of siblings
           case(ELEMENT_NODE)
@@ -86,7 +86,7 @@ CONTAINS
              if (hasChildNodes(np)) call search(getFirstChild(np))
 
           case default
-             
+
              ! do nothing
 
         end select
@@ -115,14 +115,14 @@ CONTAINS
     nn => getNamedItem(element%attributes,name)
     if (.not. associated(nn)) RETURN
     attribute = nn%nodeValue
-        
+
   end subroutine getAttribute
-  
+
 
   !-----------------------------------------------------------
 
   function getAttributeNode(element, name)
-    
+
     type(fnode), intent(in) :: element
     type(fnode), pointer    :: getAttributeNode
     character(len=*), intent(in) :: name
@@ -132,7 +132,7 @@ CONTAINS
     getAttributeNode => getNamedItem(element%attributes,name)
 
   end function getAttributeNode
-  
+
   !-----------------------------------------------------------
 
   subroutine setAttributeNode(element, newattr)
@@ -147,7 +147,7 @@ CONTAINS
     endif
 
     dummy => setNamedItem(element%attributes,newattr)
-     
+
   end subroutine setAttributeNode
 
 !-------------------------------------------------------------------
@@ -176,7 +176,9 @@ CONTAINS
     if (.not. associated(element%attributes)) RETURN
 
     dummy => removeNamedItem(element%attributes,name)
-     
+    ! removeNamedItem only destroys the wrapper, but not the item itself
+    if (associated(dummy)) call destroyNode(dummy)
+
   end subroutine removeAttribute
 
 
@@ -270,22 +272,22 @@ CONTAINS
     endif
     call destroyNode(np)
     head%nodeValue = buffer
-    
+
   end subroutine concatenateText
 
-  
+
 
   !!* Sets a new name for a given tag.
   !!* @param element Tag to rename.
   !!* @param tagName New name
   subroutine setTagName(element, tagName)
-    type(fnode), intent(inout) :: element   
+    type(fnode), intent(inout) :: element
     character(len=*), intent(in) :: tagName
-    
+
     if (element%nodeType == ELEMENT_NODE) then
       element%nodeName = tagName
     end if
-    
+
   end subroutine setTagName
 
 

--- a/src/dftbp/api/mm/capi.F90
+++ b/src/dftbp/api/mm/capi.F90
@@ -43,7 +43,7 @@ module dftbp_capi
 
 contains
 
-  !> finalises a DFTB+ instance
+  !> finalises a DFTB+ input instance
 subroutine c_DftbPlusInput_final(handler) bind(C, name='dftbp_input_final')
 
   !> DFTB+ handler
@@ -612,9 +612,9 @@ end subroutine c_DftbPlusInput_final
     type(TDftbPlusC), intent(inout) :: this
 
     ! Note: Fortran finalizes all components of a child class instance (TDftbPlusC) first and only
-    ! then the components of its parent (TDftbPlus). TDftbPlusC contains a descriptor of an open
+    ! then the components of its parent (TDftbPlus). TDftbPlusC contains a descriptor connected to an open
     ! file, whose unit had been passed to and stored by TDftbPlus. When TDftbPlusC is finalized, the
-    ! file is closed, so TDftbPlus would try to write the timings to an invalid unit when finalized
+    ! file is closed, so TDftbPlus will try to write the timings to an invalid unit when finalized
     ! aftewards. Therefore, we call TDftbPlus_destruct explicitely before finalization of TDftbPlusC
     ! happens.
     !

--- a/src/dftbp/api/mm/capi.F90
+++ b/src/dftbp/api/mm/capi.F90
@@ -14,9 +14,7 @@ module dftbp_capi
   use dftbp_common_globalenv, only : instanceSafeBuild
   use dftbp_dftbplus_qdepextpotgenc, only :&
       & getExtPotIfaceC, getExtPotGradIfaceC, TQDepExtPotGenC, TQDepExtPotGenC_init
-  use dftbp_mmapi, only :&
-      & TDftbPlus, TDftbPlus_init, TDftbPlus_destruct, TDftbPlusInput, TDftbPlusInput_destruct,&
-      & TDftbPlusAtomList
+  use dftbp_mmapi, only : TDftbPlus, TDftbPlus_init, TDftbPlusInput, TDftbPlusAtomList
   use dftbp_type_linkedlist, only : TListString, append, init, destruct
   implicit none
   private
@@ -54,7 +52,6 @@ subroutine c_DftbPlusInput_final(handler) bind(C, name='dftbp_input_final')
 
   if (.not. c_associated(handler%pDftbPlusInput)) return
   call c_f_pointer(handler%pDftbPlusInput, instance)
-  call TDftbPlusInput_destruct(instance)
   deallocate(instance)
   handler%pDftbPlusInput = c_null_ptr
 
@@ -138,7 +135,6 @@ end subroutine c_DftbPlusInput_final
 
     if (.not. c_associated(handler%instance)) return
     call c_f_pointer(handler%instance, instance)
-    call TDftbPlus_destruct(instance%TDftbPlus)
     deallocate(instance)
     handler%instance = c_null_ptr
 

--- a/src/dftbp/api/mm/dftbplus.F90
+++ b/src/dftbp/api/mm/dftbplus.F90
@@ -12,8 +12,8 @@ module dftbplus
   use dftbp_capi  ! does not export anything but needed for bind(C) routines
   use dftbp_hsdapi, only : fnode, setChild, setChildValue, dumpHsd
   use dftbp_mmapi, only : TDftbPlus, getDftbPlusBuild, getDftbPlusApi, TDftbPlus_init,&
-      & TDftbPlus_destruct, TDftbPlusAtomList, TDftbPlusInput, TQDepExtPotGen,&
-      & getMaxAngFromSlakoFile, convertAtomTypesToSpecies
+      & TDftbPlus_destruct, TDftbPlusAtomList, TDftbPlusInput, TDftbPlusInput_destruct,&
+      & TQDepExtPotGen, getMaxAngFromSlakoFile, convertAtomTypesToSpecies
   implicit none
 
 end module dftbplus

--- a/src/dftbp/api/mm/dftbplus.h
+++ b/src/dftbp/api/mm/dftbplus.h
@@ -107,6 +107,15 @@ void dftbp_api(int *major, int *minor, int *patch);
  */
 _Bool dftbp_is_instance_safe();
 
+
+/**
+ * Finalizes a DftbPlusInput instance.
+ *
+ * \param[inout] instance Handler of the DftbPlusInput instance.
+*/
+void dftbp_input_final(DftbPlusInput *instance);
+
+
 /**
  * Initializes a DFTB+ calculator.
  *

--- a/src/dftbp/api/mm/mmapi.F90
+++ b/src/dftbp/api/mm/mmapi.F90
@@ -67,6 +67,8 @@ module dftbp_mmapi
   contains
     !> obtain the root of the tree of input
     procedure :: getRootNode => TDftbPlusInput_getRootNode
+    !> finaliser
+    final :: TDftbPlusInput_final
   end type TDftbPlusInput
 
 
@@ -75,7 +77,7 @@ module dftbp_mmapi
     private
     type(TEnvironment), allocatable :: env
     type(TDftbPlusMain), allocatable :: main
-    logical :: tInit = .false.
+    logical :: isInitialised = .false.
   contains
     !> read input from a file
     procedure :: getInputFromFile => TDftbPlus_getInputFromFile
@@ -142,6 +144,8 @@ module dftbp_mmapi
     procedure :: getNOrbitalsOnAtoms => TDftbPlus_getNOrbAtoms
     !> get the maximum cutoff distance
     procedure :: getCutOff => TDftbPlus_getCutOff
+    !> Finalizer
+    final :: TDftbPlus_final
   end type TDftbPlus
 
 
@@ -190,6 +194,17 @@ contains
     end if
 
   end subroutine getDftbPlusApi
+
+
+  !> Finalizer for the DFTB+ input type
+  subroutine TDftbPlusInput_final(this)
+
+    !> Instance.
+    type(TDftbPlusInput), intent(inout) :: this
+
+    call TDftbPlusInput_destruct(this)
+
+  end subroutine TDftbPlusInput_final
 
 
   !> Destructs the DFTB+ input type
@@ -295,7 +310,8 @@ contains
   !>
   !> Note: due to some remaining global variables in the DFTB+ core, only one instance can be
   !> initialised within one process. Therefore, this routine can not be called twice, unless the
-  !> TDftbPlus_destruct() has been called in between. Otherwise the subroutine will stop.
+  !> TDftbPlus_destruct() has been called in between (or the instance had been finalized).
+  !> Otherwise the subroutine will stop.
   !>
   subroutine TDftbPlus_init(this, outputUnit, mpiComm, devNull)
 
@@ -336,9 +352,20 @@ contains
     allocate(this%main)
     call TEnvironment_init(this%env)
     this%env%tAPICalculation = .true.
-    this%tInit = .true.
+    this%isInitialised = .true.
 
   end subroutine TDftbPlus_init
+
+
+  !> Finalizer for DFTB+
+  subroutine TDftbPlus_final(this)
+
+    !> Instance
+    type(TDftbPlus), intent(inout) :: this
+
+    call TDftbPlus_destruct(this)
+
+  end subroutine TDftbPlus_final
 
 
   !> Destroys a DFTB+ instance
@@ -347,13 +374,14 @@ contains
     !> Instance
     type(TDftbPlus), intent(inout) :: this
 
+    if (.not. this%isInitialised) return
     call this%checkInit()
 
     call this%main%destructProgramVariables()
     call this%env%destruct()
     deallocate(this%main, this%env)
     call destructGlobalEnv()
-    this%tInit = .false.
+    this%isInitialised = .false.
 
     #:if not INSTANCE_SAFE_BUILD
       nInstance_ = 0
@@ -829,7 +857,7 @@ contains
     !> Instance.
     class(TDftbPlus), intent(in) :: this
 
-    if (.not. this%tInit) then
+    if (.not. this%isInitialised) then
       call error("Received uninitialized TDftbPlus instance")
     end if
 

--- a/src/dftbp/api/mm/mmapi.F90
+++ b/src/dftbp/api/mm/mmapi.F90
@@ -310,7 +310,7 @@ contains
   !>
   !> Note: due to some remaining global variables in the DFTB+ core, only one instance can be
   !> initialised within one process. Therefore, this routine can not be called twice, unless the
-  !> TDftbPlus_destruct() has been called in between (or the instance had been finalized).
+  !> TDftbPlus_destruct() has been called in between the inits (or the instance had already been finalized).
   !> Otherwise the subroutine will stop.
   !>
   subroutine TDftbPlus_init(this, outputUnit, mpiComm, devNull)
@@ -357,7 +357,7 @@ contains
   end subroutine TDftbPlus_init
 
 
-  !> Finalizer for DFTB+
+  !> Finalizer for TDftbPlus.
   subroutine TDftbPlus_final(this)
 
     !> Instance
@@ -368,7 +368,7 @@ contains
   end subroutine TDftbPlus_final
 
 
-  !> Destroys a DFTB+ instance
+  !> Destroys a DFTB+ calculation instance
   subroutine TDftbPlus_destruct(this)
 
     !> Instance

--- a/src/dftbp/api/mm/mmapi.F90
+++ b/src/dftbp/api/mm/mmapi.F90
@@ -26,7 +26,8 @@ module dftbp_mmapi
   use dftbp_dftbplus_parser, only : TParserFlags, rootTag, parseHsdTree, readHsdFile
   use dftbp_dftbplus_qdepextpotgen, only : TQDepExtPotGen, TQDepExtPotGenWrapper
   use dftbp_dftbplus_qdepextpotproxy, only : TQDepExtPotProxy, TQDepExtPotProxy_init
-  use dftbp_extlibs_xmlf90, only : fnode, createDocumentNode, createElement, appendChild
+  use dftbp_extlibs_xmlf90, only : fnode, createDocumentNode, createElement, appendChild,&
+      & destroyNode
   use dftbp_io_charmanip, only : newline
   use dftbp_io_hsdutils, only : getChild
   use dftbp_io_message, only: error
@@ -38,7 +39,7 @@ module dftbp_mmapi
   public :: TDftbPlus, getDftbPlusBuild, getDftbPlusApi
   public :: TDftbPlus_init, TDftbPlus_destruct
   public :: TDftbPlusAtomList
-  public :: TDftbPlusInput
+  public :: TDftbPlusInput, TDftbPlusInput_destruct
   public :: TQDepExtPotGen
   public :: getMaxAngFromSlakoFile, convertAtomTypesToSpecies
 
@@ -189,6 +190,20 @@ contains
     end if
 
   end subroutine getDftbPlusApi
+
+
+  !> Destructs the DFTB+ input type
+  subroutine TDftbPlusInput_destruct(this)
+
+    !> Instance.
+    type(TDftbPlusInput), intent(inout) :: this
+
+    if (associated(this%hsdTree)) then
+      call destroyNode(this%hsdTree)
+      this%hsdTree => null()
+    end if
+
+  end subroutine TDftbPlusInput_destruct
 
 
   !> Returns the root node of the input, so that it can be further processed

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -740,7 +740,7 @@ module dftbp_dftbplus_initprogram
     logical :: isLinResp
 
     !> Calculate Z vector for excited properties
-    logical :: tLinRespZVect
+    logical :: tLinRespZVect = .false.
 
     !> Data type for pp-RPA
     type(TppRPAcal), allocatable :: ppRPA

--- a/test/app/dftb+/bin/autotest2
+++ b/test/app/dftb+/bin/autotest2
@@ -339,10 +339,15 @@ do
 	test -n "$verbose" && echo_n " running .."
 
 	if [ -e "$TEST_SCRIPT" ]; then
-	    $TIME_CMD ./$TEST_SCRIPT $app_prerun $app_cmd $app_postrun >> $APP_STDOUT 2>> $APP_STDERR
+	    ./$TEST_SCRIPT $app_prerun $app_cmd $app_postrun >> $APP_STDOUT 2>> $APP_STDERR
 	else
-	    $TIME_CMD $app_prerun $app_cmd $app_postrun  >> $APP_STDOUT 2>> $APP_STDERR
+	    $app_prerun $app_cmd $app_postrun  >> $APP_STDOUT 2>> $APP_STDERR
 	fi
+  # If run was not successful, make sure tagdiff fails by removing the tagged data file
+  if [ $? != 0 ]; then
+    echo "Test script returned non-zero exit code: deleting file '${APP_TAGDATA}'" 1>&2
+    rm -f ./${APP_TAGDATA}
+  fi
 
 	if [ -n "$app_globalpost" ]; then
 	    if [ ! -x "$app_globalpost" ]; then

--- a/test/src/dftbp/api/mm/testers/test_ehrenfest.f90
+++ b/test/src/dftbp/api/mm/testers/test_ehrenfest.f90
@@ -40,108 +40,122 @@ program test_ehrenfest
   real(dp), parameter :: fstrength = 0.01_dp ! V/angstrom
   real(dp), parameter :: poldir(3) = [ 0.0_dp, 1.0_dp, 1.0_dp ]
   real(dp), parameter :: omega = 6.795 ! eV
-  type(TDftbPlus) :: dftbp
-  type(TDftbPlusInput) :: input
 
-  real(dp) :: coords(3, nAtom), merminEnergy, dipole(3, 1), energy, atomNetCharges(nAtom, 1)
-  real(dp) :: force(3, nAtom)
-  real(dp) :: norm, fielddir(3), angFreq, envelope, field(3), time
-  real(dp) :: time0 = 0.0_dp, time1 = 6.0_dp ! fs
-  type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pType2Files, pElecDyn
-  type(fnode), pointer :: pPerturb, pLaser
+  call main_()
 
-  character(:), allocatable :: DftbVersion
-  integer :: major, minor, patch, istep, ii
+contains
 
+  !! Main test routine
+  !!
+  !! All non-constant variables must be defined here to ensure that they are all explicitely
+  !! deallocated before the program finishes.
+  !!
+  subroutine main_()
 
-  call getDftbPlusBuild(DftbVersion)
-  write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
-  call getDftbPlusApi(major, minor, patch)
-  write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
+    type(TDftbPlus) :: dftbp
+    type(TDftbPlusInput) :: input
 
-  call TDftbPlus_init(dftbp)
+    real(dp) :: coords(3, nAtom), merminEnergy, dipole(3, 1), energy, atomNetCharges(nAtom, 1)
+    real(dp) :: force(3, nAtom)
+    real(dp) :: norm, fielddir(3), angFreq, envelope, field(3), time
+    real(dp) :: time0 = 0.0_dp, time1 = 6.0_dp ! fs
+    type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pType2Files, pElecDyn
+    type(fnode), pointer :: pPerturb, pLaser
 
-  call dftbp%getEmptyInput(input)
-  call input%getRootNode(pRoot)
-  call setChild(pRoot, "Geometry", pGeo)
-  call setChildValue(pGeo, "Periodic", .false.)
-  call setChildValue(pGeo, "TypeNames", ["C", "H"])
-  coords(:,:) = 0.0_dp
-  call setChildValue(pGeo, "TypesAndCoordinates", reshape(species, [1, size(species)]), coords)
-  call setChild(pRoot, "Hamiltonian", pHam)
-  call setChild(pHam, "Dftb", pDftb)
-  call setChildValue(pDftb, "Scc", .true.)
-  call setChildValue(pDftb, "SccTolerance", 1e-10_dp)
-
-  call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
-  call setChildValue(pMaxAng, "C", "p")
-  call setChildValue(pMaxAng, "H", "s")
-
-  call setChild(pDftb, "SlaterKosterFiles", pSlakos)
-  call setChild(pSlakos, "Type2FileNames", pType2Files)
-  call setChildValue(pType2Files, "Prefix", "./")
-  call setChildValue(pType2Files, "Separator", "-")
-  call setChildValue(pType2Files, "Suffix", ".skf")
-
-  !  set up electron dynamics options
-  call setChild(pRoot, "ElectronDynamics", pElecDyn)
-  call setChildValue(pElecDyn, "Steps", nsteps)
-  call setChildValue(pElecDyn, "TimeStep", timestep)
-  call setChildValue(pElecDyn, "FieldStrength", fstrength*1.0e10_dp*V_m__au)
-  call setChildValue(pElecDyn, "IonDynamics", .true.)
-  call setChildValue(pElecDyn, "InitialTemperature", 0.0_dp)
-
-  call setChild(pElecDyn, "Perturbation", pPerturb)
-  call setChild(pPerturb, "Laser", pLaser)
-  ! these twovalues will be overriden
-  call setChildValue(pLaser, "PolarisationDirection", [0.0_dp, 1.0_dp, 1.0_dp])
-  call setChildValue(pLaser, "LaserEnergy", 1.0_dp)
-
-  norm = sqrt(dot_product(poldir, poldir))
-  fielddir = poldir / norm
-  angFreq = omega * eV__Hartree
-  time0 = time0 * fs__au
-  time1 = time1 * fs__au
-
-  print "(A)", 'Input tree in HSD format:'
-  call dumpHsd(input%hsdTree, output_unit)
+    character(:), allocatable :: DftbVersion
+    integer :: major, minor, patch, istep, ii
 
 
-  ! initialise the DFTB+ calculator
-  call dftbp%setupCalculator(input)
+    call getDftbPlusBuild(DftbVersion)
+    write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
+    call getDftbPlusApi(major, minor, patch)
+    write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
 
-  ! Replace coordinates
-  coords(:,:) = initialCoords*AA__Bohr
-  call dftbp%setGeometry(coords)
+    call TDftbPlus_init(dftbp)
 
-  ! get ground state
-  call dftbp%getEnergy(merminEnergy)
+    call dftbp%getEmptyInput(input)
+    call input%getRootNode(pRoot)
+    call setChild(pRoot, "Geometry", pGeo)
+    call setChildValue(pGeo, "Periodic", .false.)
+    call setChildValue(pGeo, "TypeNames", ["C", "H"])
+    coords(:,:) = 0.0_dp
+    call setChildValue(pGeo, "TypesAndCoordinates", reshape(species, [1, size(species)]), coords)
+    call setChild(pRoot, "Hamiltonian", pHam)
+    call setChild(pHam, "Dftb", pDftb)
+    call setChildValue(pDftb, "Scc", .true.)
+    call setChildValue(pDftb, "SccTolerance", 1e-10_dp)
 
-  call dftbp%initializeTimeProp(timestep, .true., .false.)
+    call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
+    call setChildValue(pMaxAng, "C", "p")
+    call setChildValue(pMaxAng, "H", "s")
 
-  do istep = 1, nsteps
-    ! calculate field at present timestep
-    time = istep * timestep
-    if (time >= time0 .and. time <= time1) then
-      envelope = sin(pi*(time - time0)/(time1 - time0))**2
-    else
-      envelope = 0.0_dp
-    end if
-    field = fstrength * 1.0e10_dp * V_m__au * envelope * aimag(exp(imag*time*angFreq) * fielddir)
-    call dftbp%setTdElectricField(field)
-    call dftbp%doOneTdStep(istep, dipole=dipole, energy=energy, atomNetCharges=atomNetCharges,&
-         & coord=coords, force=force)
-  end do
+    call setChild(pDftb, "SlaterKosterFiles", pSlakos)
+    call setChild(pSlakos, "Type2FileNames", pType2Files)
+    call setChildValue(pType2Files, "Prefix", "./")
+    call setChildValue(pType2Files, "Separator", "-")
+    call setChildValue(pType2Files, "Suffix", ".skf")
 
-  print "(A,F15.10)", 'Final SCC Energy:', energy
-  print "(A,3F15.10)", 'Final dipole:', (dipole(ii,1), ii=1,3)
-  print "(A,100F15.10)", 'Final net atomic charges:', (atomNetCharges(ii,1), ii=1,nAtom)
-  print "(A,100F15.10)", 'Final coordinates:', (coords(:,ii), ii=1,nAtom)
+    !  set up electron dynamics options
+    call setChild(pRoot, "ElectronDynamics", pElecDyn)
+    call setChildValue(pElecDyn, "Steps", nsteps)
+    call setChildValue(pElecDyn, "TimeStep", timestep)
+    call setChildValue(pElecDyn, "FieldStrength", fstrength*1.0e10_dp*V_m__au)
+    call setChildValue(pElecDyn, "IonDynamics", .true.)
+    call setChildValue(pElecDyn, "InitialTemperature", 0.0_dp)
 
-  call TDftbPlus_destruct(dftbp)
+    call setChild(pElecDyn, "Perturbation", pPerturb)
+    call setChild(pPerturb, "Laser", pLaser)
+    ! these twovalues will be overriden
+    call setChildValue(pLaser, "PolarisationDirection", [0.0_dp, 1.0_dp, 1.0_dp])
+    call setChildValue(pLaser, "LaserEnergy", 1.0_dp)
 
-  ! Write file for internal test system
-  call writeAutotestTag(tdEnergy=energy, tdDipole=dipole, tdCharges=atomNetCharges,&
-       & tdCoords=coords, tdForces=force)
+    norm = sqrt(dot_product(poldir, poldir))
+    fielddir = poldir / norm
+    angFreq = omega * eV__Hartree
+    time0 = time0 * fs__au
+    time1 = time1 * fs__au
+
+    print "(A)", 'Input tree in HSD format:'
+    call dumpHsd(input%hsdTree, output_unit)
+
+    ! initialise the DFTB+ calculator
+    call dftbp%setupCalculator(input)
+    call TDftbPlusInput_destruct(input)
+
+    ! Replace coordinates
+    coords(:,:) = initialCoords*AA__Bohr
+    call dftbp%setGeometry(coords)
+
+    ! get ground state
+    call dftbp%getEnergy(merminEnergy)
+
+    call dftbp%initializeTimeProp(timestep, .true., .false.)
+
+    do istep = 1, nsteps
+      ! calculate field at present timestep
+      time = istep * timestep
+      if (time >= time0 .and. time <= time1) then
+        envelope = sin(pi*(time - time0)/(time1 - time0))**2
+      else
+        envelope = 0.0_dp
+      end if
+      field = fstrength * 1.0e10_dp * V_m__au * envelope * aimag(exp(imag*time*angFreq) * fielddir)
+      call dftbp%setTdElectricField(field)
+      call dftbp%doOneTdStep(istep, dipole=dipole, energy=energy, atomNetCharges=atomNetCharges,&
+          & coord=coords, force=force)
+    end do
+
+    print "(A,F15.10)", 'Final SCC Energy:', energy
+    print "(A,3F15.10)", 'Final dipole:', (dipole(ii,1), ii=1,3)
+    print "(A,100F15.10)", 'Final net atomic charges:', (atomNetCharges(ii,1), ii=1,nAtom)
+    print "(A,100F15.10)", 'Final coordinates:', (coords(:,ii), ii=1,nAtom)
+
+    call TDftbPlus_destruct(dftbp)
+
+    ! Write file for internal test system
+    call writeAutotestTag(tdEnergy=energy, tdDipole=dipole, tdCharges=atomNetCharges,&
+        & tdCoords=coords, tdForces=force)
+
+  end subroutine main_
 
 end program test_ehrenfest

--- a/test/src/dftbp/api/mm/testers/test_ehrenfest.f90
+++ b/test/src/dftbp/api/mm/testers/test_ehrenfest.f90
@@ -47,8 +47,8 @@ contains
 
   !! Main test routine
   !!
-  !! All non-constant variables must be defined here to ensure that they are all explicitely
-  !! deallocated before the program finishes.
+  !! All non-constant variables must be defined here to ensure that they are all explicitly
+  !! deallocated before the program finishes (avoiding residual memory that tools like valgrind notice).
   !!
   subroutine main_()
 

--- a/test/src/dftbp/api/mm/testers/test_ehrenfest.f90
+++ b/test/src/dftbp/api/mm/testers/test_ehrenfest.f90
@@ -120,7 +120,6 @@ contains
 
     ! initialise the DFTB+ calculator
     call dftbp%setupCalculator(input)
-    call TDftbPlusInput_destruct(input)
 
     ! Replace coordinates
     coords(:,:) = initialCoords*AA__Bohr
@@ -149,8 +148,6 @@ contains
     print "(A,3F15.10)", 'Final dipole:', (dipole(ii,1), ii=1,3)
     print "(A,100F15.10)", 'Final net atomic charges:', (atomNetCharges(ii,1), ii=1,nAtom)
     print "(A,100F15.10)", 'Final coordinates:', (coords(:,ii), ii=1,nAtom)
-
-    call TDftbPlus_destruct(dftbp)
 
     ! Write file for internal test system
     call writeAutotestTag(tdEnergy=energy, tdDipole=dipole, tdCharges=atomNetCharges,&

--- a/test/src/dftbp/api/mm/testers/test_ehrenfest_ext_ions.f90
+++ b/test/src/dftbp/api/mm/testers/test_ehrenfest_ext_ions.f90
@@ -48,7 +48,7 @@ contains
   !! Main test routine
   !!
   !! All non-constant variables must be defined here to ensure that they are all explicitely
-  !! deallocated before the program finishes.
+  !! deallocated before the program finishes  (avoiding residual memory that tools like valgrind notice).
   !!
   subroutine main_()
 

--- a/test/src/dftbp/api/mm/testers/test_ehrenfest_ext_ions.f90
+++ b/test/src/dftbp/api/mm/testers/test_ehrenfest_ext_ions.f90
@@ -40,48 +40,61 @@ program test_ehrenfest
   real(dp), parameter :: fstrength = 0.01_dp ! V/angstrom
   real(dp), parameter :: poldir(3) = [ 0.0_dp, 1.0_dp, 1.0_dp ]
   real(dp), parameter :: omega = 6.795 ! eV
-  type(TDftbPlus) :: dftbp
-  type(TDftbPlusInput) :: input
 
-  real(dp) :: coords(3, nAtom), merminEnergy, dipole(3, 1), energy, atomNetCharges(nAtom, 1)
-  real(dp) :: forces(3, nAtom), atomMasses(nAtom), accel(3, nAtom), velos(3, nAtom)
-  real(dp) :: velos_store(3, nAtom), norm, fielddir(3), angFreq, envelope, field(3), time
-  real(dp) :: time0 = 0.0_dp, time1 = 6.0_dp ! fs
-  type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pType2Files, pElecDyn
-  type(fnode), pointer :: pPerturb, pLaser, pAnalysis, pParserOpt
+  call main_()
 
-  character(:), allocatable :: DftbVersion
-  integer :: major, minor, patch, istep, ii, idim
+contains
 
+  !! Main test routine
+  !!
+  !! All non-constant variables must be defined here to ensure that they are all explicitely
+  !! deallocated before the program finishes.
+  !!
+  subroutine main_()
 
-  call getDftbPlusBuild(DftbVersion)
-  write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
-  call getDftbPlusApi(major, minor, patch)
-  write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
+    type(TDftbPlus) :: dftbp
+    type(TDftbPlusInput) :: input
 
-  call TDftbPlus_init(dftbp)
+    real(dp) :: coords(3, nAtom), merminEnergy, dipole(3, 1), energy, atomNetCharges(nAtom, 1)
+    real(dp) :: forces(3, nAtom), atomMasses(nAtom), accel(3, nAtom), velos(3, nAtom)
+    real(dp) :: velos_store(3, nAtom), norm, fielddir(3), angFreq, envelope, field(3), time
+    real(dp) :: time0, time1
+    type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pType2Files, pElecDyn
+    type(fnode), pointer :: pPerturb, pLaser, pAnalysis, pParserOpt
 
-  call dftbp%getEmptyInput(input)
-  call input%getRootNode(pRoot)
-  call setChild(pRoot, "Geometry", pGeo)
-  call setChildValue(pGeo, "Periodic", .false.)
-  call setChildValue(pGeo, "TypeNames", ["C", "H"])
-  coords(:,:) = 0.0_dp
-  call setChildValue(pGeo, "TypesAndCoordinates", reshape(species, [1, size(species)]), coords)
-  call setChild(pRoot, "Hamiltonian", pHam)
-  call setChild(pHam, "Dftb", pDftb)
-  call setChildValue(pDftb, "Scc", .true.)
-  call setChildValue(pDftb, "SccTolerance", 1e-10_dp)
+    character(:), allocatable :: DftbVersion
+    integer :: major, minor, patch, istep, ii, idim
 
-  call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
-  call setChildValue(pMaxAng, "C", "p")
-  call setChildValue(pMaxAng, "H", "s")
+    time0 = 0.0_dp
+    time1 = 6.0_dp  ! fs
+    call getDftbPlusBuild(DftbVersion)
+    write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
+    call getDftbPlusApi(major, minor, patch)
+    write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
 
-  call setChild(pDftb, "SlaterKosterFiles", pSlakos)
-  call setChild(pSlakos, "Type2FileNames", pType2Files)
-  call setChildValue(pType2Files, "Prefix", "./")
-  call setChildValue(pType2Files, "Separator", "-")
-  call setChildValue(pType2Files, "Suffix", ".skf")
+    call TDftbPlus_init(dftbp)
+
+    call dftbp%getEmptyInput(input)
+    call input%getRootNode(pRoot)
+    call setChild(pRoot, "Geometry", pGeo)
+    call setChildValue(pGeo, "Periodic", .false.)
+    call setChildValue(pGeo, "TypeNames", ["C", "H"])
+    coords(:,:) = 0.0_dp
+    call setChildValue(pGeo, "TypesAndCoordinates", reshape(species, [1, size(species)]), coords)
+    call setChild(pRoot, "Hamiltonian", pHam)
+    call setChild(pHam, "Dftb", pDftb)
+    call setChildValue(pDftb, "Scc", .true.)
+    call setChildValue(pDftb, "SccTolerance", 1e-10_dp)
+
+    call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
+    call setChildValue(pMaxAng, "C", "p")
+    call setChildValue(pMaxAng, "H", "s")
+
+    call setChild(pDftb, "SlaterKosterFiles", pSlakos)
+    call setChild(pSlakos, "Type2FileNames", pType2Files)
+    call setChildValue(pType2Files, "Prefix", "./")
+    call setChildValue(pType2Files, "Separator", "-")
+    call setChildValue(pType2Files, "Suffix", ".skf")
 
   call setChild(pRoot, "ParserOptions", pParserOpt)
   call setChildValue(pParserOpt, "ParserVersion", 13)
@@ -89,94 +102,97 @@ program test_ehrenfest
   call setChild(pRoot, "Analysis", pAnalysis)
   call setChildValue(pAnalysis, "CalculateForces", .true.)
 
-  !  set up electron dynamics options
-  call setChild(pRoot, "ElectronDynamics", pElecDyn)
-  call setChildValue(pElecDyn, "Steps", nsteps)
-  call setChildValue(pElecDyn, "TimeStep", timestep)
-  call setChildValue(pElecDyn, "FieldStrength", fstrength*1.0e10_dp*V_m__au)
-  call setChildValue(pElecDyn, "IonDynamics", .true.)
-  call setChildValue(pElecDyn, "InitialTemperature", 0.0_dp)
+    !  set up electron dynamics options
+    call setChild(pRoot, "ElectronDynamics", pElecDyn)
+    call setChildValue(pElecDyn, "Steps", nsteps)
+    call setChildValue(pElecDyn, "TimeStep", timestep)
+    call setChildValue(pElecDyn, "FieldStrength", fstrength*1.0e10_dp*V_m__au)
+    call setChildValue(pElecDyn, "IonDynamics", .true.)
+    call setChildValue(pElecDyn, "InitialTemperature", 0.0_dp)
 
-  call setChild(pElecDyn, "Perturbation", pPerturb)
-  call setChild(pPerturb, "Laser", pLaser)
-  ! these twovalues will be overriden
-  call setChildValue(pLaser, "PolarisationDirection", [0.0_dp, 1.0_dp, 1.0_dp])
-  call setChildValue(pLaser, "LaserEnergy", 1.0_dp)
+    call setChild(pElecDyn, "Perturbation", pPerturb)
+    call setChild(pPerturb, "Laser", pLaser)
+    ! these twovalues will be overriden
+    call setChildValue(pLaser, "PolarisationDirection", [0.0_dp, 1.0_dp, 1.0_dp])
+    call setChildValue(pLaser, "LaserEnergy", 1.0_dp)
 
-  norm = sqrt(dot_product(poldir, poldir))
-  fielddir = poldir / norm
-  angFreq = omega * eV__Hartree
-  time0 = time0 * fs__au
-  time1 = time1 * fs__au
+    norm = sqrt(dot_product(poldir, poldir))
+    fielddir = poldir / norm
+    angFreq = omega * eV__Hartree
+    time0 = time0 * fs__au
+    time1 = time1 * fs__au
 
-  print "(A)", 'Input tree in HSD format:'
-  call dumpHsd(input%hsdTree, output_unit)
+    print "(A)", 'Input tree in HSD format:'
+    call dumpHsd(input%hsdTree, output_unit)
 
-  ! initialise the DFTB+ calculator
-  call dftbp%setupCalculator(input)
+    ! initialise the DFTB+ calculator
+    call dftbp%setupCalculator(input)
+    call TDftbPlusInput_destruct(input)
 
-  ! Replace coordinates
-  coords(:,:) = initialCoords*AA__Bohr
-  call dftbp%setGeometry(coords)
+    ! Replace coordinates
+    coords(:,:) = initialCoords*AA__Bohr
+    call dftbp%setGeometry(coords)
 
-  ! get ground state
-  call dftbp%getEnergy(merminEnergy)
+    ! get ground state
+    call dftbp%getEnergy(merminEnergy)
 
-  ! get ground state forces
-  call dftbp%getGradients(forces) ! forces are actually gradients here (minus sign included)
-  call dftbp%getAtomicMasses(atomMasses)
-  do idim = 1, 3
-    accel(idim,:) = -forces(idim,:)/atomMasses(:) !minus sign, bc forces are gradients
-  end do
+    ! get ground state forces
+    call dftbp%getGradients(forces) ! forces are actually gradients here (minus sign included)
+    call dftbp%getAtomicMasses(atomMasses)
+    do idim = 1, 3
+      accel(idim,:) = -forces(idim,:)/atomMasses(:) !minus sign, bc forces are gradients
+    end do
 
-  velos(:,:) = 0.5_dp * accel * timestep
-  coords(:,:) = coords + velos * timestep
-  velos_store(:,:) = velos
+    velos(:,:) = 0.5_dp * accel * timestep
+    coords(:,:) = coords + velos * timestep
+    velos_store(:,:) = velos
 
-  call dftbp%initializeTimeProp(timestep, .true., .true.)
+    call dftbp%initializeTimeProp(timestep, .true., .true.)
 
-  ! get forces after initialization (forces for 1st step of dynamics)
-  call dftbp%getTdForces(forces)
-  do idim = 1, 3
-    accel(idim,:) = forces(idim,:)/atomMasses(:)
-  end do
-
-  do istep = 1, nsteps
-
-    ! calculate field at present timestep
-    time = istep * timestep
-    if (time >= time0 .and. time <= time1) then
-      envelope = sin(pi*(time - time0)/(time1 - time0))**2
-    else
-      envelope = 0.0_dp
-    end if
-    field = fstrength * 1.0e10_dp * V_m__au * envelope * aimag(exp(imag*time*angFreq) * fielddir)
-
-    ! evolve nuclear positions (using Velocity Verlet exactly as implemented in DFTB+)
-    velos(:,:) = velos_store + 0.5 * accel * timestep
-    velos_store(:,:) = velos + 0.5 * accel * timestep
-    coords(:,:) = coords + timestep * velos_store
-
-    call dftbp%setTdCoordsAndVelos(coords, velos)
-    call dftbp%setTdElectricField(field)
-    call dftbp%doOneTdStep(istep, dipole=dipole, energy=energy, atomNetCharges=atomNetCharges,&
-        & coord=coords, force=forces)
-
+    ! get forces after initialization (forces for 1st step of dynamics)
+    call dftbp%getTdForces(forces)
     do idim = 1, 3
       accel(idim,:) = forces(idim,:)/atomMasses(:)
     end do
 
-  end do
+    do istep = 1, nsteps
 
-  print "(A,F15.10)", 'Final SCC Energy:', energy
-  print "(A,3F15.10)", 'Final dipole:', (dipole(ii,1), ii=1,3)
-  print "(A,100F15.10)", 'Final net atomic charges:', (atomNetCharges(ii,1), ii=1,nAtom)
-  print "(A,100F15.10)", 'Final coordinates:', (coords(:,ii), ii=1,nAtom)
+      ! calculate field at present timestep
+      time = istep * timestep
+      if (time >= time0 .and. time <= time1) then
+        envelope = sin(pi*(time - time0)/(time1 - time0))**2
+      else
+        envelope = 0.0_dp
+      end if
+      field = fstrength * 1.0e10_dp * V_m__au * envelope * aimag(exp(imag*time*angFreq) * fielddir)
 
-  call TDftbPlus_destruct(dftbp)
+      ! evolve nuclear positions (using Velocity Verlet exactly as implemented in DFTB+)
+      velos(:,:) = velos_store + 0.5 * accel * timestep
+      velos_store(:,:) = velos + 0.5 * accel * timestep
+      coords(:,:) = coords + timestep * velos_store
 
-  ! Write file for internal test system
-  call writeAutotestTag(tdEnergy=energy, tdDipole=dipole, tdCharges=atomNetCharges,&
-       & tdCoords=coords, tdForces=forces)
+      call dftbp%setTdCoordsAndVelos(coords, velos)
+      call dftbp%setTdElectricField(field)
+      call dftbp%doOneTdStep(istep, dipole=dipole, energy=energy, atomNetCharges=atomNetCharges,&
+          & coord=coords, force=forces)
+
+      do idim = 1, 3
+        accel(idim,:) = forces(idim,:)/atomMasses(:)
+      end do
+
+    end do
+
+    print "(A,F15.10)", 'Final SCC Energy:', energy
+    print "(A,3F15.10)", 'Final dipole:', (dipole(ii,1), ii=1,3)
+    print "(A,100F15.10)", 'Final net atomic charges:', (atomNetCharges(ii,1), ii=1,nAtom)
+    print "(A,100F15.10)", 'Final coordinates:', (coords(:,ii), ii=1,nAtom)
+
+    call TDftbPlus_destruct(dftbp)
+
+    ! Write file for internal test system
+    call writeAutotestTag(tdEnergy=energy, tdDipole=dipole, tdCharges=atomNetCharges,&
+        & tdCoords=coords, tdForces=forces)
+
+  end subroutine main_
 
 end program test_ehrenfest

--- a/test/src/dftbp/api/mm/testers/test_ehrenfest_ext_ions.f90
+++ b/test/src/dftbp/api/mm/testers/test_ehrenfest_ext_ions.f90
@@ -127,7 +127,6 @@ contains
 
     ! initialise the DFTB+ calculator
     call dftbp%setupCalculator(input)
-    call TDftbPlusInput_destruct(input)
 
     ! Replace coordinates
     coords(:,:) = initialCoords*AA__Bohr
@@ -186,8 +185,6 @@ contains
     print "(A,3F15.10)", 'Final dipole:', (dipole(ii,1), ii=1,3)
     print "(A,100F15.10)", 'Final net atomic charges:', (atomNetCharges(ii,1), ii=1,nAtom)
     print "(A,100F15.10)", 'Final coordinates:', (coords(:,ii), ii=1,nAtom)
-
-    call TDftbPlus_destruct(dftbp)
 
     ! Write file for internal test system
     call writeAutotestTag(tdEnergy=energy, tdDipole=dipole, tdCharges=atomNetCharges,&

--- a/test/src/dftbp/api/mm/testers/test_extcharges.f90
+++ b/test/src/dftbp/api/mm/testers/test_extcharges.f90
@@ -52,120 +52,135 @@ program test_extcharges
 
   character(1), parameter :: maxAngNames(4) = ["s", "p", "d", "f"]
 
+  call main_()
 
-  type(TDftbPlus) :: dftbp
-  type(TDftbPlusInput) :: input
-
-  integer, allocatable :: species(:)
-  character(2), allocatable :: speciesNames(:)
-  real(dp) :: merminEnergy
-  real(dp) :: coords(3, nAtom), gradients(3, nAtom), extChargeGrads(3, nExtChrg)
-  real(dp) :: atomCharges(nAtom), cm5Charges(nAtom), atomMasses(nAtom)
-  type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pAnalysis, pCm5
-  type(fnode), pointer :: pParserOpts
-
-  character(:), allocatable :: DftbVersion
-  integer :: major, minor, patch
-
-  !integer :: devNull
-
-  call getDftbPlusBuild(DftbVersion)
-  write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
-  call getDftbPlusApi(major, minor, patch)
-  write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
-
-  ! Note: setting the global standard output to /dev/null will also suppress run-time error messages
-  !open(newunit=devNull, file="/dev/null", action="write")
-  !call TDftbPlus_init(dftbp, outputUnit=devNull)
-  call TDftbPlus_init(dftbp)
-
-  ! You should provide the skfiles as found in the external/slakos/origin/mio-1-1/ folder. These can
-  ! be downloaded with the utils/get_opt_externals script
-  call dftbp%getEmptyInput(input)
-  call input%getRootNode(pRoot)
-  call setChild(pRoot, "Geometry", pGeo)
-  call setChildValue(pGeo, "Periodic", .false.)
-
-  ! Demonstrates how to convert the atom types if they are not numbered from 1 but use atomic
-  ! numbers instead. The atomTypeNames array is optional, if not present, the resulting type names
-  ! (which will have to be used at other places) will be X1, X2, etc.
-  print "(A)", "Converting atom types"
-  call convertAtomTypesToSpecies(atomTypes, species, speciesNames, atomTypeNames)
-
-  call setChildValue(pGeo, "TypeNames", speciesNames)
-  coords(:,:) = 0.0_dp
-  call setChildValue(pGeo, "TypesAndCoordinates", reshape(species, [1, size(species)]), coords)
-  call setChild(pRoot, "Hamiltonian", pHam)
-  call setChild(pHam, "Dftb", pDftb)
-  call setChildValue(pDftb, "Scc", .true.)
-  call setChildValue(pDftb, "SccTolerance", 1e-12_dp)
-  call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
-
-  ! read angular momenta from SK data
-  call setChildValue(pMaxAng, speciesNames(1),&
-      & maxAngNames(getMaxAngFromSlakoFile(slakoFiles(1, 1)) + 1))
-  call setChildValue(pMaxAng, speciesNames(2),&
-      & maxAngNames(getMaxAngFromSlakoFile(slakoFiles(2, 2)) + 1))
-
-  ! set up locations for SK file data
-  call setChild(pDftb, "SlaterKosterFiles", pSlakos)
-  call setChildValue(pSlakos, "O-O", trim(slakoFiles(1, 1)))
-  call setChildValue(pSlakos, "H-O", trim(slakoFiles(2, 1)))
-  call setChildValue(pSlakos, "O-H", trim(slakoFiles(1, 2)))
-  call setChildValue(pSlakos, "H-H", trim(slakoFiles(2, 2)))
-  call setChild(pRoot, "Analysis", pAnalysis)
-  call setChildValue(pAnalysis, "CalculateForces", .true.)
-  call setChild(pAnalysis, "CM5", pCm5)
-  call setChild(pRoot, "ParserOptions", pParserOpts)
-  call setChildValue(pParserOpts, "ParserVersion", 5)
-
-  print "(A)", 'Input tree in HSD format:'
-  call dumpHsd(input%hsdTree, output_unit)
-
-  ! convert input into settings for the DFTB+ calculator
-  call dftbp%setupCalculator(input)
-
-  ! replace QM atom coordinates
-  coords(:,:) = initialCoords
-  call dftbp%setGeometry(coords)
-
-  ! add a single external charge
-  call dftbp%setExternalCharges(extCharges(:3,:1), extCharges(4,:1), extChargeBlur(:1))
-  ! get energy and forces for the single external charge
-  call dftbp%getEnergy(merminEnergy)
-  call dftbp%getExtChargeGradients(extChargeGrads(:,:1))
-
-  ! replace with a different number of external charges and re-compute
-  call dftbp%setExternalCharges(extCharges(:3,:3), extCharges(4,:3), extChargeBlur(:3))
-  ! get energy
-  call dftbp%getEnergy(merminEnergy)
-
-  ! Finally, external charges corresponding to the regression data
-  call dftbp%setExternalCharges(extCharges(:3,:2), extCharges(4,:2), extChargeBlur(:2))
-
-  ! get energy, charges and forces
-  call dftbp%getEnergy(merminEnergy)
-  call dftbp%getGradients(gradients)
-  call dftbp%getExtChargeGradients(extChargeGrads)
-  call dftbp%getGrossCharges(atomCharges)
-  call dftbp%getCM5Charges(cm5Charges)
-  call dftbp%getAtomicMasses(atomMasses)
+contains
 
 
-  print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
-  print "(A,3F15.10)", 'Obtained gross charges:', atomCharges
-  print "(A,3F15.10)", 'Obtained CM5 charges:', cm5Charges
-  print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
-  print "(A,3F15.10)", 'Obtained gradient of atom 2:', gradients(:,2)
-  print "(A,3F15.10)", 'Obtained gradient of atom 3:', gradients(:,3)
-  print "(A,3F15.10)", 'Obtained gradient of charge 1:', extChargeGrads(:,1)
-  print "(A,3F15.10)", 'Obtained gradient of charge 2:', extChargeGrads(:,2)
+  !! Main test routine
+  !!
+  !! All non-constant variables must be defined here to ensure that they are all explicitely
+  !! deallocated before the program finishes.
+  !!
+  subroutine main_()
 
-  ! clean up
-  call TDftbPlus_destruct(dftbp)
+    type(TDftbPlus) :: dftbp
+    type(TDftbPlusInput) :: input
 
-  ! Write file for internal test system
-  call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=atomCharges,&
-      & extChargeGradients=extChargeGrads, atomMasses=atomMasses, cm5Charges=cm5Charges)
+    integer, allocatable :: species(:)
+    character(2), allocatable :: speciesNames(:)
+    real(dp) :: merminEnergy
+    real(dp) :: coords(3, nAtom), gradients(3, nAtom), extChargeGrads(3, nExtChrg)
+    real(dp) :: atomCharges(nAtom), cm5Charges(nAtom), atomMasses(nAtom)
+    type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pAnalysis, pCm5
+    type(fnode), pointer :: pParserOpts
+
+    character(:), allocatable :: DftbVersion
+    integer :: major, minor, patch
+
+    !integer :: devNull
+
+    call getDftbPlusBuild(DftbVersion)
+    write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
+    call getDftbPlusApi(major, minor, patch)
+    write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
+
+    ! Note: setting the global standard output to /dev/null will also suppress run-time error messages
+    !open(newunit=devNull, file="/dev/null", action="write")
+    !call TDftbPlus_init(dftbp, outputUnit=devNull)
+    call TDftbPlus_init(dftbp)
+
+    ! You should provide the skfiles as found in the external/slakos/origin/mio-1-1/ folder. These can
+    ! be downloaded with the utils/get_opt_externals script
+    call dftbp%getEmptyInput(input)
+    call input%getRootNode(pRoot)
+    call setChild(pRoot, "Geometry", pGeo)
+    call setChildValue(pGeo, "Periodic", .false.)
+
+    ! Demonstrates how to convert the atom types if they are not numbered from 1 but use atomic
+    ! numbers instead. The atomTypeNames array is optional, if not present, the resulting type names
+    ! (which will have to be used at other places) will be X1, X2, etc.
+    print "(A)", "Converting atom types"
+    call convertAtomTypesToSpecies(atomTypes, species, speciesNames, atomTypeNames)
+
+    call setChildValue(pGeo, "TypeNames", speciesNames)
+    coords(:,:) = 0.0_dp
+    call setChildValue(pGeo, "TypesAndCoordinates", reshape(species, [1, size(species)]), coords)
+    call setChild(pRoot, "Hamiltonian", pHam)
+    call setChild(pHam, "Dftb", pDftb)
+    call setChildValue(pDftb, "Scc", .true.)
+    call setChildValue(pDftb, "SccTolerance", 1e-12_dp)
+    call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
+
+    ! read angular momenta from SK data
+    call setChildValue(pMaxAng, speciesNames(1),&
+        & maxAngNames(getMaxAngFromSlakoFile(slakoFiles(1, 1)) + 1))
+    call setChildValue(pMaxAng, speciesNames(2),&
+        & maxAngNames(getMaxAngFromSlakoFile(slakoFiles(2, 2)) + 1))
+
+    ! set up locations for SK file data
+    call setChild(pDftb, "SlaterKosterFiles", pSlakos)
+    call setChildValue(pSlakos, "O-O", trim(slakoFiles(1, 1)))
+    call setChildValue(pSlakos, "H-O", trim(slakoFiles(2, 1)))
+    call setChildValue(pSlakos, "O-H", trim(slakoFiles(1, 2)))
+    call setChildValue(pSlakos, "H-H", trim(slakoFiles(2, 2)))
+    call setChild(pRoot, "Analysis", pAnalysis)
+    call setChildValue(pAnalysis, "CalculateForces", .true.)
+    call setChild(pAnalysis, "CM5", pCm5)
+    call setChild(pRoot, "ParserOptions", pParserOpts)
+    call setChildValue(pParserOpts, "ParserVersion", 5)
+
+    print "(A)", 'Input tree in HSD format:'
+    call dumpHsd(input%hsdTree, output_unit)
+
+    ! convert input into settings for the DFTB+ calculator
+    call dftbp%setupCalculator(input)
+    call TDftbPlusInput_destruct(input)
+
+    ! replace QM atom coordinates
+    coords(:,:) = initialCoords
+    call dftbp%setGeometry(coords)
+
+    ! add external charges
+    call dftbp%setExternalCharges(extCharges(1:3,:), extCharges(4,:1), extChargeBlur(:1))
+
+    ! get energy, charges and forces
+    call dftbp%getEnergy(merminEnergy)
+    call dftbp%getExtChargeGradients(extChargeGrads(:,:1))
+
+    ! replace with a different number of external charges and re-compute
+    call dftbp%setExternalCharges(extCharges(:3,:3), extCharges(4,:3), extChargeBlur(:3))
+
+    ! get energy
+    call dftbp%getEnergy(merminEnergy)
+  
+    ! Finally, external charges corresponding to the regression data
+    call dftbp%setExternalCharges(extCharges(:3,:2), extCharges(4,:2), extChargeBlur(:2))
+
+    ! get energy, charges and forces
+    call dftbp%getEnergy(merminEnergy)
+    call dftbp%getGradients(gradients)
+    call dftbp%getExtChargeGradients(extChargeGrads)
+    call dftbp%getGrossCharges(atomCharges)
+    call dftbp%getCM5Charges(cm5Charges)
+    call dftbp%getAtomicMasses(atomMasses)
+
+    print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
+    print "(A,3F15.10)", 'Obtained gross charges:', atomCharges
+    print "(A,3F15.10)", 'Obtained CM5 charges:', cm5Charges
+    print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
+    print "(A,3F15.10)", 'Obtained gradient of atom 2:', gradients(:,2)
+    print "(A,3F15.10)", 'Obtained gradient of atom 3:', gradients(:,3)
+    print "(A,3F15.10)", 'Obtained gradient of charge 1:', extChargeGrads(:,1)
+    print "(A,3F15.10)", 'Obtained gradient of charge 2:', extChargeGrads(:,2)
+
+    ! clean up
+    call TDftbPlus_destruct(dftbp)
+
+    ! Write file for internal test system
+    call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=atomCharges,&
+        & extChargeGradients=extChargeGrads, atomMasses=atomMasses, cm5Charges=cm5Charges)
+
+  end subroutine main_
 
 end program test_extcharges

--- a/test/src/dftbp/api/mm/testers/test_extcharges.f90
+++ b/test/src/dftbp/api/mm/testers/test_extcharges.f90
@@ -140,10 +140,10 @@ contains
     coords(:,:) = initialCoords
     call dftbp%setGeometry(coords)
 
-    ! add external charges
-    call dftbp%setExternalCharges(extCharges(1:3,:), extCharges(4,:1), extChargeBlur(:1))
+    ! add a single external charge
+    call dftbp%setExternalCharges(extCharges(:3,:1), extCharges(4,:1), extChargeBlur(:1))
 
-    ! get energy, charges and forces
+    ! get energy, charges and forces for the single external charge
     call dftbp%getEnergy(merminEnergy)
     call dftbp%getExtChargeGradients(extChargeGrads(:,:1))
 
@@ -152,7 +152,7 @@ contains
 
     ! get energy
     call dftbp%getEnergy(merminEnergy)
-  
+
     ! Finally, external charges corresponding to the regression data
     call dftbp%setExternalCharges(extCharges(:3,:2), extCharges(4,:2), extChargeBlur(:2))
 

--- a/test/src/dftbp/api/mm/testers/test_extcharges.f90
+++ b/test/src/dftbp/api/mm/testers/test_extcharges.f90
@@ -60,7 +60,7 @@ contains
   !! Main test routine
   !!
   !! All non-constant variables must be defined here to ensure that they are all explicitely
-  !! deallocated before the program finishes.
+  !! deallocated before the program finishes  (avoiding residual memory that tools like valgrind notice).
   !!
   subroutine main_()
 

--- a/test/src/dftbp/api/mm/testers/test_extcharges.f90
+++ b/test/src/dftbp/api/mm/testers/test_extcharges.f90
@@ -135,7 +135,6 @@ contains
 
     ! convert input into settings for the DFTB+ calculator
     call dftbp%setupCalculator(input)
-    call TDftbPlusInput_destruct(input)
 
     ! replace QM atom coordinates
     coords(:,:) = initialCoords
@@ -173,9 +172,6 @@ contains
     print "(A,3F15.10)", 'Obtained gradient of atom 3:', gradients(:,3)
     print "(A,3F15.10)", 'Obtained gradient of charge 1:', extChargeGrads(:,1)
     print "(A,3F15.10)", 'Obtained gradient of charge 2:', extChargeGrads(:,2)
-
-    ! clean up
-    call TDftbPlus_destruct(dftbp)
 
     ! Write file for internal test system
     call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=atomCharges,&

--- a/test/src/dftbp/api/mm/testers/test_extpot.f90
+++ b/test/src/dftbp/api/mm/testers/test_extpot.f90
@@ -35,105 +35,119 @@ program test_extpot
       & 0.43463718188810203E+01_dp,-0.58581533211004997E+01_dp, 0.26456176288841000E+01_dp, -1.9_dp&
       &], [4, nExtChrg])
 
-  type(TDftbPlus) :: dftbp
-  type(TDftbPlusInput) :: input
+  call main_()
 
-  real(dp) :: merminEnergy
-  real(dp) :: coords(3, nAtom), gradients(3, nAtom), extPot(nAtom), extPotGrad(3, nAtom)
-  real(dp) :: atomCharges(nAtom), cm5Charges(nAtom), extChargeGrads(3, nExtChrg)
-  real(dp) :: esps(2)
-  real(dp), parameter :: espLocations(3,2) = reshape([1.0_dp,0.0_dp,0.0_dp,1.0_dp,0.1_dp,0.0_dp],&
-      & [3,2])
-  type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pType2Files, pAnalysis, pCm5
-  type(fnode), pointer :: pParserOpts
+contains
 
-  character(:), allocatable :: DftbVersion
-  integer :: major, minor, patch
+  !! Main test routine
+  !!
+  !! All non-constant variables must be defined here to ensure that they are all explicitely
+  !! deallocated before the program finishes.
+  !!
+  subroutine main_()
 
-  !integer :: devNull
+    type(TDftbPlus) :: dftbp
+    type(TDftbPlusInput) :: input
 
-  call getDftbPlusBuild(DftbVersion)
-  write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
-  call getDftbPlusApi(major, minor, patch)
-  write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
+    real(dp) :: merminEnergy
+    real(dp) :: coords(3, nAtom), gradients(3, nAtom), extPot(nAtom), extPotGrad(3, nAtom)
+    real(dp) :: atomCharges(nAtom), cm5Charges(nAtom), extChargeGrads(3, nExtChrg)
+    real(dp) :: esps(2)
+    real(dp), parameter :: espLocations(3,2) = reshape([1.0_dp,0.0_dp,0.0_dp,1.0_dp,0.1_dp,0.0_dp],&
+        & [3,2])
+    type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pType2Files, pAnalysis, pCm5
+    type(fnode), pointer :: pParserOpts
 
-  ! Note: setting the global standard output to /dev/null will also suppress run-time error messages
-  !open(newunit=devNull, file="/dev/null", action="write")
-  !call TDftbPlus_init(dftbp, outputUnit=devNull)
-  call TDftbPlus_init(dftbp)
+    character(:), allocatable :: DftbVersion
+    integer :: major, minor, patch
 
-  call dftbp%getEmptyInput(input)
-  call input%getRootNode(pRoot)
-  call setChild(pRoot, "Geometry", pGeo)
-  call setChildValue(pGeo, "Periodic", .false.)
-  call setChildValue(pGeo, "TypeNames", ["O", "H"])
-  coords(:,:) = 0.0_dp
-  call setChildValue(pGeo, "TypesAndCoordinates", reshape(species, [1, size(species)]), coords)
-  call setChild(pRoot, "Hamiltonian", pHam)
-  call setChild(pHam, "Dftb", pDftb)
-  call setChildValue(pDftb, "Scc", .true.)
-  call setChildValue(pDftb, "SccTolerance", 1e-12_dp)
+    !integer :: devNull
 
-  ! sub-block inside hamiltonian for the maximum angular momenta
-  call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
-  ! explicitly set the maximum angular momenta for the species
-  call setChildValue(pMaxAng, "O", "p")
-  call setChildValue(pMaxAng, "H", "s")
+    call getDftbPlusBuild(DftbVersion)
+    write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
+    call getDftbPlusApi(major, minor, patch)
+    write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
 
-  ! get the SK data
-  ! You should provide the skfiles as found in the external/slakos/origin/mio-1-1/ folder. These can
-  ! be downloaded with the utils/get_opt_externals script
-  call setChild(pDftb, "SlaterKosterFiles", pSlakos)
-  call setChild(pSlakos, "Type2FileNames", pType2Files)
-  call setChildValue(pType2Files, "Prefix", "./")
-  call setChildValue(pType2Files, "Separator", "-")
-  call setChildValue(pType2Files, "Suffix", ".skf")
+    ! Note: setting the global standard output to /dev/null will also suppress run-time error messages
+    !open(newunit=devNull, file="/dev/null", action="write")
+    !call TDftbPlus_init(dftbp, outputUnit=devNull)
+    call TDftbPlus_init(dftbp)
 
-  !  set up analysis options
-  call setChild(pRoot, "Analysis", pAnalysis)
-  call setChildValue(pAnalysis, "CalculateForces", .true.)
-  call setChild(pAnalysis, "CM5", pCm5)
+    call dftbp%getEmptyInput(input)
+    call input%getRootNode(pRoot)
+    call setChild(pRoot, "Geometry", pGeo)
+    call setChildValue(pGeo, "Periodic", .false.)
+    call setChildValue(pGeo, "TypeNames", ["O", "H"])
+    coords(:,:) = 0.0_dp
+    call setChildValue(pGeo, "TypesAndCoordinates", reshape(species, [1, size(species)]), coords)
+    call setChild(pRoot, "Hamiltonian", pHam)
+    call setChild(pHam, "Dftb", pDftb)
+    call setChildValue(pDftb, "Scc", .true.)
+    call setChildValue(pDftb, "SccTolerance", 1e-12_dp)
 
-  call setChild(pRoot, "ParserOptions", pParserOpts)
-  call setChildValue(pParserOpts, "ParserVersion", 5)
+    ! sub-block inside hamiltonian for the maximum angular momenta
+    call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
+    ! explicitly set the maximum angular momenta for the species
+    call setChildValue(pMaxAng, "O", "p")
+    call setChildValue(pMaxAng, "H", "s")
 
-  print "(A)", 'Input tree in HSD format:'
-  call dumpHsd(input%hsdTree, output_unit)
+    ! get the SK data
+    ! You should provide the skfiles as found in the external/slakos/origin/mio-1-1/ folder. These can
+    ! be downloaded with the utils/get_opt_externals script
+    call setChild(pDftb, "SlaterKosterFiles", pSlakos)
+    call setChild(pSlakos, "Type2FileNames", pType2Files)
+    call setChildValue(pType2Files, "Prefix", "./")
+    call setChildValue(pType2Files, "Separator", "-")
+    call setChildValue(pType2Files, "Suffix", ".skf")
 
-  ! initialise the DFTB+ calculator
-  call dftbp%setupCalculator(input)
+    !  set up analysis options
+    call setChild(pRoot, "Analysis", pAnalysis)
+    call setChildValue(pAnalysis, "CalculateForces", .true.)
+    call setChild(pAnalysis, "CM5", pCm5)
 
-  ! Replace coordinates
-  coords(:,:) = initialCoords
-  call dftbp%setGeometry(coords)
+    call setChild(pRoot, "ParserOptions", pParserOpts)
+    call setChildValue(pParserOpts, "ParserVersion", 5)
 
-  ! add external point charges
-  call getPointChargePotential(extCharges(1:3,:), extCharges(4,:), coords, extPot, extPotGrad)
-  call dftbp%setExternalPotential(atomPot=extPot, potGrad=extPotGrad)
+    print "(A)", 'Input tree in HSD format:'
+    call dumpHsd(input%hsdTree, output_unit)
 
-  ! get results
-  call dftbp%getEnergy(merminEnergy)
-  call dftbp%getGradients(gradients)
-  call dftbp%getGrossCharges(atomCharges)
-  call dftbp%getCM5Charges(cm5Charges)
-  call dftbp%getElStatPotential(esps, espLocations)
-  call getPointChargeGradients(coords, atomCharges, extCharges(1:3,:), extCharges(4,:),&
-      & extChargeGrads)
+    ! initialise the DFTB+ calculator
+    call dftbp%setupCalculator(input)
+    call TDftbPlusInput_destruct(input)
 
-  print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
-  print "(A,3F15.10)", 'Obtained gross charges:', atomCharges
-  print "(A,3F15.10)", 'Obtained cm5 charges:', cm5Charges
-  print "(A,2F15.10)", 'Obtained electrostatic potentials:', esps
-  print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
-  print "(A,3F15.10)", 'Obtained gradient of atom 2:', gradients(:,2)
-  print "(A,3F15.10)", 'Obtained gradient of atom 3:', gradients(:,3)
-  print "(A,3F15.10)", 'Obtained gradient of charge 1:', extChargeGrads(:,1)
-  print "(A,3F15.10)", 'Obtained gradient of charge 2:', extChargeGrads(:,2)
+    ! Replace coordinates
+    coords(:,:) = initialCoords
+    call dftbp%setGeometry(coords)
 
-  call TDftbPlus_destruct(dftbp)
+    ! add external point charges
+    call getPointChargePotential(extCharges(1:3,:), extCharges(4,:), coords, extPot, extPotGrad)
+    call dftbp%setExternalPotential(atomPot=extPot, potGrad=extPotGrad)
 
-  ! Write file for internal test system
-  call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=atomCharges,&
-      & extChargeGradients=extChargeGrads, potential=esps, cm5Charges=cm5Charges)
+    ! get results
+    call dftbp%getEnergy(merminEnergy)
+    call dftbp%getGradients(gradients)
+    call dftbp%getGrossCharges(atomCharges)
+    call dftbp%getCM5Charges(cm5Charges)
+    call dftbp%getElStatPotential(esps, espLocations)
+    call getPointChargeGradients(coords, atomCharges, extCharges(1:3,:), extCharges(4,:),&
+        & extChargeGrads)
+
+    print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
+    print "(A,3F15.10)", 'Obtained gross charges:', atomCharges
+    print "(A,3F15.10)", 'Obtained cm5 charges:', cm5Charges
+    print "(A,2F15.10)", 'Obtained electrostatic potentials:', esps
+    print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
+    print "(A,3F15.10)", 'Obtained gradient of atom 2:', gradients(:,2)
+    print "(A,3F15.10)", 'Obtained gradient of atom 3:', gradients(:,3)
+    print "(A,3F15.10)", 'Obtained gradient of charge 1:', extChargeGrads(:,1)
+    print "(A,3F15.10)", 'Obtained gradient of charge 2:', extChargeGrads(:,2)
+
+    call TDftbPlus_destruct(dftbp)
+
+    ! Write file for internal test system
+    call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=atomCharges,&
+        & extChargeGradients=extChargeGrads, potential=esps, cm5Charges=cm5Charges)
+
+  end subroutine main_
 
 end program test_extpot

--- a/test/src/dftbp/api/mm/testers/test_extpot.f90
+++ b/test/src/dftbp/api/mm/testers/test_extpot.f90
@@ -42,7 +42,7 @@ contains
   !! Main test routine
   !!
   !! All non-constant variables must be defined here to ensure that they are all explicitely
-  !! deallocated before the program finishes.
+  !! deallocated before the program finishes  (avoiding residual memory that tools like valgrind notice).
   !!
   subroutine main_()
 

--- a/test/src/dftbp/api/mm/testers/test_extpot.f90
+++ b/test/src/dftbp/api/mm/testers/test_extpot.f90
@@ -113,7 +113,6 @@ contains
 
     ! initialise the DFTB+ calculator
     call dftbp%setupCalculator(input)
-    call TDftbPlusInput_destruct(input)
 
     ! Replace coordinates
     coords(:,:) = initialCoords
@@ -141,8 +140,6 @@ contains
     print "(A,3F15.10)", 'Obtained gradient of atom 3:', gradients(:,3)
     print "(A,3F15.10)", 'Obtained gradient of charge 1:', extChargeGrads(:,1)
     print "(A,3F15.10)", 'Obtained gradient of charge 2:', extChargeGrads(:,2)
-
-    call TDftbPlus_destruct(dftbp)
 
     ! Write file for internal test system
     call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=atomCharges,&

--- a/test/src/dftbp/api/mm/testers/test_extpot2.f90
+++ b/test/src/dftbp/api/mm/testers/test_extpot2.f90
@@ -57,7 +57,7 @@ contains
   !! Main test routine
   !!
   !! All non-constant variables must be defined here to ensure that they are all explicitely
-  !! deallocated before the program finishes.
+  !! deallocated before the program finishes  (avoiding residual memory that tools like valgrind notice).
   !!
   subroutine main_()
 

--- a/test/src/dftbp/api/mm/testers/test_extpot2.f90
+++ b/test/src/dftbp/api/mm/testers/test_extpot2.f90
@@ -50,115 +50,129 @@ program test_extpot2
   ! labels for l shells
   character(1), parameter :: maxAngNames(4) = ["s", "p", "d", "f"]
 
-  type(TDftbPlus) :: dftbp
-  type(TDftbPlusInput) :: input
+  call main_()
 
-  real(dp) :: merminEnergy
-  real(dp) :: coords(3, nAtom), gradients(3, nAtom), extPot(nAtom), extPotGrad(3, nAtom)
-  real(dp) :: atomCharges(nAtom), extChargeGrads(3, nExtChrg)
-  type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pAnalysis
-  type(fnode), pointer :: pParserOpts
+contains
 
-  !integer :: devNull
+  !! Main test routine
+  !!
+  !! All non-constant variables must be defined here to ensure that they are all explicitely
+  !! deallocated before the program finishes.
+  !!
+  subroutine main_()
 
-  character(:), allocatable :: DftbVersion
-  integer :: major, minor, patch
+    type(TDftbPlus) :: dftbp
+    type(TDftbPlusInput) :: input
 
-  call getDftbPlusBuild(DftbVersion)
-  write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
-  call getDftbPlusApi(major, minor, patch)
-  write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
+    real(dp) :: merminEnergy
+    real(dp) :: coords(3, nAtom), gradients(3, nAtom), extPot(nAtom), extPotGrad(3, nAtom)
+    real(dp) :: atomCharges(nAtom), extChargeGrads(3, nExtChrg)
+    type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pAnalysis
+    type(fnode), pointer :: pParserOpts
 
-  ! Note: setting the global standard output to /dev/null will also suppress run-time error messages
-  !open(newunit=devNull, file="/dev/null", action="write")
-  !call TDftbPlus_init(dftbp, outputUnit=devNull)
-  call TDftbPlus_init(dftbp)
+    !integer :: devNull
 
-  ! start a new instance
-  call dftbp%getEmptyInput(input)
-  ! get the root node of the input tree
-  call input%getRootNode(pRoot)
+    character(:), allocatable :: DftbVersion
+    integer :: major, minor, patch
 
-  ! from the root fill the geometry block
-  call setChild(pRoot, "Geometry", pGeo)
-  call setChildValue(pGeo, "Periodic", .false.)
-  call setChildValue(pGeo, "TypeNames", ["O", "H"])
-  coords(:,:) = 0.0_dp
-  call setChildValue(pGeo, "TypesAndCoordinates", reshape(species, [1, size(species)]), coords)
+    call getDftbPlusBuild(DftbVersion)
+    write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
+    call getDftbPlusApi(major, minor, patch)
+    write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
 
-  ! from the root, fill the hamitonian block
-  call setChild(pRoot, "Hamiltonian", pHam)
-  call setChild(pHam, "Dftb", pDftb)
-  call setChildValue(pDftb, "Scc", .true.)
-  call setChildValue(pDftb, "SccTolerance", 1e-12_dp)
-  call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
-  ! read angular momenta from SK data
-  call setChildValue(pMaxAng, "O", maxAngNames(getMaxAngFromSlakoFile(slakoFiles(1, 1)) + 1))
-  call setChildValue(pMaxAng, "H", maxAngNames(getMaxAngFromSlakoFile(slakoFiles(2, 2)) + 1))
-  ! read the actual SK files in
-  call setChild(pDftb, "SlaterKosterFiles", pSlakos)
-  call setChildValue(pSlakos, "O-O", trim(slakoFiles(1, 1)))
-  call setChildValue(pSlakos, "H-O", trim(slakoFiles(2, 1)))
-  call setChildValue(pSlakos, "O-H", trim(slakoFiles(1, 2)))
-  call setChildValue(pSlakos, "H-H", trim(slakoFiles(2, 2)))
+    ! Note: setting the global standard output to /dev/null will also suppress run-time error messages
+    !open(newunit=devNull, file="/dev/null", action="write")
+    !call TDftbPlus_init(dftbp, outputUnit=devNull)
+    call TDftbPlus_init(dftbp)
 
-  ! Analysis block for input
-  call setChild(pRoot, "Analysis", pAnalysis)
-  call setChildValue(pAnalysis, "CalculateForces", .true.)
+    ! start a new instance
+    call dftbp%getEmptyInput(input)
+    ! get the root node of the input tree
+    call input%getRootNode(pRoot)
 
-  ! DFTB+ parser options
-  call setChild(pRoot, "ParserOptions", pParserOpts)
-  call setChildValue(pParserOpts, "ParserVersion", 5)
+    ! from the root fill the geometry block
+    call setChild(pRoot, "Geometry", pGeo)
+    call setChildValue(pGeo, "Periodic", .false.)
+    call setChildValue(pGeo, "TypeNames", ["O", "H"])
+    coords(:,:) = 0.0_dp
+    call setChildValue(pGeo, "TypesAndCoordinates", reshape(species, [1, size(species)]), coords)
 
-  print "(A)", 'Input tree in HSD format:'
-  call dumpHsd(input%hsdTree, output_unit)
+    ! from the root, fill the hamitonian block
+    call setChild(pRoot, "Hamiltonian", pHam)
+    call setChild(pHam, "Dftb", pDftb)
+    call setChildValue(pDftb, "Scc", .true.)
+    call setChildValue(pDftb, "SccTolerance", 1e-12_dp)
+    call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
+    ! read angular momenta from SK data
+    call setChildValue(pMaxAng, "O", maxAngNames(getMaxAngFromSlakoFile(slakoFiles(1, 1)) + 1))
+    call setChildValue(pMaxAng, "H", maxAngNames(getMaxAngFromSlakoFile(slakoFiles(2, 2)) + 1))
+    ! read the actual SK files in
+    call setChild(pDftb, "SlaterKosterFiles", pSlakos)
+    call setChildValue(pSlakos, "O-O", trim(slakoFiles(1, 1)))
+    call setChildValue(pSlakos, "H-O", trim(slakoFiles(2, 1)))
+    call setChildValue(pSlakos, "O-H", trim(slakoFiles(1, 2)))
+    call setChildValue(pSlakos, "H-H", trim(slakoFiles(2, 2)))
 
-  call dftbp%setupCalculator(input)
+    ! Analysis block for input
+    call setChild(pRoot, "Analysis", pAnalysis)
+    call setChildValue(pAnalysis, "CalculateForces", .true.)
 
-  ! over-write coordinates
-  coords(:,:) = initialCoords
-  call dftbp%setGeometry(coords)
+    ! DFTB+ parser options
+    call setChild(pRoot, "ParserOptions", pParserOpts)
+    call setChildValue(pParserOpts, "ParserVersion", 5)
 
-  ! add external potential from some charges
-  call getPointChargePotential(extCharges(1:3,:), extCharges(4,:), coords, extPot, extPotGrad)
-  call dftbp%setExternalPotential(atomPot=extPot, potGrad=extPotGrad)
+    print "(A)", 'Input tree in HSD format:'
+    call dumpHsd(input%hsdTree, output_unit)
 
-  ! get energy, forces and charges
-  call dftbp%getEnergy(merminEnergy)
-  call dftbp%getGradients(gradients)
-  call dftbp%getGrossCharges(atomCharges)
+    call dftbp%setupCalculator(input)
+    call TDftbPlusInput_destruct(input)
 
-  ! get forces on the external charges
-  call getPointChargeGradients(coords, atomCharges, extCharges(1:3,:), extCharges(4,:),&
-      & extChargeGrads)
+    ! over-write coordinates
+    coords(:,:) = initialCoords
+    call dftbp%setGeometry(coords)
 
-  print "(A,F15.10)", 'Expected Mermin Energy:', -0.398548033919583E+001_dp
-  print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
-  print "(A,3F15.10)", 'Expected gross charges:', -(6.49439832790185_dp - 6.0_dp),&
-      & -(0.735827787218271E+000_dp - 1.0_dp), -(0.769773884872109E+000_dp - 1.0_dp)
-  print "(A,3F15.10)", 'Obtained gross charges:', atomCharges
+    ! add external potential from some charges
+    call getPointChargePotential(extCharges(1:3,:), extCharges(4,:), coords, extPot, extPotGrad)
+    call dftbp%setExternalPotential(atomPot=extPot, potGrad=extPotGrad)
 
-  print "(A,3F15.10)", 'Expected gradient of atom 1:', 0.176513637737736E-001_dp,&
-      & -0.183137601772536E+000_dp, 0.319825151816764E-002_dp
-  print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
-  print "(A,3F15.10)", 'Expected gradient of atom 2:', -0.614022657776373E-002_dp,&
-      & 0.955090293319614E-001_dp, 0.394035230277817E-001_dp
-  print "(A,3F15.10)", 'Obtained gradient of atom 2:', gradients(:,2)
-  print "(A,3F15.10)", 'Expected gradient of atom 3:', -0.377202598396707E-002_dp,&
-      & 0.923535862104179E-001_dp, -0.402979579635372E-001_dp
-  print "(A,3F15.10)", 'Obtained gradient of atom 3:', gradients(:,3)
+    ! get energy, forces and charges
+    call dftbp%getEnergy(merminEnergy)
+    call dftbp%getGradients(gradients)
+    call dftbp%getGrossCharges(atomCharges)
 
-  print "(A,3F15.10)", 'Expected gradient of charge 1:', -0.118623591287408E-002_dp,&
-      & -0.695045328370150E-002_dp, 0.242761119930661E-002_dp
-  print "(A,3F15.10)", 'Obtained gradient of charge 1:', extChargeGrads(:,1)
-  print "(A,3F15.10)", 'Expected gradient of charge 2:', -0.655287529916873E-002_dp,&
-      & 0.222543951385786E-002_dp, -0.473142778171874E-002_dp
-  print "(A,3F15.10)", 'Obtained gradient of charge 2:', extChargeGrads(:,2)
+    ! get forces on the external charges
+    call getPointChargeGradients(coords, atomCharges, extCharges(1:3,:), extCharges(4,:),&
+        & extChargeGrads)
 
-  call TDftbPlus_destruct(dftbp)
+    print "(A,F15.10)", 'Expected Mermin Energy:', -0.398548033919583E+001_dp
+    print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
+    print "(A,3F15.10)", 'Expected gross charges:', -(6.49439832790185_dp - 6.0_dp),&
+        & -(0.735827787218271E+000_dp - 1.0_dp), -(0.769773884872109E+000_dp - 1.0_dp)
+    print "(A,3F15.10)", 'Obtained gross charges:', atomCharges
 
-  ! Write file for internal test system
-  call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=atomCharges,&
-      & extChargeGradients=extChargeGrads)
+    print "(A,3F15.10)", 'Expected gradient of atom 1:', 0.176513637737736E-001_dp,&
+        & -0.183137601772536E+000_dp, 0.319825151816764E-002_dp
+    print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
+    print "(A,3F15.10)", 'Expected gradient of atom 2:', -0.614022657776373E-002_dp,&
+        & 0.955090293319614E-001_dp, 0.394035230277817E-001_dp
+    print "(A,3F15.10)", 'Obtained gradient of atom 2:', gradients(:,2)
+    print "(A,3F15.10)", 'Expected gradient of atom 3:', -0.377202598396707E-002_dp,&
+        & 0.923535862104179E-001_dp, -0.402979579635372E-001_dp
+    print "(A,3F15.10)", 'Obtained gradient of atom 3:', gradients(:,3)
+
+    print "(A,3F15.10)", 'Expected gradient of charge 1:', -0.118623591287408E-002_dp,&
+        & -0.695045328370150E-002_dp, 0.242761119930661E-002_dp
+    print "(A,3F15.10)", 'Obtained gradient of charge 1:', extChargeGrads(:,1)
+    print "(A,3F15.10)", 'Expected gradient of charge 2:', -0.655287529916873E-002_dp,&
+        & 0.222543951385786E-002_dp, -0.473142778171874E-002_dp
+    print "(A,3F15.10)", 'Obtained gradient of charge 2:', extChargeGrads(:,2)
+
+    call TDftbPlus_destruct(dftbp)
+
+    ! Write file for internal test system
+    call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=atomCharges,&
+        & extChargeGradients=extChargeGrads)
+
+  end subroutine main_
 
 end program test_extpot2

--- a/test/src/dftbp/api/mm/testers/test_extpot2.f90
+++ b/test/src/dftbp/api/mm/testers/test_extpot2.f90
@@ -125,7 +125,6 @@ contains
     call dumpHsd(input%hsdTree, output_unit)
 
     call dftbp%setupCalculator(input)
-    call TDftbPlusInput_destruct(input)
 
     ! over-write coordinates
     coords(:,:) = initialCoords
@@ -166,8 +165,6 @@ contains
     print "(A,3F15.10)", 'Expected gradient of charge 2:', -0.655287529916873E-002_dp,&
         & 0.222543951385786E-002_dp, -0.473142778171874E-002_dp
     print "(A,3F15.10)", 'Obtained gradient of charge 2:', extChargeGrads(:,2)
-
-    call TDftbPlus_destruct(dftbp)
 
     ! Write file for internal test system
     call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=atomCharges,&

--- a/test/src/dftbp/api/mm/testers/test_fileinit.f90
+++ b/test/src/dftbp/api/mm/testers/test_fileinit.f90
@@ -38,7 +38,7 @@ contains
   !! Main test routine
   !!
   !! All non-constant variables must be defined here to ensure that they are all explicitely
-  !! deallocated before the program finishes.
+  !! deallocated before the program finishes  (avoiding residual memory that tools like valgrind notice).
   !!
   subroutine main_()
 

--- a/test/src/dftbp/api/mm/testers/test_fileinit.f90
+++ b/test/src/dftbp/api/mm/testers/test_fileinit.f90
@@ -14,6 +14,9 @@ program test_fileinit
   use testhelpers, only : writeAutotestTag
   implicit none
 
+  ! How often should the test repeated
+  integer, parameter :: nIter = 2
+
   ! double precision real
   integer, parameter :: dp = kind(1.0d0)
 
@@ -28,70 +31,88 @@ program test_fileinit
       & 0.0000000000000000_dp, 5.1278583974043830_dp, 5.1278583974043830_dp,&
       & 5.1278583974043830_dp, 0.0000000000000000_dp, 5.1278583974043830_dp], [3, 3])
 
-  type(TDftbPlus) :: dftbp
-  type(TDftbPlusInput) :: input
+  call main_()
 
-  real(dp) :: merminEnergy
-  real(dp) :: coords(3, 2), latVecs(3, 3), gradients(3, 2), grossCharges(2), stressTensor(3, 3)
+contains
 
-  integer :: devNull
+  !! Main test routine
+  !!
+  !! All non-constant variables must be defined here to ensure that they are all explicitely
+  !! deallocated before the program finishes.
+  !!
+  subroutine main_()
 
-  character(:), allocatable :: DftbVersion
-  integer :: major, minor, patch
+    type(TDftbPlus) :: dftbp
+    type(TDftbPlusInput) :: input
 
-  call getDftbPlusBuild(DftbVersion)
-  write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
-  call getDftbPlusApi(major, minor, patch)
-  write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
+    real(dp) :: merminEnergy
+    real(dp) :: coords(3, 2), latVecs(3, 3), gradients(3, 2), grossCharges(2), stressTensor(3, 3)
 
-  ! Note: setting the global standard output to /dev/null to suppress output and run-time error
-  ! messages
-  open(newunit=devNull, file="/dev/null", action="write")
-  !call TDftbPlus_init(dftbp, outputUnit=devNull)
+    integer :: devNull
 
-  call TDftbPlus_init(dftbp)
+    character(:), allocatable :: DftbVersion
+    integer :: major, minor, patch
+    integer :: iIter
 
-  ! You should provide the dftb_in.hsd and skfile found in the test/app/dftb+/non-scc/Si_2/ folder
-  call dftbp%getInputFromFile("dftb_in.hsd", input)
-  call dftbp%setupCalculator(input)
+    do iIter = 1, nIter
+      call getDftbPlusBuild(DftbVersion)
+      write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
+      call getDftbPlusApi(major, minor, patch)
+      write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
 
-  ! a simple check for data values in the file
-  if (dftbp%nrOfAtoms() /= size(coords, dim=2)) then
-    print *, "Mismatch between expected number of atoms and dftb_in.hsd file"
-    call TDftbPlus_destruct(dftbp)
-    stop
-  end if
+      ! Note: setting the global standard output to /dev/null to suppress output and run-time error
+      ! messages
+      open(newunit=devNull, file="/dev/null", action="write")
 
-  ! replace the lattice vectors and coordinates in the document tree
-  latVecs(:,:) = initialLatVecs
-  coords(:,:) = initialCoords
-  call dftbp%setGeometry(coords, latVecs)
+      !call TDftbPlus_init(dftbp, outputUnit=devNull)
+      call TDftbPlus_init(dftbp)
 
-  ! evaluate energy and forces
-  call dftbp%getEnergy(merminEnergy)
-  call dftbp%getGradients(gradients)
-  print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
-  print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
+      ! You should provide the dftb_in.hsd and skfile found in the test/app/dftb+/non-scc/Si_2/ folder
+      call dftbp%getInputFromFile("dftb_in.hsd", input)
+      call dftbp%setupCalculator(input)
+      call TDftbPlusInput_destruct(input)
 
-  ! make a small displacement in the lattice vectors and coordinates
-  latVecs(1, 1) = latVecs(1, 1) + 0.1_dp * AA__Bohr
-  coords(1, 1) = coords(1, 1) + 0.2_dp * AA__Bohr
-  call dftbp%setGeometry(coords, latVecs)
+      ! a simple check for data values in the file
+      if (dftbp%nrOfAtoms() /= size(coords, dim=2)) then
+        print *, "Mismatch between expected number of atoms and dftb_in.hsd file"
+        call TDftbPlus_destruct(dftbp)
+        stop
+      end if
 
-  ! re-calculate energy and forces
-  call dftbp%getEnergy(merminEnergy)
-  call dftbp%getGradients(gradients)
-  call dftbp%getGrossCharges(grossCharges)
-  call dftbp%getStressTensor(stressTensor)
-  print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
-  print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
-  print "(A,2F15.10)", 'Obtained charges:', grossCharges
+      ! replace the lattice vectors and coordinates in the document tree
+      latVecs(:,:) = initialLatVecs
+      coords(:,:) = initialCoords
+      call dftbp%setGeometry(coords, latVecs)
 
-  ! clean up
-  call TDftbPlus_destruct(dftbp)
+      ! evaluate energy and forces
+      call dftbp%getEnergy(merminEnergy)
+      call dftbp%getGradients(gradients)
+      print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
+      print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
 
-  ! Write file for internal test system
-  call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=grossCharges,&
-      & stressTensor = stressTensor)
+      ! make a small displacement in the lattice vectors and coordinates
+      latVecs(1, 1) = latVecs(1, 1) + 0.1_dp * AA__Bohr
+      coords(1, 1) = coords(1, 1) + 0.2_dp * AA__Bohr
+      call dftbp%setGeometry(coords, latVecs)
+
+      ! re-calculate energy and forces
+      call dftbp%getEnergy(merminEnergy)
+      call dftbp%getGradients(gradients)
+      call dftbp%getGrossCharges(grossCharges)
+      call dftbp%getStressTensor(stressTensor)
+      print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
+      print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
+      print "(A,2F15.10)", 'Obtained charges:', grossCharges
+
+      ! clean up
+      call TDftbPlus_destruct(dftbp)
+
+    end do
+
+    ! Write file for internal test system
+    call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=grossCharges,&
+        & stressTensor=stressTensor)
+
+  end subroutine main_
 
 end program test_fileinit

--- a/test/src/dftbp/api/mm/testers/test_fileinitc.c
+++ b/test/src/dftbp/api/mm/testers/test_fileinitc.c
@@ -147,6 +147,7 @@ int main()
       dftbp_get_input_from_file(&calculator, "dftb_in.H2O.hsd", &input);
     }
     dftbp_process_input(&calculator, &input);
+    dftbp_input_final(&input);
 
     /* Check whether the calculator was initialized with the correct nr. of atoms */
     natom = dftbp_get_nr_atoms(&calculator);

--- a/test/src/dftbp/api/mm/testers/test_intcharges.f90
+++ b/test/src/dftbp/api/mm/testers/test_intcharges.f90
@@ -43,7 +43,7 @@ contains
   !! Main test routine
   !!
   !! All non-constant variables must be defined here to ensure that they are all explicitely
-  !! deallocated before the program finishes.
+  !! deallocated before the program finishes  (avoiding residual memory that tools like valgrind notice).
   !!
   subroutine main_()
 

--- a/test/src/dftbp/api/mm/testers/test_intcharges.f90
+++ b/test/src/dftbp/api/mm/testers/test_intcharges.f90
@@ -114,7 +114,6 @@ contains
 
     ! convert input into settings for the DFTB+ calculator
     call dftbp%setupCalculator(input)
-    call TDftbPlusInput_destruct(input)
 
     ! replace QM atom coordinates
     coords(:,:) = initialCoords
@@ -168,9 +167,6 @@ contains
     print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
     print "(A,3F15.10)", 'Obtained gradient of atom 2:', gradients(:,2)
     print "(A,3F15.10)", 'Obtained gradient of atom 3:', gradients(:,3)
-
-    ! clean up
-    call TDftbPlus_destruct(dftbp)
 
     ! Write file for internal test system
     call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=atomCharges,&

--- a/test/src/dftbp/api/mm/testers/test_intcharges.f90
+++ b/test/src/dftbp/api/mm/testers/test_intcharges.f90
@@ -35,133 +35,147 @@ program test_intcharges
 
   character(1), parameter :: maxAngNames(4) = ["s", "p", "d", "f"]
 
+  call main_()
 
-  type(TDftbPlus) :: dftbp
-  type(TDftbPlusInput) :: input
+contains
 
-  integer, allocatable :: species(:)
-  character(2), allocatable :: speciesNames(:)
-  real(dp) :: merminEnergy
-  real(dp) :: coords(3, nAtom), gradients(3, nAtom)
-  real(dp) :: atomCharges(nAtom), cm5Charges(nAtom), atomMasses(nAtom)
-  real(dp) :: q0(nAtom)
-  type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pAnalysis, pCm5
-  type(fnode), pointer :: pParserOpts
 
-  character(:), allocatable :: DftbVersion
-  integer :: major, minor, patch
-  integer :: ii
+  !! Main test routine
+  !!
+  !! All non-constant variables must be defined here to ensure that they are all explicitely
+  !! deallocated before the program finishes.
+  !!
+  subroutine main_()
 
-  call getDftbPlusBuild(DftbVersion)
-  write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
-  call getDftbPlusApi(major, minor, patch)
-  write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
+    type(TDftbPlus) :: dftbp
+    type(TDftbPlusInput) :: input
 
-  ! Note: could pass an optional file unit to use for standard output as the argument outputUnit
-  call TDftbPlus_init(dftbp)
+    integer, allocatable :: species(:)
+    character(2), allocatable :: speciesNames(:)
+    real(dp) :: merminEnergy
+    real(dp) :: coords(3, nAtom), gradients(3, nAtom)
+    real(dp) :: atomCharges(nAtom), cm5Charges(nAtom), atomMasses(nAtom)
+    real(dp) :: q0(nAtom)
+    type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pAnalysis, pCm5
+    type(fnode), pointer :: pParserOpts
 
-  call dftbp%getEmptyInput(input)
-  call input%getRootNode(pRoot)
-  call setChild(pRoot, "Geometry", pGeo)
-  call setChildValue(pGeo, "Periodic", .false.)
+    character(:), allocatable :: DftbVersion
+    integer :: major, minor, patch
+    integer :: ii
 
-  ! Demonstrates how to convert the atom types if they are not numbered from 1 but use atomic
-  ! numbers instead. The atomTypeNames array is optional, if not present, the resulting type names
-  ! (which will have to be used at other places) will be X1, X2, etc.
-  print "(A)", "Converting atom types"
-  call convertAtomTypesToSpecies(atomTypes, species, speciesNames, atomTypeNames)
+    call getDftbPlusBuild(DftbVersion)
+    write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
+    call getDftbPlusApi(major, minor, patch)
+    write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
 
-  call setChildValue(pGeo, "TypeNames", speciesNames)
-  coords(:,:) = 0.0_dp
-  call setChildValue(pGeo, "TypesAndCoordinates", reshape(species, [1, size(species)]), coords)
-  call setChild(pRoot, "Hamiltonian", pHam)
-  call setChild(pHam, "Dftb", pDftb)
-  call setChildValue(pDftb, "Scc", .true.)
-  call setChildValue(pDftb, "SccTolerance", 1e-12_dp)
-  call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
+    ! Note: could pass an optional file unit to use for standard output as the argument outputUnit
+    call TDftbPlus_init(dftbp)
 
-  ! read angular momenta from SK data
-  call setChildValue(pMaxAng, speciesNames(1),&
-      & maxAngNames(getMaxAngFromSlakoFile(slakoFiles(1, 1)) + 1))
-  call setChildValue(pMaxAng, speciesNames(2),&
-      & maxAngNames(getMaxAngFromSlakoFile(slakoFiles(2, 2)) + 1))
+    call dftbp%getEmptyInput(input)
+    call input%getRootNode(pRoot)
+    call setChild(pRoot, "Geometry", pGeo)
+    call setChildValue(pGeo, "Periodic", .false.)
 
-  ! set up locations for SK file data
-  call setChild(pDftb, "SlaterKosterFiles", pSlakos)
-  call setChildValue(pSlakos, "O-O", trim(slakoFiles(1, 1)))
-  call setChildValue(pSlakos, "H-O", trim(slakoFiles(2, 1)))
-  call setChildValue(pSlakos, "O-H", trim(slakoFiles(1, 2)))
-  call setChildValue(pSlakos, "H-H", trim(slakoFiles(2, 2)))
-  call setChild(pRoot, "Analysis", pAnalysis)
-  call setChildValue(pAnalysis, "CalculateForces", .true.)
-  call setChild(pAnalysis, "CM5", pCm5)
-  call setChild(pRoot, "ParserOptions", pParserOpts)
-  call setChildValue(pParserOpts, "ParserVersion", 13)
+    ! Demonstrates how to convert the atom types if they are not numbered from 1 but use atomic
+    ! numbers instead. The atomTypeNames array is optional, if not present, the resulting type names
+    ! (which will have to be used at other places) will be X1, X2, etc.
+    print "(A)", "Converting atom types"
+    call convertAtomTypesToSpecies(atomTypes, species, speciesNames, atomTypeNames)
 
-  print "(A)", 'Input tree in HSD format:'
-  call dumpHsd(input%hsdTree, output_unit)
+    call setChildValue(pGeo, "TypeNames", speciesNames)
+    coords(:,:) = 0.0_dp
+    call setChildValue(pGeo, "TypesAndCoordinates", reshape(species, [1, size(species)]), coords)
+    call setChild(pRoot, "Hamiltonian", pHam)
+    call setChild(pHam, "Dftb", pDftb)
+    call setChildValue(pDftb, "Scc", .true.)
+    call setChildValue(pDftb, "SccTolerance", 1e-12_dp)
+    call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
 
-  ! convert input into settings for the DFTB+ calculator
-  call dftbp%setupCalculator(input)
+    ! read angular momenta from SK data
+    call setChildValue(pMaxAng, speciesNames(1),&
+        & maxAngNames(getMaxAngFromSlakoFile(slakoFiles(1, 1)) + 1))
+    call setChildValue(pMaxAng, speciesNames(2),&
+        & maxAngNames(getMaxAngFromSlakoFile(slakoFiles(2, 2)) + 1))
 
-  ! replace QM atom coordinates
-  coords(:,:) = initialCoords
-  call dftbp%setGeometry(coords)
+    ! set up locations for SK file data
+    call setChild(pDftb, "SlaterKosterFiles", pSlakos)
+    call setChildValue(pSlakos, "O-O", trim(slakoFiles(1, 1)))
+    call setChildValue(pSlakos, "H-O", trim(slakoFiles(2, 1)))
+    call setChildValue(pSlakos, "O-H", trim(slakoFiles(1, 2)))
+    call setChildValue(pSlakos, "H-H", trim(slakoFiles(2, 2)))
+    call setChild(pRoot, "Analysis", pAnalysis)
+    call setChildValue(pAnalysis, "CalculateForces", .true.)
+    call setChild(pAnalysis, "CM5", pCm5)
+    call setChild(pRoot, "ParserOptions", pParserOpts)
+    call setChildValue(pParserOpts, "ParserVersion", 13)
 
-  ! get energy, charges and forces
-  call dftbp%getEnergy(merminEnergy)
-  call dftbp%getGradients(gradients)
-  call dftbp%getGrossCharges(atomCharges)
-  call dftbp%getCM5Charges(cm5Charges)
-  call dftbp%getAtomicMasses(atomMasses)
+    print "(A)", 'Input tree in HSD format:'
+    call dumpHsd(input%hsdTree, output_unit)
 
-  print "(A)", "Neutral system"
-  print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
-  print "(A,3F15.10)", 'Obtained total charge:', sum(atomCharges)
-  print "(A,3F15.10)", 'Obtained individual gross charges:', atomCharges
-  print "(A,3F15.10)", 'Obtained CM5 charges:', cm5Charges
-  print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
-  print "(A,3F15.10)", 'Obtained gradient of atom 2:', gradients(:,2)
-  print "(A,3F15.10)", 'Obtained gradient of atom 3:', gradients(:,3)
+    ! convert input into settings for the DFTB+ calculator
+    call dftbp%setupCalculator(input)
+    call TDftbPlusInput_destruct(input)
 
-  call dftbp%getRefCharges(q0)
-  print "(A)", "Original reference atomic charges"
-  do ii = 1, 3
-    print "(I2,F8.4)", ii, q0(ii)
-  end do
+    ! replace QM atom coordinates
+    coords(:,:) = initialCoords
+    call dftbp%setGeometry(coords)
 
-  print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
+    ! get energy, charges and forces
+    call dftbp%getEnergy(merminEnergy)
+    call dftbp%getGradients(gradients)
+    call dftbp%getGrossCharges(atomCharges)
+    call dftbp%getCM5Charges(cm5Charges)
+    call dftbp%getAtomicMasses(atomMasses)
 
-  q0(1) = q0(1) + 0.5_dp
-  call dftbp%setRefCharges(q0)
+    print "(A)", "Neutral system"
+    print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
+    print "(A,3F15.10)", 'Obtained total charge:', sum(atomCharges)
+    print "(A,3F15.10)", 'Obtained individual gross charges:', atomCharges
+    print "(A,3F15.10)", 'Obtained CM5 charges:', cm5Charges
+    print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
+    print "(A,3F15.10)", 'Obtained gradient of atom 2:', gradients(:,2)
+    print "(A,3F15.10)", 'Obtained gradient of atom 3:', gradients(:,3)
 
-  call dftbp%getRefCharges(q0)
-  print "(A)", "New reference charges"
-  do ii = 1, 3
-    print "(I2,F8.4)", ii, q0(ii)
-  end do
+    call dftbp%getRefCharges(q0)
+    print "(A)", "Original reference atomic charges"
+    do ii = 1, 3
+      print "(I2,F8.4)", ii, q0(ii)
+    end do
 
-  ! get energy, charges and forces
-  call dftbp%getEnergy(merminEnergy)
-  call dftbp%getGradients(gradients)
-  call dftbp%getGrossCharges(atomCharges)
-  call dftbp%getCM5Charges(cm5Charges)
-  call dftbp%getAtomicMasses(atomMasses)
+    print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
 
-  print "(A)", "Neutral system"
-  print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
-  print "(A,3F15.10)", 'Obtained total charge:', sum(atomCharges)
-  print "(A,3F15.10)", 'Obtained individual gross charges:', atomCharges
-  print "(A,3F15.10)", 'Obtained CM5 charges:', cm5Charges
-  print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
-  print "(A,3F15.10)", 'Obtained gradient of atom 2:', gradients(:,2)
-  print "(A,3F15.10)", 'Obtained gradient of atom 3:', gradients(:,3)
+    q0(1) = q0(1) + 0.5_dp
+    call dftbp%setRefCharges(q0)
 
-  ! clean up
-  call TDftbPlus_destruct(dftbp)
+    call dftbp%getRefCharges(q0)
+    print "(A)", "New reference charges"
+    do ii = 1, 3
+      print "(I2,F8.4)", ii, q0(ii)
+    end do
 
-  ! Write file for internal test system
-  call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=atomCharges,&
-      & atomMasses=atomMasses, cm5Charges=cm5Charges)
+    ! get energy, charges and forces
+    call dftbp%getEnergy(merminEnergy)
+    call dftbp%getGradients(gradients)
+    call dftbp%getGrossCharges(atomCharges)
+    call dftbp%getCM5Charges(cm5Charges)
+    call dftbp%getAtomicMasses(atomMasses)
+
+    print "(A)", "Neutral system"
+    print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
+    print "(A,3F15.10)", 'Obtained total charge:', sum(atomCharges)
+    print "(A,3F15.10)", 'Obtained individual gross charges:', atomCharges
+    print "(A,3F15.10)", 'Obtained CM5 charges:', cm5Charges
+    print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
+    print "(A,3F15.10)", 'Obtained gradient of atom 2:', gradients(:,2)
+    print "(A,3F15.10)", 'Obtained gradient of atom 3:', gradients(:,3)
+
+    ! clean up
+    call TDftbPlus_destruct(dftbp)
+
+    ! Write file for internal test system
+    call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=atomCharges,&
+        & atomMasses=atomMasses, cm5Charges=cm5Charges)
+
+  end subroutine main_
 
 end program test_intcharges

--- a/test/src/dftbp/api/mm/testers/test_mpic.c
+++ b/test/src/dftbp/api/mm/testers/test_mpic.c
@@ -51,6 +51,7 @@ int main(int argc, char** argv) {
   DftbPlusInput input;
   dftbp_get_input_from_file(&calculator, "dftb_in.hsd", &input);
   dftbp_process_input(&calculator, &input);
+  dftbp_input_final(&input);
 
   // Evaluate energy and forces
   double mermin_energy;

--- a/test/src/dftbp/api/mm/testers/test_mpisubgrids.f90
+++ b/test/src/dftbp/api/mm/testers/test_mpisubgrids.f90
@@ -52,7 +52,7 @@ contains
   !! Main test routine
   !!
   !! All non-constant variables must be defined here to ensure that they are all explicitely
-  !! deallocated before the program finishes.
+  !! deallocated before the program finishes  (avoiding residual memory).
   !!
   subroutine main_()
 
@@ -65,7 +65,6 @@ contains
     integer :: providedThreading, iErr, myId, myGroup, nProc
     integer :: iRepeat, nAtom
 
-    !type(mpi_comm) :: groupComm
     integer :: groupComm
     integer :: nGroup, myIdGroup, nProcGroup
 

--- a/test/src/dftbp/api/mm/testers/test_mpisubgrids.f90
+++ b/test/src/dftbp/api/mm/testers/test_mpisubgrids.f90
@@ -16,7 +16,7 @@ program test_mpisubgrids
       !, only : MPI_COMM_WORLD, MPI_THREAD_FUNNELED, MPI_REAL8, MPI_SUM, mpi_comm,&
       !& mpi_init_thread, mpi_comm_rank, mpi_comm_size, mpi_comm_split, mpi_ireduce, mpi_barrier,&
       !& mpi_comm_free, mpi_finalize
-  use dftbplus, only : TDftbPlusInput, TDftbPlus, TDftbPlus_init, TDftbPlus_destruct
+  use dftbplus, only : TDftbPlusInput, TDftbPlus, TDftbPlus_init
   use dftbp_common_constants, only : AA__Bohr   ! Imported to ensure accurate conversion
   use testhelpers, only : writeAutotestTag   ! Only needed for the internal test system
   use, intrinsic :: iso_fortran_env, only : real64
@@ -44,112 +44,131 @@ program test_mpisubgrids
 
   integer, parameter :: groupSize = 4
 
-  type(TDftbPlus) :: dftbp
-  type(TDftbPlusInput) :: input
+  call main_()
 
-  real(dp) :: merminEnergy, totalMerminEnergy, reducedMerminEnergy
-  real(dp) :: gradients(3, 3), totalGradients(3, 3), reducedGradients(3, 3)
-  integer :: devNull
-  integer :: providedThreading, iErr, myId, myGroup, nProc
-  integer :: iRepeat, nAtom
+contains
 
-  !type(mpi_comm) :: groupComm
-  integer :: groupComm
-  integer :: nGroup, myIdGroup, nProcGroup
 
-  logical :: doSi2
+  !! Main test routine
+  !!
+  !! All non-constant variables must be defined here to ensure that they are all explicitely
+  !! deallocated before the program finishes.
+  !!
+  subroutine main_()
 
-  open(newunit=devNull, file="/dev/null", action="write")
+    type(TDftbPlus), allocatable :: dftbp
+    type(TDftbPlusInput), allocatable :: input
 
-  call mpi_init_thread(requiredThreading, providedThreading, iErr)
-  call mpi_comm_rank(MPI_COMM_WORLD, myId, iErr)
-  call mpi_comm_size(MPI_COMM_WORLD, nProc, iErr)
+    real(dp) :: merminEnergy, totalMerminEnergy, reducedMerminEnergy
+    real(dp) :: gradients(3, 3), totalGradients(3, 3), reducedGradients(3, 3)
+    integer :: devNull
+    integer :: providedThreading, iErr, myId, myGroup, nProc
+    integer :: iRepeat, nAtom
 
-  if (modulo(nProc, groupSize) /= 0) then
-    error stop "Number of processors must be a multiple of the groupSize"
-  end if
+    !type(mpi_comm) :: groupComm
+    integer :: groupComm
+    integer :: nGroup, myIdGroup, nProcGroup
 
-  nGroup = nProc / groupSize
-  if (myId == 0) then
-    print "('Creating ', I0, ' group(s)')", nGroup
-  end if
+    logical :: doSi2
 
-  ! Processes are assigned to group in round-Robin fashion
-  myGroup = modulo(myId, nGroup)
-  call mpi_comm_split(MPI_COMM_WORLD, modulo(myId, nGroup), myId / nGroup, groupComm, iErr)
-  call mpi_comm_rank(groupComm, myIdGroup, iErr)
-  call mpi_comm_size(groupComm, nProcGroup, iErr)
+    open(newunit=devNull, file="/dev/null", action="write")
 
-  print "('ID: ', I2.2, ' | Group: ', I2.2, ' | ID in group: ', I2.2, ' (of ', I2.2, ')')",&
-      & myId, myGroup, myIdGroup, nProcGroup
+    call mpi_init_thread(requiredThreading, providedThreading, iErr)
+    call mpi_comm_rank(MPI_COMM_WORLD, myId, iErr)
+    call mpi_comm_size(MPI_COMM_WORLD, nProc, iErr)
 
-  totalMerminEnergy = 0.0_dp
-  totalGradients(:,:) = 0.0_dp
+    if (modulo(nProc, groupSize) /= 0) then
+      error stop "Number of processors must be a multiple of the groupSize"
+    end if
 
-  repeat: do iRepeat = 1, nRepeat
+    nGroup = nProc / groupSize
+    if (myId == 0) then
+      print "('Creating ', I0, ' group(s)')", nGroup
+    end if
+
+    ! Processes are assigned to group in round-Robin fashion
+    myGroup = modulo(myId, nGroup)
+    call mpi_comm_split(MPI_COMM_WORLD, modulo(myId, nGroup), myId / nGroup, groupComm, iErr)
+    call mpi_comm_rank(groupComm, myIdGroup, iErr)
+    call mpi_comm_size(groupComm, nProcGroup, iErr)
+
+    print "('ID: ', I2.2, ' | Group: ', I2.2, ' | ID in group: ', I2.2, ' (of ', I2.2, ')')",&
+        & myId, myGroup, myIdGroup, nProcGroup
+
+    totalMerminEnergy = 0.0_dp
+    totalGradients(:,:) = 0.0_dp
+
+    repeat: do iRepeat = 1, nRepeat
+
+      allocate(dftbp)
+      allocate(input)
+
+      if (myId == 0) then
+        print "('*** Cycle ', I0)", iRepeat
+      end if
+
+      doSi2 = modulo(iRepeat + myGroup, 2) == 0
+      if (doSi2) then
+        nAtom = 2
+      else
+        nAtom =3
+      end if
+
+      call TDftbPlus_init(dftbp, mpiComm=groupComm, devNull=devNull)
+      !call TDftbPlus_init(dftbp, outputUnit=devNull, mpiComm=groupComm, devNull=devNull)
+
+      if (doSi2) then
+        call dftbp%getInputFromFile("dftb_in.Si2.hsd", input)
+      else
+        call dftbp%getInputFromFile("dftb_in.H2O.hsd", input)
+      end if
+
+      call dftbp%setupCalculator(input)
+
+      if (doSi2) then
+        call dftbp%setGeometry(coordsSi2, latVecsSi2)
+      else
+        call dftbp%setGeometry(coordsH2O)
+      end if
+
+      call dftbp%getEnergy(merminEnergy)
+      totalMerminEnergy = totalMerminEnergy + merminEnergy
+      print "('[', I2.2, '|', I2.2, '] (', I3.3, ') Obtained Mermin Energy:', F15.10)", myGroup,&
+          & myIdGroup, iRepeat, merminEnergy
+
+      call dftbp%getGradients(gradients(:, :nAtom))
+      totalGradients(:, :nAtom) = totalGradients(:, :nAtom) + gradients(:, :nAtom)
+      print "('[', I2.2, '|', I2.2, '] (', I3.3, ') Obtained gradient of atom 1:', 3F15.10)",&
+          & myGroup, myIdGroup, iRepeat, gradients(:, 1)
+
+      ! Deallocating instances to trigger finalizers
+      deallocate(dftbp)
+      deallocate(input)
+
+    end do repeat
+
+    call mpi_reduce(totalMerminEnergy, reducedMerminEnergy, 1, MPI_REAL8, MPI_SUM, 0,&
+        & MPI_COMM_WORLD, iErr)
+    call mpi_reduce(totalGradients, reducedGradients, size(totalGradients), MPI_REAL8, MPI_SUM, 0,&
+        & MPI_COMM_WORLD, iErr)
 
     if (myId == 0) then
-      print "('*** Cycle ', I0)", iRepeat
+      reducedMerminEnergy = reducedMerminEnergy / real(nProc * nRepeat, dp)
+      reducedGradients(:,:) = reducedGradients / real(nProc * nRepeat, dp)
+      print *, "REDUCED MERMIN:"
+      print *, reducedMerminEnergy
+      print *, "REDUCED GRAD:"
+      print *, reducedGradients
+
+      ! Write file for internal test system
+      call writeAutotestTag(merminEnergy=reducedMerminEnergy, gradients=reducedGradients)
     end if
 
-    doSi2 = modulo(iRepeat + myGroup, 2) == 0
-    if (doSi2) then
-      nAtom = 2
-    else
-      nAtom =3
-    end if
+    call mpi_barrier(MPI_COMM_WORLD, iErr)
+    call mpi_comm_free(groupComm, iErr)
+    call mpi_finalize(iErr)
 
-    call TDftbPlus_init(dftbp, mpiComm=groupComm, devNull=devNull)
-    !call TDftbPlus_init(dftbp, outputUnit=devNull, mpiComm=groupComm, devNull=devNull)
-
-    if (doSi2) then
-      call dftbp%getInputFromFile("dftb_in.Si2.hsd", input)
-    else
-      call dftbp%getInputFromFile("dftb_in.H2O.hsd", input)
-    end if
-
-    call dftbp%setupCalculator(input)
-
-    if (doSi2) then
-      call dftbp%setGeometry(coordsSi2, latVecsSi2)
-    else
-      call dftbp%setGeometry(coordsH2O)
-    end if
-
-    call dftbp%getEnergy(merminEnergy)
-    totalMerminEnergy = totalMerminEnergy + merminEnergy
-    print "('[', I2.2, '|', I2.2, '] (', I3.3, ') Obtained Mermin Energy:', F15.10)", myGroup,&
-        & myIdGroup, iRepeat, merminEnergy
-
-    call dftbp%getGradients(gradients(:, :nAtom))
-    totalGradients(:, :nAtom) = totalGradients(:, :nAtom) + gradients(:, :nAtom)
-    print "('[', I2.2, '|', I2.2, '] (', I3.3, ') Obtained gradient of atom 1:', 3F15.10)",&
-        & myGroup, myIdGroup, iRepeat, gradients(:, 1)
-    call TDftbPlus_destruct(dftbp)
-
-  end do repeat
-
-  call mpi_reduce(totalMerminEnergy, reducedMerminEnergy, 1, MPI_REAL8, MPI_SUM, 0,&
-      & MPI_COMM_WORLD, iErr)
-  call mpi_reduce(totalGradients, reducedGradients, size(totalGradients), MPI_REAL8, MPI_SUM, 0,&
-      & MPI_COMM_WORLD, iErr)
-
-  if (myId == 0) then
-    reducedMerminEnergy = reducedMerminEnergy / real(nProc * nRepeat, dp)
-    reducedGradients(:,:) = reducedGradients / real(nProc * nRepeat, dp)
-    print *, "REDUCED MERMIN:"
-    print *, reducedMerminEnergy
-    print *, "REDUCED GRAD:"
-    print *, reducedGradients
-
-    ! Write file for internal test system
-    call writeAutotestTag(merminEnergy=reducedMerminEnergy, gradients=reducedGradients)
-  end if
-
-  call mpi_barrier(MPI_COMM_WORLD, iErr)
-  call mpi_comm_free(groupComm, iErr)
-  call mpi_finalize(iErr)
-
+  end subroutine main_
 
 end program test_mpisubgrids
 

--- a/test/src/dftbp/api/mm/testers/test_neighbour_list.f90
+++ b/test/src/dftbp/api/mm/testers/test_neighbour_list.f90
@@ -47,7 +47,6 @@ contains
 
     call dftbp%getInputFromFile("dftb_in.hsd", input)
     call dftbp%setupCalculator(input)
-    call TDftbPlusInput_destruct(input)
 
     ! setup all data for the neighbour list
     cutoff = 6.0_dp
@@ -66,9 +65,6 @@ contains
     ! evaluate energy and forces
     call dftbp%getEnergy(merminEnergy)
     call dftbp%getGradients(gradients)
-
-    ! clean up
-    call TDftbPlus_destruct(dftbp)
 
     ! Write file for internal test system
     call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients)

--- a/test/src/dftbp/api/mm/testers/test_neighbour_list.f90
+++ b/test/src/dftbp/api/mm/testers/test_neighbour_list.f90
@@ -23,7 +23,7 @@ contains
   !! Main test routine
   !!
   !! All non-constant variables must be defined here to ensure that they are all explicitely
-  !! deallocated before the program finishes.
+  !! deallocated before the program finishes  (avoiding residual memory that tools like valgrind notice).
   !!
   subroutine main_()
 

--- a/test/src/dftbp/api/mm/testers/test_neighbour_list.f90
+++ b/test/src/dftbp/api/mm/testers/test_neighbour_list.f90
@@ -15,49 +15,64 @@ program test_neighbour_list
   ! double precision real
   integer, parameter :: dp = kind(1.0d0)
 
-  type(TDftbPlus) :: dftbp
-  type(TDftbPlusInput) :: input
+  call main_()
 
-  real(dp) :: merminEnergy, cutoff, x, dist
-  real(dp) :: gradients(3, 2)
-  real(dp) :: coord(3, 4), neighDist(4, 2)
-  integer :: img2CentCell(4), nNeighbour(2), iNeighbour(4, 2)
+contains
 
-  character(:), allocatable :: DftbVersion
-  integer :: major, minor, patch
 
-  call getDftbPlusBuild(DftbVersion)
-  write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
-  call getDftbPlusApi(major, minor, patch)
-  write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
+  !! Main test routine
+  !!
+  !! All non-constant variables must be defined here to ensure that they are all explicitely
+  !! deallocated before the program finishes.
+  !!
+  subroutine main_()
 
-  call TDftbPlus_init(dftbp)
+    type(TDftbPlus) :: dftbp
+    type(TDftbPlusInput) :: input
 
-  call dftbp%getInputFromFile("dftb_in.hsd", input)
-  call dftbp%setupCalculator(input)
+    real(dp) :: merminEnergy, cutoff, x, dist
+    real(dp) :: gradients(3, 2)
+    real(dp) :: coord(3, 4), neighDist(4, 2)
+    integer :: img2CentCell(4), nNeighbour(2), iNeighbour(4, 2)
 
-  ! setup all data for the neighbour list
-  cutoff = 6.0_dp
-  x = 2.5639291987021915_dp
-  coord(:,:) = reshape([-x, -x, x, x, -x, -x, -x, x, -x, x, x, x], shape(coord))
-  img2CentCell(:) = [2, 2, 2, 2]
-  nNeighbour(:) = [4, 0]
-  iNeighbour(:,:) = reshape([1, 2, 3, 4, 0, 0, 0, 0], shape(iNeighbour))
-  dist = sqrt(19.721198807872987_dp)
-  neighDist(:,:) = reshape([dist, dist, dist, dist, 0.0_dp, 0.0_dp, 0.0_dp, 0.0_dp],&
-      & shape(neighDist))
+    character(:), allocatable :: DftbVersion
+    integer :: major, minor, patch
 
-  ! set the neighbour list
-  call dftbp%setNeighbourList(nNeighbour, iNeighbour, neighDist, cutoff, coord, img2CentCell)
+    call getDftbPlusBuild(DftbVersion)
+    write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
+    call getDftbPlusApi(major, minor, patch)
+    write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
 
-  ! evaluate energy and forces
-  call dftbp%getEnergy(merminEnergy)
-  call dftbp%getGradients(gradients)
+    call TDftbPlus_init(dftbp)
 
-  ! clean up
-  call TDftbPlus_destruct(dftbp)
+    call dftbp%getInputFromFile("dftb_in.hsd", input)
+    call dftbp%setupCalculator(input)
+    call TDftbPlusInput_destruct(input)
 
-  ! Write file for internal test system
-  call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients)
+    ! setup all data for the neighbour list
+    cutoff = 6.0_dp
+    x = 2.5639291987021915_dp
+    coord(:,:) = reshape([-x, -x, x, x, -x, -x, -x, x, -x, x, x, x], shape(coord))
+    img2CentCell(:) = [2, 2, 2, 2]
+    nNeighbour(:) = [4, 0]
+    iNeighbour(:,:) = reshape([1, 2, 3, 4, 0, 0, 0, 0], shape(iNeighbour))
+    dist = sqrt(19.721198807872987_dp)
+    neighDist(:,:) = reshape([dist, dist, dist, dist, 0.0_dp, 0.0_dp, 0.0_dp, 0.0_dp],&
+        & shape(neighDist))
+
+    ! set the neighbour list
+    call dftbp%setNeighbourList(nNeighbour, iNeighbour, neighDist, cutoff, coord, img2CentCell)
+
+    ! evaluate energy and forces
+    call dftbp%getEnergy(merminEnergy)
+    call dftbp%getGradients(gradients)
+
+    ! clean up
+    call TDftbPlus_destruct(dftbp)
+
+    ! Write file for internal test system
+    call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients)
+
+  end subroutine main_
 
 end program test_neighbour_list

--- a/test/src/dftbp/api/mm/testers/test_neighbour_list_c.c
+++ b/test/src/dftbp/api/mm/testers/test_neighbour_list_c.c
@@ -27,6 +27,7 @@ int main()
 
   dftbp_get_input_from_file(&calculator, "dftb_in.hsd", &input);
   dftbp_process_input(&calculator, &input);
+  dftbp_input_final(&input);
 
   // setup all data for the neighbour list
   double cutoff = 6.0;

--- a/test/src/dftbp/api/mm/testers/test_qdepextpot.f90
+++ b/test/src/dftbp/api/mm/testers/test_qdepextpot.f90
@@ -44,7 +44,7 @@ contains
   !! Main test routine
   !!
   !! All non-constant variables must be defined here to ensure that they are all explicitely
-  !! deallocated before the program finishes.
+  !! deallocated before the program finishes (avoiding residual memory that tools like valgrind notice).
   !!
   subroutine main_()
 

--- a/test/src/dftbp/api/mm/testers/test_qdepextpot.f90
+++ b/test/src/dftbp/api/mm/testers/test_qdepextpot.f90
@@ -36,62 +36,76 @@ program test_qdepextpot
 
   real(dp), parameter :: extCharges(nExtCharge) = [2.5_dp, -1.9_dp]
 
+  call main_()
 
-  type(TDftbPlus) :: dftbp
-  type(TDftbPlusInput) :: input
-  type(TExtChargePotGen) :: potGen
+contains
 
-  real(dp), allocatable :: extPot(:), extPotGrad(:,:)
-  real(dp) :: merminEnergy
-  real(dp) :: gradients(3, nQmAtom), grossCharges(nQmAtom)
 
-  character(:), allocatable :: DftbVersion
-  integer :: major, minor, patch
+  !! Main test routine
+  !!
+  !! All non-constant variables must be defined here to ensure that they are all explicitely
+  !! deallocated before the program finishes.
+  !!
+  subroutine main_()
 
-  !integer :: devNull
+    type(TDftbPlus) :: dftbp
+    type(TDftbPlusInput) :: input
+    type(TExtChargePotGen) :: potGen
 
-  call getDftbPlusBuild(DftbVersion)
-  write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
-  call getDftbPlusApi(major, minor, patch)
-  write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
+    real(dp), allocatable :: extPot(:), extPotGrad(:,:)
+    real(dp) :: merminEnergy
+    real(dp) :: gradients(3, nQmAtom), grossCharges(nQmAtom)
 
-  ! Pass the 1st external charge to dynamic potential generator from the extchargepotgen module,
-  ! while the 2nd charge will be set as constant electrostatic potential
-  call TExtChargePotGen_init(potGen, coords, extChargeCoords(:,1:1), extCharges(1:1))
+    character(:), allocatable :: DftbVersion
+    integer :: major, minor, patch
 
-  ! Note: setting the global standard output to /dev/null will also suppress run-time error messages
-  !open(newunit=devNull, file="/dev/null", action="write")
-  !call TDftbPlus_init(dftbp, outputUnit=devNull)
+    !integer :: devNull
 
-  ! initialise a calculation then read input from file
-  call TDftbPlus_init(dftbp)
-  call dftbp%getInputFromFile("dftb_in.hsd", input)
-  call dftbp%setupCalculator(input)
+    call getDftbPlusBuild(DftbVersion)
+    write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
+    call getDftbPlusApi(major, minor, patch)
+    write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
 
-  ! set up the above external potential generator for this calculation
-  call dftbp%setQDepExtPotGen(potGen)
+    ! Pass the 1st external charge to dynamic potential generator from the extchargepotgen module,
+    ! while the 2nd charge will be set as constant electrostatic potential
+    call TExtChargePotGen_init(potGen, coords, extChargeCoords(:,1:1), extCharges(1:1))
 
-  ! add an extra fixed external charge
-  allocate(extPot(nQmAtom))
-  allocate(extPotGrad(3, nQmAtom))
-  call getPointChargePotential(extChargeCoords(:,2:2), extCharges(2:2), coords, extPot, extPotGrad)
-  call dftbp%setExternalPotential(extPot, extPotGrad)
+    ! Note: setting the global standard output to /dev/null will also suppress run-time error messages
+    !open(newunit=devNull, file="/dev/null", action="write")
+    !call TDftbPlus_init(dftbp, outputUnit=devNull)
 
-  ! set the geometry from this program, replacing the dftb_in.hsd values
-  call dftbp%setGeometry(coords)
+    ! initialise a calculation then read input from file
+    call TDftbPlus_init(dftbp)
+    call dftbp%getInputFromFile("dftb_in.hsd", input)
+    call dftbp%setupCalculator(input)
+    call TDftbPlusInput_destruct(input)
 
-  ! obtain energy and forces
-  call dftbp%getEnergy(merminEnergy)
-  call dftbp%getGradients(gradients)
-  call dftbp%getGrossCharges(grossCharges)
-  print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
-  print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
-  print "(A,3F15.10)", 'Obtained gross charges:', grossCharges
+    ! set up the above external potential generator for this calculation
+    call dftbp%setQDepExtPotGen(potGen)
 
-  ! clean up
-  call TDftbPlus_destruct(dftbp)
+    ! add an extra fixed external charge
+    allocate(extPot(nQmAtom))
+    allocate(extPotGrad(3, nQmAtom))
+    call getPointChargePotential(extChargeCoords(:,2:2), extCharges(2:2), coords, extPot, extPotGrad)
+    call dftbp%setExternalPotential(extPot, extPotGrad)
 
-  ! Write file for internal test system
-  call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=grossCharges)
+    ! set the geometry from this program, replacing the dftb_in.hsd values
+    call dftbp%setGeometry(coords)
+
+    ! obtain energy and forces
+    call dftbp%getEnergy(merminEnergy)
+    call dftbp%getGradients(gradients)
+    call dftbp%getGrossCharges(grossCharges)
+    print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
+    print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
+    print "(A,3F15.10)", 'Obtained gross charges:', grossCharges
+
+    ! clean up
+    call TDftbPlus_destruct(dftbp)
+
+    ! Write file for internal test system
+    call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=grossCharges)
+
+  end subroutine main_
 
 end program test_qdepextpot

--- a/test/src/dftbp/api/mm/testers/test_qdepextpot.f90
+++ b/test/src/dftbp/api/mm/testers/test_qdepextpot.f90
@@ -78,7 +78,6 @@ contains
     call TDftbPlus_init(dftbp)
     call dftbp%getInputFromFile("dftb_in.hsd", input)
     call dftbp%setupCalculator(input)
-    call TDftbPlusInput_destruct(input)
 
     ! set up the above external potential generator for this calculation
     call dftbp%setQDepExtPotGen(potGen)
@@ -99,9 +98,6 @@ contains
     print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
     print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
     print "(A,3F15.10)", 'Obtained gross charges:', grossCharges
-
-    ! clean up
-    call TDftbPlus_destruct(dftbp)
 
     ! Write file for internal test system
     call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, grossCharges=grossCharges)

--- a/test/src/dftbp/api/mm/testers/test_qdepextpotc.c
+++ b/test/src/dftbp/api/mm/testers/test_qdepextpotc.c
@@ -225,6 +225,7 @@ int main()
 
   /* Set up the calculator by processing the input tree */
   dftbp_process_input(&calculator, &input);
+  dftbp_input_final(&input);
 
   /* Register the callback functions calculating population dependent external potential */
   dftbp_register_ext_pot_generator(&calculator, &cont, get_external_potential,

--- a/test/src/dftbp/api/mm/testers/test_setspeciesanddependents.F90
+++ b/test/src/dftbp/api/mm/testers/test_setspeciesanddependents.F90
@@ -30,8 +30,7 @@ program test_setSpeciesAndDependents
 #:if WITH_MPI
   use mpi
 #:endif
-  use dftbp_mmapi, only: TDftbPlus_init, TDftbPlus_destruct, TDftbPlus, TDftbPlusInput,&
-      & TDftbPlusInput_destruct
+  use dftbp_mmapi, only: TDftbPlus_init, TDftbPlus, TDftbPlusInput
   use dftbp_hsdapi, only: fnode, getChild, getChildren, setChild, getChildValue, setChildValue
   use dftbp_hsdapi, only: dumpHsd
   use testhelpers, only: writeAutotestTag
@@ -161,7 +160,6 @@ contains
         ! Dump hsd tree to file "fort.1" if debugging
         ! call dumpHsd(hsd_tree%hsdTree, 001)
         call dftb%setupCalculator(hsd_tree)
-        call TDftbPlusInput_destruct(hsd_tree)
       endif
 
       ! Update coordinates and lattice vectors
@@ -192,9 +190,6 @@ contains
       ! call output_forces_per_process(gradients, imd_lab)
 
     enddo
-
-    ! Clean up
-    call TDftbPlus_destruct(dftb)
 
     ! Write file for internal test system, using the last structure that was run
     call writeAutotestTag(merminEnergy=merminEnergy, cutOff=cutOff, gradients=gradients, stressTensor=stressTensor,&

--- a/test/src/dftbp/api/mm/testers/test_setspeciesanddependents.F90
+++ b/test/src/dftbp/api/mm/testers/test_setspeciesanddependents.F90
@@ -30,7 +30,8 @@ program test_setSpeciesAndDependents
 #:if WITH_MPI
   use mpi
 #:endif
-  use dftbp_mmapi, only: TDftbPlus_init, TDftbPlus_destruct, TDftbPlus, TDftbPlusInput
+  use dftbp_mmapi, only: TDftbPlus_init, TDftbPlus_destruct, TDftbPlus, TDftbPlusInput,&
+      & TDftbPlusInput_destruct
   use dftbp_hsdapi, only: fnode, getChild, getChildren, setChild, getChildValue, setChildValue
   use dftbp_hsdapi, only: dumpHsd
   use testhelpers, only: writeAutotestTag
@@ -40,11 +41,6 @@ program test_setSpeciesAndDependents
   integer, parameter :: dp = REAL64
   real(dp), parameter :: Bohr__AA = 0.529177249_dp
   real(dp), parameter :: AA__Bohr = 1.0_dp / Bohr__AA
-
-  !> DFTB Objects
-  type(TDftbPlus) :: dftb
-  type(TDftbPlusInput) :: hsd_tree
-  character(*), parameter :: dftb_fname = 'dftb_in.hsd'
 
   !> Type for containing geometrical information
   !> One can write your own type, rather than copy DTFB+
@@ -67,123 +63,149 @@ program test_setSpeciesAndDependents
     integer :: final_step
   end type MDstatus_type
 
-#:if WITH_MPI
-  !> MPI variables
-  integer, parameter :: requiredThreading = MPI_THREAD_FUNNELED
-  integer :: providedThreading, rank, np, ierr
-  integer, parameter :: lead_id = 0
-  logical :: IO
-#:else
-  !> Dummy variables for serial code
-  integer, parameter :: MPI_COMM_WORLD = 0
-  integer, parameter :: lead_id = 0
-  logical :: IO = .true.
-#:endif
+  character(*), parameter :: dftb_fname = 'dftb_in.hsd'
 
-  ! Local
-  integer, parameter :: nSteps = 2
-  integer :: nAtoms
-
-  type(MDstatus_type):: MDstatus
-  type(TGeometry) :: geo
-  integer :: imd
-  real(dp) :: merminEnergy, cutOff
-  character(100) :: imd_lab
-  character(100) :: fname
-  real(dp), allocatable :: gradients(:,:), stressTensor(:,:), grossCharges(:)
-
-#:if WITH_MPI
-  ! Initialise MPI environment
-  call mpi_init_thread(requiredThreading, providedThreading, ierr)
-  call mpi_comm_rank(MPI_COMM_WORLD, rank, ierr)
-  call mpi_comm_size(MPI_COMM_WORLD, np, ierr)
-  IO = (rank == lead_id)
-#:endif
-
-  nAtoms = get_number_of_atoms('structure_1.gen')
-  MDstatus = MDstatus_type(1, nSteps) ! initialise type
-  allocate(gradients(3,nAtoms))
-  allocate(grossCharges(nAtoms))
-
-  do imd = MDstatus%initial_step, MDstatus%final_step
-
-    if(IO) then
-      write(*,*) 'MD step ', imd, 'of ', MDstatus%final_step
-    end if
-
-    ! For every step, read in atomic positions from file
-    ! Equivalent to obtaining data externally, e.g. from an MD package
-    write(imd_lab, '(I0)') imd
-    fname = 'structure_'//trim(imd_lab)//'.gen'
-    call read_in_geo(trim(fname), geo)
   #:if WITH_MPI
-    call broadcast_geometry(MPI_COMM_WORLD, geo)
+    ! MPI variables
+    integer, parameter :: requiredThreading = MPI_THREAD_FUNNELED
+    integer, parameter :: lead_id = 0
+  #:else
+    ! Dummy variables for serial code
+    integer, parameter :: MPI_COMM_WORLD = 0
+    integer, parameter :: lead_id = 0
   #:endif
 
-    if (geo%nAtom /= nAtoms) then
-      write(*,*) 'Error: Number of atoms not conserved between MD steps'
-    #:if WITH_MPI
-      call mpi_abort(MPI_COMM_WORLD, 0, ierr)
-    #:else
-      stop
-    #:endif
-    endif
-
-    if(imd == MDstatus%initial_step) then
-    #:if WITH_MPI
-      call TDftbPlus_init(dftb, output_unit, MPI_COMM_WORLD)
-    #:else
-      call TDftbPlus_init(dftb, output_unit)
-    #:endif
-
-      call initialise_dftbplus_tree(geo, dftb, hsd_tree)
-
-      ! Dump hsd tree to file "fort.1" if debugging
-      ! call dumpHsd(hsd_tree%hsdTree, 001)
-      call dftb%setupCalculator(hsd_tree)
-    endif
-
-    ! Update coordinates and lattice vectors
-    call dftb%setGeometry(geo%coords, geo%latVecs)
-
-    ! Update species order every step
-    call dftb%setSpeciesAndDependents(geo%speciesNames, geo%species)
-
-    ! get the cutoff
-    cutOff = dftb%getCutOff()
-
-    ! Do a total energy calculation
-    call dftb%getEnergy(merminEnergy)
-    call dftb%getGradients(gradients)
-    call dftb%getGrossCharges(grossCharges)
-
-    if (geo%tPeriodic) then
-      if (.not.allocated(stressTensor)) then
-        allocate(stressTensor(3,3))
-      end if
-      call dftb%getStressTensor(stressTensor)
-    else
-      if (allocated(stressTensor)) then
-        deallocate(stressTensor)
-      end if
-    end if
-
-    ! call output_forces_per_process(gradients, imd_lab)
-
-  enddo
-
-  ! Clean up
-  call TDftbPlus_destruct(dftb)
-
-  ! Write file for internal test system, using the last structure that was run
-  call writeAutotestTag(merminEnergy=merminEnergy, cutOff=cutOff, gradients=gradients, stressTensor=stressTensor,&
-      & grossCharges=grossCharges)
-
-#:if WITH_MPI
-  call mpi_finalize(ierr)
-#:endif
+  call main_()
 
 contains
+
+  !! Main test routine
+  !!
+  !! All non-constant variables must be defined here to ensure that they are all explicitely
+  !! deallocated before the program finishes.
+  !!
+  subroutine main_()
+
+    ! DFTB Objects
+    type(TDftbPlus) :: dftb
+    type(TDftbPlusInput) :: hsd_tree
+
+  #:if WITH_MPI
+    ! MPI variables
+    integer :: providedThreading, rank, np, ierr
+    logical :: IO
+  #:else
+    ! Dummy variables for serial code
+    logical :: IO
+  #:endif
+
+    integer, parameter :: nSteps = 2
+    integer :: nAtoms
+
+    type(MDstatus_type):: MDstatus
+    type(TGeometry) :: geo
+    integer :: imd
+    real(dp) :: merminEnergy, cutOff
+    character(100) :: imd_lab
+    character(100) :: fname
+    real(dp), allocatable :: gradients(:,:), stressTensor(:,:), grossCharges(:)
+
+  #:if WITH_MPI
+    ! Initialise MPI environment
+    call mpi_init_thread(requiredThreading, providedThreading, ierr)
+    call mpi_comm_rank(MPI_COMM_WORLD, rank, ierr)
+    call mpi_comm_size(MPI_COMM_WORLD, np, ierr)
+    IO = (rank == lead_id)
+  #:else
+    IO = .true.
+  #:endif
+
+    nAtoms = get_number_of_atoms(io, 'structure_1.gen')
+    MDstatus = MDstatus_type(1, nSteps) ! initialise type
+    allocate(gradients(3,nAtoms))
+    allocate(grossCharges(nAtoms))
+
+    do imd = MDstatus%initial_step, MDstatus%final_step
+
+      if(IO) then
+        write(*,*) 'MD step ', imd, 'of ', MDstatus%final_step
+      end if
+
+      ! For every step, read in atomic positions from file
+      ! Equivalent to obtaining data externally, e.g. from an MD package
+      write(imd_lab, '(I0)') imd
+      fname = 'structure_'//trim(imd_lab)//'.gen'
+      call read_in_geo(io, trim(fname), geo)
+    #:if WITH_MPI
+      call broadcast_geometry(MPI_COMM_WORLD, geo)
+    #:endif
+
+      if (geo%nAtom /= nAtoms) then
+        write(*,*) 'Error: Number of atoms not conserved between MD steps'
+      #:if WITH_MPI
+        call mpi_abort(MPI_COMM_WORLD, 0, ierr)
+      #:else
+        stop
+      #:endif
+      endif
+
+      if(imd == MDstatus%initial_step) then
+      #:if WITH_MPI
+        call TDftbPlus_init(dftb, output_unit, MPI_COMM_WORLD)
+      #:else
+        call TDftbPlus_init(dftb, output_unit)
+      #:endif
+
+        call initialise_dftbplus_tree(geo, dftb, hsd_tree)
+
+        ! Dump hsd tree to file "fort.1" if debugging
+        ! call dumpHsd(hsd_tree%hsdTree, 001)
+        call dftb%setupCalculator(hsd_tree)
+        call TDftbPlusInput_destruct(hsd_tree)
+      endif
+
+      ! Update coordinates and lattice vectors
+      call dftb%setGeometry(geo%coords, geo%latVecs)
+
+      ! Update species order every step
+      call dftb%setSpeciesAndDependents(geo%speciesNames, geo%species)
+
+      ! get the cutoff
+      cutOff = dftb%getCutOff()
+
+      ! Do a total energy calculation
+      call dftb%getEnergy(merminEnergy)
+      call dftb%getGradients(gradients)
+      call dftb%getGrossCharges(grossCharges)
+
+      if (geo%tPeriodic) then
+        if (.not.allocated(stressTensor)) then
+          allocate(stressTensor(3,3))
+        end if
+        call dftb%getStressTensor(stressTensor)
+      else
+        if (allocated(stressTensor)) then
+          deallocate(stressTensor)
+        end if
+      end if
+
+      ! call output_forces_per_process(gradients, imd_lab)
+
+    enddo
+
+    ! Clean up
+    call TDftbPlus_destruct(dftb)
+
+    ! Write file for internal test system, using the last structure that was run
+    call writeAutotestTag(merminEnergy=merminEnergy, cutOff=cutOff, gradients=gradients, stressTensor=stressTensor,&
+        & grossCharges=grossCharges)
+
+  #:if WITH_MPI
+    call mpi_finalize(ierr)
+  #:endif
+
+  end subroutine main_
+
 
   !--------------------------------------------
   ! Utility routines based on DL_POLY V4.10 API
@@ -307,8 +329,11 @@ contains
 
 
   !> Get number of atoms from DFTB+ geometry file
-  function get_number_of_atoms(fname, headerLines) result(nAtoms)
+  function get_number_of_atoms(io, fname, headerLines) result(nAtoms)
     implicit none
+
+    !> Whether current process is the io process
+    logical, intent(in) :: io
 
     !> File name to read
     character(*), intent(in) :: fname
@@ -347,8 +372,11 @@ contains
 
 
   !> Read DFTB+ geometry file (on lead_id processor and broadcast, if MPI parallel)
-  subroutine read_in_geo(fname, geo, headerLines)
+  subroutine read_in_geo(io, fname, geo, headerLines)
     implicit none
+
+    !> Whether current process is the io process
+    logical, intent(in) :: io
 
     !> Name of file to read
     character(*), intent(in) :: fname

--- a/test/src/dftbp/api/mm/testers/test_setspeciesanddependents.F90
+++ b/test/src/dftbp/api/mm/testers/test_setspeciesanddependents.F90
@@ -191,9 +191,11 @@ contains
 
     enddo
 
-    ! Write file for internal test system, using the last structure that was run
-    call writeAutotestTag(merminEnergy=merminEnergy, cutOff=cutOff, gradients=gradients, stressTensor=stressTensor,&
-        & grossCharges=grossCharges)
+    if (IO) then
+      ! Write file for internal test system, using the last structure that was run
+      call writeAutotestTag(merminEnergy=merminEnergy, cutOff=cutOff, gradients=gradients,&
+          & stressTensor=stressTensor, grossCharges=grossCharges)
+    end if
 
     ! Note: the TDftbPlus instance must be explicited destroyed here, as in the next line the
     ! MPI-framework is finalized, so that the finalizer of TDftbPlus would not be able to free

--- a/test/src/dftbp/api/mm/testers/test_setspeciesanddependents.F90
+++ b/test/src/dftbp/api/mm/testers/test_setspeciesanddependents.F90
@@ -156,9 +156,6 @@ contains
       #:endif
 
         call initialise_dftbplus_tree(geo, dftb, hsd_tree)
-
-        ! Dump hsd tree to file "fort.1" if debugging
-        ! call dumpHsd(hsd_tree%hsdTree, 001)
         call dftb%setupCalculator(hsd_tree)
       endif
 

--- a/test/src/dftbp/api/mm/testers/test_timeprop.f90
+++ b/test/src/dftbp/api/mm/testers/test_timeprop.f90
@@ -105,7 +105,6 @@ contains
 
     ! initialise the DFTB+ calculator
     call dftbp%setupCalculator(input)
-    call TDftbPlusInput_destruct(input)
 
     ! Replace coordinates
     coords(:,:) = initialCoords*AA__Bohr
@@ -123,8 +122,6 @@ contains
     print "(A,F15.10)", 'Final SCC Energy:', energy
     print "(A,3F15.10)", 'Final dipole:', (dipole(ii,1), ii=1,3)
     print "(A,100F15.10)", 'Final net atomic charges:', (atomNetCharges(ii,1), ii=1,nAtom)
-
-    call TDftbPlus_destruct(dftbp)
 
     ! Write file for internal test system
     call writeAutotestTag(tdEnergy=energy, tdDipole=dipole, tdCharges=atomNetCharges)

--- a/test/src/dftbp/api/mm/testers/test_timeprop.f90
+++ b/test/src/dftbp/api/mm/testers/test_timeprop.f90
@@ -39,82 +39,96 @@ program test_timeprop
   real(dp), parameter :: fstrength = 0.001_dp
   integer, parameter :: nsteps = 1000
 
-  type(TDftbPlus) :: dftbp
-  type(TDftbPlusInput) :: input
+  call main_()
 
-  real(dp) :: coords(3, nAtom), merminEnergy, dipole(3, 1), energy, atomNetCharges(nAtom, 1)
-  type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pType2Files, pElecDyn
-  type(fnode), pointer :: pPerturb, pKick
+contains
 
-  character(:), allocatable :: DftbVersion
-  integer :: major, minor, patch, istep, ii
+  !! Main test routine
+  !!
+  !! All non-constant variables must be defined here to ensure that they are all explicitely
+  !! deallocated before the program finishes.
+  !!
+  subroutine main_()
+
+    type(TDftbPlus) :: dftbp
+    type(TDftbPlusInput) :: input
+
+    real(dp) :: coords(3, nAtom), merminEnergy, dipole(3, 1), energy, atomNetCharges(nAtom, 1)
+    type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pType2Files, pElecDyn
+    type(fnode), pointer :: pPerturb, pKick
+
+    character(:), allocatable :: DftbVersion
+    integer :: major, minor, patch, istep, ii
 
 
-  call getDftbPlusBuild(DftbVersion)
-  write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
-  call getDftbPlusApi(major, minor, patch)
-  write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
+    call getDftbPlusBuild(DftbVersion)
+    write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
+    call getDftbPlusApi(major, minor, patch)
+    write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
 
-  call TDftbPlus_init(dftbp)
+    call TDftbPlus_init(dftbp)
 
-  call dftbp%getEmptyInput(input)
-  call input%getRootNode(pRoot)
-  call setChild(pRoot, "Geometry", pGeo)
-  call setChildValue(pGeo, "Periodic", .false.)
-  call setChildValue(pGeo, "TypeNames", ["C", "H"])
-  coords(:,:) = 0.0_dp
-  call setChildValue(pGeo, "TypesAndCoordinates", reshape(species, [1, size(species)]), coords)
-  call setChild(pRoot, "Hamiltonian", pHam)
-  call setChild(pHam, "Dftb", pDftb)
-  call setChildValue(pDftb, "Scc", .true.)
-  call setChildValue(pDftb, "SccTolerance", 1e-10_dp)
+    call dftbp%getEmptyInput(input)
+    call input%getRootNode(pRoot)
+    call setChild(pRoot, "Geometry", pGeo)
+    call setChildValue(pGeo, "Periodic", .false.)
+    call setChildValue(pGeo, "TypeNames", ["C", "H"])
+    coords(:,:) = 0.0_dp
+    call setChildValue(pGeo, "TypesAndCoordinates", reshape(species, [1, size(species)]), coords)
+    call setChild(pRoot, "Hamiltonian", pHam)
+    call setChild(pHam, "Dftb", pDftb)
+    call setChildValue(pDftb, "Scc", .true.)
+    call setChildValue(pDftb, "SccTolerance", 1e-10_dp)
 
-  call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
-  call setChildValue(pMaxAng, "C", "p")
-  call setChildValue(pMaxAng, "H", "s")
+    call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
+    call setChildValue(pMaxAng, "C", "p")
+    call setChildValue(pMaxAng, "H", "s")
 
-  call setChild(pDftb, "SlaterKosterFiles", pSlakos)
-  call setChild(pSlakos, "Type2FileNames", pType2Files)
-  call setChildValue(pType2Files, "Prefix", "./")
-  call setChildValue(pType2Files, "Separator", "-")
-  call setChildValue(pType2Files, "Suffix", ".skf")
+    call setChild(pDftb, "SlaterKosterFiles", pSlakos)
+    call setChild(pSlakos, "Type2FileNames", pType2Files)
+    call setChildValue(pType2Files, "Prefix", "./")
+    call setChildValue(pType2Files, "Separator", "-")
+    call setChildValue(pType2Files, "Suffix", ".skf")
 
-  !  set up electron dynamics options
-  call setChild(pRoot, "ElectronDynamics", pElecDyn)
-  call setChildValue(pElecDyn, "Steps", nsteps)
-  call setChildValue(pElecDyn, "TimeStep", timestep)
-  call setChildValue(pElecDyn, "FieldStrength", fstrength*1.0e10_dp*V_m__au)
-  call setChild(pElecDyn, "Perturbation", pPerturb)
-  call setChild(pPerturb, "Kick", pKick)
-  call setChildValue(pKick, "PolarisationDirection", "z")
-  call setChildValue(pElecDyn, "WriteBondPopulation", .true.)
+    !  set up electron dynamics options
+    call setChild(pRoot, "ElectronDynamics", pElecDyn)
+    call setChildValue(pElecDyn, "Steps", nsteps)
+    call setChildValue(pElecDyn, "TimeStep", timestep)
+    call setChildValue(pElecDyn, "FieldStrength", fstrength*1.0e10_dp*V_m__au)
+    call setChild(pElecDyn, "Perturbation", pPerturb)
+    call setChild(pPerturb, "Kick", pKick)
+    call setChildValue(pKick, "PolarisationDirection", "z")
+    ! call setChildValue(pElecDyn, "WriteBondPopulation", .true.)
 
-  print "(A)", 'Input tree in HSD format:'
-  call dumpHsd(input%hsdTree, output_unit)
+    print "(A)", 'Input tree in HSD format:'
+    call dumpHsd(input%hsdTree, output_unit)
 
-  ! initialise the DFTB+ calculator
-  call dftbp%setupCalculator(input)
+    ! initialise the DFTB+ calculator
+    call dftbp%setupCalculator(input)
+    call TDftbPlusInput_destruct(input)
 
-  ! Replace coordinates
-  coords(:,:) = initialCoords*AA__Bohr
-  call dftbp%setGeometry(coords)
+    ! Replace coordinates
+    coords(:,:) = initialCoords*AA__Bohr
+    call dftbp%setGeometry(coords)
 
-  ! get ground state
-  call dftbp%getEnergy(merminEnergy)
+    ! get ground state
+    call dftbp%getEnergy(merminEnergy)
 
-  call dftbp%initializeTimeProp(timestep, .false., .false.)
+    call dftbp%initializeTimeProp(timestep, .false., .false.)
 
-  do istep = 1, nsteps
-    call dftbp%doOneTdStep(istep, dipole=dipole, energy=energy, atomNetCharges=atomNetCharges)
-  end do
+    do istep = 1, nsteps
+      call dftbp%doOneTdStep(istep, dipole=dipole, energy=energy, atomNetCharges=atomNetCharges)
+    end do
 
-  print "(A,F15.10)", 'Final SCC Energy:', energy
-  print "(A,3F15.10)", 'Final dipole:', (dipole(ii,1), ii=1,3)
-  print "(A,100F15.10)", 'Final net atomic charges:', (atomNetCharges(ii,1), ii=1,nAtom)
+    print "(A,F15.10)", 'Final SCC Energy:', energy
+    print "(A,3F15.10)", 'Final dipole:', (dipole(ii,1), ii=1,3)
+    print "(A,100F15.10)", 'Final net atomic charges:', (atomNetCharges(ii,1), ii=1,nAtom)
 
-  call TDftbPlus_destruct(dftbp)
+    call TDftbPlus_destruct(dftbp)
 
-  ! Write file for internal test system
-  call writeAutotestTag(tdEnergy=energy, tdDipole=dipole, tdCharges=atomNetCharges)
+    ! Write file for internal test system
+    call writeAutotestTag(tdEnergy=energy, tdDipole=dipole, tdCharges=atomNetCharges)
+
+  end subroutine main_
 
 end program test_timeprop

--- a/test/src/dftbp/api/mm/testers/test_timeprop.f90
+++ b/test/src/dftbp/api/mm/testers/test_timeprop.f90
@@ -46,7 +46,7 @@ contains
   !! Main test routine
   !!
   !! All non-constant variables must be defined here to ensure that they are all explicitely
-  !! deallocated before the program finishes.
+  !! deallocated before the program finishes (avoiding residual memory that tools like valgrind notice).
   !!
   subroutine main_()
 

--- a/test/src/dftbp/api/mm/testers/test_treeinit.f90
+++ b/test/src/dftbp/api/mm/testers/test_treeinit.f90
@@ -28,95 +28,110 @@ program test_treeinit
       & 0.0000000000000000_dp, 5.1278583974043830_dp, 5.1278583974043830_dp,&
       & 5.1278583974043830_dp, 0.0000000000000000_dp, 5.1278583974043830_dp], [3, 3])
 
-  ! DFTB+ calculation itself
-  type(TDftbPlus) :: dftbp
-  ! input settings
-  type(TDftbPlusInput) :: input
+  call main_()
 
-  real(dp) :: merminEnergy
-  real(dp) :: coords(3, 2), latVecs(3, 3), gradients(3, 2), stressTensor(3,3)
+contains
 
-  ! pointers to the parts of the input tree that will be set
-  type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pOptions, pParserOpts
 
-  character(:), allocatable :: DftbVersion
-  integer :: major, minor, patch
+  !! Main test routine
+  !!
+  !! All non-constant variables must be defined here to ensure that they are all explicitely
+  !! deallocated before the program finishes.
+  !!
+  subroutine main_()
 
-  !integer :: devNull
+    ! DFTB+ calculation itself
+    type(TDftbPlus) :: dftbp
+    ! input settings
+    type(TDftbPlusInput) :: input
 
-  call getDftbPlusBuild(DftbVersion)
-  write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
-  call getDftbPlusApi(major, minor, patch)
-  write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
+    real(dp) :: merminEnergy
+    real(dp) :: coords(3, 2), latVecs(3, 3), gradients(3, 2), stressTensor(3,3)
 
-  ! Note: setting the global standard output to /dev/null will also suppress run-time error messages
-  !open(newunit=devNull, file="/dev/null", action="write")
-  !call TDftbPlus_init(dftbp, outputUnit=devNull)
-  call TDftbPlus_init(dftbp)
+    ! pointers to the parts of the input tree that will be set
+    type(fnode), pointer :: pRoot, pGeo, pHam, pDftb, pMaxAng, pSlakos, pOptions, pParserOpts
 
-  ! You should provide the skfiles found in the external/slakos/origin/pbc-0-3/ folder. These can be
-  ! downloaded with the utils/get_opt_externals script.
+    character(:), allocatable :: DftbVersion
+    integer :: major, minor, patch
 
-  ! initialise a DFTB input tree and populate entries which do not have relevant or appropriate
-  ! default values
-  call dftbp%getEmptyInput(input)
-  call input%getRootNode(pRoot)
-  call setChild(pRoot, "Geometry", pGeo)
-  call setChildValue(pGeo, "Periodic", .true.)
-  call setChildValue(pGeo, "LatticeVectors", initialLatVecs)
-  call setChildValue(pGeo, "TypeNames", ["Si"])
-  coords(:,:) = 0.0_dp
-  call setChildValue(pGeo, "TypesAndCoordinates", reshape([1, 1], [1, 2]), coords)
-  call setChild(pRoot, "Hamiltonian", pHam)
-  call setChild(pHam, "Dftb", pDftb)
-  call setChildValue(pDftb, "Scc", .false.)
-  call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
-  call setChildValue(pMaxAng, "Si", "p")
-  call setChild(pDftb, "SlaterKosterFiles", pSlakos)
-  call setChildValue(pSlakos, "Si-Si", "./Si-Si.skf")
-  call setChildValue(pDftb, "KPointsAndWeights", reshape([&
-      &  0.25_dp,  0.25_dp, 0.25_dp, 1.00_dp,&
-      & -0.25_dp,  0.25_dp, 0.25_dp, 1.00_dp,&
-      &  0.25_dp, -0.25_dp, 0.25_dp, 1.00_dp,&
-      & -0.25_dp, -0.25_dp, 0.25_dp, 1.00_dp], [4, 4]))
-  call setChild(pRoot, "Options", pOptions)
-  call setChildValue(pOptions, "CalculateForces", .true.)
-  call setChild(pRoot, "ParserOptions", pParserOpts)
-  call setChildValue(pParserOpts, "ParserVersion", 3)
+    !integer :: devNull
 
-  ! print resulting input file, including defaults
-  print *, 'Input tree in HSD format:'
-  call dumpHsd(input%hsdTree, output_unit)
-  print *
+    call getDftbPlusBuild(DftbVersion)
+    write(*,*)'DFTB+ build: ' // "'" // trim(DftbVersion) // "'"
+    call getDftbPlusApi(major, minor, patch)
+    write(*,"(1X,A,1X,I0,'.',I0,'.',I0)")'API version:', major, minor, patch
 
-  ! parse the input for the DFTB+ instance
-  call dftbp%setupCalculator(input)
+    ! Note: setting the global standard output to /dev/null will also suppress run-time error messages
+    !open(newunit=devNull, file="/dev/null", action="write")
+    !call TDftbPlus_init(dftbp, outputUnit=devNull)
+    call TDftbPlus_init(dftbp)
 
-  ! set the lattice vectors and coordinates in the document tree
-  latVecs(:,:) = initialLatVecs
-  coords(:,:) = initialCoords
-  call dftbp%setGeometry(coords, latVecs)
-  call dftbp%getEnergy(merminEnergy)
-  call dftbp%getGradients(gradients)
-  print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
-  print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
+    ! You should provide the skfiles found in the external/slakos/origin/pbc-0-3/ folder. These can be
+    ! downloaded with the utils/get_opt_externals script.
 
-  ! make a small displacement in the lattice vectors and coordinates
-  latVecs(1, 1) = latVecs(1, 1) + 0.1_dp * AA__Bohr
-  coords(1, 1) = coords(1, 1) + 0.1_dp * AA__Bohr
-  call dftbp%setGeometry(coords, latVecs)
+    ! initialise a DFTB input tree and populate entries which do not have relevant or appropriate
+    ! default values
+    call dftbp%getEmptyInput(input)
+    call input%getRootNode(pRoot)
+    call setChild(pRoot, "Geometry", pGeo)
+    call setChildValue(pGeo, "Periodic", .true.)
+    call setChildValue(pGeo, "LatticeVectors", initialLatVecs)
+    call setChildValue(pGeo, "TypeNames", ["Si"])
+    coords(:,:) = 0.0_dp
+    call setChildValue(pGeo, "TypesAndCoordinates", reshape([1, 1], [1, 2]), coords)
+    call setChild(pRoot, "Hamiltonian", pHam)
+    call setChild(pHam, "Dftb", pDftb)
+    call setChildValue(pDftb, "Scc", .false.)
+    call setChild(pDftb, "MaxAngularMomentum", pMaxAng)
+    call setChildValue(pMaxAng, "Si", "p")
+    call setChild(pDftb, "SlaterKosterFiles", pSlakos)
+    call setChildValue(pSlakos, "Si-Si", "./Si-Si.skf")
+    call setChildValue(pDftb, "KPointsAndWeights", reshape([&
+        &  0.25_dp,  0.25_dp, 0.25_dp, 1.00_dp,&
+        & -0.25_dp,  0.25_dp, 0.25_dp, 1.00_dp,&
+        &  0.25_dp, -0.25_dp, 0.25_dp, 1.00_dp,&
+        & -0.25_dp, -0.25_dp, 0.25_dp, 1.00_dp], [4, 4]))
+    call setChild(pRoot, "Options", pOptions)
+    call setChildValue(pOptions, "CalculateForces", .true.)
+    call setChild(pRoot, "ParserOptions", pParserOpts)
+    call setChildValue(pParserOpts, "ParserVersion", 3)
 
-  ! re-calculate energy and forces
-  call dftbp%getEnergy(merminEnergy)
-  call dftbp%getGradients(gradients)
-  call dftbp%getStressTensor(stressTensor)
-  print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
-  print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
+    ! print resulting input file, including defaults
+    print *, 'Input tree in HSD format:'
+    call dumpHsd(input%hsdTree, output_unit)
+    print *
 
-  ! clean up
-  call TDftbPlus_destruct(dftbp)
+    ! parse the input for the DFTB+ instance
+    call dftbp%setupCalculator(input)
+    call TDftbPlusInput_destruct(input)
 
-  ! Write file for internal test system
-  call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, stressTensor=stressTensor)
+    ! set the lattice vectors and coordinates in the document tree
+    latVecs(:,:) = initialLatVecs
+    coords(:,:) = initialCoords
+    call dftbp%setGeometry(coords, latVecs)
+    call dftbp%getEnergy(merminEnergy)
+    call dftbp%getGradients(gradients)
+    print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
+    print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
+
+    ! make a small displacement in the lattice vectors and coordinates
+    latVecs(1, 1) = latVecs(1, 1) + 0.1_dp * AA__Bohr
+    coords(1, 1) = coords(1, 1) + 0.1_dp * AA__Bohr
+    call dftbp%setGeometry(coords, latVecs)
+
+    ! re-calculate energy and forces
+    call dftbp%getEnergy(merminEnergy)
+    call dftbp%getGradients(gradients)
+    call dftbp%getStressTensor(stressTensor)
+    print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
+    print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
+
+    ! clean up
+    call TDftbPlus_destruct(dftbp)
+
+    ! Write file for internal test system
+    call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, stressTensor=stressTensor)
+
+  end subroutine main_
 
 end program test_treeinit

--- a/test/src/dftbp/api/mm/testers/test_treeinit.f90
+++ b/test/src/dftbp/api/mm/testers/test_treeinit.f90
@@ -103,7 +103,6 @@ contains
 
     ! parse the input for the DFTB+ instance
     call dftbp%setupCalculator(input)
-    call TDftbPlusInput_destruct(input)
 
     ! set the lattice vectors and coordinates in the document tree
     latVecs(:,:) = initialLatVecs
@@ -125,9 +124,6 @@ contains
     call dftbp%getStressTensor(stressTensor)
     print "(A,F15.10)", 'Obtained Mermin Energy:', merminEnergy
     print "(A,3F15.10)", 'Obtained gradient of atom 1:', gradients(:,1)
-
-    ! clean up
-    call TDftbPlus_destruct(dftbp)
 
     ! Write file for internal test system
     call writeAutotestTag(merminEnergy=merminEnergy, gradients=gradients, stressTensor=stressTensor)

--- a/test/src/dftbp/api/mm/testers/test_treeinit.f90
+++ b/test/src/dftbp/api/mm/testers/test_treeinit.f90
@@ -36,7 +36,7 @@ contains
   !! Main test routine
   !!
   !! All non-constant variables must be defined here to ensure that they are all explicitely
-  !! deallocated before the program finishes.
+  !! deallocated before the program finishes (avoiding residual memory that tools like valgrind notice).
   !!
   subroutine main_()
 


### PR DESCRIPTION
Several changes, but all of them are memory leak related and minimal and were triggered during the effort to close the neighbour list memory-leaks.

* Fixed memory caused when API created and destroyed DFTB+ instances multiple times consecutively.
* Resource allocation in non-MPI and MPI case for the neighbour lists are basically identical now (apart of the MPI-window calls), so that hopefully less confusion arises.
* Fixed a memory leak in the xmlf90 library, which was triggered when the same attribute had been set on a node multiple times (e.g. `hsdProcessed` during oldcompat-conversions).
* Added build option to invoke valgrind during the testing, when desired.
* Adjusted `autotest2`, so that it stops when executed program returns with a non-zero exit code  (and deletes the `autotest.tag` file and emits a message about it)
* Put the main code of API-tests in subroutines, so that meaningful valgrind-evaluation can be done (all entries must be deallocated and finalized explicitly before the program finishes)
* Added finalizers for `TDftbPlus`, `TDftbPlusC` and `TDftbPlusInput` to make sure, they are finalized when leaving scope.
* Added `destruct` routine for `TDftbPlusInput` and a C-binding to the C-API, so that it can be destroyed when used from C. (So far, the input tree was never freed when DFTB+ was used via the API).

Currently all API-tests seem to be memory-leak free. Some standalone DFTB+ runs are reported to leak, they need to be inverstigated further (might be false positives).

Note: One racing condition for MPI-IO had been eliminated. However, there are apparently more of them, it needs probably a detailed check. (Some of the MPI-examples fail on NAG due to the MPI-issues...)