### PR TITLE
Require Magma only if WITH_MAGMA in GPU build

### DIFF
--- a/utils/export/dftbplus-config.cmake.in
+++ b/utils/export/dftbplus-config.cmake.in
@@ -49,7 +49,7 @@ if(NOT TARGET DftbPlus::DftbPlus)
     find_dependency(elsi)
   endif()
 
-  if(DftbPlus_WITH_GPU AND NOT TARGET Magma::Magma)
+  if(DftbPlus_WITH_GPU AND DftbPlus_WITH_MAGMA AND NOT TARGET Magma::Magma)
     find_dependency(CustomMagma)
   endif()
 


### PR DESCRIPTION
When DFTB+ is built `WITH_GPU`, it enforces to have a custom Magma, although the user uses ELPA. From my point of view, it should only be enforced if `WITH_MAGMA` has been set.