### PR TITLE
Api tester symmlinks

### DIFF
--- a/test/src/dftbp/api/mm/CMakeLists.txt
+++ b/test/src/dftbp/api/mm/CMakeLists.txt
@@ -33,6 +33,10 @@ foreach(test IN LISTS tests)
     NAME api_${test}
     COMMAND ${projectdir}/test/app/dftb+/bin/autotest2
         -r ${srcdir}/testcases -w ${builddir}/testcases
-	-d ${projectdir}/test/app/dftb+/bin/tagdiff
+        -d ${projectdir}/test/app/dftb+/bin/tagdiff
         -P "${TEST_RUNNER}" -s P,R,C,S ${test})
+  set_tests_properties(
+    api_${test}
+    PROPERTIES
+    ENVIRONMENT "DFTBPLUS_PARAM_DIR=${PROJECT_SOURCE_DIR}/external")
 endforeach()

--- a/test/src/dftbp/api/mm/testcases/ehrenfest/C-C.skf
+++ b/test/src/dftbp/api/mm/testcases/ehrenfest/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/src/dftbp/api/mm/testcases/ehrenfest/C-H.skf
+++ b/test/src/dftbp/api/mm/testcases/ehrenfest/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/src/dftbp/api/mm/testcases/ehrenfest/H-C.skf
+++ b/test/src/dftbp/api/mm/testcases/ehrenfest/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/src/dftbp/api/mm/testcases/ehrenfest/H-H.skf
+++ b/test/src/dftbp/api/mm/testcases/ehrenfest/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/src/dftbp/api/mm/testcases/ehrenfest_ext_ions/C-C.skf
+++ b/test/src/dftbp/api/mm/testcases/ehrenfest_ext_ions/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/src/dftbp/api/mm/testcases/ehrenfest_ext_ions/C-H.skf
+++ b/test/src/dftbp/api/mm/testcases/ehrenfest_ext_ions/C-H.skf
@@ -1,1 +1,0 @@
-../../../../../../../external/slakos/origin/mio-1-1/C-H.skf

--- a/test/src/dftbp/api/mm/testcases/ehrenfest_ext_ions/H-C.skf
+++ b/test/src/dftbp/api/mm/testcases/ehrenfest_ext_ions/H-C.skf
@@ -1,1 +1,0 @@
-../../../../../../../external/slakos/origin/mio-1-1/H-C.skf

--- a/test/src/dftbp/api/mm/testcases/ehrenfest_ext_ions/H-H.skf
+++ b/test/src/dftbp/api/mm/testcases/ehrenfest_ext_ions/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/src/dftbp/api/mm/testcases/fileinit/Si-Si.skf
+++ b/test/src/dftbp/api/mm/testcases/fileinit/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../../../external/slakos/origin/pbc-0-3/Si-Si.skf

