### PR TITLE
Remove unused old energy eval routine

### DIFF
--- a/src/dftbp/dftb/hybridxc.F90
+++ b/src/dftbp/dftb/hybridxc.F90
@@ -285,8 +285,6 @@ module dftbp_dftb_hybridxc
     procedure :: getCamGammaCluster
     procedure :: getCamGammaDerivCluster
 
-    procedure :: evaluateLrEnergyDirect_cluster
-
     procedure(gammaFunc), deferred :: getLrGammaValue
     procedure(gammaFunc), deferred :: getLrGammaPrimeValue
 
@@ -7159,74 +7157,6 @@ contains
     gradients(:,:) = gradients + tmpGradients
 
   end subroutine addCamGradientsNeighbour_kpts_ct
-
-
-  !> Explicitly evaluates the LR-Energy contribution (very slow, use addHybridEnergy_* instead).
-  function evaluateLrEnergyDirect_cluster(this, env, deltaRho, overlap, iSquare) result(energy)
-
-    !> Instance of LR
-    class(THybridXcFunc), intent(in) :: this
-
-    !> Environment settings
-    type(TEnvironment), intent(inout) :: env
-
-    !> Square density matrix
-    real(dp), intent(in) :: deltaRho(:,:)
-
-    !> Square overlap matrix
-    real(dp), intent(in) :: overlap(:,:)
-
-    !> Dense matrix atom indexing
-    integer, intent(in) :: iSquare(:)
-
-    !> Resulting energy
-    real(dp) :: energy
-
-    !! Number of atoms in central cell
-    integer :: nAtom0
-
-    !! Atom indices, where orbitals \mu and \nu are located
-    integer :: iAt1, iAt2, mu, nu, alpha, beta
-
-    !!
-    real(dp), allocatable :: tmpOvr(:,:), tmpDRho(:,:)
-    real(dp) :: tmp
-
-    call env%globalTimer%startTimer(globalTimers%energyEval)
-
-    nAtom0 = size(this%species0)
-
-    allocate(tmpOvr(size(overlap, dim=1), size(overlap, dim=1)))
-    allocate(tmpDRho(size(deltaRho, dim=1), size(deltaRho, dim=1)))
-    tmpOvr(:,:) = overlap
-    tmpDRho(:,:) = deltaRho
-
-    call adjointLowerTriangle(tmpOvr)
-    call adjointLowerTriangle(tmpDRho)
-
-    energy = 0.0_dp
-    do iAt1 = 1, nAtom0
-      do iAt2 = 1, nAtom0
-        tmp = 0.0_dp
-        do mu = iSquare(iAt1), iSquare(iAt1 + 1) - 1
-          do nu = iSquare(iAt2), iSquare(iAt2 + 1) - 1
-            do alpha = 1, size(tmpOvr, dim=1)
-              do beta = 1, size(tmpOvr, dim=1)
-                tmp = tmp + (&
-                    & tmpDRho(alpha, beta) * tmpDRho(mu, nu)&
-                    & + tmpDRho(mu,beta) * tmpDRho(alpha,nu)) * tmpOvr(mu,alpha) * tmpOvr(nu,beta)
-              end do
-            end do
-          end do
-        end do
-        energy = energy + tmp * this%camGammaEval0(iAt1, iAt2)
-      end do
-    end do
-    energy = -energy / 8.0_dp
-
-    call env%globalTimer%stopTimer(globalTimers%energyEval)
-
-  end function evaluateLrEnergyDirect_cluster
 
 
   !> Returns the array of atomic species in central cell.


### PR DESCRIPTION
Routine is not used anywhere and, as per its comments, is slower than the actual routines (plus is only for clusters).