### PR TITLE
Revise constraint syntax for charge

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -1871,21 +1871,22 @@ potential~\cite{Hourahine2010}.
 \item[\is{Regions}]
   Specifies region (e.g.\ of atoms) targeted by electronic constraints.
   \begin{ptable}
-    \kw{Atoms} & p &  & \cb & \\
+    \kw{Electrons} & p &  & \cb & \\
   \end{ptable}
     \begin{description}
-      \item[\is{Atoms}] Defines a region of atoms (the specification of several blocks is possible).
+      \item[\is{Electrons}] Defines the number of \emph{valence}
+        electrons in a region in units of $-e$ (specifying several
+        \kwcb{Electrons} blocks is possible).
     \begin{ptable}
-      \kw{Domain} & (i|s)+ &  &  & \\
-      \kw{Population} & r &  &  & \\
+      \kw{Atoms} & (i|s)+ &  &  & \\
+      \kw{Total} & r &  &  & \\
     \end{ptable}
       \begin{description}
-        \item[\is{Domain}] Indices of the atoms building a constrained region. The
+        \item[\is{Atoms}] Indices of the atoms building a constrained region. The
           atoms can be specified via index selection expressions, as described
           in appendix \ref{sec:index_selection}.
-
-        \item[\is{Population}] Sets constraint on the Mulliken population of all
-          atoms included in the region.
+        \item[\is{Total}] Sets constraint on the Mulliken
+          population of all atoms included in the region.
       \end{description}
     \end{description}
 
@@ -1918,7 +1919,8 @@ potential~\cite{Hourahine2010}.
 
 \item[\is{MaxConstrIterations}] Maximal number of micro-iterations to reach
   convergence. If convergence is not reached after the specified
