### PR TITLE
Formatting for variable comments about k-points

### DIFF
--- a/app/phonons/libnegfint.F90
+++ b/app/phonons/libnegfint.F90
@@ -823,13 +823,13 @@ module phonons_libnegfint
     !> Total data to be written
     real(dp), intent(in) :: pTot(:,:)
 
-    !> k-point resolved data, if allocated
+    !> The k-point resolved data, if allocated
     real(dp), allocatable, intent(in) :: pKRes(:,:,:)
 
     !> file to print out to
     character(*), intent(in) :: filename
 
-    !> k-points for the system
+    !> The k-points for the system
     real(dp), intent(in) :: kPoints(:,:)
 
     !> Weights for k-points

--- a/app/waveplot/gridcache.F90
+++ b/app/waveplot/gridcache.F90
@@ -67,7 +67,7 @@ module waveplot_gridcache
     !> Levels in the eigenvec file
     integer :: nAllLevel
 
-    !> K-points in the eigenv. file
+    !> The k-points in the eigenv. file
     integer :: nAllKPoint
 
     !> Spins in the eigenvec. file

--- a/app/waveplot/initwaveplot.F90
+++ b/app/waveplot/initwaveplot.F90
@@ -74,7 +74,7 @@ module waveplot_initwaveplot
     !> Levels to plot
     integer, allocatable :: plottedLevels(:)
 
-    !> K-points to plot
+    !> The k-points to plot
     integer, allocatable :: plottedKPoints(:)
 
     !> Spins to plot
@@ -389,7 +389,7 @@ contains
     !> Wether to look for ground state occupations (True) or excited (False)
     logical, intent(in) :: tGroundState
 
-    !> K-points and weights
+    !> The k-points and weights
     real(dp), intent(out), allocatable :: kPointsWeights(:,:)
 
     !! Pointers to input nodes

--- a/src/dftbp/derivs/linearresponse.F90
+++ b/src/dftbp/derivs/linearresponse.F90
@@ -1815,7 +1815,7 @@ contains
     !> Spin index
     integer, intent(in) :: iS
 
-    !> K-point index
+    !> The k-point index
     integer, intent(in) :: iK
 
     !> Fermi level
@@ -1887,7 +1887,7 @@ contains
     !> Spin index
     integer, intent(in) :: iS
 
-    !> K-point index
+    !> The k-point index
     integer, intent(in) :: iK
 
     !> Fermi level
@@ -1961,7 +1961,7 @@ contains
     !> Spin index
     integer, intent(in) :: iS
 
-    !> K-point index
+    !> The k-point index
     integer, intent(in) :: iK
 
     !> Number of levels
@@ -2021,7 +2021,7 @@ contains
     !> Spin index
     integer, intent(in) :: iS
 
-    !> K-point index
+    !> The k-point index
     integer, intent(in) :: iK
 
     !> Frequency and imaginary part

--- a/src/dftbp/derivs/perturb.F90
+++ b/src/dftbp/derivs/perturb.F90
@@ -289,7 +289,7 @@ contains
     !> Charge mixing object
     type(TMixer), intent(inout), allocatable :: pChrgMixer
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -624,7 +624,7 @@ contains
     !> Charge mixing object
     type(TMixer), intent(inout), allocatable :: pChrgMixer
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -1045,7 +1045,7 @@ contains
     !> Square matrix for overlap (if needed)
     real(dp), allocatable, intent(inout) :: sSqrReal(:,:)
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points

