### PR TITLE
Separate Delta-DFTB band.out writes

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -5085,8 +5085,16 @@ calculation and/or calculate properties.
   text version of the data should be printed in \verb|eigenvec.out|. For a
   description of the file format see p.~\pref{sec:dftbp.eigenvec}.
 
-\item[\is{WriteBandOut}]  Controls the creation of the file \verb|band.out|
-  which contains the band structure in a more or less human friendly format.
+\item[\is{WriteBandOut}] Controls the creation of the file
+  \verb|band.out| which contains the band structure in a more or less
+  human friendly format.
+
+  Note: in the case of \iscb{nonAufbau} calculations (See
+  p.~\pref{sec:dftbp.NonAufbau}), separate files are written for each
+  configuration, prepended by the name of the state. The $s_1$ state
+  will be spin contaminated, so if used for density of states will
+  require processing according to the Ziegler sum
+  rule.\cite{baerends-TCA-43-261}
 
 \item[\is{Printforces}] If \is{Yes}, forces are reported, even if not needed
   for the actual calculation (e.g.\ static geometry calculation).
@@ -5296,7 +5304,8 @@ Evaluates electric polarisability using coupled-perturbed linear
 response (hence can only be used with cases initially evaluating
 unperturbed eigenvalues/band structure). Currently only the DFTB
 hamiltonian is supported (see section~\ref{sec:dftbp.DFTB}, REKS and
-Delta-DFTB calculations are also not currently supported).
+Delta-DFTB (\iscb{nonAufbau}) calculations are also not currently
+supported).
 
 In the case of degenerate single particle levels, the reported level
 derivatives (see p.~\pref{sec:dftbp.bandout}) for those states are
@@ -5347,8 +5356,8 @@ Evaluates responses to potentials added at individual atomic sites,
 using coupled-perturbed linear response (hence can only be used with
 cases initially evaluating unperturbed eigenvalues/band
 structure). Currently only the DFTB hamiltonian is supported (see
-section~\ref{sec:dftbp.DFTB}, REKS and Delta-DFTB calculations are
-also not currently supported).
+section~\ref{sec:dftbp.DFTB}, REKS and Delta-DFTB (\iscb{nonAufbau})
+calculations are also not currently supported).
 
 The same options as \is{Polarisability} are supported, but in
 addition:

--- a/src/dftbp/dftb/determinants.F90
+++ b/src/dftbp/dftb/determinants.F90
@@ -38,6 +38,10 @@ module dftbp_dftb_determinants
   type(TDeterminantsEnum), parameter :: determinants = TDeterminantsEnum()
 
 
+  !> Names of the determinants, matching TDeterminantsEnum
+  character(len=2), parameter :: detNames(0:2) = ['s0', 't1', 's1']
+
+
   !> Control type for Delta DFTB / TI-DFTB
   type TDftbDeterminants
 
@@ -80,6 +84,7 @@ module dftbp_dftb_determinants
     procedure :: nDeterminant
     procedure :: whichDeterminant
     procedure :: detFilling
+    procedure :: determinantName
 
   end type TDftbDeterminants
 
@@ -117,6 +122,26 @@ contains
     det = this%determinants(iDet)
 
   end function whichDeterminant
+
+
+  !> Converts determinant number into what it is called
+  function determinantName(this, iDet) result(det)
+
+    !> Instance
+    class(TDftbDeterminants), intent(in) :: this
+
+    !> Number of current determinant
+    integer, intent(in) :: iDet
+
+    character(2) :: det
+
+    if (iDet > size(this%determinants)) then
+      call error("Internal error: invalid determinant")
+    endif
+
+    det = detNames(this%determinants(iDet))
+
+  end function determinantName
 
 
   !> Spin Purifies Non-Aufbau excited state energy and forces

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -5066,6 +5066,8 @@ contains
     !> Environment
     type(TEnvironment), intent(inout) :: env
 
+    integer :: iDet
+
     call TTaggedWriter_init(this%taggedWriter)
 
     if (this%tWriteAutotest) then
@@ -5075,11 +5077,18 @@ contains
       call clearFile(resultsTag)
     end if
     if (this%tWriteBandDat) then
-      call clearFile(bandOut)
+      if (this%deltaDftb%nDeterminant() == 1) then
+        call clearFile(bandOut)
+      else
+        do iDet = 1, this%deltaDftb%nDeterminant()
+          call clearFile(this%deltaDftb%determinantName(iDet) // '_' //  bandOut)
+        end do
+      end if
       if (this%doPerturbation .and. this%isEResp) then
         call clearFile(derivEBandOut)
       end if
     end if
+
     if (this%tDerivs) then
       call clearFile(hessianOut)
     end if

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -1417,8 +1417,13 @@ contains
               & this%nNeighbourCam, this%nNeighbourCamSym, this%deltaDftb, errStatus)
           if (errStatus%hasError()) call error(errStatus%message)
 
-          if (this%tWriteBandDat .and. this%deltaDftb%nDeterminant() == 1) then
-            call writeBandOut(bandOut, this%eigen, this%filling, this%kWeight)
+          if (this%tWriteBandDat) then
+            if (this%deltaDftb%nDeterminant() == 1) then
+              call writeBandOut(bandOut, this%eigen, this%filling, this%kWeight)
+            else
+              call writeBandOut(this%deltaDftb%determinantName(this%deltaDftb%iDeterminant) // '_'&
+                  & //  bandOut, this%eigen, this%filling, this%kWeight)
+            end if
           end if
 
           call processOutputCharges(env, this)

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -5134,7 +5134,7 @@ contains
     type(TListRealR1) :: lr1
     type(TListReal) :: lr
     logical :: tPipekDense
-    logical :: tWriteBandDatDef, tHaveEigenDecomposition, tHaveDensityMatrix
+    logical :: tWriteBandDatDefault, tHaveEigenDecomposition, tHaveDensityMatrix
     logical :: isEtaNeeded
 
     tHaveEigenDecomposition = .false.
@@ -5228,12 +5228,12 @@ contains
       call getChildValue(node, "WriteEigenvectors", ctrl%tPrintEigVecs, .false.)
 
     #:if WITH_SOCKETS
-      tWriteBandDatDef = .not. allocated(ctrl%socketInput)
+      tWriteBandDatDefault = .not. allocated(ctrl%socketInput)
     #:else
-      tWriteBandDatDef = .true.
+      tWriteBandDatDefault = .true.
     #:endif
 
-      call getChildValue(node, "WriteBandOut", ctrl%tWriteBandDat, tWriteBandDatDef)
+      call getChildValue(node, "WriteBandOut", ctrl%tWriteBandDat, tWriteBandDatDefault)
 
       call getChild(node, "Polarisability", child=child, requested=.false.)
       call getChild(node, "ResponseKernel", child=child2, requested=.false.)


### PR DESCRIPTION
Prints individual Delta-SCF band data to separate files, unless there is only one determinant, in which case band.out is used.