### PR TITLE
Rework the hybrid functional extra tag parser

### DIFF
--- a/src/dftbp/dftb/hybridxc.F90
+++ b/src/dftbp/dftb/hybridxc.F90
@@ -142,13 +142,13 @@ module dftbp_dftb_hybridxc
   type :: THybridXcSKTag
 
     !> Range-separation parameter
-    real(dp) :: omega
+    real(dp) :: omega = 0.0_dp
 
     !> CAM alpha parameter
-    real(dp) :: camAlpha
+    real(dp) :: camAlpha = 0.0_dp
 
     !> CAM beta parameter
-    real(dp) :: camBeta
+    real(dp) :: camBeta = 0.0_dp
 
   end type THybridXcSKTag
 

--- a/src/dftbp/type/oldskdata.F90
+++ b/src/dftbp/type/oldskdata.F90
@@ -21,7 +21,7 @@ module dftbp_type_oldskdata
   implicit none
 
   private
-  public :: TOldSKData, readFromFile, readSplineRep, inquireHybridXcTag
+  public :: TOldSKData, readFromFile, readSplineRep, parseHybridXcTag
 
 
   !> Represents the Slater-Koster data in an SK file.
@@ -107,6 +107,9 @@ contains
     !> Reads hybrid xc-functional parameter(s) from SK file
     type(THybridXcSKTag), intent(inout), optional :: hybridXcSK
 
+    !! Type of hybrid xc-functional found in the SK-file
+    integer :: hybridXcType
+
     type(TFileDescr) :: file
     character(lc) :: chDummy
 
@@ -185,80 +188,18 @@ contains
 
     ! Read hybrid xc-functional parameter(s)
     if (present(hybridXcSK)) then
-      call readHybridXcParams(file%unit, fileName, hybridXcSK)
+      call parseHybridXcTag(fileName, fp=file%unit, hybridXcType=hybridXcType,&
+          & hybridXcSK=hybridXcSK)
+      if (hybridXcType == hybridXcFunc%none) then
+        write(chDummy, "(A,A,A)") "Hybrid xc-functional calculation requested, but SK-file '",&
+            & trim(fileName), "' is not a suitable parametrization."
+        call error(chDummy)
+      end if
     end if
 
     call closeFile(file)
 
   end subroutine TOldSKData_readFromFile
-
-
-  !> Reads hybrid xc-functional parameter(s) from an open file.
-  subroutine readHybridXcParams(fp, fname, hybridXcSK)
-
-    !> File identifier
-    integer, intent(in) :: fp
-
-    !> File name
-    character(len=*), intent(in) :: fname
-
-    !> Hybrid xc-functional parameter(s)
-    type(THybridXcSKTag), intent(inout) :: hybridXcSK
-
-    !! Error status
-    integer :: iErr
-
-    !! Temporary character storage
-    character(lc) :: strDummy
-
-    !! True, if hybrid xc-functional extra tag was found in SK-file
-    logical :: isHybridXcTag
-
-    !! Extra tag in SK-files, defining the type of hybrid xc-functional
-    integer :: hybridXcTag
-
-    call inquireHybridXcTag(fname, hybridXcTag, fp=fp)
-    rewind(fp)
-
-    ! Seek hybrid xc-functional section in SK file
-    do
-      read(fp, "(A)", iostat=iErr) strDummy
-      if (iErr /= 0) then
-        isHybridXcTag = .false.
-        exit
-      elseif (strDummy == "RangeSep" .or. strDummy == "GlobalHybrid") then
-        isHybridXcTag = .true.
-        exit
-      end if
-    end do
-
-    if (.not. isHybridXcTag) then
-      write(strDummy, "(A,A,A)") "Hybrid xc-functional calculation requested, but SK-file '",&
-          & trim(fname), "' is not a suitable parametrization."
-      call error(strDummy)
-    end if
-
-    if (hybridXcTag == hybridXcFunc%hyb) then
-      hybridXcSK%omega = 0.0_dp
-      hybridXcSK%camBeta = 0.0_dp
-      read(fp, *, iostat=iErr) strDummy, hybridXcSK%camAlpha
-      call checkioerror(iErr, fname, "Error in reading hybrid xc-functional parameter(s)")
-    elseif (hybridXcTag == hybridXcFunc%lc) then
-      hybridXcSK%camAlpha = 0.0_dp
-      hybridXcSK%camBeta = 1.0_dp
-      read(fp, *, iostat=iErr) strDummy, hybridXcSK%omega
-      call checkioerror(iErr, fname, "Error in reading hybrid xc-functional parameter(s)")
-    elseif (hybridXcTag == hybridXcFunc%cam) then
-      read(fp, *, iostat=iErr) strDummy, hybridXcSK%omega, hybridXcSK%camAlpha, hybridXcSK%camBeta
-      call checkioerror(iErr, fname, "Error in reading hybrid xc-functional parameter(s)")
-    end if
-
-    if (hybridXcTag /= hybridXcFunc%hyb .and. hybridXcSK%omega < 0.0_dp) then
-      write(strDummy, "(A)") "Range-separation parameter is negative."
-      call error(strDummy)
-    end if
-
-  end subroutine readHybridXcParams
 
 
   !> Reads the repulsive from an open file.
