### PR TITLE
Fix wrong printing for SA-REKS energy

### DIFF
--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -571,7 +571,7 @@ contains
           & this%tStress, this%totalStress, pDynMatrix, pDipDerivMatrix, this%tPeriodic,&
           & this%cellVol, this%tMulliken, this%qOutput, this%q0, this%taggedWriter, this%cm5Cont,&
           & this%polarisability, this%dEidE, this%dqOut, this%neFermi, this%dEfdE,&
-          & this%dipoleMoment, this%multipoleOut, this%eFieldScaling)
+          & this%dipoleMoment, this%multipoleOut, this%eFieldScaling, this%reks)
     end if
     if (this%tWriteCosmoFile .and. allocated(this%solvation)) then
       call writeCosmoFile(this%solvation, this%species0, this%speciesName, this%coord0, &
@@ -1305,7 +1305,7 @@ contains
 
         if (tConverged .or. tStopScc) then
 
-          call printReksSAInfo(this%reks, this%dftbEnergy(1)%Etotal)
+          call printReksSAInfo(this%reks, this%dftbEnergy(1)%Eavg)
 
           call getStateInteraction(env, this%denseDesc, this%neighbourList, this%nNeighbourSK,&
               & this%iSparseStart, this%img2CentCell, this%coord, this%iAtInCentralRegion,&

--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -2037,7 +2037,7 @@ contains
   subroutine writeResultsTag(fileName, energy, derivs, chrgForces, nEl, Ef, eigen, filling,&
       & electronicSolver, tStress, totalStress, pDynMatrix, pBornMatrix, tPeriodic, cellVol,&
       & tMulliken, qOutput, q0, taggedWriter, cm5Cont, polarisability, dEidE, dqOut, neFermi,&
-      & dEfdE, dipoleMoment, multipole, eFieldScaling)
+      & dEfdE, dipoleMoment, multipole, eFieldScaling, reks)
 
     !> Name of output file
     character(len=*), intent(in) :: fileName
@@ -2123,11 +2123,17 @@ contains
     !> Any dielectric environment scaling
     class(TScaleExtEField), intent(in) :: eFieldScaling
 
+    !> Data type for REKS
+    type(TReksCalc), allocatable, intent(inout) :: reks
+
     real(dp), allocatable :: qOutputUpDown(:,:,:), qDiff(:,:,:)
     type(TFileDescr) :: fd
 
     call openFile(fd, fileName, mode="a")
 
+    if (allocated(reks)) then
+      call taggedWriter%write(fd%unit, tagLabels%egyAvg, energy%Eavg)
+    end if
     call taggedWriter%write(fd%unit, tagLabels%egyTotal, energy%ETotal)
     if (electronicSolver%elecChemPotAvailable) then
       call taggedWriter%write(fd%unit, tagLabels%fermiLvl, Ef)

--- a/src/dftbp/io/taggedoutput.F90
+++ b/src/dftbp/io/taggedoutput.F90
@@ -167,6 +167,9 @@ module dftbp_io_taggedoutput
     !> total internal energy
     character(lenLabel) :: egyTotal   = 'total_energy'
 
+    !> total internal energy for averaged state in REKS
+    character(lenLabel) :: egyAvg   = 'averaged_energy'
+
     !> total internal energy extrapolated to 0 K
     character(lenLabel) :: egy0Total   = 'extrapolated0_energy'
 

--- a/src/dftbp/reks/reksio.F90
+++ b/src/dftbp/reks/reksio.F90
@@ -92,18 +92,18 @@ module dftbp_reks_reksio
 
 
   !> print SA-REKS result in standard output
-  subroutine printReksSAInfo(this, Etotal)
+  subroutine printReksSAInfo(this, Eavg)
 
     !> data type for REKS
     type(TReksCalc), intent(inout) :: this
 
-    !> state-averaged energy
-    real(dp), intent(in) :: Etotal
+    !> Total energy for averaged state in REKS
+    real(dp), intent(in) :: Eavg
 
     select case (this%reksAlg)
     case (reksTypes%noReks)
     case (reksTypes%ssr22)
-      call printReksSAInfo22_(Etotal, this%enLtot, this%energy, this%FONs, this%Efunction,&
+      call printReksSAInfo22_(Eavg, this%enLtot, this%energy, this%FONs, this%Efunction,&
           & this%Plevel)
     case (reksTypes%ssr44)
       call error("SSR(4,4) is not implemented yet")
@@ -437,10 +437,10 @@ module dftbp_reks_reksio
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> print SA-REKS(2,2) result in standard output
-  subroutine printReksSAInfo22_(Etotal, enLtot, energy, FONs, Efunction, Plevel)
+  subroutine printReksSAInfo22_(Eavg, enLtot, energy, FONs, Efunction, Plevel)
 
-    !> state-averaged energy
-    real(dp), intent(in) :: Etotal
+    !> Total energy for averaged state in REKS
+    real(dp), intent(in) :: Eavg
 
     !> total energy for each microstate
     real(dp), intent(in) :: enLtot(:)
@@ -470,14 +470,14 @@ module dftbp_reks_reksio
     write(stdOut,*) " "
     write(stdOut, "(A)") repeat("-", 50)
     if (Efunction == 1) then
-      write(stdOut,'(A25,2x,F15.8)') " Final REKS(2,2) energy:", Etotal
+      write(stdOut,'(A25,2x,F15.8)') " Final REKS(2,2) energy:", Eavg
       write(stdOut,*) " "
       write(stdOut,'(A46)') " State     Energy      FON(1)    FON(2)   Spin"
       write(strTmp,'(A)') "PPS"
       write(stdOut,'(1x,a4,1x,f13.8,1x,2(f10.6),2x,f4.2)') &
           & trim(strTmp), energy(1), n_a, n_b, 0.0_dp
     else if (Efunction == 2) then
-      write(stdOut,'(A27,2x,F15.8)') " Final SA-REKS(2,2) energy:", Etotal
+      write(stdOut,'(A27,2x,F15.8)') " Final SA-REKS(2,2) energy:", Eavg
       write(stdOut,*) " "
       write(stdOut,'(A46)') " State     Energy      FON(1)    FON(2)   Spin"
       do ist = 1, nstates


### PR DESCRIPTION
This error occurs from commit 2551dc7, and now correct SA-REKS energy is printed after converging the SCC procedure.