### PR TITLE
Checks consistency of cmake and submodule repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,22 +18,22 @@
 	url = https://github.com/tblite/tblite.git
 [submodule "external/mctc-lib/origin"]
 	path = external/mctc-lib/origin
-	url = https://github.com/grimme-lab/mctc-lib
+	url = https://github.com/grimme-lab/mctc-lib.git
 [submodule "external/s-dftd3/origin"]
 	path = external/s-dftd3/origin
-	url = https://github.com/dftd3/simple-dftd3
+	url = https://github.com/dftd3/simple-dftd3.git
 [submodule "external/dftd4/origin"]
 	path = external/dftd4/origin
-	url = https://github.com/dftd4/dftd4
+	url = https://github.com/dftd4/dftd4.git
 [submodule "external/multicharge/origin"]
 	path = external/multicharge/origin
-	url = https://github.com/grimme-lab/multicharge
+	url = https://github.com/grimme-lab/multicharge.git
 [submodule "external/mstore/origin"]
 	path = external/mstore/origin
-	url = https://github.com/grimme-lab/mstore
+	url = https://github.com/grimme-lab/mstore.git
 [submodule "external/toml-f/origin"]
 	path = external/toml-f/origin
-	url = https://github.com/toml-f/toml-f
+	url = https://github.com/toml-f/toml-f.git
 [submodule "external/chimes/origin"]
 	path = external/chimes/origin
-	url = https://github.com/rk-lindsey/chimes_calculator
+	url = https://github.com/rk-lindsey/chimes_calculator.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ if(WITH_TBLITE OR WITH_SDFTD3)
     #list(APPEND PKG_CONFIG_REQUIRES toml-f)
   endif()
 
-  set(S_DFTD3_GIT_REPOSITORY "https://github.com/awvwgk/simple-dftd3.git")
+  set(S_DFTD3_GIT_REPOSITORY "https://github.com/dftd3/simple-dftd3.git")
   set(S_DFTD3_GIT_TAG "5ee8c4d71414bf54db0b680ee3c532215847e0f9")  # do not change manually!
   dftbp_config_hybrid_dependency(s-dftd3 s-dftd3::s-dftd3 "${HYBRID_CONFIG_METHODS}" "QUIET"
     external/s-dftd3 "${exclude}" "${S_DFTD3_GIT_REPOSITORY}" "${S_DFTD3_GIT_TAG}")
@@ -285,7 +285,7 @@ endif()
 
 # ChIMES currently can only be integrated as a submodule
 if(WITH_CHIMES)
-  set(CHIMES_GIT_REPOSITORY "https://github.com/dftbplus/chimes_calculator.git")
+  set(CHIMES_GIT_REPOSITORY "https://github.com/rk-lindsey/chimes_calculator.git")
   set(CHIMES_GIT_TAG "7ca7d397197ac8ca4b1fc54ee12164911a6254b7")  # do not change manually!
   dftbp_config_hybrid_dependency(ChimesCalc ChimesCalc::ChimesCalc_Fortran
     "${HYBRID_CONFIG_METHODS}" "QUIET"

--- a/utils/test/check_submodule_commits
+++ b/utils/test/check_submodule_commits
@@ -2,10 +2,11 @@
 
 """Checks the submodule commit IDs in integration CMake files."""
 
-import os
-import subprocess
-import re
 import argparse
+import configparser
+import os
+import re
+import subprocess
 import sys
 
 _DESCRIPTION = """
@@ -33,12 +34,21 @@ def main():
     result = subprocess.run(["git", "submodule", "status"],
                             stdout=subprocess.PIPE, check=True)
     output = result.stdout.decode('ascii')
+    if args.check:
+        gitconfig = configparser.ConfigParser()
+        gitconfig.read('.git/config')
     allsync = True
     with open("CMakeLists.txt", "r") as fp:
         origcontent = fp.read()
     content = origcontent
     for match in _PAT_SUBMOD_COMMIT.finditer(output):
         commit, submodule = match.groups()
+        if args.check:
+            locale = ('submodule "external/%s/origin"' % submodule)
+            active = gitconfig.get(locale, 'active')
+            if active == 'true':
+                url = gitconfig.get(locale, 'url')
+                _check_submodule_url(content, submodule, url)
         newcontent, nn = _replace_submodule_commit(content, submodule, commit)
         if nn < 1:
             print("! Commit for submodule {} was NOT FOUND".format(submodule))
@@ -46,10 +56,10 @@ def main():
             continue
         sync = (newcontent == content)
         if sync:
-            print("+ Commit for submodule {} matches.".format(submodule))
+            print("+ Commit ID for submodule {} matches.".format(submodule))
         elif args.update:
             content = newcontent
-            print("* Commit for submodule {} had been updated."\
+            print("* Commit for submodule {} has been updated."\
                   .format(submodule))
         else:
             print("! Commit for submodule {} DOES NOT MATCH!".format(submodule))
@@ -66,6 +76,8 @@ def _parse_arguments():
     parser = argparse.ArgumentParser(description=_DESCRIPTION)
     msg = "Whether the commits should be updated in the CMakeLists.txt files"
     parser.add_argument("-u", "--update", action='store_true', help=msg)
+    msg = "Check consistency between CMakeLists.txt and submodules"
+    parser.add_argument("-c", "--check", action='store_true', help=msg)
     return parser.parse_args()
 
 
@@ -80,6 +92,21 @@ def _replace_submodule_commit(content, submodule, commit):
         'set({}_GIT_TAG "{}")'.format(submodule_normed, commit),
         content)
     return newcontent, nsubs
+
+
+def _check_submodule_url(content, submodule, url):
+    """Checks consistency of the submodule url in the CMakeLists.txt file"""
+    submodule_normed = submodule.upper()
+    submodule_normed = re.sub(
+        _PAT_SPECIAL_CHAR, _SPECIAL_CHAR_REPLACEMENT, submodule_normed)
+    match = re.findall(
+        r"set\({}_GIT_REPOSITORY \"({})(\.git)?\"\)".format(submodule_normed, url),
+        content)
+    if (len(match) == 0):
+        print('** {} : mismatch between .git/config and CMakeLists.txt'.format(submodule))
+    else:
+        if (match[0][1] == '.git'):
+            print("* {} : bare vs non-bare repository address in CMakeLists.txt and .git/config".format(submodule))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changes script to optionally check for 
* Mismatch between CMakeLists.txt and .gitmodules urls
* Whether the git urls have consistent .git extension (i.e. headless or not)
* Update the 2 urls that point to the wrong places