### PR TITLE
Fix installation path of Python components

### DIFF
--- a/tools/dptools/CMakeLists.txt
+++ b/tools/dptools/CMakeLists.txt
@@ -1,4 +1,9 @@
-set(prefix ${CMAKE_INSTALL_PREFIX})
+if(IS_ABSOLUTE ${CMAKE_INSTALL_PREFIX})
+  set(prefix ${CMAKE_INSTALL_PREFIX})
+else()
+  set(prefix "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_PREFIX}")
+endif()
+
 set(cmake-command "
   execute_process(
     COMMAND ${PYTHON_INTERPRETER} -m pip install --no-deps --prefix ${prefix} .

--- a/tools/pythonapi/CMakeLists.txt
+++ b/tools/pythonapi/CMakeLists.txt
@@ -1,4 +1,9 @@
-set(prefix ${CMAKE_INSTALL_PREFIX})
+if(IS_ABSOLUTE ${CMAKE_INSTALL_PREFIX})
+  set(prefix ${CMAKE_INSTALL_PREFIX})
+else()
+  set(prefix "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_PREFIX}")
+endif()
+
 set(cmake-command "
   execute_process(
     COMMAND ${PYTHON_INTERPRETER} -m pip install --no-deps --prefix ${prefix} .


### PR DESCRIPTION
My 'fix' in #1539 actually only fixed the cases where `CMAKE_INSTALL_PREFIX` is an absolute path, however broke the installation directory in the case of relative prefixes.