@@ -339,32 +280,48 @@ contains
   end subroutine TOldSKData_readsplinerep
 
 
-  !> Inquires hybrid xc-functional extra tag of SK-file.
-  subroutine inquireHybridXcTag(fname, hybridXcTag, fp)
+  !> Reads hybrid xc-functional parameter(s) from an SK-file, by opening the file or accessing an
+  !! already open file using its identifier if provided.
+  subroutine parseHybridXcTag(fname, fp, hybridXcTag, hybridXcType, hybridXcSK)
 
     !> File name
     character(len=*), intent(in) :: fname
 
-    !> Hybrid xc-functional extra tag, if allocated
-    integer, intent(out) :: hybridXcTag
-
     !> File identifier, if file is already open
     integer, intent(in), optional :: fp
 
-    !! File descriptor
-    type(TFileDescr) :: file
+    !> Hybrid xc-functional extra tag found in the SK-file
+    integer, intent(out), optional :: hybridXcTag
+
+    !> Type of hybrid xc-functional found in the SK-file
+    integer, intent(out), optional :: hybridXcType
+
+    !> Hybrid xc-functional parameter(s)
+    type(THybridXcSKTag), intent(inout), optional :: hybridXcSK
 
     !! Error status
     integer :: iErr
 
     !! Temporary character storage
-    character(lc) :: strDummy
-
-    !! File identifier
-    integer :: fd
+    character(lc) :: strDummy, tag
 
     !! True, if hybrid xc-functional extra tag was found in SK-file
     logical :: isHybridXcTag
+
+    !! Hybrid xc-functional parameter(s)
+    type(THybridXcSKTag) :: hybridXcSK_
+
+    !! Hybrid xc-functional extra tag found in the SK-file
+    integer :: hybridXcTag_
+
+    !! Type of hybrid xc-functional found in the SK-file
+    integer :: hybridXcType_
+
+    !! File descriptor
+    type(TFileDescr) :: file
+
+    !! File identifier
+    integer :: fd
 
     if (present(fp)) then
       fd = fp
@@ -376,41 +333,80 @@ contains
 
     rewind(fd)
 
-    ! Seek hybrid xc-functional extra tag in SK-file
+    ! Seek hybrid xc-functional section in SK-file
     do
       read(fd, "(A)", iostat=iErr) strDummy
       if (iErr /= 0) then
         isHybridXcTag = .false.
         exit
-      elseif (strDummy == "RangeSep" .or. strDummy == "GlobalHybrid") then
+      elseif (strDummy == "RangeSep") then
         isHybridXcTag = .true.
         exit
       end if
     end do
 
     if (isHybridXcTag) then
-      read(fd, *, iostat=iErr) strDummy
+      read(fd, "(A)", iostat=iErr) strDummy
+      call checkIoError(iErr, fname, "Error in reading hybrid xc-functional extra tag and method.")
+      read(strDummy, *, iostat=iErr) tag
       call checkIoError(iErr, fname, "Error in reading hybrid xc-functional extra tag and method.")
 
-      select case(tolower(trim(strDummy)))
-      case ("hf")
-        hybridXcTag = hybridXcFunc%hyb
+      select case(tolower(trim(tag)))
       case ("lc")
-        hybridXcTag = hybridXcFunc%lc
+        hybridXcTag_ = hybridXcFunc%lc
       case ("cam")
-        hybridXcTag = hybridXcFunc%cam
+        hybridXcTag_ = hybridXcFunc%cam
       case default
         write(strDummy, "(A,A,A)") "Unknown hybrid xc-functional method in SK-file '",&
             & trim(fname), "'"
         call error(strDummy)
       end select
     else
