### PR TITLE
Dense HFX algorithms meta-programming

### DIFF
--- a/src/dftbp/dftb/hybridxc.F90
+++ b/src/dftbp/dftb/hybridxc.F90
@@ -49,8 +49,8 @@ module dftbp_dftb_hybridxc
 
   implicit none
 
-! Routine NAME label, main variable TYPE, variable CONVersion, matrix multiplication routine (MATOP)
-#:set FLAVOURS = [('real', 'real', 'real', 'symm'), ('cmplx', 'complex', 'cmplx', 'hemm')]
+#! Routine NAME label, main variable TYPE
+#:set FLAVOURS = [('real', 'real'), ('cmplx', 'complex')]
 
   private
 
@@ -2146,10 +2146,15 @@ contains
 
 #:else
 
-#:for NAME, TYPE, CONV, MATOP in FLAVOURS
+#:for NAME, TYPE in FLAVOURS
+
+#:set LABEL = 'complex' if NAME == 'cmplx' else 'real'
+#:set CONV = 'cmplx' if TYPE == 'complex' else 'real'
+#:set MATOP = 'hemm' if TYPE == 'complex' else 'symm'
+
   !> Update Hamiltonian with CAM range-separated contributions, using a matrix-matrix multiplication
   !! based algorithm.
-  !! (${NAME}$ non-periodic and ${NAME}$ Gamma-only version)
+  !! (${LABEL}$ non-periodic and ${LABEL}$ Gamma-only version)
   !!
   !! Eq.(B3) of Phys. Rev. Materials 7, 063802 (DOI: 10.1103/PhysRevMaterials.7.063802)
   subroutine addCamHamiltonianMatrix_${NAME}$(this, iSquare, sSqr, rhoSqr, hamSqr)
@@ -2310,6 +2315,7 @@ contains
     end subroutine evaluateHamiltonian
 
   end subroutine addCamHamiltonianMatrix_${NAME}$
+
 #:endfor
 
 #:endif

--- a/src/dftbp/timedep/timeprop.F90
+++ b/src/dftbp/timedep/timeprop.F90
@@ -1539,18 +1539,24 @@ contains
 
     ! add hybrid xc-functional contribution
     if (this%isHybridXc) then
+    #:if WITH_MPI
+      @:RAISE_ERROR(errStatus, -1, "Timeprop Module: MPI-parallelization not implemented for hybrid&
+          & xc-functionals.")
+    #:else
       deltaRho = rho
       if (this%nSpin > 2) then
         @:RAISE_ERROR(errStatus, -1, "HybridXc: Not implemented for non-colinear spin.")
       end if
       call denseSubtractDensityOfAtomsCmplxNonperiodic(q0, iSquare, deltaRho)
+
       do iSpin = 1, this%nSpin
         H1LC(:,:) = (0.0_dp, 0.0_dp)
-        call hybridXc%addCamHamiltonianMatrix_cluster_cmplx(iSquare, sSqr(:,:, iSpin),&
+        call hybridXc%addCamHamiltonianMatrix_cmplx(iSquare, sSqr(:,:, iSpin),&
             & deltaRho(:,:, iSpin), H1LC)
         call adjointLowerTriangle(H1LC)
         H1(:,:,iSpin) = H1(:,:,iSpin) + H1LC
       end do
+    #:endif
     end if
 
   end subroutine updateH


### PR DESCRIPTION
I absorbed `addCamHamiltonianMatrix_cluster_cmplx()` in a newly implemented meta-routine `addCamHamiltonianMatrix_${NAME}$`, that covers the real and complex case for non-periodic (or $\Gamma$-periodic) systems.

In a forthcoming PR I will switch to the same strategy for the MPI-parallel versions of the respective routines, in anticipation of #1390 and MPI-parallel time-propagation + hybrid xc-functionals.