### PR TITLE
Fix GitHub CI-related issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,11 +33,11 @@ jobs:
         mpi: [nompi, openmpi]
         config: [Debug]
         version: [13]
-        include:
-          - os: ubuntu-latest
-            mpi: nompi
-            config: Coverage
-            version: 13
+        # include:
+        #   - os: ubuntu-latest
+        #     mpi: nompi
+        #     config: Coverage
+        #     version: 13
 
     steps:
     - name: Checkout code
@@ -133,12 +133,12 @@ jobs:
       if: contains(matrix.config, 'Coverage')
       run: ./utils/test/make_gcov_reports ${PWD} ${PWD}/_build/gcovs ${PWD}/_build/src ${PWD}/_build/app
 
-    - name: Upload coverage report
-      if: contains(matrix.config, 'Coverage')
-      uses: codecov/codecov-action@v1
-      with:
-        directory: _build/gcovs
-        functionalities: gcov
+    # - name: Upload coverage report
+    #   if: contains(matrix.config, 'Coverage')
+    #   uses: codecov/codecov-action@v1
+    #   with:
+    #     directory: _build/gcovs
+    #     functionalities: gcov
 
     - name: Run integration CMake test
       run: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         mpi: [nompi, openmpi]
         config: [Debug]
         version: [13]
@@ -37,11 +37,6 @@ jobs:
           - os: ubuntu-latest
             mpi: nompi
             config: Coverage
-            version: 13
-        exclude:
-          - os: macos-latest
-            mpi: openmpi
-            config: Debug
             version: 13
 
     steps:
@@ -53,17 +48,7 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Install GCC (OSX)
-      if: ${{ contains(matrix.os, 'macos') }}
-      run: |
-        brew install gcc@${{ matrix.version }} openblas pkg-config
-        ln -s /usr/local/bin/gfortran-${{ matrix.version }} /usr/local/bin/gfortran
-        ln -s /usr/local/bin/gcc-${{ matrix.version }} /usr/local/bin/gcc
-        ln -s /usr/local/bin/g++-${{ matrix.version }} /usr/local/bin/g++
-        echo "PKG_CONFIG_PATH=/usr/local/opt/openblas/lib/pkgconfig" >> $GITHUB_ENV
-
     - name: Install GCC (Linux)
-      if: ${{ contains(matrix.os, 'ubuntu') }}
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get update
@@ -82,44 +67,31 @@ jobs:
       if: contains(matrix.mpi, 'nompi')
       run: echo "WITH_MPI=false" >> $GITHUB_ENV
 
-    - name: Set Compiler (Linux)
-      if: contains(matrix.os, 'ubuntu')
+    - name: Set Compiler
       run: |
         echo "FC=gfortran" >> $GITHUB_ENV
         echo "CC=gcc" >> $GITHUB_ENV
         echo "CXX=g++" >> $GITHUB_ENV
 
-    - name: Set Compiler (OSX)
-      if: contains(matrix.os, 'macos')
-      run: |
-        echo "FC=gfortran-${{ matrix.version }}" >> $GITHUB_ENV
-        echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
-        echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
-
     - name: Check submodule commits
       run: ./utils/test/check_submodule_commits
 
-    - name: Install ARPACK (Linux)
-      if: contains(matrix.os, 'ubuntu') && contains(matrix.mpi, 'nompi')
+    - name: Install ARPACK
+      if: contains(matrix.mpi, 'nompi')
       run: |
         sudo apt-get install libarpack2-dev
         echo "CMAKE_OPTIONS=${CMAKE_OPTIONS} -DWITH_ARPACK=true" >> $GITHUB_ENV
 
-    - name: Install OpenMPI (OSX)
-      if: contains(matrix.os, 'macos') && contains(matrix.mpi, 'openmpi')
-      run: |
-        brew install open-mpi scalapack
-
-    - name: Install OpenMPI (Linux)
-      if: contains(matrix.os, 'ubuntu') && contains(matrix.mpi, 'openmpi')
+    - name: Install OpenMPI
+      if: contains(matrix.mpi, 'openmpi')
       run: |
         sudo apt-get update
         sudo apt-get install libopenmpi-dev libscalapack-openmpi-dev
         echo "CMAKE_OPTIONS=${CMAKE_OPTIONS} -DSCALAPACK_LIBRARY='scalapack-openmpi'" >> $GITHUB_ENV
         echo "CMAKE_DEP_OPTIONS=-DSCALAPACK_LIBRARY='scalapack-openmpi'" >> $GITHUB_ENV
 
-    - name: Install MPICH (Linux)
-      if: contains(matrix.os, 'ubuntu') && contains(matrix.mpi, 'mpich')
+    - name: Install MPICH
+      if: contains(matrix.mpi, 'mpich')
       run: |
         sudo apt-get update
         sudo apt-get install mpich libscalapack-mpich-dev
@@ -132,8 +104,7 @@ jobs:
     - name: Get external dependencies
       run: echo "y" | ./utils/get_opt_externals ALL
 
