### PR TITLE
Fix Readme download links

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -158,7 +158,7 @@ Obtaining the source
 ====================
 
 The source code of the last stable release can be downloaded from the `DFTB+
-homepage <https://www.dftbplus.org/download/dftb-stable/>`_.
+homepage <https://www.dftbplus.org/download/stable.html>`_.
 
 Alternatively you can clone the `public git repository
 <https://github.com/dftbplus/dftbplus>`_. The tagged revisions correspond to

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Downloading the binary
 
 A non-MPI (OpenMP-threaded) distribution of the latest stable release can be
 found on the `stable release page
-<http://www.dftbplus.org/download/dftb-stable/>`_.
+<http://www.dftbplus.org/download/stable.html>`_.
 
 
 Building from source
@@ -72,7 +72,7 @@ build process, consult the **detailed building instructions** in `INSTALL.rst
 <INSTALL.rst>`_.
 
 Download the source code from the `stable release page
-<http://www.dftbplus.org/download/dftb-stable/>`_.
+<http://www.dftbplus.org/download/stable.html>`_.
 
 You need CMake (>= 3.16) to build DFTB+. If your environment offers no CMake or
 only an older one, you can easily install the latest CMake via Python's ``pip``

--- a/src/dftbp/dftb/etemp.F90
+++ b/src/dftbp/dftb/etemp.F90
@@ -361,7 +361,7 @@ contains
   !>
   !> Ref: G. Kresse and J. Furthm&uuml;ller, Phys. Rev. B vol 54, pp 11169 (1996).
   !> Ref: M. Methfessel and A. T. Paxton,, Phys. Rev. B vol 40, pp 3616 (1989).
-  !> Ref: F. Wagner, Th.\ Laloyaux and M. Scheffler, Phys. Rev. B, vol 57 pp 2102 (1998).
+  !> Ref: F. Wagner, Th. Laloyaux and M. Scheffler, Phys. Rev. B, vol 57 pp 2102 (1998).
   subroutine electronFill(Eband, filling, TS, E0, Ef, eigenvals, kT, distrib, kWeights)
 
     !> Band structure energy at T


### PR DESCRIPTION
Replaces the currently advertised stable release download page link
[https://www.dftbplus.org/download/dftb-stable/](https://www.dftbplus.org/download/dftb-stable/) (which returns 404)
with
[https://www.dftbplus.org/download/stable.html](https://www.dftbplus.org/download/stable.html)

Removes a stray backslash that was causing a fypp warning.