### PR TITLE
Facilitate vectorization of ewaldReciprocal

### DIFF
--- a/src/dftbp/dftb/coulomb.F90
+++ b/src/dftbp/dftb/coulomb.F90
@@ -2050,19 +2050,24 @@ contains
     !> contribution to the sum
     real(dp) :: recSum
 
-    real(dp) :: gg(3), g2
+    real(dp), allocatable :: recSumArray(:)
+
+    real(dp) :: g2Factor, g2, gr
     integer :: iG
 
     @:ASSERT(vol > 0.0_dp)
 
-    recSum = 0.0_dp
+    g2Factor = -1.0_dp / (4.0_dp*alpha**2)
+
+    allocate(recSumArray(size(gVec, dim=2)), source=0.0_dp)
+
     do iG = 1, size(gVec, dim=2)
-      gg = gVec(:,iG)
-      g2 = sum(gg(:)**2)
-      recSum = recSum + exp(-g2/(4.0_dp*alpha**2))/g2 * cos(dot_product(gg,rr))
+      g2 = gVec(1,iG)**2 + gVec(2,iG)**2 + gVec(3,iG)**2
+      gr = gVec(1,iG) * rr(1) + gVec(2,iG) * rr(2) + gVec(3,iG) * rr(3)
+      recSumArray(iG) = exp(g2Factor * g2)/g2 * cos(gr)
     end do
     ! note factor of 2 as only summing half of reciprocal space
-    recSum = 2.0_dp * recSum * 4.0_dp * pi / vol
+    recSum = 2.0_dp * sum(recSumArray) * 4.0_dp * pi / vol
 
   end function ewaldReciprocal
 


### PR DESCRIPTION
These changes help vectorizing the loop in the function `ewaldReciprocal`. In my tests, its runtime is reduced to 33% of its previous runtime. Note that the dot products have to be written explicitly. Otherwise, the compiler will only vectorize the innermost loops (with 3 elements) instead of the outer large loop.