### PR TITLE
Remove imports without "only"

### DIFF
--- a/app/misc/skderivs/skderivs.F90
+++ b/app/misc/skderivs/skderivs.F90
@@ -9,22 +9,23 @@
 
 !> Calculates the first and second derivatives of matrix elements
 program skderivs
-  use dftbp_common_accuracy
-  use dftbp_common_constants
+  use dftbp_common_accuracy, only : dp, lc
+  use dftbp_common_constants, only : maxL, shellNames
+  use dftbp_common_file, only : closeFile, openFile, TFileDescr
   use dftbp_common_globalenv, only : stdOut
-  use dftbp_common_file, only : TFileDescr, openFile, closeFile
-  use dftbp_dftb_slakoeqgrid
-  use dftbp_io_charmanip
-  use dftbp_io_hsdparser, only : parseHSD, dumpHSD, getNodeHSDName
-  use dftbp_io_hsdutils
-  use dftbp_io_hsdutils2
-  use dftbp_io_message
-  use dftbp_type_linkedlist
-  use dftbp_type_oldskdata
+  use dftbp_dftb_slakoeqgrid, only : getNIntegrals, getSKIntegrals, init, skEqGridNew, skEqGridOld,&
+      & TSlakoEqGrid
+  use dftbp_io_charmanip, only : i2c, unquote
+  use dftbp_io_hsdparser, only : dumpHSD, getNodeHSDName, parseHSD
+  use dftbp_io_hsdutils, only : detailedError, getChild, getChildValue
+  use dftbp_io_hsdutils2, only : warnUnprocessedNodes
+  use dftbp_type_linkedlist, only : append, asArray, init, intoArray, len, TListInt, TListIntR1
+  use dftbp_type_oldskdata, only : readFromFile, TOldSKData
 #:if WITH_MPI
   use dftbp_common_mpienv
 #:endif
-  use xmlf90_flib_dom
+  use dftbp_extlibs_xmlf90, only : append_to_string, assignment(=), char, fNode, resize_string,&
+      & string
 implicit none
 
 

--- a/app/misc/slakovalue/integvalue.F90
+++ b/app/misc/slakovalue/integvalue.F90
@@ -8,11 +8,11 @@
 !> Reads a spline repulsive from an SK-table and returns its value and its first
 !! and second derivatives.
 program integvalue
-  use dftbp_common_accuracy
+  use dftbp_common_accuracy, only : dp, lc
   use dftbp_common_globalenv, only : stdOut
-  use dftbp_dftb_slakoeqgrid
-  use dftbp_io_message
-  use dftbp_type_oldskdata
+  use dftbp_dftb_slakoeqgrid, only : getCutoff, getSKIntegrals, init, skEqGridNew, TSlakoEqGrid
+  use dftbp_io_message, only : error
+  use dftbp_type_oldskdata, only : readFromFile, TOldSKData
   implicit none
 
   integer, parameter :: nSKInter = 20

--- a/app/phonons/initphonons.F90
+++ b/app/phonons/initphonons.F90
@@ -8,29 +8,32 @@
 #:include 'common.fypp'
 
 module phonons_initphonons
-  use dftbp_common_accuracy
-  use dftbp_common_atomicmass
-  use dftbp_common_constants
-  use dftbp_common_environment
-  use dftbp_common_file, only : TFileDescr, closeFile, openFile
-  use dftbp_common_globalenv
+  use dftbp_common_accuracy, only : dp, lc, mc
+  use dftbp_common_atomicmass, only : getAtomicMass
+  use dftbp_common_constants, only : amu__au
+  use dftbp_common_environment, only : TEnvironment
+  use dftbp_common_file, only : closeFile, openFile, TFileDescr
+  use dftbp_common_globalenv, only : stdOut, tIoProc
   use dftbp_common_status, only : TStatus
-  use dftbp_common_unitconversion
-  use dftbp_dftb_periodic
-  use dftbp_io_charmanip
-  use dftbp_io_hsdparser, only : parseHSD, dumpHSD
-  use dftbp_io_hsdutils
-  use dftbp_io_hsdutils2
-  use dftbp_io_message
-  use dftbp_io_tokenreader
-  use dftbp_io_xmlutils
-  use dftbp_math_simplealgebra
-  use dftbp_transport_negfvars
-  use dftbp_type_linkedlist
-  use dftbp_type_oldskdata
-  use dftbp_type_typegeometryhsd
-  use dftbp_type_wrappedintr
-  use xmlf90_flib_dom
+  use dftbp_common_unitconversion, only : energyUnits, lengthUnits
+  use dftbp_dftb_periodic, only : getCellTranslations, getNrOfNeighboursForAll, getSuperSampling,&
+      & TNeighbourList, TNeighbourlist_init, updateNeighbourList
+  use dftbp_extlibs_xmlf90, only : assignment(=), char, destroyNodeList, fnode, fnodelist, getItem1,&
+      & getLength, getNodeName, string, textNodeName
+  use dftbp_io_charmanip, only : i2c, tolower, unquote
+  use dftbp_io_hsdparser, only : dumpHSD, parseHSD
+  use dftbp_io_hsdutils, only : detailedError, getChild, getChildren, getChildValue,&
+      & getFirstTextChild, getSelectedAtomIndices, getSelectedIndices, setChild, setChildValue
+  use dftbp_io_hsdutils2, only : convertUnitHsd, setUnprocessed, warnUnprocessedNodes
+  use dftbp_io_message, only : error
+  use dftbp_io_tokenreader, only : getNextToken
+  use dftbp_math_simplealgebra, only : determinant33
+  use dftbp_transport_negfvars, only : ContactInfo, TNEGFtundos, TTransPar
+  use dftbp_type_linkedlist, only : append, asArray, asVector, destruct, get, init, len,&
+      & TListCharLc, TListInt, TListIntR1, TListReal, TListRealR1, TListString
+  use dftbp_type_oldskdata, only : readFromFile, TOldSKData
+  use dftbp_type_typegeometryhsd, only : readTGeometryGen, readTGeometryHSD, TGeometry
+  use dftbp_type_wrappedintr, only : TWrappedInt1
   implicit none
   private
 

--- a/app/phonons/libnegfint.F90
+++ b/app/phonons/libnegfint.F90
@@ -26,25 +26,26 @@
 #:include "common.fypp"
 
 module phonons_libnegfint
-  use dftbp_common_accuracy
-  use dftbp_common_environment
-  use dftbp_common_file, only : TFileDescr, closeFile, openFile
+  use phonons_initphonons, only : modeEnum, TempMax, TempMin, TempStep
+  use dftbp_common_accuracy, only : dp
+  use dftbp_common_environment, only : TEnvironment
+  use dftbp_common_file, only : closeFile, openFile, TFileDescr
   use dftbp_common_globalenv, only : stdOut, tIoProc
