### PR TITLE
Td-rsh with mpi + tests

### DIFF
--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -5958,9 +5958,6 @@ contains
       if (.not. all(input%ctrl%lrespini%indNACouplings == 0)) then
         call error("Non-adiabatic coupling vectors not available under MPI")
       end if
-      if (isHybLinResp) then
-        call error("Hybrid functionals for excited states not available under MPI")
-      end if
     end if
 
     if (.not. tSccCalc) then

--- a/src/dftbp/timedep/linresp.F90
+++ b/src/dftbp/timedep/linresp.F90
@@ -174,7 +174,7 @@ contains
     this%oscillatorWindow = ini%oscillatorWindow
     ! Final decision on value of tCacheChargesSame is made in linRespGrad
     this%tCacheChargesOccVir = ini%tCacheCharges
-    this%tCacheChargesSame = ini%tCacheCharges
+    this%tCacheChargesSame = .false.
     this%nStat = ini%nStat
     this%symmetry = ini%sym
 

--- a/src/dftbp/timedep/linrespcommon.F90
+++ b/src/dftbp/timedep/linrespcommon.F90
@@ -1356,9 +1356,6 @@ contains
     ! A new index array is required because the standard abs index is symmetrical in a and b  
     if (tRangeSep) then
       
-      ! This part is already fully coded for MPI, but was never tested.
-      call error('You should never reach this point.')
-
       !! Number of vir-vir transitions a->b _and_ b->a, summed over spin channels
       nxvv_a = sum(nvir_ud**2)
       allocate(getABasym(nxvv_a, 3))
@@ -1431,6 +1428,7 @@ contains
         ss = getABasym(abs, 3)
         do jj = 1, nocc_ud(ss)
           jas =  iaTrans(jj, aa, ss)
+          jbs =  iaTrans(jj, bb, ss)
           qij(:) = transChrg%qTransIA(jas, env, denseDesc, ovrXev, grndEigVecs, getIA, win)
           qv(:,myab) = qv(:,myab) + qij(:) * vGlb(jbs) * sqrOccIA(jbs)
         end do
@@ -1585,9 +1583,6 @@ contains
 
     if (tRangeSep) then
 
-      !> This part is already fully coded for MPI, but was never tested.
-      call error('You should never reach this point.')
-      
       allocate(qij(natom))
       allocate(otmp(natom))
       !! Number of vir-vir transitions a->b _and_ b->a, summed over spin channels
@@ -1662,6 +1657,7 @@ contains
         ss = getABasym(abs, 3)
         do jj = 1, nocc_ud(ss)
           jas =  iaTrans(jj, aa, ss)
+          jbs =  iaTrans(jj, bb, ss)
           qij(:) = transChrg%qTransIA(jas, env, denseDesc, ovrXev, grndEigVecs, getIA, win)
           qv(:,myab) = qv(:,myab) + qij(:) * vGlb(jbs) * sqrOccIA(jbs)
         end do
@@ -1885,9 +1881,6 @@ contains
     end if
 
     if (tHybridXc) then
-
-      !> This part is already fully coded for MPI, but was never tested.
-      call error('You should never reach this point.')
 
       do jbs = 1, initDim
         jj = getIA(win(jbs), 1)

--- a/src/dftbp/timedep/linrespgrad.F90
+++ b/src/dftbp/timedep/linrespgrad.F90
@@ -376,9 +376,9 @@ contains
         & (.not. this%tNaCoupling)
 
     !> Occ-occ/vir-vir charges only required for Z-vector/forces or TD-LC-DFTB
-    if ((.not. tZVector) .and. this%tCacheChargesSame) then
-       this%tCacheChargesSame = .false.
-    endif
+    if (this%tCacheChargesOccVir) then
+      if (tZVector .or. tHybridXc) this%tCacheChargesSame = .true.
+    end if
 
     ! Sanity checks
     if (nstat < 0 .and. this%symmetry /= "S") then

--- a/test/app/dftb+/hybrid/cluster/Benzene-TD-LC-Spinpol-Iter/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/cluster/Benzene-TD-LC-Spinpol-Iter/dftb_in.hsd
@@ -45,5 +45,12 @@ Options {
     WriteAutotestTag = Yes
 }
 
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+  Blacs = BlockSize { 1 } # Very small
+}
+
 
 

--- a/test/app/dftb+/hybrid/cluster/Benzene-TD-LC-Spinpol/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/cluster/Benzene-TD-LC-Spinpol/dftb_in.hsd
@@ -45,5 +45,11 @@ Options {
     WriteAutotestTag = Yes
 }
 
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+  Blacs = BlockSize { 1 } # Very small
+}
 
 

--- a/test/app/dftb+/hybrid/cluster/C4H6-TD-LC-Triplet/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/cluster/C4H6-TD-LC-Triplet/dftb_in.hsd
@@ -44,5 +44,6 @@ Parallel {
   # Allow OMP threads explicitely to test for hybrid parallelisation with
   # MPI-binary. (Check the manual before using this in production runs!)
   UseOmpThreads = Yes
+  Blacs = BlockSize { 1 } # Very small  
 }
 

--- a/test/app/dftb+/tests
+++ b/test/app/dftb+/tests
@@ -116,10 +116,10 @@ hybrid/cluster/Thymine-spin-matrix-force-mpi-grp2  #? MPI_PROCS == 2
 hybrid/cluster/C4H6-Casida-S1-Force                #? not WITH_MPI
 hybrid/cluster/Benzene-Spinpol-matrix              #? MPI_PROCS <= 1
 hybrid/cluster/Benzene-Casida-S5-Force             #? not WITH_MPI
-hybrid/cluster/C4H6-TD-LC-Triplet                  #? not WITH_MPI
-hybrid/cluster/Benzene-TD-LC-Spinpol               #? not WITH_MPI
+hybrid/cluster/C4H6-TD-LC-Triplet                  #? MPI_PROCS <= 4  
+hybrid/cluster/Benzene-TD-LC-Spinpol               #? MPI_PROCS <= 4  
 hybrid/cluster/Benzene-TD-LC-Spinpol-Force         #? not WITH_MPI
-hybrid/cluster/Benzene-TD-LC-Spinpol-Iter          #? not WITH_MPI
+hybrid/cluster/Benzene-TD-LC-Spinpol-Iter          #? MPI_PROCS <= 4
 
 hybrid/periodic/Acene-gamma-matrix-force-cam          #? MPI_PROCS <= 1
 hybrid/periodic/Acene-gamma-matrix-restart            #? not WITH_MPI


### PR DESCRIPTION
Extension of the TD-MPI PR for hybrid functionals. Only few changes were required, so this one can be checked in quickly, I hope. 

The MPI algo on a single core is even faster than the serial version of the TD-LC-DFTB algo, which means that code duplication can be avoided.  