### PR TITLE
Buildbot fixes

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -95,12 +95,8 @@ option(TEST_WITH_VALGRIND "Whether valgrind should be invoked when testing binar
 # Command line used to launch the test code.
 # The escaped variables (\${VARIABLE}) will be substituted by the corresponding CMake variables.
 if(WITH_MPI)
-  if(WITH_OMP)
-    set(TEST_RUNNER_TEMPLATE "env OMP_NUM_THREADS=\${TEST_OMP_THREADS} mpiexec -n \${TEST_MPI_PROCS}"
-      CACHE STRING "How to run the tests")
-  else()
-    set(TEST_RUNNER_TEMPLATE "mpiexec -n \${TEST_MPI_PROCS}" CACHE STRING "How to run the tests")
-  endif()
+  set(TEST_RUNNER_TEMPLATE "env OMP_NUM_THREADS=\${TEST_OMP_THREADS} mpiexec -n \${TEST_MPI_PROCS}"
+    CACHE STRING "How to run the tests")
 elseif(TEST_WITH_VALGRIND)
   set(VALGRIND_OPTIONS
     "--exit-on-first-error=yes --error-exitcode=1 --leak-check=full --show-leak-kinds=definite,possible --errors-for-leak-kinds=definite,possible"

--- a/test/app/dftb+/md/Vsi+O-plumed/dftb_in.hsd
+++ b/test/app/dftb+/md/Vsi+O-plumed/dftb_in.hsd
@@ -24,6 +24,7 @@ Hamiltonian = DFTB {
   Filling = Fermi {
     Temperature [Kelvin] = 500
   }
+  Solver = QR {}
 
   SlaterKosterFiles = Type2FileNames {
 Prefix = {slakos/origin/pbc-0-3/}


### PR DESCRIPTION
Fixes two issues experienced during buildbot testing:

* Timeout of the NAG compiler (due to a complete overload of the server)

* Failing Vsi+O-plumed test with the NAG compiler