-  use dftbp_extlibs_negf, only : getel, lnParams, pass_DM, Tnegf, kb, units, convertHeatCurrent,&
-      & convertHeatConductance, z_CSR, z_DNS, READ_SGF, COMP_SGF, COMPSAVE_SGF, DELTA_SQ, DELTA_W,&
-      & DELTA_MINGO, associate_lead_currents, associate_ldos, associate_transmission,&
-      & compute_phonon_current, thermal_conductance, create, create_scratch, destroy,&
-      & set_readoldDMsgf, destroy_matrices, destroy_negf, get_params, init_contacts, init_ldos,&
-      & init_negf, init_structure, pass_hs, set_bp_dephasing, set_scratch, set_drop,&
-      & set_elph_block_dephasing, set_elph_dephasing, set_elph_s_dephasing, set_ldos_indexes,&
-      & set_tun_indexes, set_params, writememinfo, writepeakinfo, dns2csr, csr2dns, nzdrop, printcsr
-  use phonons_initphonons, only : TempMin, TempMax, TempStep, modeEnum
-  use dftbp_io_message
-  use dftbp_transport_matconv
-  use dftbp_transport_negfvars
+  use dftbp_extlibs_negf, only : associate_ldos, associate_lead_currents, associate_transmission,&
+      & COMP_SGF, COMPSAVE_SGF, compute_phonon_current, convertHeatConductance, convertHeatCurrent,&
+      & create, create_scratch, csr2dns, DELTA_MINGO, DELTA_SQ, DELTA_W, destroy, destroy_matrices,&
+      & destroy_negf, dns2csr, get_params, getel, init_contacts, init_ldos, init_negf,&
+      & init_structure, kb, lnParams, nzdrop, pass_DM, pass_hs, printcsr, READ_SGF,&
+      & set_bp_dephasing, set_drop, set_elph_block_dephasing, set_elph_dephasing,&
+      & set_elph_s_dephasing, set_ldos_indexes, set_params, set_readoldDMsgf, set_scratch,&
+      & set_tun_indexes, thermal_conductance, Tnegf, units, writememinfo, writepeakinfo, z_CSR,&
+      & z_DNS
+  use dftbp_io_message, only : error
+  use dftbp_transport_matconv, only : destruct
+  use dftbp_transport_negfvars, only : TNEGFTunDos, TTranspar
   use dftbp_type_commontypes, only : TOrbitals
 #:if WITH_MPI
-  use dftbp_extlibs_mpifx
+  use dftbp_extlibs_mpifx, only : MPI_SUM, mpifx_comm, mpifx_reduceip
   use dftbp_extlibs_negf, only : negf_mpi_init
 #:endif
   implicit none

--- a/app/phonons/phonons.F90
+++ b/app/phonons/phonons.F90
@@ -8,19 +8,21 @@
 #:include 'common.fypp'
 
 program phonons
+  use phonons_initphonons, only : atomicMasses, autotestTag, destructProgramVariables, dynMatrix,&
+      & geo, img2CentCell, iMovedAtoms, initProgramVariables, kPoint, modesToPlot, nAtomUnitCell,&
+      & nCells, nCycles, neighbourList, nKPoints, nModesToPlot, nMovedAtom, nNeighbour, nSteps,&
+      & outputUnits, selTypeModes, tAnimateModes, tCompModes, tPhonDispersion, tPlotModes, transpar,&
+      & tTransport, tundos, tWriteTagged, tXmakeMol
+  use phonons_libnegfint, only : calc_phonon_current, init_tun_proj, negf_init, negf_init_str
   use dftbp_common_accuracy, only : dp, lc
-  use dftbp_common_constants, only : Hartree__cm, Bohr__AA, Hartree__J, Hartree__eV, hbar, pi
-  use dftbp_common_environment
+  use dftbp_common_constants, only : Bohr__AA, Hartree__cm, Hartree__eV, Hartree__J, hbar, pi
+  use dftbp_common_environment, only : TEnvironment, TEnvironment_init
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv
-  use phonons_initphonons
-  use dftbp_io_message
-  use dftbp_io_taggedoutput
+  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv, stdOut, tIOProc
+  use dftbp_io_message, only : error
+  use dftbp_io_taggedoutput, only : TTaggedWriter, TTaggedWriter_init
   use dftbp_math_eigensolver, only : heev
   use dftbp_math_simplealgebra, only : invert33
-  use dftbp_type_typegeometry
-  use phonons_libnegfint
-  use ln_structure
   implicit none
 
   type(TEnvironment) :: env

--- a/app/transporttools/helpsetupgeom.F90
+++ b/app/transporttools/helpsetupgeom.F90
@@ -6,18 +6,17 @@
 !--------------------------------------------------------------------------------------------------!
 
 module transporttools_helpsetupgeom
-  use dftbp_common_accuracy
-  use dftbp_common_constants
-  use dftbp_common_globalenv
-  use dftbp_common_file, only : TFileDescr, openFile, closeFile
-  use dftbp_io_message
-  use dftbp_math_f08math
-  use dftbp_math_simplealgebra
-  use dftbp_math_sorting
+  use dftbp_common_accuracy, only : dp, lc
+  use dftbp_common_constants, only : Bohr__AA
+  use dftbp_common_file, only : closeFile, openFile, TFileDescr
+  use dftbp_common_globalenv, only : stdOut
+  use dftbp_io_message, only : error, warning
+  use dftbp_math_simplealgebra, only : cross3
+  use dftbp_math_sorting, only : index_heap_sort
   use dftbp_transport_negfvars, only : contactInfo
-  use dftbp_type_linkedlist
-  use dftbp_type_typegeometry
-  use dftbp_type_wrappedintr
+  use dftbp_type_linkedlist, only : append, asArray, destruct, get, init, len, TListInt, TListIntR1
+  use dftbp_type_typegeometry, only : TGeometry
+  use dftbp_type_wrappedintr, only : TWrappedInt1
   implicit none
 
   private

--- a/app/transporttools/inputdata.F90
+++ b/app/transporttools/inputdata.F90
@@ -9,14 +9,8 @@
 
 !> Contains data type representing the input data for setupgeom
 module transporttools_inputdata
-  use dftbp_common_accuracy
-  use dftbp_io_message
-  use dftbp_transport_negfvars
-  use dftbp_type_commontypes
-  use dftbp_type_linkedlist
-  use dftbp_type_typegeometry
-  use dftbp_type_wrappedintr
-
+  use dftbp_transport_negfvars, only : TTransPar
+  use dftbp_type_typegeometry, only : TGeometry
   implicit none
   private
 

--- a/app/transporttools/setupgeom.F90
+++ b/app/transporttools/setupgeom.F90
@@ -8,15 +8,15 @@
 #:include 'common.fypp'
 
 program setupgeom
-  use dftbp_common_globalenv
-  use dftbp_common_release, only : releaseYear
-  use dftbp_io_formatout, only : printDftbHeader
   use transporttools_inputdata, only : TInputData
   use transporttools_parser, only : parseHsdInput
+  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv
+  use dftbp_common_release, only : releaseYear
+  use dftbp_io_formatout, only : printDftbHeader
 #:if WITH_MPI
-  use mpi, only : MPI_THREAD_FUNNELED, MPI_COMM_WORLD
+  use mpi, only : MPI_COMM_WORLD, MPI_THREAD_FUNNELED
   use dftbp_common_mpienv, only : TMpiEnv, TMpiEnv_init
-  use dftbp_extlibs_mpifx, only : mpifx_init_thread, mpifx_finalize
+  use dftbp_extlibs_mpifx, only : mpifx_finalize, mpifx_init_thread
 #:endif
   implicit none
 

--- a/src/dftbp/api/mm/capi.F90
+++ b/src/dftbp/api/mm/capi.F90
@@ -7,16 +7,17 @@
 
 !> Contains the C-API of DFTB+.
 module dftbp_capi
-  use, intrinsic :: iso_c_binding
-  use, intrinsic :: iso_fortran_env
+  use, intrinsic :: iso_c_binding, only : c_associated, c_bool, c_char, c_double, c_f_pointer,&
+      & c_f_procpointer, c_funptr, c_int, c_loc, c_null_char, c_null_ptr, c_ptr
+  use, intrinsic :: iso_fortran_env, only : output_unit
   use dftbp_common_accuracy, only : dp
