### PR TITLE
Fix logic for OMP target in exported dftbplus-config.cmake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,10 @@ jobs:
     - name: Check submodule commits
       run: ./utils/test/check_submodule_commits
 
+    - name: Install LAPACK/BLAS
+      run: |
+        sudo apt-get install liblapack-dev libblas-dev
+
     - name: Install ARPACK
       if: contains(matrix.mpi, 'nompi')
       run: |

--- a/utils/export/dftbplus-config.cmake.in
+++ b/utils/export/dftbplus-config.cmake.in
@@ -28,12 +28,14 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/Modules)
 
 if(NOT TARGET DftbPlus::DftbPlus)
 
-  if(DftbPlus_WITH_OMP AND NOT TARGET OpenMP::OpenMP_Fortran)
-    find_dependency(OpenMP)
-  else()
+ if (NOT TARGET OpenMP::OpenMP_Fortran)
+   if (DftbPlus_WITH_OMP)
+     find_dependency(OpenMP)
+   else ()
     # DFTB+ uses dummy target for non-OMP compilation
     add_library(OpenMP::OpenMP_Fortran INTERFACE IMPORTED)
-  endif()
+   endif ()
+ endif ()
 
   if(NOT TARGET BLAS::BLAS)
     find_dependency(CustomBlas)


### PR DESCRIPTION
Fixes a logic bug in our cmake export file. Additionally cures the problem with missing BLAS in the GitHUB workflow.