### PR TITLE
Partial clean up of hybrid namespace

### DIFF
--- a/src/dftbp/dftb/getenergies.F90
+++ b/src/dftbp/dftb/getenergies.F90
@@ -283,13 +283,13 @@ contains
     if (allocated(hybridXc) .and. .not. allocated(reks)) then
       energy%Efock = 0.0_dp
       if (tRealHS) then
-        call hybridXc%addCamEnergy_real(env, energy%Efock)
+        call hybridXc%addHybridEnergy_real(env, energy%Efock)
       else
         if ((.not. present(densityMatrix)) .or. (.not. present(kWeights))) then
           @:RAISE_ERROR(errStatus, -1, "Missing expected array(s) for hybrid xc-functional&
               & calculation.")
         end if
-        call hybridXc%addCamEnergy_kpts(env, localKS, densityMatrix%iKiSToiGlobalKS, kWeights,&
+        call hybridXc%addHybridEnergy_kpts(env, localKS, densityMatrix%iKiSToiGlobalKS, kWeights,&
             & densityMatrix%deltaRhoOutCplx, energy%Efock)
       end if
     end if

--- a/src/dftbp/dftb/hybridxc.F90
+++ b/src/dftbp/dftb/hybridxc.F90
@@ -272,8 +272,8 @@ module dftbp_dftb_hybridxc
 
     procedure :: addCamHamiltonianMatrix_cluster_cmplx
 
-    procedure :: addCamEnergy_real
-    procedure :: addCamEnergy_kpts
+    procedure :: addHybridEnergy_real
+    procedure :: addHybridEnergy_kpts
 
     procedure :: tabulateCamdGammaEval0_cluster
     procedure :: tabulateCamdGammaEval0_gamma
@@ -3459,8 +3459,8 @@ contains
   end subroutine addCamHamiltonianNeighbour_kpts_ct
 
 
-  !> Adds the CAM-energy contribution to the total energy.
-  subroutine addCamEnergy_real(this, env, energy)
+  !> Adds the hybrid functional contribution to the total energy.
+  subroutine addHybridEnergy_real(this, env, energy)
 
     !> Class instance
     class(THybridXcFunc), intent(inout) :: this
@@ -3481,11 +3481,11 @@ contains
     ! probably broken for MPI groups over spin
     this%camEnergy = 0.0_dp
 
-  end subroutine addCamEnergy_real
+  end subroutine addHybridEnergy_real
 
 
-  !> Adds the CAM-energy contribution to the total energy.
-  subroutine addCamEnergy_kpts(this, env, localKS, iKiSToiGlobalKS, kWeights, deltaRhoOutCplx,&
+  !> Adds the hybrid functional contribution to the total energy.
+  subroutine addHybridEnergy_kpts(this, env, localKS, iKiSToiGlobalKS, kWeights, deltaRhoOutCplx,&
       & energy)
 
     !> Class instance
@@ -3539,7 +3539,7 @@ contains
     ! hack for spin unrestricted calculation
     this%camEnergy = 0.0_dp
 
-  end subroutine addCamEnergy_kpts
+  end subroutine addHybridEnergy_kpts
 
 
   !> Finds location of relevant atomic block indices in a dense matrix.
@@ -7165,7 +7165,7 @@ contains
   end subroutine addCamGradientsNeighbour_kpts_ct
 
 
-  !> Explicitly evaluates the LR-Energy contribution (very slow, use addLrEnergy instead).
+  !> Explicitly evaluates the LR-Energy contribution (very slow, use addHybridEnergy_* instead).
   function evaluateLrEnergyDirect_cluster(this, env, deltaRho, overlap, iSquare) result(energy)
 
     !> Instance of LR

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -8164,8 +8164,8 @@ contains
             & iSparseStart, orb, img2CentCell, reks%tPeriodic, reks%hamSqrL(:,:, 1, iL), errStatus)
       #:endif
         @:PROPAGATE_ERROR(errStatus)
-        ! Calculate range-separated exchange energy for spin up
-        call hybridXc%addCamEnergy_real(env, tmpEn(iL))
+        ! Calculate hybrid functional exchange energy
+        call hybridXc%addHybridEnergy_real(env, tmpEn(iL))
       end do
     end if
 

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -3589,7 +3589,7 @@ contains
     real(dp), intent(in), optional :: truncationCutOff
 
     !> If calculation uses a hybrid functional, try to read extra data from end of SK file and
-    !> confirm is is a suitable parameterisation
+    !! confirm it is a suitable parameterisation
     type(THybridXcSKTag), intent(inout), optional :: hybridXcSK
 
     integer :: iSp1, iSp2, nSK1, nSK2, iSK1, iSK2, ind, nInteract, iSh1

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -1340,7 +1340,7 @@ contains
     type(string), allocatable :: searchPath(:)
     character(len=:), allocatable :: strOut
 
-    !> For range separation
+    !> For hybrid functional calculations
     type(THybridXcSKTag) :: hybridXcSK
 
     ctrl%hamiltonian = hamiltonianTypes%dftb
@@ -3558,7 +3558,7 @@ contains
   !> Should be replaced with a more sophisticated routine, once the new SK-format has been
   !> established.
   subroutine readSKFiles(skFiles, nSpecies, slako, orb, angShells, orbRes, skInterMeth, repPoly,&
-      & truncationCutOff, hybridXcSK, tHyb, tLc, tCam)
+      & truncationCutOff, hybridXcSK)
 
     !> List of SK file names to read in for every interaction
     type(TListCharLc), intent(inout) :: skFiles(:,:)
@@ -3588,17 +3588,9 @@ contains
     !> Distances to artificially truncate tables of SK integrals
     real(dp), intent(in), optional :: truncationCutOff
 
-    !> if calculation range separated then read omega from end of SK file
+    !> If calculation uses a hybrid functional, try to read extra data from end of SK file and
+    !> confirm is is a suitable parameterisation
     type(THybridXcSKTag), intent(inout), optional :: hybridXcSK
-
-    !> True, if global hybrid functional is requested
-    logical, intent(in), optional :: tHyb
-
-    !> True, if purely long-range corrected functional is requested
-    logical, intent(in), optional :: tLc
-
-    !> True, if CAM range-separation is requested
-    logical, intent(in), optional :: tCam
 
     integer :: iSp1, iSp2, nSK1, nSK2, iSK1, iSK2, ind, nInteract, iSh1
     integer :: angShell(maxL+1), nShell

--- a/src/dftbp/timedep/timeprop.F90
+++ b/src/dftbp/timedep/timeprop.F90
@@ -3777,7 +3777,7 @@ contains
       energy%eDisp = 0.0_dp
     end if
     if (allocated(hybridXc)) then
-      call hybridXc%addCamEnergy_real(env, energy%Efock)
+      call hybridXc%addHybridEnergy_real(env, energy%Efock)
     else
       energy%Efock = 0.0_dp
     end if


### PR DESCRIPTION
* Rename Cam to Hybrid in energy-related routines
* Removal of some unused variables
* Correction of some outdated comments

Note, needs another PR to clean up H and gradient naming