-  use dftbp_common_file, only : TFileDescr, openFile
+  use dftbp_common_file, only : openFile, TFileDescr
   use dftbp_common_globalenv, only : instanceSafeBuild
-  use dftbp_dftbplus_qdepextpotgenc, only :&
-      & getExtPotIfaceC, getExtPotGradIfaceC, TQDepExtPotGenC, TQDepExtPotGenC_init
-  use dftbp_mmapi, only : TDftbPlus, TDftbPlus_init, TDftbPlus_destruct, TDftbPlusInput,&
-      & TDftbPlusAtomList
-  use dftbp_type_linkedlist, only : TListString, append, init, destruct
+  use dftbp_dftbplus_qdepextpotgenc, only : getExtPotGradIfaceC, getExtPotIfaceC, TQDepExtPotGenC,&
+      & TQDepExtPotGenC_init
+  use dftbp_mmapi, only : TDftbPlus, TDftbPlus_destruct, TDftbPlus_init, TDftbPlusAtomList,&
+      & TDftbPlusInput
+  use dftbp_type_linkedlist, only : append, destruct, init, TListString
   implicit none
   private
 

--- a/src/dftbp/api/mm/mmapi.F90
+++ b/src/dftbp/api/mm/mmapi.F90
@@ -9,29 +9,29 @@
 
 !> Provides DFTB+ API for MM-type high level access
 module dftbp_mmapi
-  use iso_fortran_env, only : output_unit
+  use, intrinsic :: iso_fortran_env, only : output_unit
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : TEnvironment, TEnvironment_init
-  use dftbp_common_file, only : TFileDescr, openFile, closeFile
-  use dftbp_common_globalenv, only : initGlobalEnv, destructGlobalEnv, instanceSafeBuild, withMpi
+  use dftbp_common_file, only : closeFile, openFile, TFileDescr
+  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv, instanceSafeBuild, withMpi
   use dftbp_dftbplus_hsdhelpers, only : doPostParseJobs
-  use dftbp_dftbplus_initprogram, only: TDftbPlusMain
+  use dftbp_dftbplus_initprogram, only : TDftbPlusMain
   use dftbp_dftbplus_inputdata, only : TInputData
-  use dftbp_dftbplus_mainapi, only : doOneTdStep, checkSpeciesNames, nrOfAtoms, nrOfKPoints,&
-      & setExternalPotential, getTdForces, setTdCoordsAndVelos, setTdElectricField,&
-      & initializeTimeProp, finalizeTimeProp, updateDataDependentOnSpeciesOrdering,&
-      & getAtomicMasses, getGrossCharges, getCM5Charges, getElStatPotential, getExtChargeGradients,&
-      & getStressTensor, getGradients, getEnergy, getCutOff, setQDepExtPotProxy,&
-      & setExternalCharges, setGeometry, setNeighbourList, getRefCharges, setRefCharges
-  use dftbp_dftbplus_parser, only : TParserFlags, rootTag, parseHsdTree, readHsdFile
+  use dftbp_dftbplus_mainapi, only : checkSpeciesNames, doOneTdStep, finalizeTimeProp,&
+      & getAtomicMasses, getCM5Charges, getCutOff, getElStatPotential, getEnergy,&
+      & getExtChargeGradients, getGradients, getGrossCharges, getRefCharges, getStressTensor,&
+      & getTdForces, initializeTimeProp, nrOfAtoms, nrOfKPoints, setExternalCharges,&
+      & setExternalPotential, setGeometry, setNeighbourList, setQDepExtPotProxy, setRefCharges,&
+      & setTdCoordsAndVelos, setTdElectricField, updateDataDependentOnSpeciesOrdering
+  use dftbp_dftbplus_parser, only : parseHsdTree, readHsdFile, rootTag, TParserFlags
   use dftbp_dftbplus_qdepextpotgen, only : TQDepExtPotGen, TQDepExtPotGenWrapper
   use dftbp_dftbplus_qdepextpotproxy, only : TQDepExtPotProxy, TQDepExtPotProxy_init
-  use dftbp_extlibs_xmlf90, only : fnode, createDocumentNode, createElement, appendChild,&
-      & destroyNode
+  use dftbp_extlibs_xmlf90, only : appendChild, createDocumentNode, createElement, destroyNode,&
+      & fnode
   use dftbp_io_charmanip, only : newline
   use dftbp_io_hsdutils, only : getChild
-  use dftbp_io_message, only: error
-  use dftbp_type_linkedlist, only : TListString, init, append, get, len, asArray
+  use dftbp_io_message, only : error
+  use dftbp_type_linkedlist, only : append, asArray, get, init, len, TListString
   use dftbp_type_typegeometry, only : TGeometry
   implicit none
   private

--- a/src/dftbp/api/mm/qdepextpotgenc.F90
+++ b/src/dftbp/api/mm/qdepextpotgenc.F90
@@ -7,7 +7,7 @@
 
 !> Simplified C-interface with callbacks for population dependant external potential generators.
 module dftbp_dftbplus_qdepextpotgenc
-  use, intrinsic :: iso_c_binding
+  use, intrinsic :: iso_c_binding, only : c_double, c_ptr
   use dftbp_common_accuracy, only : dp
   use dftbp_dftbplus_qdepextpotgen, only : TQDepExtPotGen
   implicit none

--- a/src/dftbp/common/gpuenv.F90
+++ b/src/dftbp/common/gpuenv.F90
@@ -10,7 +10,7 @@
 
 !> Information on any GPUs on the system
 module dftbp_common_gpuenv
-  use iso_c_binding, only :  c_int
+  use, intrinsic :: iso_c_binding, only : c_int
   use dftbp_common_globalenv, only : stdOut
   use dftbp_extlibs_magma, only : getGpusAvailable, getGpusRequested, gpusInit
   implicit none

--- a/src/dftbp/derivs/rotatedegen.F90
+++ b/src/dftbp/derivs/rotatedegen.F90
@@ -15,11 +15,11 @@ module dftbp_derivs_rotatedegen
   use dftbp_common_status, only : TStatus
   use dftbp_math_eigensolver, only : heev
   use dftbp_math_qm, only : makeSimilarityTrans
-  use dftbp_type_wrappedintr, only : TwrappedReal2, TwrappedCmplx2
+  use dftbp_type_wrappedintr, only : TwrappedCmplx2, TwrappedReal2
 #:if WITH_SCALAPACK
   use dftbp_common_environment, only : TEnvironment
-  use dftbp_type_densedescr, only: TDenseDescr
-  use linecomm_module, only : linecomm
+  use dftbp_extlibs_scalapackfx, only : linecomm
+  use dftbp_type_densedescr, only : TDenseDescr
 #:endif
   implicit none
 

--- a/src/dftbp/dftb/dispmbd.F90
+++ b/src/dftbp/dftb/dispmbd.F90
@@ -10,17 +10,17 @@
 
 !> MBD/TS dispersion model.
 module dftbp_dftb_dispmbd
-  use dftbp_common_accuracy, only: dp, mc, lc
-  use dftbp_common_constants, only: symbolToNumber
-  use dftbp_common_environment, only: TEnvironment
-  use dftbp_common_globalenv, only: stdOut
+  use dftbp_common_accuracy, only : dp, lc, mc
+  use dftbp_common_constants, only : symbolToNumber
+  use dftbp_common_environment, only : TEnvironment
+  use dftbp_common_globalenv, only : stdOut
   use dftbp_common_status, only : TStatus
