### PR TITLE
Possible bug when deltaRhoOut generated

### DIFF
--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -3660,8 +3660,13 @@ contains
     #:endif
 
       if (allocated(rhoSqrReal)) then
-        rhoSqrReal(:,:, iSpin) = work
+        if (.not. allocated(deltaRhoOut)) then
+          rhoSqrReal(:,:, iSpin) = work
+        else
+          rhoSqrReal(:,:, iSpin) = deltaRhoOut(:,:,iSpin)
+        end if
       end if
+
     end do
 
   #:if WITH_SCALAPACK


### PR DESCRIPTION
As the work array is then not used, so nothing to copy. Would impact excited state use of resulting density matrix.