### PR TITLE
Enforce SCC for hybrid hamiltonians

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -1411,8 +1411,9 @@ To select the DFTB Hamiltonian you must set \is{Hamiltonian =
 
 \begin{description}
 \item[\is{SCC}] If set to \is{Yes}, a self consistent charge (SCC)
-  calculation is made.
-
+  calculation is made. {\bf Note:} this keyword is not read for hybrid
+  calculations (\pref{sec:dftbp.Hybrid}), as these are {\em always}
+  SCC.
 \item[\is{SCCTolerance}] Stopping criteria for the SCC.  Specifies the
   tolerance for the maximum difference in any charge between two SCC
   cycles.
@@ -4553,7 +4554,9 @@ Hamiltonian = DFTB {
 \subsection{Hybrid}
 \label{sec:dftbp.Hybrid}
 
-The \kw{Hybrid} keyword specifies the use of a (range-separated) hybrid functional.
+The \kw{Hybrid} keyword specifies the use of a (range-separated)
+hybrid functional.  This model automatically enforces self-consistent
+(SCC) calculations, so does not use the \kw{SCC} keyword in its input.
 For the non-periodic formalism we refer to
 Refs.~\cite{niehaus-PSSB-249-237,lutsker-JCP-143-184107}, whereas the formalism for
 periodic boundary conditions is developed in Ref.~\cite{vdH-PRM-7-063802}.

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -1397,6 +1397,7 @@ contains
     this%isElecDyn = allocated(input%ctrl%elecDynInp)
     this%isLinResp = allocated(input%ctrl%lrespini)
     this%isHybridXc = allocated(input%ctrl%hybridXcInp)
+    if (this%isHybridXc .and. .not. this%tSccCalc) call error("Hybrid calculations must be SCC")
     if (this%isHybridXc) then
       this%hybridXcAlg = input%ctrl%hybridXcInp%hybridXcAlg
       this%checkStopHybridCalc = input%ctrl%checkStopHybridCalc

--- a/src/dftbp/dftbplus/oldcompat.F90
+++ b/src/dftbp/dftbplus/oldcompat.F90
@@ -840,7 +840,7 @@ contains
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
 
-    type(fnode), pointer :: ch1
+    type(fnode), pointer :: ch1, ch2, par, dummy
 
     call getDescendant(root, "Analysis/CalculateForces", ch1)
     if (associated(ch1)) then
@@ -853,6 +853,14 @@ contains
       call detailedWarning(ch1, "'Hamiltonian/DFTB/Rangeseparated' block renamed to&
           & 'Hamiltonian/DFTB/Hybrid'.")
       call setNodeName(ch1, "Hybrid")
+    end if
+
+    call getDescendant(root, "Hamiltonian/DFTB/Hybrid", ch1)
+    if (associated(ch1)) then
+      call detailedWarning(ch1, "'Hamiltonian/DFTB/SCC' keyword removed as hybrid calculations are&
+          & always SCC.")
+      call getDescendant(root, "Hamiltonian/DFTB/SCC", ch2, parent=par)
+      dummy => removeChild(par, ch2)
     end if
 
   end subroutine convert_13_14

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -1460,8 +1460,14 @@ contains
 
     call parseChimes(node, ctrl%chimesRepInput)
 
-    ! SCC
-    call getChildValue(node, "SCC", ctrl%tSCC, .false.)
+    call parseHybridBlock(node, ctrl%hybridXcInp, geo, skFiles)
+
+    if (allocated(ctrl%hybridXcInp)) then
+      ctrl%tSCC = .true.
+    else
+      ! SCC
+      call getChildValue(node, "SCC", ctrl%tSCC, .false.)
+    end if
 
     if (ctrl%tSCC) then
       call getChildValue(node, "ShellResolvedSCC", ctrl%tShellResolved, .false.)
@@ -1475,8 +1481,6 @@ contains
     else
       skInterMeth = skEqGridNew
     end if
-
-    call parseHybridBlock(node, ctrl%hybridXcInp, geo, skFiles)
 
     if (.not. allocated(ctrl%hybridXcInp)) then
       call getChild(node, "TruncateSKRange", child, requested=.false.)

--- a/test/app/dftb+/hybrid/cluster/Benzene-Spinpol-matrix/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/cluster/Benzene-Spinpol-matrix/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SCCTolerance = 1e-08
 
   Charge = 2

--- a/test/app/dftb+/hybrid/cluster/Benzene-TD-LC-Spinpol-Force/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/cluster/Benzene-TD-LC-Spinpol-Force/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SCCTolerance = 1e-12
 
   Charge = 2

--- a/test/app/dftb+/hybrid/cluster/Thymine-spin-matrix-force-mpi-grp1/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/cluster/Thymine-spin-matrix-force-mpi-grp1/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SCCTolerance = 1.0e-10
 
   Mixer = Broyden {}

--- a/test/app/dftb+/hybrid/cluster/Thymine-spin-matrix-force-restart/dftb_in1.hsd
+++ b/test/app/dftb+/hybrid/cluster/Thymine-spin-matrix-force-restart/dftb_in1.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 50
   SccTolerance = 1e-10
 

--- a/test/app/dftb+/hybrid/cluster/Thymine-spin-matrix-force-restart/dftb_in2.hsd
+++ b/test/app/dftb+/hybrid/cluster/Thymine-spin-matrix-force-restart/dftb_in2.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 1
   ReadInitialCharges = Yes
   SccTolerance = 1e-10

--- a/test/app/dftb+/hybrid/periodic/Acene-gamma-matrix-force-cam/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-gamma-matrix-force-cam/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-12
 

--- a/test/app/dftb+/hybrid/periodic/Acene-gamma-matrix-restart-ascii/dftb_in1.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-gamma-matrix-restart-ascii/dftb_in1.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 50
   SccTolerance = 1e-10
 

--- a/test/app/dftb+/hybrid/periodic/Acene-gamma-matrix-restart-ascii/dftb_in2.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-gamma-matrix-restart-ascii/dftb_in2.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 1
   ReadInitialCharges = Yes
   SccTolerance = 1e-10

--- a/test/app/dftb+/hybrid/periodic/Acene-gamma-matrix-restart/dftb_in1.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-gamma-matrix-restart/dftb_in1.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 50
   SccTolerance = 1e-10
 

--- a/test/app/dftb+/hybrid/periodic/Acene-gamma-matrix-restart/dftb_in2.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-gamma-matrix-restart/dftb_in2.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 1
   ReadInitialCharges = Yes
   SccTolerance = 1e-10

--- a/test/app/dftb+/hybrid/periodic/Acene-gamma-neigh-force-cam/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-gamma-neigh-force-cam/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-12
 

--- a/test/app/dftb+/hybrid/periodic/Acene-gamma-neigh-force-hyb/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-gamma-neigh-force-hyb/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-12
 

--- a/test/app/dftb+/hybrid/periodic/Acene-gamma-neigh-force-lc/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-gamma-neigh-force-lc/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-12
 

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-band/dftb_in1.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-band/dftb_in1.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-08
 

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-band/dftb_in2.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-band/dftb_in2.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   ConvergentSCCOnly = No
   ReadInitialCharges = Yes
   MaxSccIterations = 1

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-force-lc/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-force-lc/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-12
 

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-lc/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-lc/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-12
 

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-restart-I/dftb_in1.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-restart-I/dftb_in1.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SccTolerance = 1e-10
   MaxSccIterations = 60
 

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-restart-I/dftb_in2.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-restart-I/dftb_in2.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SccTolerance = 1e-10
   ReadInitialCharges = Yes
   MaxSccIterations = 3

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-restart-II/dftb_in1.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-restart-II/dftb_in1.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SccTolerance = 1e-10
   MaxSccIterations = 60
 

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-restart-II/dftb_in2.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-restart-II/dftb_in2.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SccTolerance = 1e-12
   ReadInitialCharges = Yes
   MaxSccIterations = 7

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-restart-ascii/dftb_in1.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-restart-ascii/dftb_in1.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SccTolerance = 1e-10
   MaxSccIterations = 60
 

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-restart-ascii/dftb_in2.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-matrix-restart-ascii/dftb_in2.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SccTolerance = 1e-10
   ReadInitialCharges = Yes
   MaxSccIterations = 1

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-neigh-band/dftb_in1.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-neigh-band/dftb_in1.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-08
 

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-neigh-band/dftb_in2.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-neigh-band/dftb_in2.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   ConvergentSCCOnly = No
   ReadInitialCharges = Yes
   MaxSccIterations = 1

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-neigh-force-lc/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-neigh-force-lc/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-12
 

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-neigh-restart-ascii/dftb_in1.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-neigh-restart-ascii/dftb_in1.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SccTolerance = 1e-10
   MaxSccIterations = 50
 

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-neigh-restart-ascii/dftb_in2.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-neigh-restart-ascii/dftb_in2.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SccTolerance = 1e-10
   ReadInitialCharges = Yes
   MaxSccIterations = 1

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-neigh-restart/dftb_in1.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-neigh-restart/dftb_in1.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SccTolerance = 1e-10
   MaxSccIterations = 50
 

--- a/test/app/dftb+/hybrid/periodic/Acene-kpts-neigh-restart/dftb_in2.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-kpts-neigh-restart/dftb_in2.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SccTolerance = 1e-10
   ReadInitialCharges = Yes
   MaxSccIterations = 1

--- a/test/app/dftb+/hybrid/periodic/Benzene-box-spin-matrix-ct-kpts/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/Benzene-box-spin-matrix-ct-kpts/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SCCTolerance = 1e-08
 
   Charge = 2

--- a/test/app/dftb+/hybrid/periodic/Benzene-box-spin-neigh-ct-kpts/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/Benzene-box-spin-neigh-ct-kpts/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SCCTolerance = 1e-10
 
   Charge = 2

--- a/test/app/dftb+/hybrid/periodic/Benzene-gamma-matrix-spin-force-grp1/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/Benzene-gamma-matrix-spin-force-grp1/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SCCTolerance = 1e-12
 
   Charge = 8

--- a/test/app/dftb+/hybrid/periodic/Benzene-gamma-neigh-spin-force/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/Benzene-gamma-neigh-spin-force/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   SCCTolerance = 1e-12
 
   Charge = 8

--- a/test/app/dftb+/hybrid/periodic/CN-chain_transl-inv-matrix-ct/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/CN-chain_transl-inv-matrix-ct/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-09
 

--- a/test/app/dftb+/hybrid/periodic/CN-chain_transl-inv-neigh-ct/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/CN-chain_transl-inv-neigh-ct/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = GenFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-09
 

--- a/test/app/dftb+/hybrid/periodic/GaAs-gamma-matrix/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-gamma-matrix/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = VaspFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-08
 

--- a/test/app/dftb+/hybrid/periodic/GaAs-gamma-neigh/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-gamma-neigh/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = VaspFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-08
 

--- a/test/app/dftb+/hybrid/periodic/GaAs-gamma-restart/dftb_in1.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-gamma-restart/dftb_in1.hsd
@@ -4,7 +4,6 @@ Geometry = VaspFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 50
   SccTolerance = 1e-08
 

--- a/test/app/dftb+/hybrid/periodic/GaAs-gamma-restart/dftb_in2.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-gamma-restart/dftb_in2.hsd
@@ -4,7 +4,6 @@ Geometry = VaspFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   ReadInitialCharges = Yes
   MaxSccIterations = 1
   SccTolerance = 1e-08

--- a/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-anderson/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-anderson/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = VaspFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-08
 

--- a/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-diis/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-diis/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = VaspFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-08
 

--- a/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-simple/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-simple/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = VaspFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-08
 

--- a/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = VaspFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-08
 

--- a/test/app/dftb+/hybrid/periodic/GaAs-kpts-neigh-ct/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-kpts-neigh-ct/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = VaspFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-08
 

--- a/test/app/dftb+/hybrid/periodic/GaAs-kpts-neigh-mic/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-kpts-neigh-mic/dftb_in.hsd
@@ -4,7 +4,6 @@ Geometry = VaspFormat {
 
 Hamiltonian = DFTB {
 
-  SCC = Yes
   MaxSccIterations = 100
   SccTolerance = 1e-08
 


### PR DESCRIPTION
Removes the option to turn off SCC when using hybrids.

Does Scc = No (i.e. the default) even make sense for hybrid calculations?

- [x] Conditionally parse Scc keyword (first commit)
- [x] Old compatibility for parser 14 and update regression tests for v14 parser
- [x] Documentation update