-  use dftbp_dftb_dispiface, only: TDispersionIface
-  use dftbp_dftb_periodic, only: TNeighbourList
-  use dftbp_math_simplealgebra, only: determinant33
+  use dftbp_dftb_dispiface, only : TDispersionIface
+  use dftbp_dftb_periodic, only : TNeighbourList
+  use dftbp_extlibs_mbd, only : mbd_calc_t, TDispMbdInp
+  use dftbp_math_simplealgebra, only : determinant33
   use dftbp_type_commontypes, only : TOrbitals
-  use dftbp_type_typegeometry, only: TGeometry
-  use mbd, only: TDispMbdInp => mbd_input_t, mbd_calc_t
+  use dftbp_type_typegeometry, only : TGeometry
   implicit none
 
   private

--- a/src/dftbp/dftb/sccinit.F90
+++ b/src/dftbp/dftb/sccinit.F90
@@ -10,15 +10,15 @@
 !> Module for initializing SCC part of the calculation.
 module dftbp_dftb_sccinit
   use dftbp_common_accuracy, only : dp, elecTolMax
-  use dftbp_common_file, only : TFileDescr, openFile, closeFile
+  use dftbp_common_file, only : closeFile, openFile, TFileDescr
   use dftbp_common_globalenv, only : stdOut
   use dftbp_common_status, only : TStatus
+  use dftbp_dftb_densitymatrix, only : TDensityMatrix
+  use dftbp_dftb_hybridxc, only : checkSupercellFoldingMatrix, hybridXcAlgo
+  use dftbp_dftb_periodic, only : getSuperSampling
   use dftbp_io_message, only : error
   use dftbp_type_commontypes, only : TOrbitals
   use dftbp_type_multipole, only : TMultipole
-  use dftbp_dftb_densitymatrix, onLy : TDensityMatrix
-  use dftbp_dftb_hybridxc, only : checkSupercellFoldingMatrix, hybridXcAlgo
-  use dftbp_dftb_periodic, only : getSuperSampling
   implicit none
 
   private

--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -14,17 +14,17 @@
 
 !> Various I/O routines for the main program.
 module dftbp_dftbplus_mainio
-  use dftbp_common_accuracy, only : dp, mc, sc, lc
-  use dftbp_common_constants, only : Hartree__eV, Bohr__AA, au__pascal, au__V_m, au__fs, au__Debye,&
-      & Boltzmann, gfac, spinName, quaternionName
+  use dftbp_common_accuracy, only : dp, lc, mc, sc
+  use dftbp_common_constants, only : au__Debye, au__fs, au__pascal, au__V_m, Bohr__AA, Boltzmann,&
+      & gfac, Hartree__eV, quaternionName, spinName
   use dftbp_common_environment, only : TEnvironment
-  use dftbp_common_file, only : TFileDescr, openFile, closeFile
-  use dftbp_common_globalenv, only : stdOut, destructGlobalEnv, abortProgram
+  use dftbp_common_file, only : closeFile, openFile, TFileDescr
+  use dftbp_common_globalenv, only : abortProgram, destructGlobalEnv, stdOut
   use dftbp_common_status, only : TStatus
-  use dftbp_dftb_densitymatrix, onLy : TDensityMatrix
+  use dftbp_dftb_densitymatrix, only : TDensityMatrix
   use dftbp_dftb_determinants, only : TDftbDeterminants
   use dftbp_dftb_dispersions, only : TDispersionIface
-  use dftbp_dftb_elecconstraints, only: TElecConstraint
+  use dftbp_dftb_elecconstraints, only : TElecConstraint
   use dftbp_dftb_elstatpot, only : TElStatPotentials
   use dftbp_dftb_energytypes, only : TEnergies
   use dftbp_dftb_extfields, only : TEField
@@ -32,16 +32,16 @@ module dftbp_dftbplus_mainio
   use dftbp_dftb_sccinit, only : writeQToFile
   use dftbp_dftb_sparse2dense, only : unpackHS, unpackSPauli
   use dftbp_dftb_spin, only : qm2ud
-  use dftbp_elecsolvers_elecsolvers, only : TElectronicSolver, electronicSolverTypes
-  use dftbp_extlibs_xmlf90, only : xmlf_t, xml_OpenFile, xml_ADDXMLDeclaration, xml_NewElement,&
-      & xml_EndElement, xml_Close
+  use dftbp_elecsolvers_elecsolvers, only : electronicSolverTypes, TElectronicSolver
+  use dftbp_extlibs_xmlf90, only : xml_ADDXMLDeclaration, xml_Close, xml_EndElement, xml_NewElement,&
+      & xml_OpenFile, xmlf_t
   use dftbp_io_charmanip, only : i2c
-  use dftbp_io_commonformats, only : formatHessian, formatBorn, formatdBorn, formatGeoOut,&
-      & format1U, format2U, format1Ue, format2Ue, format1U1e
-  use dftbp_io_formatout, only : writeXYZFormat, writeGenFormat, writeSparse, writeSparseAsSquare
+  use dftbp_io_commonformats, only : format1U, format1U1e, format1Ue, format2U, format2Ue,&
+      & formatBorn, formatdBorn, formatGeoOut, formatHessian
+  use dftbp_io_formatout, only : writeGenFormat, writeSparse, writeSparseAsSquare, writeXYZFormat
   use dftbp_io_hsdutils, only : writeChildValue
   use dftbp_io_message, only : error, warning
-  use dftbp_io_taggedoutput, only : TTaggedWriter, tagLabels
+  use dftbp_io_taggedoutput, only : tagLabels, TTaggedWriter
   use dftbp_math_blasroutines, only : hemv
   use dftbp_math_eigensolver, only : heev
   use dftbp_md_mdintegrator, only : TMdIntegrator, state
@@ -53,14 +53,14 @@ module dftbp_dftbplus_mainio
   use dftbp_solvation_solvation, only : TSolvation
   use dftbp_type_commontypes, only : TOrbitals, TParallelKS
   use dftbp_type_densedescr, only : TDenseDescr
-  use dftbp_type_linkedlist, only : TListCharLc, TListIntR1, len, get, elemShape, intoArray
+  use dftbp_type_linkedlist, only : elemShape, get, intoArray, len, TListCharLc, TListIntR1
   use dftbp_type_multipole, only : TMultipole
-  use dftbp_type_orbitals, only : orbitalNames, getShellNames
+  use dftbp_type_orbitals, only : getShellNames, orbitalNames
 #:if WITH_MPI
-  use dftbp_extlibs_mpifx, only : mpifx_recv, mpifx_send, mpifx_bcast
+  use dftbp_extlibs_mpifx, only : mpifx_bcast, mpifx_recv, mpifx_send
 #:endif
 #:if WITH_SCALAPACK
-  use dftbp_dftb_sparse2dense, only :unpackSPauliBlacs, unpackHSCplxBlacs, unpackHSRealBlacs
+  use dftbp_dftb_sparse2dense, only : unpackHSCplxBlacs, unpackHSRealBlacs, unpackSPauliBlacs
   use dftbp_extlibs_scalapackfx, only : linecomm, pblasfx_phemm, pblasfx_psymm
 #:endif
 #:if WITH_SOCKETS

