### PR TITLE
Print error status on test fail

### DIFF
--- a/test/app/dftb+/bin/autotest2
+++ b/test/app/dftb+/bin/autotest2
@@ -343,11 +343,12 @@ do
 	else
 	    $app_prerun $app_cmd $app_postrun  >> $APP_STDOUT 2>> $APP_STDERR
 	fi
-  # If run was not successful, make sure tagdiff fails by removing the tagged data file
-  if [ $? != 0 ]; then
-    echo "Test script returned non-zero exit code: deleting file '${APP_TAGDATA}'" 1>&2
-    rm -f ./${APP_TAGDATA}
-  fi
+	# If run was not successful, make sure tagdiff fails by removing the tagged data file
+	runstatus=$?
+	if [ "$runstatus" != "0" ]; then
+	    echo -e "Test script returned non-zero exit code: $runstatus\n deleting file '${APP_TAGDATA}'" 1>&2
+	    rm -f ./${APP_TAGDATA}
+	fi
 
 	if [ -n "$app_globalpost" ]; then
 	    if [ ! -x "$app_globalpost" ]; then


### PR DESCRIPTION
Also definitely treat returns as strings.