--- a/src/dftbp/dftb/densitymatrix.F90
+++ b/src/dftbp/dftb/densitymatrix.F90
@@ -82,16 +82,16 @@ contains
     !> Complex, dense, square dual-space rho of all spins/k-points
     complex(dp), intent(in) :: rhoDual(:,:,:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
-    !> k-points in relative units
+    !> The k-points in relative units
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights of k-points
     real(dp), intent(in) :: kWeight(:)
 
-    !> K-point compatible BvK real-space shifts in relative coordinates (units of latVecs)
+    !> The k-point compatible BvK real-space shifts in relative coordinates (units of latVecs)
     real(dp), intent(in) :: bvKShifts(:,:)
 
     !> Supercell folding coefficients (diagonal elements)

--- a/src/dftbp/dftb/etemp.F90
+++ b/src/dftbp/dftb/etemp.F90
@@ -82,7 +82,7 @@ contains
     !> Thermal energy in atomic units
     real(dp), intent(in) :: kT
 
-    !> k-point weightings
+    !> The k-point weightings
     real(dp), intent(in) :: kWeight(:)
 
     !> Choice of distribution functions, currently Fermi, Gaussian and Methfessle-Paxton
@@ -236,7 +236,7 @@ contains
     !> scheme
     integer, intent(in) :: distrib
 
-    !> k-point weightings
+    !> The k-point weightings
     real(dp), intent(in) :: kWeight(:)
 
     integer :: MPorder
@@ -322,7 +322,7 @@ contains
     !> Fermi supported.
     real(dp), intent(in) :: kWeight(:)
 
-    !> k-point weightings
+    !> The k-point weightings
     real(dp) :: w
     integer i, j, ispin
     real(dp) :: x
@@ -390,7 +390,7 @@ contains
     !> scheme
     integer, intent(in) :: distrib
 
-    !> k-point weightings
+    !> The k-point weightings
     real(dp), intent(in) :: kWeights(:)
 
     integer :: MPorder

--- a/src/dftbp/dftb/getenergies.F90
+++ b/src/dftbp/dftb/getenergies.F90
@@ -180,7 +180,7 @@ contains
     !> Holds real and complex delta density matrices and pointers
     type(TDensityMatrix), intent(in), optional :: densityMatrix
 
-    !> K-point weights
+    !> The k-point weights
     real(dp), intent(in), optional :: kWeights(:)
 
     !> The (K, S) tuples of the local processor group (localKS(1:2,iKS))

--- a/src/dftbp/dftb/hybridxc.F90
+++ b/src/dftbp/dftb/hybridxc.F90
@@ -234,7 +234,7 @@ module dftbp_dftb_hybridxc
     !> Descending neighbour indices in terms of overlap estimates
     type(TWrappedInt1), allocatable :: overlapIndices(:)
 
-    !> K-point compatible BvK real-space shifts in relative coordinates (units of latVecs)
+    !> The k-point compatible BvK real-space shifts in relative coordinates (units of latVecs)
     real(dp), allocatable :: bvKShifts(:,:)
 
     !> Supercell folding coefficients (diagonal elements)
@@ -629,7 +629,7 @@ contains
       !> Supercell folding coefficients (diagonal elements)
       integer, intent(in) :: coeffsDiag(:)
 
-      !> K-point compatible BvK real-space shifts in relative coordinates
+      !> The k-point compatible BvK real-space shifts in relative coordinates
       real(dp), intent(out), allocatable :: bvKShifts(:,:)
 
       !! Number of BvK real-space shifts
@@ -1460,7 +1460,7 @@ contains
     !> Orbital information.
     type(TOrbitals), intent(in) :: orb
 
-    !> K-points in relative coordinates to calculate delta H(k) for
+    !> The k-points in relative coordinates to calculate delta H(k) for
     real(dp), intent(in) :: kPoints(:,:)
 
     !> Composite index for mapping iK/iS --> iGlobalKS for arrays present at every MPI rank
@@ -2445,7 +2445,7 @@ contains
     !> Orbital information
     type(TOrbitals), intent(in) :: orb
 
-    !> K-points in relative coordinates to calculate delta H(k) for
+    !> The k-points in relative coordinates to calculate delta H(k) for
     real(dp), intent(in) :: kPoints(:,:)
 
     !> Composite index for mapping iK/iS --> iGlobalKS for arrays present at every MPI rank
@@ -2769,7 +2769,7 @@ contains
     !> Orbital information
     type(TOrbitals), intent(in) :: orb
 
-    !> K-points in relative coordinates to calculate delta H(k) for
+    !> The k-points in relative coordinates to calculate delta H(k) for
     real(dp), intent(in) :: kPoints(:,:)
 
     !> Composite index for mapping iK/iS --> iGlobalKS for arrays present at every MPI rank
@@ -3099,7 +3099,7 @@ contains
     !> Composite index for mapping iK/iS --> iGlobalKS for arrays present at every MPI rank
     integer, intent(in) :: iKiSToiGlobalKS(:,:)
 
-    !> K-point weights
+    !> The k-point weights
     real(dp), intent(in) :: kWeights(:)
 
     !> Complex, dense, square k-space delta density matrix of all spins/k-points
@@ -3195,7 +3195,7 @@ contains
     !> Hamiltonian matrix
     complex(dp), intent(in) :: hamiltonian(:,:)
 
-    !> K-point weight (for energy contribution)
+    !> The k-point weight (for energy contribution)
     real(dp), intent(in) :: kWeight
 
     !> Density matrix in k-space
@@ -4057,7 +4057,7 @@ contains
     !> Environment settings
     type(TEnvironment), intent(in) :: env
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Square (unpacked) delta density matrix
@@ -4741,7 +4741,7 @@ contains
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Distributed matrix (source)
@@ -4813,7 +4813,7 @@ contains
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Collected, full square matrix (source)
@@ -4887,7 +4887,7 @@ contains
     !> Environment settings
     type(TEnvironment), intent(in) :: env
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Square (unpacked) delta density matrix
@@ -5487,10 +5487,10 @@ contains
     !> Orbital information.
     type(TOrbitals), intent(in) :: orb
 
-    !> K-points in relative coordinates to calculate delta H(k) for
+    !> The k-points in relative coordinates to calculate delta H(k) for
     real(dp), intent(in) :: kPoints(:,:)
 
-    !> K-point weights (for energy contribution)
+    !> The k-point weights (for energy contribution)
     real(dp), intent(in) :: kWeights(:)
 
     !> Sparse overlap container

--- a/src/dftbp/dftb/pmlocalisation.F90
+++ b/src/dftbp/dftb/pmlocalisation.F90
@@ -8,8 +8,8 @@
 #:include 'common.fypp'
 
 !> Construct Pipek-Mezey localised orbitals, either for molecules/gamma point periodic, or for each
-!> k-point separately. Note that for the k-point case these are NOT localised Wannier functions as
-!> each k-point is localised independently.
+!! The k-point separately. Note that for the k-point case these are NOT localised Wannier functions
+!! as each k-point is localised independently.
 module dftbp_dftb_pmlocalisation
   use dftbp_common_accuracy, only : dp
   use dftbp_common_globalenv, only : stdOut

--- a/src/dftbp/dftb/populations.F90
+++ b/src/dftbp/dftb/populations.F90
@@ -475,7 +475,7 @@ contains
     !> Environment settings
     type(TEnvironment), intent(in) :: env
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Dense matrix descriptor
@@ -824,13 +824,13 @@ contains
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc
 
-    !> K-points and spins to be handled
+    !> The k-points and spins to be handled
     type(TParallelKS), intent(in) :: parallelKS
 
     !> List of neighbours for each atom
     type(TNeighbourList), intent(in) :: neighbourList
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Number of neighbours for each of the atoms
@@ -996,7 +996,7 @@ contains
     !> Environment settings
     type(TEnvironment), intent(in) :: env
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Reference atom populations
@@ -1042,7 +1042,7 @@ contains
     !> Environment settings
     type(TEnvironment), intent(in) :: env
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Reference atom populations

--- a/src/dftbp/dftb/sparse2dense.F90
+++ b/src/dftbp/dftb/sparse2dense.F90
@@ -584,7 +584,7 @@ contains
     !> sparse hamiltonian
     real(dp), intent(in) :: ham(:, :)
 
-    !> k-point at which to unpack
+    !> The k-point at which to unpack
     real(dp), intent(in) :: kPoint(:)
 
     !> Neighbour list for each atom (First index from 0!)
@@ -713,7 +713,7 @@ contains
     !> sparse overlap matrix
     real(dp), intent(in) :: over(:)
 
-    !> k-point at which to unpack
+    !> The k-point at which to unpack
     real(dp), intent(in) :: kPoint(:)
 
     !> Neighbour list for each atom (First index from 0!)
@@ -2253,7 +2253,7 @@ contains
     !> sparse matrix to unpack
     real(dp), intent(in) :: orig(:, :)
 
-    !> k-point at which to unpack
+    !> The k-point at which to unpack
     real(dp), intent(in) :: kPoint(:)
 
     !> Neighbour list for the atoms (First index from 0!)
@@ -2379,7 +2379,7 @@ contains
     !> sparse matrix to unpack
     real(dp), intent(in) :: orig(:)
 
-    !> k-point at which to unpack
+    !> The k-point at which to unpack
     real(dp), intent(in) :: kPoint(:)
 
     !> Neighbour list for the atoms (First index from 0!)
@@ -2544,7 +2544,7 @@ contains
     !> Distributed dense matrix to pack
     complex(dp), intent(in) :: square(:, :)
 
-    !> k-point at which to pack
+    !> The k-point at which to pack
     real(dp), intent(in) :: kPoint(:)
 
     !> weight for this k-point
@@ -2647,7 +2647,7 @@ contains
     !> dense distributed matrix to pack
     complex(dp), intent(in) :: square(:, :)
 
-    !> k-point at which to pack
+    !> The k-point at which to pack
     real(dp), intent(in) :: kPoint(:)
 
     !> weight for this k-point
@@ -2705,7 +2705,7 @@ contains
     !> distributed sparse matrix to pack
     complex(dp), intent(in) :: square(:, :)
 
-    !> k-point at which to unpack
+    !> The k-point at which to unpack
     real(dp), intent(in) :: kPoint(:)
 
     !> weight for this k-point
@@ -2876,7 +2876,7 @@ contains
     !> local part of the distributed matrix
     complex(dp), intent(in) :: square(:, :)
 
-    !> k-point at which to pack
+    !> The k-point at which to pack
     real(dp), intent(in) :: kPoint(:)
 
     !> weight at this k-point
@@ -3239,7 +3239,7 @@ contains
     !> Distributed dense matrix to pack
     complex(dp), intent(in) :: square(:, :)
 
-    !> k-point at which to pack
+    !> The k-point at which to pack
     real(dp), intent(in) :: kPoint(:)
 
     !> weight for this k-point

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -344,7 +344,7 @@ module dftbp_dftbplus_initprogram
     !> Nr. of K-points
     integer :: nKPoint
 
-    !> K-points
+    !> The k-points
     real(dp), allocatable :: kPoint(:,:)
 
     !> Weight of the K-Points
@@ -6190,7 +6190,7 @@ contains
     !> Correction to energy from on-site matrix elements
     real(dp), allocatable, intent(in) :: onSiteElements(:,:,:,:)
 
-    !> K-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Nr. of electrons

--- a/src/dftbp/dftbplus/inputdata.F90
+++ b/src/dftbp/dftbplus/inputdata.F90
@@ -373,7 +373,7 @@ module dftbp_dftbplus_inputdata
     !> Number of k-points for the calculation
     integer :: nKPoint = 0
 
-    !> K-points for the system (= 0 for molecular in free space and no symmetries)
+    !> The k-points for the system (= 0 for molecular in free space and no symmetries)
     real(dp), allocatable :: kPoint(:,:)
 
     !> Weights for the k-points

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -2670,7 +2670,7 @@ contains
     !> Vectors (in units of the lattice constants) to cells of the lattice
     real(dp), intent(in) :: cellVec(:,:)
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -2733,7 +2733,7 @@ contains
     !> Number of electrons
     real(dp), intent(in) :: nEl(:)
 
-    !> k-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Fermi level(s)
@@ -2893,7 +2893,7 @@ contains
     !> Vectors (in units of the lattice constants) to cells of the lattice
     real(dp), intent(in) :: cellVec(:,:)
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -2956,7 +2956,7 @@ contains
     !> Number of electrons
     real(dp), intent(in) :: nEl(:)
 
-    !> k-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Fermi level(s)
@@ -3129,7 +3129,7 @@ contains
     !> Electronic solver information
     type(TElectronicSolver), intent(inout) :: electronicSolver
 
-    !> k-points and spins to be handled
+    !> The k-points and spins to be handled
     type(TParallelKS), intent(in) :: parallelKS
 
     !>Data for hybrid xc-functional calculation
@@ -3246,10 +3246,10 @@ contains
     !> Integral container
     type(TIntegral), intent(in) :: ints
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
-    !> K-point weight (for energy contribution)
+    !> The k-point weight (for energy contribution)
     real(dp), intent(in) :: kWeight(:)
 
     !> List of neighbours for each atom
@@ -3282,7 +3282,7 @@ contains
     !> Electronic solver information
     type(TElectronicSolver), intent(inout) :: electronicSolver
 
-    !> k-points and spins to be handled
+    !> The k-points and spins to be handled
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Is the geometry helical
@@ -3427,7 +3427,7 @@ contains
     !> Integral container
     type(TIntegral), intent(in) :: ints
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> List of neighbours for each atom
@@ -3454,7 +3454,7 @@ contains
     !> Electronic solver information
     type(TElectronicSolver), intent(inout) :: electronicSolver
 
-    !> k-points and spins to be handled
+    !> The k-points and spins to be handled
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Eigenvalues (orbital, kpoint)
@@ -3565,7 +3565,7 @@ contains
     !> Species of atoms
     integer, intent(in), optional :: species(:)
 
-    !> k-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> All coordinates
@@ -3695,7 +3695,7 @@ contains
     !> Occupations of single particle states in the ground state
     real(dp), intent(in) :: filling(:,:,:)
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -3722,7 +3722,7 @@ contains
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
 
-    !> k-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Is the geometry helical
@@ -3829,7 +3829,7 @@ contains
     !> Should Mulliken populations be generated/output
     logical, intent(in) :: tMulliken
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -3862,7 +3862,7 @@ contains
     !> Species of all atoms in the system
     integer, intent(in) :: species(:)
 
-    !> k-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Eigenvectors
@@ -4381,7 +4381,7 @@ contains
     !> Environment settings
     type(TEnvironment), intent(in) :: env
 
-    !> k-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Square dense overlap storage
@@ -4962,7 +4962,7 @@ contains
     !> Excited state settings
     type(TLinResp), intent(inout), allocatable :: linearResponse
 
-    !> k-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> SCC module internal variables
@@ -5372,7 +5372,7 @@ contains
     !> Eigenvalues
     real(dp), intent(in) :: eigen(:,:,:)
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -5405,7 +5405,7 @@ contains
     !> Integral container
     type(TIntegral), intent(in) :: ints
 
-    !> k-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Is the geometry helical
@@ -5519,7 +5519,7 @@ contains
     !> Eigenvalues
     real(dp), intent(in) :: eigen(:,:,:)
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -5552,7 +5552,7 @@ contains
     !> Integral container
     type(TIntegral), intent(in) :: ints
 
-    !> k-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Is the geometry helical
@@ -5646,7 +5646,7 @@ contains
     !> Integral container
     type(TIntegral), intent(in) :: ints
 
-    !> k-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Is the geometry helical
@@ -5829,7 +5829,7 @@ contains
     !> Eigen-values of the system
     real(dp), intent(in) :: eigen(:,:,:)
 
-    !> k-points of the system
+    !> The k-points of the system
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -5859,7 +5859,7 @@ contains
     !> Integral container
     type(TIntegral), intent(in) :: ints
 
-    !> k-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Is the geometry helical
@@ -6052,7 +6052,7 @@ contains
     !> Eigenvalues
     real(dp), intent(in) :: eigen(:,:,:)
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -6082,7 +6082,7 @@ contains
     !> Is the hamiltonian real (no k-points/molecule/gamma point)?
     logical, intent(in) :: tRealHS
 
-    !> k-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Eigenvectors
@@ -6148,7 +6148,7 @@ contains
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
 
-    !> k-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Boundary conditions on the geometry
@@ -6289,7 +6289,7 @@ contains
     !> Is the hamiltonian real (no k-points/molecule/gamma point)?
     logical, intent(in) :: tRealHS
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -7158,7 +7158,7 @@ contains
     !> Integral container
     type(TIntegral), intent(in) :: ints
 
-    !> k-points in the system (0,0,0) if molecular
+    !> The k-points in the system (0,0,0) if molecular
     real(dp), intent(in) :: kPoint(:,:)
 
     !> List of neighbours for each atom
@@ -7194,7 +7194,7 @@ contains
     !> Label for each atomic chemical species
     character(*), intent(in) :: speciesName(:)
 
-    !> k-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Localisation measure of single particle states
@@ -7571,7 +7571,7 @@ contains
     !> Eigenvectors
     real(dp), intent(inout) :: eigvecs(:,:,:)
 
-    !> k-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Sparse density matrix

--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -165,13 +165,13 @@ contains
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> sparse overlap matrix
     real(dp), intent(in) :: over(:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Whether eigenvectors should be also written in text form
@@ -243,7 +243,7 @@ contains
     !> sparse overlap matrix
     real(dp), intent(in) :: over(:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Whether eigenvectors should be also written in text form
@@ -317,13 +317,13 @@ contains
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> sparse overlap matrix
     real(dp), intent(in) :: over(:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Whether eigenvectors should be also written in text form
@@ -388,7 +388,7 @@ contains
     !> Id of the current program run.
     integer, intent(in) :: runId
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> optional alternative file prefix, to appear as "fileName".bin
@@ -459,7 +459,7 @@ contains
     !> Id of the current program run.
     integer, intent(in) :: runId
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> optional alternative file prefix, to appear as "fileName".bin
@@ -500,7 +500,7 @@ contains
     !> Square Hamiltonian (or work array)
     real(dp), intent(in) :: eigvecs(:,:,:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Orbital information
@@ -642,7 +642,7 @@ contains
     !> Sparse overlap matrix.
     real(dp), intent(in) :: over(:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Square Hamiltonian (or work array)
@@ -696,7 +696,7 @@ contains
     !> Square Hamiltonian (or work array)
     complex(dp), intent(in) :: eigvecs(:,:,:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Orbital information
@@ -854,7 +854,7 @@ contains
     !> Sparse overlap matrix.
     real(dp), intent(in) :: over(:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> K point coordinates
@@ -916,7 +916,7 @@ contains
     !> Square Hamiltonian (or work array)
     complex(dp), intent(in) :: eigvecs(:,:,:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Orbital information
@@ -1078,7 +1078,7 @@ contains
     !> Sparse overlap matrix.
     real(dp), intent(in) :: over(:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> K point coordinates
@@ -1164,7 +1164,7 @@ contains
     !> sparse overlap matrix
     real(dp), intent(in) :: over(:)
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -1173,7 +1173,7 @@ contains
     !> Orbital regions to project
     type(TListIntR1), intent(inout) :: iOrbRegion
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Storage for eigenvectors (real)
@@ -1250,7 +1250,7 @@ contains
     !> Eigenvectors
     real(dp), intent(in) :: eigvecs(:,:,:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Sparse overlap
@@ -1370,7 +1370,7 @@ contains
     !> Sparse overlap matrix
     real(dp), intent(in) :: over(:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Square Hamiltonian (or work array)
@@ -1436,10 +1436,10 @@ contains
     !> Eigenvectors
     complex(dp), intent(in) :: eigvecs(:,:,:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
-    !> K-points
+    !> The k-points
     real(dp), intent(in) :: kPoints(:,:)
 
     !> Weights of the k-points
@@ -1585,7 +1585,7 @@ contains
     !> KPoints weights
     real(dp), intent(in) :: kWeights(:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Eigen vectors
@@ -1656,10 +1656,10 @@ contains
     !> Basis orbital information
     type(TOrbitals), intent(in) :: orb
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
-    !> K-points
+    !> The k-points
     real(dp), intent(in) :: kPoints(:,:)
 
     !> Weights of the k-points
@@ -1815,7 +1815,7 @@ contains
     !> KPoints weights
     real(dp), intent(in) :: kWeights(:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Eigenvectors
@@ -2283,7 +2283,7 @@ contains
     !> Number of atomic orbitals (may not match nStates if non-collinear)
     integer, intent(in) :: nOrb
 
-    !> k-points in the system
+    !> The k-points in the system
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights of the k-points
@@ -2735,7 +2735,7 @@ contains
     !> Reciprocal lattice vectors if periodic
     real(dp), intent(in) :: invLatVec(:,:)
 
-    !> K-points if periodic
+    !> The k-points if periodic
     real(dp), intent(in) :: kPoints(:,:)
 
     integer :: nKPoint, nMovedAtom, iAt, iK
@@ -4184,7 +4184,7 @@ contains
     !> Image atoms to central cell
     integer, intent(in) :: img2CentCell(:)
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> index  for which unit cell an atom is in
@@ -5090,7 +5090,7 @@ contains
     !> Spin index of the eigenvector
     integer, intent(in) :: iS
 
-    !> K-point index of the eigenvector
+    !> The k-point index of the eigenvector
     integer, intent(in) :: iK
 
     !> Index of the eigenvector
@@ -5158,7 +5158,7 @@ contains
     !> Fraction of each orbital in the eigenvector, decomposed into 4 components.
     real(dp), intent(in) :: fracs(:,:)
 
-    !> K-point index of the eigenvector
+    !> The k-point index of the eigenvector
     integer, intent(in) :: iK
 
     !> Index of the eigenvector
@@ -5585,7 +5585,7 @@ contains
     !> Reciprocal lattice vectors if periodic
     real(dp), intent(in) :: invLatVec(:,:)
 
-    !> K-points if periodic
+    !> The k-points if periodic
     real(dp), intent(in) :: kPoints(:,:)
 
     !> atoms in the central cell (or device region if transport)

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -2881,7 +2881,7 @@ contains
     !> Number of k-points for the calculation
     integer, intent(in) :: nKPoint
 
-    !> K-points for the system
+    !> The k-points for the system
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for the k-points
@@ -2900,7 +2900,7 @@ contains
   end function isGammaOnly
 
 
-  !> K-points in Euclidean space
+  !> The k-points in Euclidean space
   subroutine getEuclideanKSampling(poorKSampling, checkStopHybridCalc, ctrl, node, geo, errStatus)
 
     !> Is this k-point grid usable to integrate properties like the energy, charges, ...?
@@ -3088,7 +3088,7 @@ contains
   end subroutine getEuclideanKSampling
 
 
-  !> K-points for helical boundaries
+  !> The k-points for helical boundaries
   subroutine getHelicalKSampling(poorKSampling, ctrl, node, geo)
 
     !> Is this k-point grid usable to integrate properties like the energy, charges, ...?

--- a/src/dftbp/elecsolvers/elsisolver.F90
+++ b/src/dftbp/elecsolvers/elsisolver.F90
@@ -333,7 +333,7 @@ contains
     !> total number of k-points
     integer, intent(in) :: nKPoint
 
-    !> K-point processed by current process.
+    !> The k-point processed by current process.
     integer, intent(in) :: iKPoint
 
     !> Weight of current k-point
@@ -855,7 +855,7 @@ contains
     !> Vectors (in units of the lattice constants) to cells of the lattice
     real(dp), intent(in) :: cellVec(:,:)
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -888,7 +888,7 @@ contains
     !> Should Mulliken populations be generated/output
     logical, intent(in) :: tMulliken
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Fermi level(s)
@@ -1051,7 +1051,7 @@ contains
     !> Number of spin channels
     integer, intent(in) :: nSpin
 
-    !> K-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -1090,7 +1090,7 @@ contains
     !> Is the hamiltonian real (no k-points/molecule/gamma point)?
     logical, intent(in) :: tRealHS
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Energy weighted sparse matrix
@@ -1305,7 +1305,7 @@ contains
     !> atomic coordinates
     real(dp), intent(in) :: coord(:,:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> sparse density matrix
@@ -1409,7 +1409,7 @@ contains
     !> Vectors (in units of the lattice constants) to cells of the lattice
     real(dp), intent(in) :: cellVec(:,:)
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -1427,7 +1427,7 @@ contains
     !> atomic coordinates
     real(dp), intent(in) :: coord(:,:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> sparse density matrix
@@ -1542,7 +1542,7 @@ contains
     !> Vectors (in units of the lattice constants) to cells of the lattice
     real(dp), intent(in) :: cellVec(:,:)
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -1563,7 +1563,7 @@ contains
     !> Should Mulliken populations be generated/output
     logical, intent(in) :: tMulliken
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Energy contributions and total
@@ -1990,7 +1990,7 @@ contains
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc
 
-    !> K-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -2026,7 +2026,7 @@ contains
     !> Vectors (in units of the lattice constants) to cells of the lattice
     real(dp), intent(in) :: cellVec(:,:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Energy weighted sparse matrix
@@ -2085,7 +2085,7 @@ contains
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc
 
-    !> K-points
+    !> The k-points
     real(dp), intent(in) :: kPoint(:,:)
 
     !> Weights for k-points
@@ -2112,7 +2112,7 @@ contains
     !> Vectors (in units of the lattice constants) to cells of the lattice
     real(dp), intent(in) :: cellVec(:,:)
 
-    !> K-points and spins to process
+    !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
 
     !> Energy weighted sparse matrix

--- a/src/dftbp/timedep/timeprop.F90
+++ b/src/dftbp/timedep/timeprop.F90
@@ -754,7 +754,7 @@ contains
     !> H and S are real
     logical, intent(in) :: tRealHS
 
-    !> K-points
+    !> The k-points
     real(dp) :: kPoint(:,:)
 
     !> Weight of the K-Points

--- a/src/dftbp/transport/negfint.F90
+++ b/src/dftbp/transport/negfint.F90
@@ -1103,10 +1103,10 @@ contains
     !> atomic orbital information
     type(TOrbitals), intent(in) :: orb
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoints(:,:)
 
-    !> k-point weights
+    !> The k-point weights
     real(dp), intent(in) :: kWeights(:)
 
     !> chemical potentials of reservoirs
@@ -1260,10 +1260,10 @@ contains
     !> atomic orbital information Needs only orb%nOrbAtom, orb%mOrb
     type(TOrbitals), intent(in) :: orb
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoints(:,:)
 
-    !> k-point weights
+    !> The k-point weights
     real(dp), intent(in) :: kWeights(:)
 
     !> chemical potentials
@@ -1395,10 +1395,10 @@ contains
     !> atomic orbital information Needs only orb%nOrbAtom, orb%mOrb
     type(TOrbitals), intent(in) :: orb
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoints(:,:)
 
-    !> k-point weights
+    !> The k-point weights
     real(dp), intent(in) :: kWeights(:)
 
     !> matrix of tunnelling amplitudes at each energy from contacts
@@ -1739,7 +1739,7 @@ contains
     !> number of spins
     integer, intent(in) :: nS
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoints(:,:)
 
     !> Weights for k-points
@@ -1816,7 +1816,7 @@ contains
     !> number of spins
     integer, intent(in) :: nS
 
-    !> k-points
+    !> The k-points
     real(dp), intent(in) :: kPoints(:,:)
 
     !> Weights for k-points
@@ -1920,7 +1920,7 @@ contains
     !> Orbital descriptor
     type(TOrbitals), intent(in) :: orb
 
-    !> k-points and weights
+    !> The k-points and weights
     real(dp), intent(in) :: kPoints(:,:), kWeights(:)
 
     !> central cell coordinates (folded to central cell)

--- a/src/dftbp/type/parallelks.F90
+++ b/src/dftbp/type/parallelks.F90
@@ -19,8 +19,8 @@ module dftbp_type_parallelks
   !> Contains information about which k-points and spins must be processed by which processor group
   type :: TParallelKS
 
-    !> K-point and spin-channels to be processed by each processor group (groupKS(1:2,iKS,iGroup)).
-    !> Note: third index (group index) starts from 0
+    !> The k-point and spin-channels to be processed by each processor group
+    !! (groupKS(1:2,iKS,iGroup)).  Note: third index (group index) starts from 0
     integer, allocatable :: groupKS(:,:,:)
 
     !> Number of (K, S) tuples to process for each group.


### PR DESCRIPTION
Changes comments starting "!> k-point" or "!> K-point" to "!> The k-point", avoiding caps for k, but also starting the comment in accordance with the convention.