### PR TITLE
Check agregate processors not grid shape

### DIFF
--- a/src/dftbp/common/blacsenv.F90
+++ b/src/dftbp/common/blacsenv.F90
@@ -85,7 +85,7 @@ contains
     ! diagonalisers may return garbage
     maxProcRow = (nOrb - 1) / rowBlock + 1
     maxProcColMax = (nOrb - 1) / colblock + 1
-    if (nProcRow > maxProcRow .or. nProcCol > maxProcColMax) then
+    if (nProcRow * nProcCol > maxProcRow * maxProcColMax) then
       write(buffer, "(A,I0,A,I0,A,I0,A,I0,A)") "Processor grid (", nProcRow, " x ",  nProcCol,&
           & ") too big (> ", maxProcRow, " x ", maxProcColMax, ")"
       @:RAISE_ERROR(errStatus, -1, trim(buffer))


### PR DESCRIPTION
The intcharges_c test case was failing on 3 procs but not 2 or 4, due to testing the linear dimensions of the processor grid not the number of processors.