### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,9 @@ needed for the test ::
   ./utils/get_opt_externals slakos
   ./utils/get_opt_externals gbsa
 
+or ::
+  ./utils/get_opt_externals ALL
+
 and then run the tests with ::
 
   pushd _build; ctest -j; popd

--- a/README.rst
+++ b/README.rst
@@ -90,10 +90,11 @@ If the configuration was successful, start the build with::
 
   cmake --build _build -- -j
 
-After successful build, you should test the code. First download the SK-files
+After successful build, you should test the code. First download the files
 needed for the test ::
 
   ./utils/get_opt_externals slakos
+  ./utils/get_opt_externals gbsa
 
 and then run the tests with ::
 

--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,7 @@ needed for the test ::
   ./utils/get_opt_externals gbsa
 
 or ::
+  
   ./utils/get_opt_externals ALL
 
 and then run the tests with ::


### PR DESCRIPTION
on a fresh install, there are additional files needed for testing that are not pulled when downloading the slakos-files. These files are apparently needed for the tests solvation/gbsa_param{1 2 3}, which fail otherwise.