### PR TITLE
Symmetrises the charges in contact calculations

### DIFF
--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -93,6 +93,7 @@ module dftbp_dftbplus_initprogram
   use dftbp_io_commonformats, only : format2Ue
   use dftbp_io_message, only : error, warning
   use dftbp_io_taggedoutput, only : TTaggedWriter, TTaggedWriter_init
+  use dftbp_math_contactsymm, only : TEquivContactAtoms_init, TEquivContactAtoms
   use dftbp_math_duplicate, only : isRepeated
   use dftbp_math_randomgenpool, only : TRandomGenPool, init
   use dftbp_math_ranlux, only : TRanlux, getRandom
@@ -1053,11 +1054,14 @@ module dftbp_dftbplus_initprogram
     type(TNegfInt) :: negfInt
 
     !> Whether contact Hamiltonians are uploaded
-    !> Synonym for G.F. calculation of density
+    !! Synonym for G.F. calculation of density
     logical :: tUpload
 
     !> Whether a contact Hamiltonian is being computed and stored
     logical :: isAContactCalc
+
+    !> Equivalent atoms in the structure
+    type(TEquivContactAtoms), allocatable :: equivContactAtoms
 
     !> Whether Poisson solver is invoked
     logical :: tPoisson
@@ -1690,6 +1694,11 @@ contains
     this%tUpload = .false.
     this%isAContactCalc = .false.
   #:endif
+
+    if (this%isAContactCalc) then
+      allocate(this%equivContactAtoms)
+      call TEquivContactAtoms_init(this%equivContactAtoms, this%nAtom)
+    end if
 
     this%tPoisson = input%ctrl%tPoisson .and. this%tSccCalc
     this%updateSccAfterDiag = input%ctrl%updateSccAfterDiag

--- a/src/dftbp/math/CMakeLists.txt
+++ b/src/dftbp/math/CMakeLists.txt
@@ -4,6 +4,7 @@ set(sources-fpp
   ${curdir}/angmomentum.F90
   ${curdir}/bisect.F90
   ${curdir}/blasroutines.F90
+  ${curdir}/contactsymm.F90
   ${curdir}/degeneracy.F90
   ${curdir}/duplicate.F90
   ${curdir}/eigensolver.F90

--- a/src/dftbp/math/contactsymm.F90
+++ b/src/dftbp/math/contactsymm.F90
@@ -1,0 +1,131 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2025 DFTB+ developers group                                                !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+!> Contains routines to symmetrize parts of a calculation
+module dftbp_math_contactsymm
+  use dftbp_common_accuracy, only : dp
+  implicit none
+
+  !> Atoms that are equivalent in some sense
+  type TEquivContactAtoms
+
+    !> Number of atoms that are equivalents
+    integer, allocatable :: nMappedAtoms(:)
+
+    !> List of equivalent atoms
+    integer, allocatable :: iMappedAtoms(:,:)
+
+  contains
+
+    procedure, private :: map0D
+    procedure, private :: map1D
+    procedure, private :: map2D
+    generic :: mapAtomicQuantities => map0D, map1D, map2D
+
+  end type TEquivContactAtoms
+
+
+  private
+  public :: TEquivContactAtoms_init, TEquivContactAtoms
+
+contains
+
+
+  !> Processing for transport contact calculations only at the moment, mapping atoms in two
+  !! principle layers to be identical
+  subroutine TEquivContactAtoms_init(this, nAtom)
+
+    !> Instance
+    type(TEquivContactAtoms), intent(out) :: this
+
+    !> Number of atoms in system
+    integer, intent(in) :: nAtom
+
+    integer :: iAt
+
+    allocate(this%nMappedAtoms(nAtom/2), source=2)
+    allocate(this%iMappedAtoms(2, nAtom/2), source=0)
+    do iAt = 1, nAtom/2
+      this%iMappedAtoms(1, iAt) = iAt
+    end do
+    this%iMappedAtoms(2, :nAtom/2) = this%iMappedAtoms(1, :nAtom/2) + nAtom/2
+
+  end subroutine TEquivContactAtoms_init
+
+
+  !> Map (spin channel resolved) atom charges
+  subroutine map0D(this, qq)
+
+    !> Instance
+    class(TEquivContactAtoms), intent(in) :: this
+
+    !> Charges
+    real(dp), intent(inout) :: qq(:, :)
+
+    integer :: iGrp, nAtoms, iAtoms
+    real(dp) :: work(size(qq, dim=2))
+
+    do iGrp = 1, size(this%nMappedAtoms)
+      nAtoms = this%nMappedAtoms(iGrp)
+      work(:) = sum(qq(this%iMappedAtoms(:nAtoms, iGrp), :), dim=1)
+      work(:) = work / real(nAtoms, dp)
+      do iAtoms = 1, nAtoms
+        qq(this%iMappedAtoms(iAtoms, iGrp), :) = work
+      end do
+    end do
+
+  end subroutine map0D
+
+
+  !> Map (spin channel resolved) atomic shell or orbital charges
+  subroutine map1D(this, qq)
+
+    !> Instance
+    class(TEquivContactAtoms), intent(in) :: this
+
+    !> Charges
+    real(dp), intent(inout) :: qq(:, :, :)
+
+    integer :: iGrp, nAtoms, iAtoms
+    real(dp) :: work(size(qq, dim=1), size(qq, dim=3))
+
+    do iGrp = 1, size(this%nMappedAtoms)
+      nAtoms = this%nMappedAtoms(iGrp)
+      work(:,:) = sum(qq(:, this%iMappedAtoms(:nAtoms, iGrp), :), dim=2)
+      work(:,:) = work / real(nAtoms, dp)
+      do iAtoms = 1, nAtoms
+        qq(:, this%iMappedAtoms(iAtoms, iGrp), :) = work
+      end do
+    end do
+
+  end subroutine map1D
+
+
+  !> Map (spin channel resolved) atomic block charges
+  subroutine map2D(this, qq)
+
+    !> Instance
+    class(TEquivContactAtoms), intent(in) :: this
+
+    !> Charges
+    real(dp), intent(inout) :: qq(:, :, :, :)
+
+    integer :: iGrp, nAtoms, iAtoms
+    real(dp) :: work(size(qq, dim=1), size(qq, dim=2), size(qq, dim=4))
+
+    do iGrp = 1, size(this%nMappedAtoms)
+      nAtoms = this%nMappedAtoms(iGrp)
+      work(:,:,:) = sum(qq(:, :, this%iMappedAtoms(:nAtoms, iGrp), :), dim=3)
+      work(:,:,:) = work / real(nAtoms, dp)
+      do iAtoms = 1, nAtoms
+        qq(:, :, this%iMappedAtoms(iAtoms, iGrp), :) = work
+      end do
+    end do
+
+  end subroutine map2D
+
+end module dftbp_math_contactsymm


### PR DESCRIPTION
As the two principal layers are identical, their charges should be symmetric. In the absence of code changes to just calculate one PL and duplicate it, this instead symmetrises the charge between equivalent atoms in the two layers.

Note, this will need revisiting for hybrids, but covers atomic, block and multipolar populations.