--- a/src/dftbp/extlibs/CMakeLists.txt
+++ b/src/dftbp/extlibs/CMakeLists.txt
@@ -32,5 +32,9 @@ if(WITH_MAGMA)
     ${curdir}/magmac.c)
 endif()
 
+if(WITH_MBD)
+  list(APPEND sources-fpp ${curdir}/mbd.F90)
+endif()
+
 set(ALL-SOURCES-FPP ${ALL-SOURCES-FPP} ${sources-fpp} PARENT_SCOPE)
 set(ALL-SOURCES-C ${ALL-SOURCES-C} ${sources-c} PARENT_SCOPE)

--- a/src/dftbp/extlibs/arpack.F90
+++ b/src/dftbp/extlibs/arpack.F90
@@ -17,7 +17,10 @@
 !> Interfaces for the ARPACK routines needed in DFTB+ (currently for the linear response excited
 !> state calculations).
 module dftbp_extlibs_arpack
-  use dftbp_common_accuracy, only : rsp, rdp
+  use dftbp_common_accuracy, only : rdp, rsp
+#:if not WITH_ARPACK
+  use dftbp_io_message, only : error
+#:endif
   implicit none
 
   private

--- a/src/dftbp/extlibs/elsiiface.F90
+++ b/src/dftbp/extlibs/elsiiface.F90
@@ -13,9 +13,24 @@
 module dftbp_extlibs_elsiiface
   use dftbp_common_accuracy, only : dp
 #:if WITH_ELSI
-  use elsi
+  use elsi, only : elsi_dm_complex, elsi_dm_complex_sparse, elsi_dm_real, elsi_dm_real_sparse,&
+      & elsi_ev_complex, elsi_ev_real, elsi_finalize, elsi_finalize_rw, elsi_get_datestamp,&
+      & elsi_get_edm_complex, elsi_get_edm_complex_sparse, elsi_get_edm_real,&
+      & elsi_get_edm_real_sparse, elsi_get_entropy, elsi_get_mu, elsi_get_pexsi_mu_max,&
+      & elsi_get_pexsi_mu_min, elsi_get_version, elsi_handle, elsi_init, elsi_init_rw, elsi_reinit,&
+      & elsi_rw_handle, elsi_set_blacs, elsi_set_csc, elsi_set_csc_blk, elsi_set_elpa_autotune,&
+      & elsi_set_elpa_gpu, elsi_set_elpa_solver, elsi_set_kpoint, elsi_set_mpi, elsi_set_mpi_global,&
+      & elsi_set_mu_broaden_scheme, elsi_set_mu_broaden_width, elsi_set_mu_mp_order,&
+      & elsi_set_ntpoly_filter, elsi_set_ntpoly_method, elsi_set_ntpoly_tol, elsi_set_omm_flavor,&
+      & elsi_set_omm_n_elpa, elsi_set_omm_tol, elsi_set_output, elsi_set_output_log,&
+      & elsi_set_pexsi_delta_e, elsi_set_pexsi_method, elsi_set_pexsi_mu_max, elsi_set_pexsi_mu_min,&
+      & elsi_set_pexsi_n_mu, elsi_set_pexsi_n_pole, elsi_set_pexsi_np_per_pole,&
+      & elsi_set_pexsi_np_symbo, elsi_set_pexsi_temp, elsi_set_rw_blacs, elsi_set_rw_csc,&
+      & elsi_set_rw_mpi, elsi_set_rw_zero_def, elsi_set_sing_check, elsi_set_sparsity_mask,&
+      & elsi_set_spin, elsi_set_zero_def, elsi_write_mat_complex, elsi_write_mat_complex_sparse,&
+      & elsi_write_mat_real, elsi_write_mat_real_sparse
 #:else
-  use iso_c_binding, only : r8 => c_double, i4 => c_int32_t
+  use, intrinsic :: iso_c_binding, only : r8 => c_double, i4 => c_int32_t
   use dftbp_io_message, only : error
 #:endif
   implicit none

--- a/src/dftbp/extlibs/fsockets.F90
+++ b/src/dftbp/extlibs/fsockets.F90
@@ -7,7 +7,8 @@
 
 !> Socket interface library
 module dftbp_extlibs_fsockets
-  use fsockets
+  use fsockets, only : close_socket, connect_inet_socket, connect_unix_socket, readbuffer,&
+      & writebuffer
   implicit none
 
 #:if WITH_SOCKETS

--- a/src/dftbp/extlibs/mbd.F90
+++ b/src/dftbp/extlibs/mbd.F90
@@ -1,0 +1,16 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2024  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+!> Exporting the functionality we use from the library mbd.
+module dftbp_extlibs_mbd
+  use mbd, only : mbd_calc_t, TDispMbdInp => mbd_input_t
+  implicit none
+
+  private
+  public :: TDispMbdInp, mbd_calc_t
+
+end module dftbp_extlibs_mbd

--- a/src/dftbp/extlibs/mpifx.F90
+++ b/src/dftbp/extlibs/mpifx.F90
@@ -10,7 +10,10 @@
 !> Exporting mpifx functionality if compiled with mpi support, otherwise empty.
 module dftbp_extlibs_mpifx
 #:if WITH_MPI
-  use libmpifx_module
+  use libmpifx_module, only : MPI_COMM_TYPE_SHARED, MPI_LAND, MPI_LOR, MPI_MAX, MPI_SUM,&
+      & MPI_THREAD_FUNNELED, mpifx_abort, mpifx_allgather, mpifx_allgatherv, mpifx_allreduce,&
+      & mpifx_allreduceip, mpifx_barrier, mpifx_bcast, mpifx_comm, mpifx_finalize, mpifx_gatherv,&
+      & mpifx_init_thread, mpifx_recv, mpifx_reduceip, mpifx_send, MPIFX_SIZE_T, mpifx_win
 #:endif
   implicit none
   public

--- a/src/dftbp/extlibs/negf.F90
+++ b/src/dftbp/extlibs/negf.F90
@@ -11,17 +11,18 @@
 
 !> Interfaces to libNEGF
 module dftbp_extlibs_negf
-  use libnegf, only : convertcurrent, eovh, getel, lnParams, pass_DM, Tnegf, kb, units,&
-      & z_CSR, z_DNS, READ_SGF, COMP_SGF, COMPSAVE_SGF, DELTA_SQ, DELTA_W, DELTA_MINGO,&
-      & associate_lead_currents, associate_ldos, associate_transmission, associate_current,&
-      & compute_current, compute_density_dft, compute_ldos, create, create_scratch, destroy,&
-      & set_readoldDMsgf, destroy_matrices, destroy_negf, get_params, init_contacts, init_ldos,&
-      & init_negf, init_structure, pass_hs, set_bp_dephasing, set_drop, set_elph_block_dephasing,&
-      & set_elph_dephasing, set_elph_s_dephasing, set_ldos_indexes, set_params, set_scratch,&
-      & set_tun_indexes, writememinfo, writepeakinfo, dns2csr, csr2dns, nzdrop, printcsr,&
-      & compute_phonon_current, thermal_conductance, convertHeatCurrent, convertHeatConductance
+  use libnegf, only : associate_current, associate_ldos, associate_lead_currents,&
+      & associate_transmission, COMP_SGF, COMPSAVE_SGF, compute_current, compute_density_dft,&
+      & compute_ldos, compute_phonon_current, convertcurrent, convertHeatConductance,&
+      & convertHeatCurrent, create, create_scratch, csr2dns, DELTA_MINGO, DELTA_SQ, DELTA_W,&
+      & destroy, destroy_matrices, destroy_negf, dns2csr, eovh, get_params, getel, init_contacts,&
+      & init_ldos, init_negf, init_structure, kb, lnParams, nzdrop, pass_DM, pass_hs, printcsr,&
+      & r_CSR, r_DNS, READ_SGF, set_bp_dephasing, set_drop, set_elph_block_dephasing,&
+      & set_elph_dephasing, set_elph_s_dephasing, set_ldos_indexes, set_params, set_readoldDMsgf,&
+      & set_scratch, set_tun_indexes, thermal_conductance, Tnegf, units, writememinfo,&
+      & writepeakinfo, z_CSR, z_DNS
 #:if WITH_MPI
