### PR TITLE
Move from deprecated icc to icx Intel compiler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         fc: [ifort]
-        cc: [icc]
+        cc: [icx]
     env:
       FC: ${{ matrix.fc }}
       CC: ${{ matrix.cc }}


### PR DESCRIPTION
Updates GitHub workflow to use the ICX compiler, instead of the deprecated and soon to be removed ICC.