--- a/test/src/dftbp/api/mm/testcases/fileinit/dftb_in.hsd
+++ b/test/src/dftbp/api/mm/testcases/fileinit/dftb_in.hsd
@@ -19,7 +19,8 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = {
-    Si-Si = "./Si-Si.skf"
+    Prefix = "slakos/origin/pbc-0-3/"
+    Si-Si = "Si-Si.skf"
   }
   KPointsAndWeights = {
  0.250000000000000 0.250000000000000 0.250000000000000 1.00000000000000

--- a/test/src/dftbp/api/mm/testcases/fileinitc/H-H.skf
+++ b/test/src/dftbp/api/mm/testcases/fileinitc/H-H.skf
@@ -1,1 +1,0 @@
-../../../../../../../external/slakos/origin/mio-1-1/H-H.skf

--- a/test/src/dftbp/api/mm/testcases/fileinitc/H-O.skf
+++ b/test/src/dftbp/api/mm/testcases/fileinitc/H-O.skf
@@ -1,1 +1,0 @@
-../../../../../../../external/slakos/origin/mio-1-1/H-O.skf

--- a/test/src/dftbp/api/mm/testcases/fileinitc/O-H.skf
+++ b/test/src/dftbp/api/mm/testcases/fileinitc/O-H.skf
@@ -1,1 +1,0 @@
-../../../../../../../external/slakos/origin/mio-1-1/O-H.skf

--- a/test/src/dftbp/api/mm/testcases/fileinitc/O-O.skf
+++ b/test/src/dftbp/api/mm/testcases/fileinitc/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/src/dftbp/api/mm/testcases/fileinitc/Si-Si.skf
+++ b/test/src/dftbp/api/mm/testcases/fileinitc/Si-Si.skf
@@ -1,1 +1,0 @@
-../../../../../../../external/slakos/origin/pbc-0-3/Si-Si.skf

--- a/test/src/dftbp/api/mm/testcases/fileinitc/dftb_in.H2O.hsd
+++ b/test/src/dftbp/api/mm/testcases/fileinitc/dftb_in.H2O.hsd
@@ -21,6 +21,7 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = Type2FileNames {
+    Prefix = "slakos/origin/mio-1-1/"
     Separator = "-"
     Suffix  = ".skf"
   }

--- a/test/src/dftbp/api/mm/testcases/fileinitc/dftb_in.Si2.hsd
+++ b/test/src/dftbp/api/mm/testcases/fileinitc/dftb_in.Si2.hsd
@@ -19,7 +19,8 @@ Hamiltonian = DFTB {
     Temperature [Kelvin] = 1.000000000000000E-008
   }
   SlaterKosterFiles = {
-    Si-Si = "./Si-Si.skf"
+    Prefix = "slakos/origin/pbc-0-3/"
+    Si-Si = "Si-Si.skf"
   }
   KPointsAndWeights = {
  0.250000000000000 0.250000000000000 0.250000000000000 1.00000000000000

--- a/test/src/dftbp/api/mm/testers/test_ehrenfest.f90
+++ b/test/src/dftbp/api/mm/testers/test_ehrenfest.f90
@@ -48,7 +48,8 @@ contains
   !! Main test routine
   !!
   !! All non-constant variables must be defined here to ensure that they are all explicitly
-  !! deallocated before the program finishes (avoiding residual memory that tools like valgrind notice).
+  !! deallocated before the program finishes (avoiding residual memory that tools like valgrind
+  !! notice).
   !!
   subroutine main_()
 
@@ -91,7 +92,7 @@ contains
 
     call setChild(pDftb, "SlaterKosterFiles", pSlakos)
     call setChild(pSlakos, "Type2FileNames", pType2Files)
-    call setChildValue(pType2Files, "Prefix", "./")
+    call setChildValue(pType2Files, "Prefix", "slakos/origin/mio-1-1/")
     call setChildValue(pType2Files, "Separator", "-")
     call setChildValue(pType2Files, "Suffix", ".skf")
 

--- a/test/src/dftbp/api/mm/testers/test_ehrenfest_ext_ions.f90
+++ b/test/src/dftbp/api/mm/testers/test_ehrenfest_ext_ions.f90
@@ -48,7 +48,8 @@ contains
   !! Main test routine
   !!
   !! All non-constant variables must be defined here to ensure that they are all explicitely
-  !! deallocated before the program finishes  (avoiding residual memory that tools like valgrind notice).
+  !! deallocated before the program finishes (avoiding residual memory that tools like valgrind
+  !! notice).
   !!
   subroutine main_()
 
@@ -92,7 +93,7 @@ contains
 
     call setChild(pDftb, "SlaterKosterFiles", pSlakos)
     call setChild(pSlakos, "Type2FileNames", pType2Files)
-    call setChildValue(pType2Files, "Prefix", "./")
+    call setChildValue(pType2Files, "Prefix", "slakos/origin/mio-1-1/")
     call setChildValue(pType2Files, "Separator", "-")
     call setChildValue(pType2Files, "Suffix", ".skf")
 


### PR DESCRIPTION
Propagate environment variable into the API testers, allowing for removal of symlinks for SK files. Also includes several conversion of tests to remove the links.