-  use libnegf, only : negf_mpi_init, negf_cart_init
+  use libnegf, only : negf_cart_init, negf_mpi_init
 #:endif
   implicit none
 

--- a/src/dftbp/extlibs/poisson.F90
+++ b/src/dftbp/extlibs/poisson.F90
@@ -16,31 +16,30 @@
 module dftbp_extlibs_poisson
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : pi
-  use dftbp_common_environment, only : TEnvironment, globalTimers
+  use dftbp_common_environment, only : globalTimers, TEnvironment
   use dftbp_common_globalenv, only : stdOut
   use dftbp_io_message, only : error
   use dftbp_type_commontypes, only : TOrbitals
 #:if WITH_MPI
-  use libmpifx_module, only : mpifx_barrier, mpifx_bcast
+  use dftbp_extlibs_mpifx, only : mpifx_barrier, mpifx_bcast
 #:endif
 #:if WITH_POISSON
-  use dftbp_poisson_poisson, only : poiss_savepotential, poiss_updcoords, active_id, natoms,&
-      & verbose, bufferBox, deltaR_max, DoCilGate, DoGate, dR_cont, dr_eps, eps_r, fixed_renorm,&
-      & FoundBox, Gate, GateDir, GateLength_l, GateLength_t, id0, InitPot, localBC, MaxPoissIter,&
-      & numprocs, overrBulkBC, overrideBC, OxLength, period, ReadBulk, Rmin_Gate, Rmin_Ins,&
-      & SavePot, scratchfolder, uhubb, lmax, nshells, angShells, izp, dQmat, init_poissbox,&
-      & mudpack_drv, poiss_freepoisson, set_scratch, init_structure, init_skdata, init_charges,&
-      & init_defaults, set_temperature, set_ncont, set_cluster, set_mol_indeces, set_dopoisson,&
-      & set_poissonbox, set_poissongrid, set_accuracy, set_verbose, check_biasdir,&
-      & check_poisson_box, check_parameters, check_localbc, check_contacts, write_parameters,&
-      & poiss_getlatvecs
+  use dftbp_poisson_poisson, only : active_id, angShells, bufferBox, check_biasdir, check_contacts,&
+      & check_localbc, check_parameters, check_poisson_box, deltaR_max, DoCilGate, DoGate, dQmat,&
+      & dR_cont, dr_eps, eps_r, fixed_renorm, FoundBox, Gate, GateDir, GateLength_l, GateLength_t,&
+      & id0, init_charges, init_defaults, init_poissbox, init_skdata, init_structure, InitPot, izp,&
+      & lmax, localBC, MaxPoissIter, mudpack_drv, natoms, nshells, numprocs, overrBulkBC,&
+      & overrideBC, OxLength, period, poiss_freepoisson, poiss_getlatvecs, poiss_savepotential,&
+      & poiss_updcoords, ReadBulk, Rmin_Gate, Rmin_Ins, SavePot, scratchfolder, set_accuracy,&
+      & set_cluster, set_dopoisson, set_mol_indeces, set_ncont, set_poissonbox, set_poissongrid,&
+      & set_scratch, set_temperature, set_verbose, uhubb, verbose, write_parameters
   #:if WITH_MPI
   use dftbp_poisson_poisson, only : global_comm, poiss_mpi_init, poiss_mpi_split
   #:endif
 #:endif
 #:if WITH_TRANSPORT
-  use dftbp_poisson_poisson, only : ncont, set_cont_indices, set_contdir, set_contlabels,&
-      & set_fermi, set_potentials, set_builtin
+  use dftbp_poisson_poisson, only : ncont, set_builtin, set_cont_indices, set_contdir,&
+      & set_contlabels, set_fermi, set_potentials
   use dftbp_transport_negfvars, only : TTransPar
 #:endif
   implicit none

--- a/src/dftbp/extlibs/scalapackfx.F90
+++ b/src/dftbp/extlibs/scalapackfx.F90
@@ -10,7 +10,13 @@
 !> Exports scalapackfx functionality if compiled with scalapack support, otherwise empty.
 module dftbp_extlibs_scalapackfx
 #:if WITH_SCALAPACK
-  use libscalapackfx_module
+  use libscalapackfx_module, only : blacsfx_gemr2d, blacsfx_gsum, blacsgrid, blocklist, CSRC_,&
+      & DLEN_, linecomm, M_, MB_, N_, NB_, pblasfx_pgemm, pblasfx_phemm, pblasfx_psymm,&
+      & pblasfx_psymv, pblasfx_ptran, pblasfx_ptranc, RSRC_, scalafx_addg2l, scalafx_addl2g,&
+      & scalafx_cpg2l, scalafx_cpl2g, scalafx_getdescriptor, scalafx_getlocalshape,&
+      & scalafx_indxl2g, scalafx_islocal, scalafx_pgetrf, scalafx_phegv, scalafx_phegvd,&
+      & scalafx_phegvr, scalafx_ppotrf, scalafx_ppotri, scalafx_psygv, scalafx_psygvd,&
+      & scalafx_psygvr, size
 #:endif
   implicit none
   public

--- a/src/dftbp/extlibs/xmlf90.F90
+++ b/src/dftbp/extlibs/xmlf90.F90
@@ -7,12 +7,16 @@
 
 !> Exporting the functionality we use from the library XMLF90.
 module dftbp_extlibs_xmlf90
-  use xmlf90_flib_dom
-  use xmlf90_flib_wxml
-  use xmlf90_strings
+  use xmlf90_flib_dom, only : append, append_to_string, appendChild, assignment(=), char,&
+      & createDocumentNode, createElement, createTextNode, destroyNode, destroyNodeList,&
+      & ELEMENT_NODE, fnode, fnodeList, getAttribute, getAttributeNode, getFirstChild, getItem1,&
+      & getLastChild, getLength, getNextSibling, getNodeName, getNodeType, getNodeValue,&
+      & getParentNode, getPreviousSibling, item, len, normalize, operator(==), parsefile,&
+      & prepend_to_string, removeAttribute, removeChild, replaceChild, resize_string, setAttribute,&
+      & setTagName, string, TEXT_NODE, textNodeName, trim
+  use xmlf90_flib_wxml, only : xml_AddPCData, xml_ADDXMLDeclaration, xml_Close, xml_EndElement,&
+      & xml_NewElement, xml_OpenFile, xmlf_t
   implicit none
   public
-
-  public :: xmlf_t
 
 end module dftbp_extlibs_xmlf90

--- a/src/dftbp/include/common.fypp
+++ b/src/dftbp/include/common.fypp
@@ -130,7 +130,7 @@ end block
 #! Simple macro printing out the position of a line
 #:def PRINT_POSITION()
 block
