### PR TITLE
Compiler fixes

### DIFF
--- a/src/dftbp/extlibs/magmac.c
+++ b/src/dftbp/extlibs/magmac.c
@@ -6,10 +6,17 @@
 /*------------------------------------------------------------------------------------------------*/
 
 /**
+ * Note, MAGMA header file (as of version 2.9.0) has no declaration for type bool, causing newer
+ * (more pedantic) C compilers to stop with error. Including <stdbool.h> before MAGMA seems provides
+ * the missing declaration.
+*/
+#include <stdbool.h>
+
+/**
  *  Functions to count or request GPUs
  */
 
-#include <magma.h>
+#include <magma_v2.h>
 
 /**
  *  Large enough to fit all device IDs

--- a/src/dftbp/extlibs/magmac.c
+++ b/src/dftbp/extlibs/magmac.c
@@ -7,7 +7,7 @@
 
 /**
  * Note, MAGMA header file (as of version 2.9.0) has no declaration for type bool, causing newer
- * (more pedantic) C compilers to stop with error. Including <stdbool.h> before MAGMA seems provides
+ * (more pedantic) C compilers to stop with error. Including <stdbool.h> before MAGMA provides
  * the missing declaration.
 */
 #include <stdbool.h>

--- a/src/dftbp/timedep/timeprop.F90
+++ b/src/dftbp/timedep/timeprop.F90
@@ -2474,10 +2474,13 @@ contains
     call gemm(T4R,T2R,T1R)
 
     ! build the commutator combining the real and imaginary parts of the previous result
-    !$OMP WORKSHARE
+    ! Note: parallelizing this construct via OMP WORKSHARE
+    ! Workaround:ifx:2024.2
+    ! OMP WORKSHARE construct drives compiler into an infinite loop and compilation never finishes
+    !!$OMP WORKSHARE
     rhoOld(:,:) = rhoOld + cmplx(0, -step, dp) * (T3R + imag * T4R)&
         & + cmplx(0, step, dp) * transpose(T3R - imag * T4R)
-    !$OMP END WORKSHARE
+    !!$OMP END WORKSHARE
 
   end subroutine propagateRhoRealH
 

--- a/src/dftbp/timedep/timeprop.F90
+++ b/src/dftbp/timedep/timeprop.F90
@@ -2886,35 +2886,31 @@ contains
     complex(dp), allocatable :: T2(:,:), T3(:,:)
     integer :: iOrb
 
-    allocate(T2(this%nOrbs, this%nOrbs), T3(this%nOrbs, this%nOrbs))
-
+    allocate(T2(this%nOrbs, this%nOrbs))
+    allocate(T3(this%nOrbs, this%nOrbs))
     if (this%tRealHS) then
-      T2 = cmplx(eigvecsReal, 0, dp)
+      T2(:,:) = cmplx(eigvecsReal, kind=dp)
     else
-      T2 = eigvecsCplx
+      T2(:,:) = eigvecsCplx
     end if
-
-    T3 = 0.0_dp
+    T3(:,:) = 0.0_dp
     do iOrb = 1, this%nOrbs
       T3(iOrb, iOrb) = 1.0_dp
     end do
-    call gesv(T2,T3)
+    call gesv(T2, T3)
     Eiginv(:,:) = T3
-
     if (this%tRealHS) then
-      T2 = cmplx(transpose(eigvecsReal), 0, dp)
+      T2(:,:) = cmplx(transpose(eigvecsReal), kind=dp)
     else
-      T2 = conjg(transpose(eigvecsCplx))
+      T2(:,:) = conjg(transpose(eigvecsCplx))
     end if
 
-    T3 = 0.0_dp
+    T3(:,:) = 0.0_dp
     do iOrb = 1, this%nOrbs
       T3(iOrb, iOrb) = 1.0_dp
     end do
-    call gesv(T2,T3)
+    call gesv(T2, T3)
     EiginvAdj(:,:) = T3
