### PR TITLE
Fix concurrent file writes in MPI parallel version

### DIFF
--- a/app/phonons/phonons.F90
+++ b/app/phonons/phonons.F90
@@ -78,7 +78,7 @@ program phonons
     call calc_phonon_current(env, dynMatrix, tunnTot, ldosTot, currLead, conductance, &
                         & twriteTunn, twriteLDOS)
 
-    if (tWriteTagged) then
+    if (tWriteTagged .and. tIoProc) then
       call writeTaggedOut(taggedWriter, tunnTot, ldosTot, conductance)
     end if
 

--- a/src/dftbp/common/file.F90
+++ b/src/dftbp/common/file.F90
@@ -282,6 +282,22 @@ contains
       end if
     end if
 
+  #:block DEBUG_CODE
+  #:if WITH_MPI
+    block
+      use dftbp_extlibs_mpifx, only : mpifx_comm
+      type(mpifx_comm) :: comm
+      character(100) :: msg
+      call comm%init()
+      if (.not. comm%lead .and. (opts%action == "write" .or. opts%action == "readwrite")) then
+        write(msg, "(a, i0, 3a)") "Follow process (rank ", comm%rank, ") tried to open file '",&
+            & file, "' for writing"
+        error stop msg
+      end if
+    end block
+  #:endif
+  #:endblock
+
     open(newunit=this%unit, file=file, access=opts%access, action=opts%action, form=opts%form,&
         & status=opts%status, position=opts%position, iostat=ioStat_, iomsg=ioMsg_)
 

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -1965,7 +1965,7 @@ contains
     if (this%tMD) this%mdOutput = input%ctrl%mdOutput
     this%tDerivs = input%ctrl%tDerivs
     this%tPrintMulliken = input%ctrl%tPrintMulliken
-    this%tWriteCosmoFile = input%ctrl%tWriteCosmoFile
+    this%tWriteCosmoFile = input%ctrl%tWriteCosmoFile .and. isIoProc
 
     if (allocated(input%ctrl%electricField) .or. allocated(input%ctrl%atomicExtPotential)) then
       allocate(this%eField)

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -1347,6 +1347,8 @@ contains
     type(TStatus) :: errStatus
     integer :: nLocalRows, nLocalCols
 
+    logical :: isIoProc
+
   #:if WITH_MPI
     !! Number of k'-points
     integer :: nKPrime
@@ -1541,6 +1543,12 @@ contains
           & groups for (', env%mpi%globalComm%size, ') total MPI processes!'
       call error(trim(tmpStr))
     end if
+  #:endif
+
+  #:if WITH_MPI
+    isIoProc = env%mpi%tGlobalLead
+  #:else
+    isIoProc = .true.
   #:endif
 
   #:if WITH_SCALAPACK
@@ -2599,7 +2607,7 @@ contains
       end if
 
       call LinResp_init(this%linearResponse, input%ctrl%lrespini, this%nAtom, this%nEl(1),&
-          & this%nSpin, this%onSiteElements)
+          & this%nSpin, this%onSiteElements, isIoProc)
 
     end if
 

--- a/src/dftbp/timedep/linresp.F90
+++ b/src/dftbp/timedep/linresp.F90
@@ -131,7 +131,7 @@ module dftbp_timedep_linresp
 contains
 
   !> Initialize an internal data type for linear response excitations.
-  subroutine LinResp_init(this, ini, nAtom, nEl, nSpin, onSiteMatrixElements)
+  subroutine LinResp_init(this, ini, nAtom, nEl, nSpin, onSiteMatrixElements, isIoProc)
 
     !> Data structure for linear response
     type(TLinResp), intent(out) :: this
@@ -150,6 +150,9 @@ contains
 
     !> Onsite corrections if in use
     real(dp), allocatable :: onSiteMatrixElements(:,:,:,:)
+
+    !> Whether current process is responsible for file I/O
+    logical, intent(in) :: isIoProc
 
     integer :: dLev
 
@@ -178,7 +181,7 @@ contains
     this%nStat = ini%nStat
     this%symmetry = ini%sym
 
-    this%tWriteDensityMatrix = ini%tWriteDensityMatrix
+    this%tWriteDensityMatrix = ini%tWriteDensityMatrix .and. isIoProc
 
     if (nSpin == 1) then
       this%tSpin = .false.
@@ -222,14 +225,15 @@ contains
     end if
     this%isCIopt = ini%isCIopt
     this%energyShiftCI = ini%energyShiftCI
-    this%writeMulliken = ini%tMulliken
-    this%writeCoeffs = ini%tCoeffs
+    this%writeMulliken = ini%tMulliken .and. isIoProc
+    this%writeCoeffs = ini%tCoeffs .and. isIoProc
     this%tGrndState = ini%tGrndState
-    this%writeTrans = ini%tTrans
-    this%writeTransQ = ini%tTransQ
-    this%writeSPTrans = ini%tSPTrans
-    this%writeXplusY = ini%tXplusY
-    this%writeTransDip = ini%tTradip
+    this%writeTrans = ini%tTrans .and. isIoProc
+    this%writeTransQ = ini%tTransQ .and. isIoProc
+    this%writeSPTrans = ini%tSPTrans .and. isIoProc
+    this%writeXplusY = ini%tXplusY .and. isIoProc
+    this%writeTransDip = ini%tTradip .and. isIoProc
+    this%writeNacv = this%tNaCoupling .and. isIoProc
 
     this%nAtom = nAtom
     this%nEl = nEl
@@ -245,7 +249,7 @@ contains
 
     select case(this%iLinRespSolver)
     case(linrespSolverTypes%Arpack)
-      this%testArnoldi = ini%tDiagnoseArnoldi
+      this%testArnoldi = ini%tDiagnoseArnoldi .and. isIoProc
       this%tArnoldi = ini%tArnoldi
     case(linrespSolverTypes%Stratmann)
       this%subSpaceFactorStratmann = ini%subSpaceFactorStratmann

--- a/src/dftbp/timedep/linresptypes.F90
+++ b/src/dftbp/timedep/linresptypes.F90
@@ -96,6 +96,9 @@ module dftbp_timedep_linresptypes
     !! natural orbitals
     logical :: tGrndState = .true.
 
+    !> Whether excitation information should be written
+    logical :: writeExcitations = .false.
+
     !> Whether excited Mulliken populations should be written
     logical :: writeMulliken = .false.
 
@@ -138,6 +141,9 @@ module dftbp_timedep_linresptypes
 
     !> Subspace dimension factor Stratmann diagonaliser
     integer :: subSpaceFactorStratmann
+
+    !> Whether the NACV file should be written
+    logical :: writeNacv  = .false.
 
     ! Data structure related
 

--- a/test/src/dftbp/CMakeLists.txt
+++ b/test/src/dftbp/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(WITH_UNIT_TESTS)
+if(WITH_UNIT_TESTS AND NOT WITH_MPI)
   add_subdirectory(unittests)
 endif()
 


### PR DESCRIPTION
It also adds a check to detect such file I/O. Unfortunately, the check is rather unspecific, and forbids any `openFile()` calls in write mode on any ranks except the lead of `MPI_COMM_WORLD`. We should refine it later, but for current purposes it seems to be OK.

With those fixes, all buildbot tests pass on dpdevel.