-  use iso_fortran_env, only : output_unit
+  use, intrinsic :: iso_fortran_env, only : output_unit
   write(output_unit, "(a)") "Reached line ${_LINE_}$ in ${_FILE_}$"
   flush(output_unit)
 end block

--- a/src/dftbp/include/error.fypp
+++ b/src/dftbp/include/error.fypp
@@ -20,7 +20,7 @@
 #:def ERROR_HANDLING(errVar, errNumber, msg)
   block
     use dftbp_common_accuracy, only : lc
-    use dftbp_io_message
+    use dftbp_io_message, only : error, warning
     !> Error handling string
     character(lc) :: stringTmp
 
@@ -41,7 +41,7 @@
 #:def FORMATTED_ERROR_HANDLING(errVar, errNumber, formating, *variables)
   block
     use dftbp_common_accuracy, only : lc
-    use dftbp_io_message
+    use dftbp_io_message, only : error, warning
     !> Error handling string
     character(lc) :: stringTmp
 

--- a/src/dftbp/io/hsdparser.F90
+++ b/src/dftbp/io/hsdparser.F90
@@ -17,13 +17,13 @@
 !>
 !> For the specification of the HSD format see the sample input
 module dftbp_io_hsdparser
-  use dftbp_common_file, only : TFileDescr, TOpenOptions, openFile, closeFile
-  use dftbp_extlibs_xmlf90, only : fnode, string, getNodeType, TEXT_NODE, len, getParentNode, char,&
-      & getAttributeNode, getFirstChild, getNextSibling, removeChild, createElement, appendChild,&
-      & createElement, createTextNode, createDocumentNode, assignment(=), prepend_to_string,&
-      & getAttribute, getNodeName, getNodeValue, destroyNode, setAttribute, getAttribute, normalize
-  use dftbp_io_charmanip, only : newline, whiteSpaces, trim2, tolower, i2c, unquotedIndex, unquote,&
-      & unquotedScan, convertWhitespaces, getFirstOccurance
+  use dftbp_common_file, only : closeFile, openFile, TFileDescr, TOpenOptions
+  use dftbp_extlibs_xmlf90, only : appendChild, assignment(=), char, createDocumentNode,&
+      & createElement, createTextNode, destroyNode, fnode, getAttribute, getAttributeNode,&
+      & getFirstChild, getNextSibling, getNodeName, getNodeType, getNodeValue, getParentNode, len,&
+      & normalize, prepend_to_string, removeChild, setAttribute, string, TEXT_NODE
+  use dftbp_io_charmanip, only : convertWhitespaces, getFirstOccurance, i2c, newline, tolower,&
+      & trim2, unquote, unquotedIndex, unquotedScan, whiteSpaces
   use dftbp_io_linereader, only : TLineReader
   use dftbp_io_message, only : error
   use dftbp_io_xmlutils, only : getFirstChildByName

--- a/src/dftbp/poisson/mpi_poisson.F90
+++ b/src/dftbp/poisson/mpi_poisson.F90
@@ -18,7 +18,7 @@
 module dftbp_poisson_mpi_poisson
 
 #:if WITH_MPI
-  use libmpifx_module, only : mpifx_comm, mpifx_gatherv
+  use dftbp_extlibs_mpifx, only : mpifx_comm, mpifx_gatherv
   implicit none
 
   private

--- a/src/dftbp/solvation/cosmo.F90
+++ b/src/dftbp/solvation/cosmo.F90
@@ -10,20 +10,19 @@
 
 !> COSMO solvent model routines
 module dftbp_solvation_cosmo
-  use ddcosmo_core, only : ddupdate, TDomainDecomposition_init, wghpot, intrhs, fdoka, fdokb,&
-      & fdoga
   use dftbp_common_accuracy, only : dp
-  use dftbp_common_constants, only : pi, Hartree__eV, Bohr__AA
+  use dftbp_common_constants, only : Bohr__AA, Hartree__eV, pi
   use dftbp_common_environment, only : TEnvironment
   use dftbp_common_status, only : TStatus
   use dftbp_dftb_charges, only : getSummedCharges
   use dftbp_dftb_periodic, only : TNeighbourList
-  use dftbp_extlibs_ddcosmo, only : TDomainDecompositionInput, TDomainDecomposition, jacobi_diis,&
-      & lx, lstarx, ldm1x, hnorm
+  use dftbp_extlibs_ddcosmo, only : ddupdate, fdoga, fdoka, fdokb, hnorm, intrhs, jacobi_diis,&
+      & ldm1x, lstarx, lx, TDomainDecomposition, TDomainDecomposition_init,&
+      & TDomainDecompositionInput, wghpot
   use dftbp_extlibs_lebedev, only : getAngGrid, gridSize
   use dftbp_io_charmanip, only : tolower
   use dftbp_math_blasroutines, only : gemv
-  use dftbp_solvation_sasa, only : TSASACont, TSASAInput, TSASACont_init, writeSASAContInfo
+  use dftbp_solvation_sasa, only : TSASACont, TSASACont_init, TSASAInput, writeSASAContInfo
   use dftbp_solvation_solvation, only : TSolvation
   use dftbp_type_commontypes, only : TOrbitals
   implicit none

--- a/src/dftbp/transport/matconv.F90
+++ b/src/dftbp/transport/matconv.F90
@@ -17,9 +17,9 @@
 !> createEquivCSR routines.
 module dftbp_transport_matconv
   use dftbp_common_accuracy, only : dp
-  use dftbp_common_constants, only : pi, imag
+  use dftbp_common_constants, only : imag, pi
+  use dftbp_extlibs_negf, only : create, destroy, r_CSR, r_DNS, z_CSR, z_DNS
   use dftbp_type_commontypes, only : TOrbitals
-  use libnegf, only: r_CSR, z_CSR, r_DNS, z_DNS, create, destroy
   implicit none
 
   private

--- a/test/src/dftbp/api/mm/testers/test_ehrenfest.f90
+++ b/test/src/dftbp/api/mm/testers/test_ehrenfest.f90
@@ -7,8 +7,9 @@
 
 program test_ehrenfest
   use, intrinsic :: iso_fortran_env, only : output_unit
-  use dftbp_common_constants, only : AA__Bohr, V_m__au, eV__Hartree, fs__au, pi, imag
-  use dftbplus
+  use dftbplus, only : dumpHsd, fnode, getDftbPlusApi, getDftbPlusBuild, setChild, setChildValue,&
+      & TDftbPlus, TDftbPlus_init, TDftbPlusInput
+  use dftbp_common_constants, only : AA__Bohr, eV__Hartree, fs__au, imag, pi, V_m__au
   ! Only needed for the internal test system
   use testhelpers, only : writeAutotestTag
   implicit none

--- a/test/src/dftbp/api/mm/testers/test_ehrenfest_ext_ions.f90
+++ b/test/src/dftbp/api/mm/testers/test_ehrenfest_ext_ions.f90
@@ -7,8 +7,9 @@
 
 program test_ehrenfest
   use, intrinsic :: iso_fortran_env, only : output_unit
-  use dftbp_common_constants, only : AA__Bohr, V_m__au, eV__Hartree, fs__au, pi, imag
-  use dftbplus
+  use dftbplus, only : dumpHsd, fnode, getDftbPlusApi, getDftbPlusBuild, setChild, setChildValue,&
+      & TDftbPlus, TDftbPlus_init, TDftbPlusInput
+  use dftbp_common_constants, only : AA__Bohr, eV__Hartree, fs__au, imag, pi, V_m__au
   ! Only needed for the internal test system
   use testhelpers, only : writeAutotestTag
   implicit none

