### PR TITLE
Match trim behaviour from 96b56a3289

### DIFF
--- a/src/dftbp/io/hsdutils.F90
+++ b/src/dftbp/io/hsdutils.F90
@@ -3609,7 +3609,7 @@ contains
 
     type(string) :: str
 
-    str = msg
+    str = trim(msg)
     call appendPathAndLine(node, str)
     call warning(char(str) // newline)
 


### PR DESCRIPTION
Warning strings now also trimmed to match handing of error strings.