### PR TITLE
Fix uninitialized variable in LBFGS

### DIFF
--- a/src/dftbp/geoopt/lbfgs.F90
+++ b/src/dftbp/geoopt/lbfgs.F90
@@ -717,6 +717,10 @@ contains
     !> Whether line minimisation converged
     logical, intent(out) :: tConverged
 
+    tConverged = .false.
+    xNew(:) = 0.0_dp
+    this%tZoom = .false.
+
     if (this%iter == 0) then
       this%phi0 = phi
       this%dx0(:) = dx
@@ -817,6 +821,8 @@ contains
 
     real(dp) :: cCheck, qCheck, dAlpha
 
+    tConverged = .false.
+
     if (this%iter > this%mIter) then
       if (abs(this%alphaLo * maxval(this%d0)) < this%minAlpha) then
         if (abs(this%alphaNew * maxval(this%d0)) < this%minAlpha) then
@@ -903,7 +909,7 @@ contains
     end if
 
     this%xNew = this%x0 + this%alphaNew * this%d0
-    xNew = this%xNew
+    xNew(:) = this%xNew
 
   end subroutine TLineSearch_zoom
 

--- a/src/dftbp/include/common.fypp
+++ b/src/dftbp/include/common.fypp
@@ -136,5 +136,14 @@ block
 end block
 #:enddef
 
+
+#:def PRINT_ITEMS(format, *items)
+block
+  use iso_fortran_env, only : output_unit
+  write(output_unit, ${format}$) ${", ".join(items)}$
+  flush(output_unit)
+end block
+#:enddef
+
 #:endif
 #:endmute

--- a/src/dftbp/include/common.fypp
+++ b/src/dftbp/include/common.fypp
@@ -137,6 +137,7 @@ end block
 #:enddef
 
 
+#! Simple macro to print (with flushing) to a unit
 #:def PRINT_ITEMS(format, *items)
 block
   use iso_fortran_env, only : output_unit


### PR DESCRIPTION
Hopefully fixes indeterministic behavior of the old LBFGS which made `GaAs_8_latopt_lbfgs` test fail in certain cases.