--- a/test/src/dftbp/api/mm/testers/test_extcharges.f90
+++ b/test/src/dftbp/api/mm/testers/test_extcharges.f90
@@ -8,7 +8,8 @@
 !> example code for adding external charges to a water molecule calculation
 program test_extcharges
   use, intrinsic :: iso_fortran_env, only : output_unit
-  use dftbplus
+  use dftbplus, only : convertAtomTypesToSpecies, dumpHsd, fnode, getDftbPlusApi, getDftbPlusBuild,&
+      & getMaxAngFromSlakoFile, setChild, setChildValue, TDftbPlus, TDftbPlus_init, TDftbPlusInput
   use dftbp_common_constants, only : AA__Bohr
   ! Only needed for the internal test system
   use testhelpers, only : writeAutotestTag

--- a/test/src/dftbp/api/mm/testers/test_extpot.f90
+++ b/test/src/dftbp/api/mm/testers/test_extpot.f90
@@ -7,9 +7,10 @@
 
 program test_extpot
   use, intrinsic :: iso_fortran_env, only : output_unit
-  use dftbplus
+  use dftbplus, only : dumpHsd, fnode, getDftbPlusApi, getDftbPlusBuild, setChild, setChildValue,&
+      & TDftbPlus, TDftbPlus_init, TDftbPlusInput
+  use extchargepot, only : getPointChargeGradients, getPointChargePotential
   use dftbp_common_constants, only : AA__Bohr
-  use extchargepot
   ! Only needed for the internal test system
   use testhelpers, only : writeAutotestTag
   implicit none

--- a/test/src/dftbp/api/mm/testers/test_extpot2.f90
+++ b/test/src/dftbp/api/mm/testers/test_extpot2.f90
@@ -13,9 +13,10 @@
 !>
 program test_extpot2
   use, intrinsic :: iso_fortran_env, only : output_unit
-  use dftbplus
+  use dftbplus, only : dumpHsd, fnode, getDftbPlusApi, getDftbPlusBuild, getMaxAngFromSlakoFile,&
+      & setChild, setChildValue, TDftbPlus, TDftbPlus_init, TDftbPlusInput
+  use extchargepot, only : getPointChargeGradients, getPointChargePotential
   use dftbp_common_constants, only : AA__Bohr
-  use extchargepot
   ! Only needed for the internal test system
   use testhelpers, only : writeAutotestTag
   implicit none

--- a/test/src/dftbp/api/mm/testers/test_fileinit.f90
+++ b/test/src/dftbp/api/mm/testers/test_fileinit.f90
@@ -8,7 +8,7 @@
 !> Reads in a dftb_in.hsd file then overrides some of its supplied setting, before calculating
 !> properties
 program test_fileinit
-  use dftbplus
+  use dftbplus, only : getDftbPlusApi, getDftbPlusBuild, TDftbPlus, TDftbPlus_init, TDftbPlusInput
   use dftbp_common_constants, only : AA__Bohr
   ! Only needed for the internal test system
   use testhelpers, only : writeAutotestTag

--- a/test/src/dftbp/api/mm/testers/test_intcharges.f90
+++ b/test/src/dftbp/api/mm/testers/test_intcharges.f90
@@ -8,7 +8,8 @@
 !> example code for changing internal charges inside calculation
 program test_intcharges
   use, intrinsic :: iso_fortran_env, only : output_unit
-  use dftbplus
+  use dftbplus, only : convertAtomTypesToSpecies, dumpHsd, fnode, getDftbPlusApi, getDftbPlusBuild,&
+      & getMaxAngFromSlakoFile, setChild, setChildValue, TDftbPlus, TDftbPlus_init, TDftbPlusInput
   ! Only needed for the internal test system
   use testhelpers, only : writeAutotestTag
   implicit none

--- a/test/src/dftbp/api/mm/testers/test_neighbour_list.f90
+++ b/test/src/dftbp/api/mm/testers/test_neighbour_list.f90
@@ -7,7 +7,7 @@
 
 !> Explicitly sets the neighbour list via the API and checks the result
 program test_neighbour_list
-  use dftbplus
+  use dftbplus, only : getDftbPlusApi, getDftbPlusBuild, TDftbPlus, TDftbPlus_init, TDftbPlusInput
   ! Only needed for the internal test system
   use testhelpers, only : writeAutotestTag
   implicit none

--- a/test/src/dftbp/api/mm/testers/test_qdepextpot.f90
+++ b/test/src/dftbp/api/mm/testers/test_qdepextpot.f90
@@ -11,7 +11,7 @@
 !> Use it with the input in the test/api/mm/qdepextpot/ folder.
 !>
 program test_qdepextpot
-  use dftbplus
+  use dftbplus, only : getDftbPlusApi, getDftbPlusBuild, TDftbPlus, TDftbPlus_init, TDftbPlusInput
   use extchargepot, only : getPointChargePotential
   use extchargepotgen, only : TExtChargePotGen, TExtChargePotGen_init
   ! Only needed for the internal test system

--- a/test/src/dftbp/api/mm/testers/test_timeprop.f90
+++ b/test/src/dftbp/api/mm/testers/test_timeprop.f90
@@ -7,8 +7,9 @@
 
 program test_timeprop
   use, intrinsic :: iso_fortran_env, only : output_unit
+  use dftbplus, only : dumpHsd, fnode, getDftbPlusApi, getDftbPlusBuild, setChild, setChildValue,&
+      & TDftbPlus, TDftbPlus_init, TDftbPlusInput
   use dftbp_common_constants, only : AA__Bohr, V_m__au
-  use dftbplus
   ! Only needed for the internal test system
   use testhelpers, only : writeAutotestTag
   implicit none

--- a/test/src/dftbp/api/mm/testers/test_treeinit.f90
+++ b/test/src/dftbp/api/mm/testers/test_treeinit.f90
@@ -9,7 +9,8 @@
 !> periodic geometry with k-points.
 program test_treeinit
   use, intrinsic :: iso_fortran_env, only : output_unit
-  use dftbplus
+  use dftbplus, only : dumpHsd, fnode, getDftbPlusApi, getDftbPlusBuild, setChild, setChildValue,&
+      & TDftbPlus, TDftbPlus_init, TDftbPlusInput
   use dftbp_common_constants, only : AA__Bohr
   ! Only needed for the internal test system
   use testhelpers, only : writeAutotestTag

--- a/test/src/dftbp/api/mm/testers/testhelpers.f90
+++ b/test/src/dftbp/api/mm/testers/testhelpers.f90
@@ -8,9 +8,9 @@
 !> Module containing routines for the automatic testing of the API functionality
 
 module testhelpers
-  use, intrinsic :: iso_c_binding
+  use, intrinsic :: iso_c_binding, only : c_associated, c_double, c_f_pointer, c_int, c_ptr
   use dftbp_common_accuracy, only : dp
-  use dftbp_common_file, only : TFileDescr, openFile, closeFile
+  use dftbp_common_file, only : closeFile, openFile, TFileDescr
   use dftbp_io_taggedoutput, only : tagLabels, TTaggedWriter, TTaggedWriter_init
   implicit none
   private


### PR DESCRIPTION
I have noticed that the following import is not reached even if it is compiled with the "WITH_MPI" flag.

https://github.com/dftbplus/dftbplus/blob/13588bb08d666d3beadc579e345dec6683fa9145/app/misc/skderivs/skderivs.F90#L24-L26

