### PR TITLE
Add references for Rational optimiser in the manual.

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -366,9 +366,9 @@ Driver = GeometryOptimisation {
 \label{sec:dftbp.Optimiser.RF}
 
 Provides a rational function based optimiser.
-The geometry displacement step is determining obtaining the lowest eigenvalue of the augmented Hessian matrix as proposed by Puley {\itshape et al.}~\cite{Eckert1997}
+The geometry displacement step is determined from the lowest eigenvalue of the augmented Hessian matrix as proposed by Pulay {\itshape et al.}~\cite{Eckert1997}.
 The eigenvalue equation is solved iteratively using a Davidson solver updating the displacement vector from the last optimisation cycle.
-The augmented Hessian is build from a guess model hessian, which is updated every cycle from the gradient change and displacement vectors using a BFGS-like scheme.~\cite{Broyden1970}
+The augmented Hessian is built from a guess model hessian, which is updated every cycle from the gradient change and displacement vectors using a BFGS-like scheme~\cite{Broyden1970}.
 A unit matrix is used as guess for the model hessian.
 
 The scaling behaviour of the computational cost and memory usage for this optimisation step is quadratic in the number of optimised variables.

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -366,9 +366,9 @@ Driver = GeometryOptimisation {
 \label{sec:dftbp.Optimiser.RF}
 
 Provides a rational function based optimiser.
-The geometry displacement step is determining obtaining the lowest eigenvalue of the augmented Hessian matrix.
+The geometry displacement step is determining obtaining the lowest eigenvalue of the augmented Hessian matrix as proposed by Puley {\itshape et al.}~\cite{Eckert1997}
 The eigenvalue equation is solved iteratively using a Davidson solver updating the displacement vector from the last optimisation cycle.
-The augmented Hessian is build from a guess model hessian, which is updated every cycle from the gradient change and displacement vectors using a BFGS-like scheme.
+The augmented Hessian is build from a guess model hessian, which is updated every cycle from the gradient change and displacement vectors using a BFGS-like scheme.~\cite{Broyden1970}
 A unit matrix is used as guess for the model hessian.
 
 The scaling behaviour of the computational cost and memory usage for this optimisation step is quadratic in the number of optimised variables.

--- a/doc/dftb+/manual/manual.bib
+++ b/doc/dftb+/manual/manual.bib
@@ -1144,3 +1144,28 @@ year = {2009}
   year={2014},
   publisher={AIP Publishing}
 }
+
+@article{Broyden1970,
+author = {Broyden, C. G.},
+doi = {10.1093/imamat/6.1.76},
+journal = {IMA Journal of Applied Mathematics},
+number = {1},
+pages = {76--90},
+title = {{The Convergence of a Class of Double-rank Minimization Algorithms 1. General Considerations}},
+url = {https://academic.oup.com/imamat/article-lookup/doi/10.1093/imamat/6.1.76},
+volume = {6},
+year = {1970}
+}
+
+@article{Eckert1997,
+author = {Eckert, Frank and Pulay, Peter and Werner, Hans-Joachim},
+doi = {10.1002/(SICI)1096-987X(199709)18:12<1473::AID-JCC5>3.0.CO;2-G},
+journal = {Journal of Computational Chemistry},
+month = {sep},
+number = {12},
+pages = {1473--1483},
+title = {{Ab initio geometry optimization for large molecules}},
+url = {https://onlinelibrary.wiley.com/doi/10.1002/(SICI)1096-987X(199709)18:12%3C1473::AID-JCC5%3E3.0.CO;2-G},
+volume = {18},
+year = {1997}
+}


### PR DESCRIPTION
There were references missing in the Rational optimiser section of the manual. I took them from the "Extended tight-binding quantum chemistry methods" where the procedure of the rational optimiser is referenced in page 22. DOI: 10.1002/wcms.1493