### PR TITLE
Remove duplicate results tag

### DIFF
--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -2136,7 +2136,6 @@ contains
     if (allocated(reks)) then
       call taggedWriter%write(fd%unit, tagLabels%egyAvg, energy%Eavg)
     end if
-    call taggedWriter%write(fd%unit, tagLabels%egyTotal, energy%ETotal)
     if (electronicSolver%elecChemPotAvailable) then
       call taggedWriter%write(fd%unit, tagLabels%fermiLvl, Ef)
     end if

--- a/test/app/dftb+/derivatives/GaAs_2/_autotest.tag
+++ b/test/app/dftb+/derivatives/GaAs_2/_autotest.tag
@@ -1,5 +1,3 @@
-total_energy        :real:0:
- -0.988230042060457E+001
 fermi_level         :real:1:1
  -0.103415997688877E+000
 number_of_electrons :real:1:1

--- a/test/app/dftb+/derivatives/gfn2_c6h6_dipole/_autotest.tag
+++ b/test/app/dftb+/derivatives/gfn2_c6h6_dipole/_autotest.tag
@@ -1,5 +1,3 @@
-total_energy        :real:0:
- -0.159011039858665E+002
 fermi_level         :real:1:1
  -0.312624317497696E+000
 number_of_electrons :real:1:1

--- a/test/app/dftb+/xtb/gfn2_benzene_resltag/_autotest.tag
+++ b/test/app/dftb+/xtb/gfn2_benzene_resltag/_autotest.tag
@@ -1,5 +1,3 @@
-total_energy        :real:0:
- -0.158793406319056E+002
 fermi_level         :real:1:1
  -0.322573667823568E+000
 number_of_electrons :real:1:1


### PR DESCRIPTION
The block after line 2136 of mainio.F90 is already printing the correct energy quantity (either internal or Mermin depending on the ensemble), so either the wrong energy is printed or two copies of the internal energy (total) are printed by the removed line.