-    - name: Set extra CMake flags (Linux)
-      if: contains(matrix.os, 'ubuntu')
+    - name: Set extra CMake flags
       run: |
         echo "CMAKE_OPTIONS=${CMAKE_OPTIONS} -DENABLE_DYNAMIC_LOADING=true" >> $GITHUB_ENV
 
@@ -183,14 +154,19 @@ jobs:
 
   intel-build:
 
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        config: [RelWithDebInfo]
+
+    runs-on: ${{ matrix.os }}
 
     env:
       FC: ifx
       CC: icx
       WITH_MPI: false
       CMAKE_OPTIONS: >-
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        -DCMAKE_BUILD_TYPE=${{ matrix.config }}
         -DWITH_API=true
         -DWITH_SDFTD3=true
         -DWITH_MBD=true
@@ -235,7 +211,6 @@ jobs:
       run: >-
         cmake -B _build -G Ninja
         -DCMAKE_INSTALL_PREFIX=${PWD}/_install
-        -DCMAKE_BUILD_TYPE=Debug
         ${CMAKE_OPTIONS}
         -DWITH_MPI=${WITH_MPI}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,26 +21,28 @@ env:
     -DWITH_PYTHON=true
 
 jobs:
+
   gcc-build:
+
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         mpi: [nompi, openmpi]
         config: [Debug]
-        version: [11]
+        version: [13]
         include:
           - os: ubuntu-latest
             mpi: nompi
             config: Coverage
-            version: 11
+            version: 13
         exclude:
           - os: macos-latest
             mpi: openmpi
             config: Debug
-            version: 11
-
+            version: 13
 
     steps:
     - name: Checkout code
@@ -51,8 +53,6 @@ jobs:
       with:
         python-version: '3.x'
 
-    # Note: xcode version 14.0 (default on macos-latest @ 2022-11-23) fails to link gfortran compiled
-    # code. Therefore, 14.1 is selected below (which seems to be installed.)
     - name: Install GCC (OSX)
       if: ${{ contains(matrix.os, 'macos') }}
       run: |
@@ -61,7 +61,6 @@ jobs:
         ln -s /usr/local/bin/gcc-${{ matrix.version }} /usr/local/bin/gcc
         ln -s /usr/local/bin/g++-${{ matrix.version }} /usr/local/bin/g++
         echo "PKG_CONFIG_PATH=/usr/local/opt/openblas/lib/pkgconfig" >> $GITHUB_ENV
-        xcversion select 14.1
 
     - name: Install GCC (Linux)
       if: ${{ contains(matrix.os, 'ubuntu') }}
@@ -181,23 +180,15 @@ jobs:
         PKG_CONFIG_PATH="${PWD}/_install/lib/pkgconfig:${PKG_CONFIG_PATH}"
         ./test/src/dftbp/integration/pkgconfig/runtest.sh ${BUILD_DIR}_pkgconfig
 
+
   intel-build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        fc: [ifx]
-        cc: [icx]
+
+    runs-on: ubuntu-latest
+
     env:
-      FC: ${{ matrix.fc }}
-      CC: ${{ matrix.cc }}
+      FC: ifx
+      CC: icx
       WITH_MPI: false
-      APT_PACKAGES: >-
-        intel-oneapi-compiler-fortran
-        intel-oneapi-compiler-dpcpp-cpp
-        intel-oneapi-mkl
-        intel-oneapi-mkl-devel
       CMAKE_OPTIONS: >-
         -DCMAKE_BUILD_TYPE=RelWithDebInfo
         -DWITH_API=true
@@ -215,22 +206,22 @@ jobs:
       with:
         python-version: 3.x
 
-    - name: Add Intel repository
-      if: contains(matrix.os, 'ubuntu')
-      run: |
-        wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
-        echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-        sudo apt-get update
+    - name: Setup Intel compiler
+      uses: rscohn2/setup-oneapi@v0
+      with:
+        components: |
+          icx@2024.0.0
+          ifx@2024.0.0
+          mkl@2024.0.0
 
-    - name: Install Intel oneAPI compiler
-      if: contains(matrix.os, 'ubuntu')
+    - name: Setup Intel environment
       run: |
-        sudo apt-get update
-        sudo apt-get install ${APT_PACKAGES}
         source /opt/intel/oneapi/setvars.sh
-        printenv >> $GITHUB_ENV
+        printenv >> ${GITHUB_ENV}
+        echo "FC=ifx" >> ${GITHUB_ENV}
+        echo "CC=icx" >> ${GITHUB_ENV}
 
-    - name: Install cmake
+    - name: Install tools via pip
       run: pip3 install cmake ninja fypp numpy
 
     - name: Get external dependencies


### PR DESCRIPTION
Quick fixes to make 
* Switch to cached Intel compiler with fixed version (fixes Intel hangup)
* Drop macOS tester (unreliably, failing recently more often than not, no possibility to debug it locally currently)
* Uncomment codecov related section, as codecov does not accept old style access any more and hangs.
* 