### PR TITLE
Separate GPU init from inquiry call

### DIFF
--- a/src/dftbp/common/gpuenv.F90
+++ b/src/dftbp/common/gpuenv.F90
@@ -12,7 +12,7 @@
 module dftbp_common_gpuenv
   use iso_c_binding, only :  c_int
   use dftbp_common_globalenv, only : stdOut
-  use dftbp_extlibs_magma, only : getGpusAvailable, getGpusRequested
+  use dftbp_extlibs_magma, only : getGpusAvailable, getGpusRequested, gpusInit
   implicit none
 
   private
@@ -39,6 +39,7 @@ contains
 
     integer(c_int) :: nGpuReq
 
+    call gpusInit()
     call getGpusAvailable(this%nGpu)
     call getGpusRequested(nGpuReq)
     write(stdOut, *) "Number of GPUs requested:", nGpuReq

--- a/src/dftbp/extlibs/magma.F90
+++ b/src/dftbp/extlibs/magma.F90
@@ -18,7 +18,7 @@ module dftbp_extlibs_magma
   private
   public :: withGpu
 #:if WITH_MAGMA
-  public :: getGpusAvailable, getGpusRequested
+  public :: getGpusAvailable, getGpusRequested, gpusInit
   public :: magmaf_ssygvd_m, magmaf_dsygvd_m, magmaf_chegvd_m, magmaf_zhegvd_m
 #:endif
 
@@ -28,6 +28,14 @@ module dftbp_extlibs_magma
 #:if WITH_MAGMA
 
   interface
+
+    !> Initialises magma.
+    subroutine  gpusInit() bind(C, name='magma_init')
+
+      implicit none
+
+    end subroutine gpusInit
+
 
     !> Initialises magma and queries the nr. of available GPUs.
     subroutine  getGpusAvailable(nGpu) bind(C, name='dftbp_extlibs_magma_get_gpus_available')

--- a/src/dftbp/extlibs/magmac.c
+++ b/src/dftbp/extlibs/magmac.c
@@ -24,7 +24,6 @@ void  dftbp_extlibs_magma_get_gpus_available(int *max_ngpus)
     magma_device_t devices[MAXGPUS];
     magma_int_t number_of_gpus;
 
-    magma_init();
     magma_getdevices(devices, MAXGPUS, &number_of_gpus);
     *max_ngpus = number_of_gpus;
     return;


### PR DESCRIPTION
Initialise GPU as its own call in gpuenv.F90, as this was mixed with a check for available GPUs.