### PR TITLE
Move nLocal* sizing out of hybrids

### DIFF
--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -2779,6 +2779,11 @@ contains
         call getDenseDescBlacs(env, blacsOpts%blockSize, blacsOpts%blockSize, this%denseDesc,&
             & this%isSparseReorderRequired)
       end associate
+      call scalafx_getlocalshape(env%blacs%orbitalGrid, this%denseDesc%blacsOrbSqr, nLocalRows,&
+          & nLocalCols)
+  #:else
+    nLocalRows = this%denseDesc%fullSize
+    nLocalCols = this%denseDesc%fullSize
   #:endif
 
     call densityMatrixSource(this%densityMatrix, this%electronicSolver, input%ctrl%isDmOnGpu)
@@ -2825,14 +2830,6 @@ contains
         end if
 
       end if
-
-    #:if WITH_SCALAPACK
-      call scalafx_getlocalshape(env%blacs%orbitalGrid, this%denseDesc%blacsOrbSqr, nLocalRows,&
-          & nLocalCols)
-    #:else
-      nLocalRows = this%denseDesc%fullSize
-      nLocalCols = this%denseDesc%fullSize
-    #:endif
 
       if (this%isHybridXc) then
         ! allocation is necessary to hint "initializeCharges" what information to extract


### PR DESCRIPTION
As this is useful for non-hybrid calculations as well.