### PR TITLE
Hides routines only unit testing should call

### DIFF
--- a/cmake/DftbPlusUtils.cmake
+++ b/cmake/DftbPlusUtils.cmake
@@ -130,6 +130,10 @@ function (dftbp_add_fypp_defines fyppflags)
     list(APPEND _fyppflags -DINSTANCE_SAFE_BUILD)
   endif()
 
+  if(WITH_UNIT_TESTS)
+    list(APPEND _fyppflags -DWITH_UNIT_TESTS)
+  endif()
+
   set(${fyppflags} ${_fyppflags} PARENT_SCOPE)
 
 endfunction()

--- a/src/dftbp/dftb/periodic.F90
+++ b/src/dftbp/dftb/periodic.F90
@@ -38,10 +38,11 @@ module dftbp_dftb_periodic
   public :: updateNeighbourList, updateNeighbourListAndSpecies, setNeighbourList
   public :: getNrOfNeighbours, getNrOfNeighboursForAll
 
-  ! NOTE: this entries are public only temporarily for unit testing purposes. Do not call them
+#:if WITH_UNIT_TESTS
+  ! NOTE: these entries are public only temporarily for unit testing purposes. Do not call them
   ! from the outside.
   public :: distributeAtoms, reallocateArrays2, allocateNeighbourArrays, fillNeighbourArrays
-
+#:endif
 
   !> Contains essential data for the neighbourlist
   type TNeighbourList

--- a/src/dftbp/include/common.fypp
+++ b/src/dftbp/include/common.fypp
@@ -30,6 +30,7 @@
 #:set WITH_SDFTD3 = defined('WITH_SDFTD3')
 #:set WITH_TBLITE = defined('WITH_TBLITE')
 #:set WITH_CHIMES = defined('WITH_CHIMES')
+#:set WITH_UNIT_TESTS = defined('WITH_UNIT_TESTS')
 #:set EXP_TRAP = defined('EXP_TRAP')
 #:set INTERNAL_ERFC = defined('INTERNAL_ERFC')
 #:set EMULATE_F08_MATH = defined('EMULATE_F08_MATH')


### PR DESCRIPTION
Reduce the chance that these routines are called somewhere they should not be.