### PR TITLE
Serial real matrix adjugate

### DIFF
--- a/src/dftbp/math/matrixops.F90
+++ b/src/dftbp/math/matrixops.F90
@@ -6,12 +6,16 @@
 !--------------------------------------------------------------------------------------------------!
 
 #:include 'common.fypp'
+#:include 'error.fypp'
 
 !> Simple matrix operations for which LAPACK does not have a direct call
 module dftbp_math_matrixops
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : TEnvironment
   use dftbp_common_schedule, only : assembleChunks
+  use dftbp_common_status, only : TStatus
+  use dftbp_math_determinant, only : det
+  use dftbp_math_lapackroutines, only : matinv, gesvd
 #:if WITH_SCALAPACK
   use dftbp_extlibs_mpifx, only : MPI_SUM, mpifx_allreduceip
   use dftbp_extlibs_scalapackfx, only : DLEN_, CSRC_, RSRC_, MB_, NB_, pblasfx_ptranc,&
@@ -21,7 +25,7 @@ module dftbp_math_matrixops
   implicit none
 
   private
-  public :: adjointLowerTriangle, orthonormalizeVectors
+  public :: adjointLowerTriangle, orthonormalizeVectors, adjugate
 #:if WITH_SCALAPACK
   public :: adjointLowerTriangle_BLACS
 
@@ -40,6 +44,13 @@ module dftbp_math_matrixops
     module procedure symmetrizeSquareMatrix
     module procedure hermitianSquareMatrix
   end interface adjointLowerTriangle
+
+
+  !> Adjugate of a well behaved square matrix
+  interface adjugate
+    module procedure adjugate_stable
+    module procedure adjugate_simple
+  end interface adjugate
 
 
 contains
@@ -193,5 +204,104 @@ contains
     end do
 
   end subroutine orthonormalizeVectors
+
+
+  !> Evaluate adjugate of matrix in stable way
+  subroutine adjugate_stable(A)
+
+    !> Matrix for which to evaluate adjugate, over-written on exit
+    real(dp), intent(inout) :: A(:,:)
+
+    real(dp), allocatable :: aTmp(:,:), U(:,:), Sigma(:), Vt(:,:), Xi(:)
+    real(dp) :: eta
+    integer :: ii, jj, kk, n
+
+    n = size(A, dim=2)
+    allocate(U(n,n))
+    allocate(Sigma(n))
+    allocate(Vt(n,n))
+    allocate(Xi(n))
+
+    call gesvd(A, U, Sigma, Vt)
+
+    do ii = 1, n
+      Xi(ii) = product_real(Sigma, ii)
+    end do
+
+    A(:,:) = 0.0_dp
+    do ii = 1, n
+      do jj = 1, n
+        do kk = 1, n
+          A(kk,jj) = A(kk,jj) + Vt(ii,kk) * Xi(ii) * U(jj,ii)
+        end do
+      end do
+    end do
+
+    U(:,:) = matmul(U, Vt)
+    eta = det(U)
+    A(:,:) = eta * A
+
+  end subroutine adjugate_stable
+
+
+  !> Evaluate adjugate of matrix from det(A) A^-1, note can be unstable even when resulting quantity
+  !! is well defined
+  subroutine adjugate_simple(A, status)
+
+    !> Matrix for which to evaluate adjugate, over-written on exit
+    real(dp), intent(inout) :: A(:,:)
+
+    !> Status of operation
+    type(TStatus), intent(out) :: status
+
+    real(dp), allocatable :: aTmp(:,:)
+    integer :: iErr
+
+    aTmp = A
+    call matinv(A, iError=iErr)
+    if (iErr /= 0) then
+      @:RAISE_FORMATTED_ERROR(status, -1, "('Matrix inversion failure in adjugate, info: ',I0)",&
+          & iErr)
+    end if
+    A(:,:) = det(aTmp) * A
+
+  end subroutine adjugate_simple
+
+
+  !> Numerically stable product of an array of numbers, excluding a specified value
+  function product_real(Sigma, ii) result(res)
+
+    !> Numbers to product
+    real(dp), intent(in) :: Sigma(:)
+
+    !> Index of value to omit
+    integer, intent(in) :: ii
+
+    real(dp), parameter :: base = 10.0_dp
+    real(dp), parameter :: invBase = 1.0_dp / base
+    real(dp) :: res
+    integer :: jj, exponent
+
+    res = 1.0_dp
+    exponent = 0
+    do jj = 1, size(sigma)
+      if (ii == jj) cycle
+      res = Sigma(jj) * res
+      if (res < epsilon(0.0_dp)) then
+        res = 0.0_dp
+        return
+      end if
+      do while (abs(res) > base)
+        res = res * invBase
+        exponent = exponent + 1
+      end do
+      do while (abs(res) < invBase)
+        res = res * base
+        exponent = exponent - 1
+      end do
+    end do
+    res = res * base ** exponent
+
+  end function product_real
 
 end module dftbp_math_matrixops


### PR DESCRIPTION
* Unit tests
* Simple and also stable algorithms

Application for this is when calculating overlap/other properties between different Slater determinants. For example Eq. 15 of https://pubs.acs.org/doi/10.1021/acs.jpca.4c04139