### PR TITLE
Fix string trunction in variable tag

### DIFF
--- a/src/dftbp/io/taggedoutput.F90
+++ b/src/dftbp/io/taggedoutput.F90
@@ -225,7 +225,7 @@ module dftbp_io_taggedoutput
     character(lenLabel) :: scaledDipole = 'scaled_dipole'
 
     !> Atomic dipole moments
-    character(lenLabel) :: dipoleAtom = 'atomic_dipole_moments'
+    character(lenLabel) :: dipoleAtom = 'atomic_dipole_moment'
 
   end type TTagLabelsEnum
 


### PR DESCRIPTION
As tag is truncated by variable length, reduce length to the character limit (which fortunaltely still makes gramatical sense).