-  number of steps, the program stops.
+  number of steps, the program stops. Setting this value as -1 runs a
+  huge() number of iterations.
 
 \item[\is{ConvergentConstrOnly}] If true, requires that the micro-iterations
   converge before proceeding to subsequent stages of the calculation (next SCC
@@ -1929,9 +1931,9 @@ Example:
 \begin{verbatim}
   ElectronicConstraints {
     Regions {
-      Atoms {
-        Domain = 1
-        Population = 1.5
+      Electrons {
+        Atoms = 1
+        Total = 1.5
       }
     }
     Optimiser = FIRE {}

--- a/src/dftbp/dftb/elecconstraints.F90
+++ b/src/dftbp/dftb/elecconstraints.F90
@@ -15,7 +15,8 @@ module dftbp_dftb_elecconstraints
   use dftbp_extlibs_xmlf90, only : fnode, string, char, getLength, getItem1, fnodeList
   use dftbp_type_wrappedintr, only : TWrappedInt1, TWrappedReal1, TWrappedReal2
   use dftbp_geoopt_package, only : TOptimizer, TOptimizerInput, createOptimizer
-  use dftbp_io_hsdutils, only : getChildValue, getChildren, getSelectedAtomIndices
+  use dftbp_io_hsdutils, only : getChildren, getChildValue, getSelectedAtomIndices
+  use dftbp_io_hsdutils2, only : renameChildren
   use dftbp_dftbplus_input_geoopt, only : readOptimizerInput
   use dftbp_extlibs_xmlf90, only : destroyNodeList
   implicit none
@@ -93,10 +94,19 @@ module dftbp_dftb_elecconstraints
 
   contains
 
+    !> Returns constraining potential (Vc)
     procedure :: getConstraintShift
+
+    !> Update constraints for current state of the system
     procedure :: propagateConstraints
+
+    !> Maximum number of iterations for driver
     procedure :: getMaxIter
+
+    !> Free energy (W) for system in constraining potential(s)
     procedure :: getFreeEnergy
+
+    !> Maximum component of free energyt derivative wrt. constraint potential(s)
     procedure :: getMaxEnergyDerivWrtVc
 
   end type TElecConstraint
@@ -105,7 +115,7 @@ module dftbp_dftb_elecconstraints
 contains
 
 
-  !> General entry point to read constraint on the electronic ground state.
+  !> General entry point to read the constraint(s) on the electronic ground state.
   subroutine readElecConstraintInput(node, geo, input, isSpinPol, is2Component)
 
     !> Node to get the information from
@@ -128,6 +138,7 @@ contains
     type(string) :: buffer
     integer :: iConstr, nConstr
 
+    call renameChildren(node, "Optimizer", "Optimiser")
     call getChildValue(node, "Optimiser", child1, "FIRE")
     call readOptimizerInput(child1, input%optimiser)
 
@@ -139,7 +150,7 @@ contains
         & dummyValue=.true., list=.true.)
 
     ! Read specification for regions of atoms
-    call getChildren(child1, "Atoms", children)
+    call getChildren(child1, "Electrons", children)
     nConstr = getLength(children)
 
     allocate(input%atomGrp(nConstr))
@@ -148,12 +159,13 @@ contains
 
     do iConstr = 1, nConstr
       call getItem1(children, iConstr, child2)
-      call getChildValue(child2, "Domain", buffer, child=child3, multiple=.true.)
+      call getChildValue(child2, "Atoms", buffer, child=child3, multiple=.true.)
       call getSelectedAtomIndices(child3, char(buffer), geo%speciesNames, geo%species,&
           & input%atomGrp(iConstr)%data)
-      call getChildValue(child2, "Population", input%atomNc(iConstr))
-      ! Functionality currently restricted to charges
+      call getChildValue(child2, "Total", input%atomNc(iConstr))
+      ! Functionality currently restricted to charges only
       if (isSpinPol) then
+        ! [q,m] representation
         if (is2Component) then
           input%atomSpinDir(iConstr)%data = [1.0_dp, 0.0_dp, 0.0_dp, 0.0_dp]
         else
@@ -193,7 +205,11 @@ contains
 
     call createOptimizer(input%optimiser, nConstr, this%potOpt)
 
-    this%nConstrIter = input%nConstrIter
+    if (input%nConstrIter == -1) then
+      input%nConstrIter = huge(1)
+    else
+      this%nConstrIter = input%nConstrIter
+    end if
     this%isConstrConvRequired = input%isConstrConvRequired
     this%constrTol = input%constrTol
     this%Nc = input%AtomNc
@@ -321,7 +337,7 @@ contains
   end subroutine propagateConstraints
 
 
-  !> Calculate artificial potential to realize constraint on atomic charge.
+  !> Calculate artificial potential to realize constraint(s) on atomic charge.
   subroutine getConstraintEnergyAndPotQ(Vc, Nc, wAt, wOrb, wSp, qq, deltaW, dWdV)
 
     !> Potential / Lagrange multiplier

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -1582,10 +1582,15 @@ contains
 
     if (allocated(this%elecConstraint)) then
       if (.not. constrConverged) then
-        call warning("Constraints did NOT converge, maximal micro-iterations exceeded")
-        if (this%elecConstraint%isConstrConvRequired) then
-          call env%shutdown()
-        end if
+        block
+          character(len=*), parameter :: msg = "Electronic constraints did NOT converge, maximal&
+              & micro-iterations exceeded"
+          if (this%elecConstraint%isConstrConvRequired) then
+            call error(msg)
+          else
+            call warning(msg)
+          end if
+        end block
       end if
     end if
 

--- a/test/app/dftb+/elecconstraints/Fe4_noncolinear/dftb_in.hsd
+++ b/test/app/dftb+/elecconstraints/Fe4_noncolinear/dftb_in.hsd
@@ -35,9 +35,9 @@ Hamiltonian = DFTB {
     }
     ElectronicConstraints {
         Regions {
-            Atoms {
-                Domain = 1
-                Population = 7.5
+	    Electrons {
+                Atoms = 1
+                Total = 7.5
             }
         }
         ConstrTolerance = 1.0E-08

--- a/test/app/dftb+/elecconstraints/H-chain_transport/dftb_in.hsd
+++ b/test/app/dftb+/elecconstraints/H-chain_transport/dftb_in.hsd
@@ -51,13 +51,13 @@ Hamiltonian = Dftb {
 
     ElectronicConstraints {
         Regions {
-            Atoms {
-                Domain = 6
-                Population = 0.5
+            Electrons {
+                Atoms = 6
+                Total = 0.5
             }
-            Atoms {
-                Domain = 1:11
-                Population = 11
+            Electrons {
+                Atoms = 1:11
+                Total = 11
             }
         }
         MaxConstrIterations = 10

--- a/test/app/dftb+/elecconstraints/H2O_gfn1/dftb_in.hsd
+++ b/test/app/dftb+/elecconstraints/H2O_gfn1/dftb_in.hsd
@@ -14,13 +14,13 @@ Hamiltonian = xtb {
   }
   ElectronicConstraints {
     Regions {
-      Atoms {
-        Domain = H
-        Population = 1.5
+      Electrons {
+        Atoms = H
+        Total = 1.5
       }
-      Atoms {
-        Domain = 2
-        Population = 1.0
+      Electrons {
+        Atoms = 2
+        Total = 1.0
       }
     }
     ConstrTolerance = 1.0E-8

--- a/test/app/dftb+/elecconstraints/H2O_non-converged/dftb_in.hsd
+++ b/test/app/dftb+/elecconstraints/H2O_non-converged/dftb_in.hsd
@@ -30,13 +30,13 @@ Hamiltonian = DFTB {
 
   ElectronicConstraints {
     Regions {
-      Atoms {
-        Domain = H
-        Population = 1.5
+      Electrons {
+        Atoms = H
+        Total = 1.5
       }
-      Atoms {
-        Domain = 2
-        Population = 1.0
+      Electrons {
+        Atoms = 2
+        Total = 1.0
       }
     }
     Optimiser = SteepestDescent {ScalingFactor = 0.15}

--- a/test/app/dftb+/elecconstraints/H2O_scc/dftb_in.hsd
+++ b/test/app/dftb+/elecconstraints/H2O_scc/dftb_in.hsd
@@ -28,13 +28,13 @@ Hamiltonian = DFTB {
 
   ElectronicConstraints {
     Regions {
-      Atoms {
-        Domain = H
-        Population = 1.5
+      Electrons {
+        Atoms = H
+        Total = 1.5
       }
-      Atoms {
-        Domain = 2
-        Population = 1.0
+      Electrons {
+        Atoms = 2
+        Total = 1.0
       }
     }
     Optimiser = SteepestDescent {ScalingFactor = 0.25}

--- a/test/app/dftb+/elecconstraints/Si8_spin/dftb_in.hsd
+++ b/test/app/dftb+/elecconstraints/Si8_spin/dftb_in.hsd
@@ -41,9 +41,9 @@ Hamiltonian = DFTB {
 
   ElectronicConstraints {
     Regions {
-      Atoms {
-        Domain = 8
-        Population = 5.0
+      Electrons {
+        Atoms = 8
+        Total = 5.0
       }
     }
     Optimiser = SteepestDescent {ScalingFactor = 0.07}


### PR DESCRIPTION
Also some minor usability (US spelling adaption) and error handling.
New syntax:
Regions {
  Electrons {
    Atoms = 1:4 Cl
    Total = 45
  }
}