### PR TITLE
Marks external neighbour set for recomputation

### DIFF
--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -261,6 +261,9 @@ module dftbp_dftbplus_initprogram
     !> Index in cellVec for each atom
     integer, allocatable :: iCellVec(:)
 
+    !> Are neighbour lists set externally (via the API), so should not be changed internally
+    logical :: areNeighSetExternal = .false.
+
     !> ADT for neighbour parameters
     type(TNeighbourList), allocatable :: neighbourList
 

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -1154,7 +1154,7 @@ contains
           & this%nAllAtom, this%coord0Fold, this%coord,this%species, this%cellVec, this%rCellVec,&
           & this%denseDesc, this%nNeighbourSk, this%nNeighbourCam, this%nNeighbourCamSym,&
           & this%ints, this%H0, this%rhoPrim, this%iRhoPrim, this%ERhoPrim, this%iSparseStart,&
-          & this%cm5Cont, this%skOverCont, errStatus)
+          & this%cm5Cont, this%skOverCont, this%areNeighSetExternal, errStatus)
         @:PROPAGATE_ERROR(errStatus)
     end if
 
@@ -2220,7 +2220,7 @@ contains
       & areSolventNeighboursSym, thirdOrd, hybridXc, reks, img2CentCell, iCellVec, neighbourList,&
       & symNeighbourList, nAllAtom, coord0Fold, coord, species, cellVec, rCellVec, denseDescr,&
       & nNeighbourSK, nNeighbourCam, nNeighbourCamSym, ints, H0, rhoPrim, iRhoPrim, ERhoPrim,&
-      & iSparseStart, cm5Cont, skOverCont, errStatus)
+      & iSparseStart, cm5Cont, skOverCont, areNeighSetExternal, errStatus)
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -2348,6 +2348,9 @@ contains
     !> Sparse overlap part
     type(TSlakoCont), intent(in) :: skOverCont
 
+    !> Are Neighbour lists set externally, so should not be updated
+    logical, intent(in) :: areNeighSetExternal
+
     !> Status of operation
     type(TStatus), intent(out) :: errStatus
 
@@ -2359,15 +2362,17 @@ contains
 
     call boundaryCond%foldCoordsToCell(coord0Fold, latVec)
 
-    if (tHelical) then
-      call updateNeighbourListAndSpecies(env, coord, species, img2CentCell, iCellVec,&
-          & neighbourList, nAllAtom, coord0Fold, species0, cutoff%mCutoff, rCellVec,&
-          & errStatus, helicalBoundConds=latVec)
-    else
-      call updateNeighbourListAndSpecies(env, coord, species, img2CentCell, iCellVec,&
-          & neighbourList, nAllAtom, coord0Fold, species0, cutoff%mCutOff, rCellVec, errStatus)
+    if (.not.areNeighSetExternal) then
+      if (tHelical) then
+        call updateNeighbourListAndSpecies(env, coord, species, img2CentCell, iCellVec,&
+            & neighbourList, nAllAtom, coord0Fold, species0, cutoff%mCutoff, rCellVec,&
+            & errStatus, helicalBoundConds=latVec)
+      else
+        call updateNeighbourListAndSpecies(env, coord, species, img2CentCell, iCellVec,&
+            & neighbourList, nAllAtom, coord0Fold, species0, cutoff%mCutOff, rCellVec, errStatus)
+      end if
+      @:PROPAGATE_ERROR(errStatus)
     end if
-    @:PROPAGATE_ERROR(errStatus)
 
     call getNrOfNeighboursForAll(nNeighbourSK, neighbourList, cutoff%skCutOff)
 

--- a/src/dftbp/dftbplus/mainapi.F90
+++ b/src/dftbp/dftbplus/mainapi.F90
@@ -138,6 +138,8 @@ contains
     call setNeighbourListOrig(main%neighbourList, env, nNeighbour, iNeighbour, neighDist, cutOff,&
         & main%coord0, main%species0, coordNeighbours, neighbour2CentCell, main%rCellVec,&
         & main%nAllAtom, main%img2CentCell, main%iCellVec, main%coord, main%species)
+    main%areNeighSetExternal = .true.
+    main%tCoordsChanged = .true.
 
   end subroutine setNeighbourList
 

--- a/test/src/dftbp/api/mm/testers/test_neighbour_list.f90
+++ b/test/src/dftbp/api/mm/testers/test_neighbour_list.f90
@@ -20,10 +20,11 @@ program test_neighbour_list
 contains
 
 
-  !! Main test routine
+  !> Main test routine
   !!
   !! All non-constant variables must be defined here to ensure that they are all explicitely
-  !! deallocated before the program finishes  (avoiding residual memory that tools like valgrind notice).
+  !! deallocated before the program finishes (avoiding residual memory that tools like valgrind
+  !! notice).
   !!
   subroutine main_()
 
@@ -47,6 +48,27 @@ contains
 
     call dftbp%getInputFromFile("dftb_in.hsd", input)
     call dftbp%setupCalculator(input)
+
+    ! setup all data for the neighbour list
+    cutoff = 6.0_dp
+    x = 2.5639291987021915_dp
+    coord(:,:) = reshape([-x, -x, x, x, -x, -x, -x, x, -x, x, x, x], shape(coord))
+    img2CentCell(:) = [2, 2, 2, 2]
+    iNeighbour(:,:) = reshape([1, 2, 3, 4, 0, 0, 0, 0], shape(iNeighbour))
+    dist = sqrt(19.721198807872987_dp)
+    neighDist(:,:) = reshape([dist, dist, dist, dist, 0.0_dp, 0.0_dp, 0.0_dp, 0.0_dp],&
+        & shape(neighDist))
+
+    nNeighbour(:) = [3, 0]
+    ! set the neighbour list
+    call dftbp%setNeighbourList(nNeighbour, iNeighbour, neighDist, cutoff, coord, img2CentCell)
+    ! evaluate energy and forces
+    call dftbp%getEnergy(merminEnergy)
+    call dftbp%getGradients(gradients)
+
+    nNeighbour(:) = [4, 0]
+    ! set the neighbour list
+    call dftbp%setNeighbourList(nNeighbour, iNeighbour, neighDist, cutoff, coord, img2CentCell)
 
     ! setup all data for the neighbour list
     cutoff = 6.0_dp


### PR DESCRIPTION
Also adds a variable to the main type to prevent DFTB+ updating the neighbourlist if it has been set externally.