-      hybridXcTag = hybridXcFunc%none
+      hybridXcTag_ = hybridXcFunc%none
+    end if
+
+    select case(hybridXcTag_)
+    case (hybridXcFunc%lc)
+      hybridXcSK_%camAlpha = 0.0_dp
+      hybridXcSK_%camBeta = 1.0_dp
+      read(strDummy, *, iostat=iErr) tag, hybridXcSK_%omega
+      call checkIoError(iErr, fname, "Error in reading hybrid xc-functional parameters.")
+      hybridXcType_ = hybridXcFunc%lc
+    case (hybridXcFunc%cam)
+      read(strDummy, *, iostat=iErr) tag, hybridXcSK_%omega, hybridXcSK_%camAlpha,&
+          & hybridXcSK_%camBeta
+      call checkIoError(iErr, fname, "Error in reading hybrid xc-functional parameters.")
+      if (abs(hybridXcSK_%camAlpha) < epsilon(1.0_dp)&
+          & .and. abs(hybridXcSK_%camBeta) < epsilon(1.0_dp)) then
+        hybridXcType_ = hybridXcFunc%none
+      elseif (abs(hybridXcSK_%camAlpha) < epsilon(1.0_dp)&
+          & .and. abs(hybridXcSK_%camBeta - 1.0_dp) < epsilon(1.0_dp)) then
+        hybridXcType_ = hybridXcFunc%lc
+      elseif (abs(hybridXcSK_%camBeta) < epsilon(1.0_dp)) then
+        hybridXcType_ = hybridXcFunc%hyb
+      else
+        hybridXcType_ = hybridXcFunc%cam
+      end if
+    case default
+      hybridXcType_ = hybridXcFunc%none
+      hybridXcSK_%omega = 0.0_dp
+      hybridXcSK_%camAlpha = 0.0_dp
+      hybridXcSK_%camBeta = 0.0_dp
+    end select
+
+    if (hybridXcSK_%omega < 0.0_dp) then
+      write(strDummy, "(A)") "Range-separation parameter is negative."
+      call error(strDummy)
     end if
 
     if (.not. present(fp)) call closeFile(file)
 
-  end subroutine inquireHybridXcTag
+    ! hand over requested information
+    if (present(hybridXcTag)) hybridXcTag = hybridXcTag_
+    if (present(hybridXcType)) hybridXcType = hybridXcType_
+    if (present(hybridXcSK)) hybridXcSK = hybridXcSK_
+
+  end subroutine parseHybridXcTag
 
 
   !> Checks for IO errors and prints message.

--- a/src/dftbp/type/oldskdata.F90
+++ b/src/dftbp/type/oldskdata.F90
@@ -281,7 +281,7 @@ contains
 
 
   !> Reads hybrid xc-functional parameter(s) from an SK-file, by opening the file or accessing an
-  !! already open file using its identifier if provided.
+  !! already open file using its identifier (if provided).
   subroutine parseHybridXcTag(fname, fp, hybridXcTag, hybridXcType, hybridXcSK)
 
     !> File name

--- a/test/app/dftb+/hybrid/cluster/C18H12-force-hyb/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/cluster/C18H12-force-hyb/dftb_in.hsd
@@ -23,7 +23,7 @@ Hamiltonian = DFTB {
     Suffix = ".skf"
   }
 
-  RangeSeparated = Global {
+  RangeSeparated = CAM {
     Screening = MatrixBased {}
   }
 

--- a/test/app/dftb+/hybrid/periodic/Acene-gamma-neigh-force-hyb/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/Acene-gamma-neigh-force-hyb/dftb_in.hsd
@@ -22,7 +22,7 @@ Hamiltonian = DFTB {
     Suffix = ".skf"
   }
 
-  Hybrid = Global {
+  Hybrid = CAM {
     CoulombMatrix = Truncated {
       CoulombCutoff = 2.885010
       GSummationCutoff = 50.985000

--- a/utils/get_opt_externals
+++ b/utils/get_opt_externals
@@ -128,9 +128,9 @@ def set_status(destdir, status):
 def get_slakos(destdir):
     '''Downloads and extracts parametrizations for the tests.'''
 
-    url = 'https://github.com/dftbplus/testparams/archive/6165104e60efbdb3ad05d005c282ada50f12dfef.tar.gz'
+    url = 'https://github.com/dftbplus/testparams/archive/f8e559e80f7b59cbd66edddb4564763a33142a71.tar.gz'
     fname = os.path.join(destdir, 'testparams.tar.gz')
-    unpackname = os.path.join(destdir, 'testparams-6165104e60efbdb3ad05d005c282ada50f12dfef')
+    unpackname = os.path.join(destdir, 'testparams-f8e559e80f7b59cbd66edddb4564763a33142a71')
     targetname = os.path.join(destdir, 'origin')
     if os.path.exists(unpackname):
         shutil.rmtree(unpackname)


### PR DESCRIPTION
As discussed in the devel. meeting.

Additionally, `Hybrid = LC {}` is kept for backwards compatibility and also works in combination with a `CAM` tag of the form:
```
RangeSep
CAM w 0.0 1.0
```