### PR TITLE
Skip invalid test configuration

### DIFF
--- a/test/src/dftbp/api/mm/tests
+++ b/test/src/dftbp/api/mm/tests
@@ -22,4 +22,4 @@ mpisubgrids         #? WITH_MPI and (MPI_PROCS % 4 == 0) and MPI_PROCS <= 4
 neighbour_list      #? not WITH_MPI
 neighbour_list_c    #? not WITH_MPI and defined('WITH_C_EXECUTABLES')
 intcharges          #? not WITH_MPI
-mpi_intcharges_c    #? WITH_MPI and MPI_PROCS <= 4 and defined('WITH_C_EXECUTABLES')
+mpi_intcharges_c    #? WITH_MPI and (MPI_PROCS % 2 == 0) and MPI_PROCS <= 4 and defined('WITH_C_EXECUTABLES')


### PR DESCRIPTION
Skip invalid test configuration for `mpi_intcharges_c`, i.e. `MPI_PROCS = 3`.