### PR TITLE
Fix definition in header file for testers

### DIFF
--- a/test/src/dftbp/api/mm/testers/testhelpers.h
+++ b/test/src/dftbp/api/mm/testers/testhelpers.h
@@ -6,7 +6,7 @@
 /*------------------------------------------------------------------------------------------------*/
 
 #ifndef __TESTHELPERS_H__
-#define __TESTHELPERS_H_
+#define __TESTHELPERS_H__
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Missing underscore in .h file definition.