-
-    deallocate(T2, T3)
 
   end subroutine tdPopulInit
 

--- a/sys/intel.cmake
+++ b/sys/intel.cmake
@@ -30,7 +30,9 @@ set(Fortran_FLAGS_RELWITHDEBINFO "-g ${Fortran_FLAGS_RELEASE}"
   CACHE STRING "Fortran compiler flags for Release build")
 
 # Note: uninit only works reliably if all linked libraries were compiled using this flag
-set(Fortran_FLAGS_DEBUG "-g -O0 -warn all -stand f08 -check all,nouninit -diag-error-limit 1 -traceback"
+# Note: boundary violation check is broken in ifx 2025.0
+# (https://community.intel.com/t5/Intel-Fortran-Compiler/Compiler-bug-boundary-check-triggering-false-positives/m-p/1664953#M175032)
+set(Fortran_FLAGS_DEBUG "-g -O0 -warn all -stand f08 -check all,nouninit,nobounds -diag-error-limit 1 -traceback"
   CACHE STRING "Fortran compiler flags for Debug build")
 
 # Use intrinsic Fortran 2008 erf/erfc functions

--- a/sys/intel.cmake
+++ b/sys/intel.cmake
@@ -29,7 +29,8 @@ endif()
 set(Fortran_FLAGS_RELWITHDEBINFO "-g ${Fortran_FLAGS_RELEASE}"
   CACHE STRING "Fortran compiler flags for Release build")
 
-set(Fortran_FLAGS_DEBUG "-g -warn all -stand f08 -check -diag-error-limit 1 -traceback"
+# Note: uninit only works reliably if all linked libraries were compiled using this flag
+set(Fortran_FLAGS_DEBUG "-g -O0 -warn all -stand f08 -check all,nouninit -diag-error-limit 1 -traceback"
   CACHE STRING "Fortran compiler flags for Debug build")
 
 # Use intrinsic Fortran 2008 erf/erfc functions

--- a/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-np2/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-np2/dftb_in.hsd
@@ -36,9 +36,8 @@ Hamiltonian = DFTB {
      0   0   3
     0.0 0.0 0.0
   }
-
+  # Using QR solver to avoid diagonalization problem with certain MKL-versions
   Solver = QR {}
-
 }
 
 Options {

--- a/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-np2/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-np2/dftb_in.hsd
@@ -37,6 +37,8 @@ Hamiltonian = DFTB {
     0.0 0.0 0.0
   }
 
+  Solver = QR {}
+
 }
 
 Options {

--- a/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-np3/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-np3/dftb_in.hsd
@@ -36,7 +36,7 @@ Hamiltonian = DFTB {
      0   0   3
     0.0 0.0 0.0
   }
-
+  # Using QR solver to avoid diagonalization problem with certain MKL-versions
   Solver = QR {}
 
 }

--- a/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-np3/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-np3/dftb_in.hsd
@@ -37,6 +37,8 @@ Hamiltonian = DFTB {
     0.0 0.0 0.0
   }
 
+  Solver = QR {}
+
 }
 
 Options {

--- a/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-np4/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-np4/dftb_in.hsd
@@ -36,7 +36,7 @@ Hamiltonian = DFTB {
      0   0   3
     0.0 0.0 0.0
   }
-
+  # Using QR solver to avoid diagonalization problem with certain MKL-versions
   Solver = QR {}
 
 }

--- a/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-np4/dftb_in.hsd
+++ b/test/app/dftb+/hybrid/periodic/GaAs-kpts-matrix-ct-np4/dftb_in.hsd
@@ -37,6 +37,8 @@ Hamiltonian = DFTB {
     0.0 0.0 0.0
   }
 
+  Solver = QR {}
+
 }
 
 Options {


### PR DESCRIPTION
Fixes several compiler issues causing buildbot tester to fail.

This branch seems to work with gnu-12, gnu-13, gnu-14, intel-2025 and nag-72 (also with MPI).