### PR TITLE
Fix for GBSA Born matrix diagonal

### DIFF
--- a/src/dftbp/solvation/born.F90
+++ b/src/dftbp/solvation/born.F90
@@ -1112,7 +1112,7 @@ contains
 
     !> self-energy part
     do iAt1 = iAtFirst, iAtLast
-      bornMat(iAt1, iAt1) = keps/bornRad(iAt1)
+      bornMat(iAt1, iAt1) = bornMat(iAt1, iAt1) + keps/bornRad(iAt1)
     end do
 
     call assembleChunks(env, bornMat)


### PR DESCRIPTION
Note, this is only part of the required fixes for this solvent model.