### PR TITLE
Pre-pend SK search path in error messages

### DIFF
--- a/src/dftbp/common/filesystem.F90
+++ b/src/dftbp/common/filesystem.F90
@@ -9,11 +9,12 @@
 
 !> File system utilities
 module dftbp_common_filesystem
+  use dftbp_io_charmanip, only : endsWith
   use dftbp_extlibs_xmlf90, only : string, char, assignment(=)
   implicit none
   private
 
-  public :: getEnvVar, isAbsolutePath, joinPaths, findFile, getParamSearchPath
+  public :: getEnvVar, isAbsolutePath, joinPaths, findFile, getParamSearchPaths, joinPathsPrettyErr
 
 
   !> Whether the operating system we are using is UNIX (FIXME: use preprocessor here instead)
@@ -93,9 +94,12 @@ contains
 
     if (isAbsolutePath(suffix)) then
       path = suffix
+    else if (endsWith(prefix, separator)) then
+      path = prefix // suffix
     else
       path = prefix // separator // suffix
     end if
+
   end function joinPaths
 
 
@@ -109,47 +113,75 @@ contains
     character(len=*), intent(in) :: inName
 
     !> Contains first match on output, unallocated if no file was found
-    character(len=:), allocatable :: outName
+    character(len=:), intent(out), allocatable :: outName
 
-    integer :: ip
+    integer :: iPath
     logical :: exists
 
     if (isAbsolutePath(inName)) then
-      outName = trim(inName)
+      inquire(file=trim(inName), exist=exists)
+      if (exists) outName = trim(inName)
       return
     end if
 
-    inquire(file=inName, exist=exists)
-    if (exists) then
-      outName = trim(inName)
-      return
-    end if
-
-    do ip = 1, size(searchPath)
-      outName = joinPaths(char(searchPath(ip)), trim(inName))
+    do iPath = 1, size(searchPath)
+      outName = joinPaths(char(searchPath(iPath)), trim(inName))
       inquire(file=outName, exist=exists)
       if (exists) exit
     end do
 
-    if (.not.exists .and. allocated(outName)) deallocate(outName)
+    if (.not. exists .and. allocated(outName)) deallocate(outName)
+
   end subroutine findFile
 
 
-  !> Get the environment variable describing the search path for DFTB+
-  subroutine getParamSearchPath(path)
-    type(string), allocatable, intent(out) :: path(:)
+  !> Get the environment variable describing the search path for DFTB+. Additionally, the current
+  !! working directory ('.') is pre-pended.
+  subroutine getParamSearchPaths(path)
+
+    !> Instance
+    type(string), intent(out), allocatable :: path(:)
 
     character(len=:), allocatable :: var
 
     call getEnvVar(paramEnv, var)
 
     if (allocated(var)) then
-      allocate(path(1))
-      path(1) = var
+      allocate(path(2))
+      path(2) = var
     else
-      allocate(path(0))
+      allocate(path(1))
     end if
-  end subroutine getParamSearchPath
 
+    path(1) = "."
+
+  end subroutine getParamSearchPaths
+
+
+  !> Joins search paths for pretty error printing.
+  function joinPathsPrettyErr(path) result(prettyStr)
+
+    !> Instance
+    type(string), intent(in), allocatable :: path(:)
+
+    !! Joined paths for pretty error printing
+    character(len=:), allocatable :: prettyStr
+
+    !! Auxiliary variables
+    integer :: iPath
+
+    if (allocated(path)) then
+      if (size(path) > 0) then
+        prettyStr = "'" // char(path(1)) // "'"
+      end if
+    else
+      return
+    end if
+
+    do iPath = 2, size(path)
+      prettyStr = prettyStr // ", '" // char(path(iPath)) // "'"
+    end do
+
+  end function joinPathsPrettyErr
 
 end module dftbp_common_filesystem

--- a/src/dftbp/io/charmanip.F90
+++ b/src/dftbp/io/charmanip.F90
@@ -56,7 +56,7 @@ module dftbp_io_charmanip
   public :: getNextQuotationPos, getFirstOccurance, complementaryScan
   public :: unquotedScan
   public :: space, lineFeed, carriageReturn, tabulator, whiteSpaces, newline
-  public :: convertWhitespaces
+  public :: convertWhitespaces, endsWith
 
 contains
 
@@ -446,5 +446,35 @@ contains
     end do
 
   end subroutine convertWhitespaces
+
+
+  !> Tests if a string ends with a specified suffix.
+  pure function endsWith(str, suffix)
+
+    !> String to check
+    character(len=*), intent(in) :: str
+
+    !> Suffix to check for
+    character(len=*), intent(in) :: suffix
+
+    !> True, if string ends with suffix, otherwise false
+    logical :: endsWith
+
+    !! Length of str
+    integer :: lenStr
+
+    !! Start index of suffix in str
+    integer :: iSuffixStart
+
+    lenStr = len(str)
+    iSuffixStart = lenStr - len(suffix) + 1
+
+    if (iSuffixStart < 1) then
+      endsWith = .false.
+    else
+      endsWith = (str(iSuffixStart:lenStr) == suffix)
+    end if
+
+  end function endsWith
 
 end module dftbp_io_charmanip

--- a/src/dftbp/solvation/solvparser.F90
+++ b/src/dftbp/solvation/solvparser.F90
@@ -13,7 +13,7 @@ module dftbp_solvation_solvparser
   use dftbp_common_accuracy, only : dp, lc
   use dftbp_common_atomicrad, only : getAtomicRad
   use dftbp_common_constants, only : Boltzmann, amu__au, kg__au, AA__Bohr
-  use dftbp_common_filesystem, only : findFile, getParamSearchPath
+  use dftbp_common_filesystem, only : findFile, getParamSearchPaths
   use dftbp_common_globalenv, only : stdOut
   use dftbp_common_unitconversion, only : lengthUnits, energyUnits, massUnits, &
       & massDensityUnits, inverseLengthUnits
@@ -115,10 +115,10 @@ contains
       allocate(defaults)
       call getChildValue(node, "ParamFile", buffer, "", child=child)
       paramFile = trim(unquote(char(buffer)))
-      call getParamSearchPath(searchPath)
+      call getParamSearchPaths(searchPath)
       call findFile(searchPath, paramFile, paramTmp)
       if (allocated(paramTmp)) call move_alloc(paramTmp, paramFile)
-      write(stdOut, '(a)') "Reading GBSA parameter file '"//paramFile//"'"
+      write(stdOut, '(a)') "Reading GBSA parameter file '" // paramFile // "'"
       call readParamGBSA(paramFile, defaults, solvent, geo%speciesNames, node=child)
     else
       call readSolvent(node, solvent)


### PR DESCRIPTION
Had to stop working on it (needs discussion). The current version assumes that the maximum number of search paths is one, not as trivial as I thought.

Eventually closes #870.