### PR TITLE
Warning promotion of invalid escape

### DIFF
--- a/test/app/dftb+/CMakeLists.txt
+++ b/test/app/dftb+/CMakeLists.txt
@@ -2,17 +2,13 @@ set(builddir ${CMAKE_CURRENT_BINARY_DIR})
 set(srcdir ${CMAKE_CURRENT_SOURCE_DIR})
 set(projectdir ${PROJECT_SOURCE_DIR})
 
-# execute_process is verbatim, therefore ";" must be replaced with " "
-string(REGEX REPLACE ";" " " releasename "${RELEASE}")
-
-
 execute_process(
   COMMAND ${projectdir}/utils/test/testlist_to_fypp
   INPUT_FILE ${srcdir}/tests
   OUTPUT_FILE ${builddir}/_dftbplus_tests.fypp)
 
 set(fypp_flags ${FYPP_CONFIG_FLAGS})
-list(APPEND fypp_flags -I${projectdir}/src/dftbp/include -DRELEASE="'${releasename}'")
+list(APPEND fypp_flags -I${projectdir}/src/dftbp/include)
 
 execute_process(
   COMMAND ${FYPP} ${fypp_flags} -DMPI_PROCS=${TEST_MPI_PROCS} -DOMP_THREADS=${TEST_OMP_THREADS}

--- a/test/app/modes/CMakeLists.txt
+++ b/test/app/modes/CMakeLists.txt
@@ -2,9 +2,6 @@ set(builddir ${CMAKE_CURRENT_BINARY_DIR})
 set(srcdir ${CMAKE_CURRENT_SOURCE_DIR})
 set(projectdir ${PROJECT_SOURCE_DIR})
 
-# execute_process is verbatim, therefore ";" must be replaced with " "
-string(REGEX REPLACE ";" " " releasename "${RELEASE}")
-
 execute_process(
   COMMAND ${projectdir}/utils/test/testlist_to_fypp
   INPUT_FILE ${srcdir}/tests
@@ -12,7 +9,7 @@ execute_process(
 
 # Make sure, the line-marker option is not set in fypp
 set(fypp_flags ${FYPP_CONFIG_FLAGS})
-list(APPEND fypp_flags -I${projectdir}/src/dftbp/include -DRELEASE="'${releasename}'")
+list(APPEND fypp_flags -I${projectdir}/src/dftbp/include)
 
 execute_process(
   COMMAND ${FYPP} ${fypp_flags} -DMPI_PROCS=${TEST_MPI_PROCS} -DOMP_THREADS=${TEST_OMP_THREADS}

--- a/test/app/phonons/CMakeLists.txt
+++ b/test/app/phonons/CMakeLists.txt
@@ -1,10 +1,7 @@
 set(builddir ${CMAKE_CURRENT_BINARY_DIR})
 set(srcdir ${CMAKE_CURRENT_SOURCE_DIR})
 
-# execute_process is verbatim, therefore ";" must be replaced with " "
-string(REGEX REPLACE ";" " " releasename "${RELEASE}")
-
-list(APPEND FYPP_FLAGS -I${CMAKE_SOURCE_DIR}/src/dftbp/include -DRELEASE="'${releasename}'")
+list(APPEND FYPP_FLAGS -I${CMAKE_SOURCE_DIR}/src/dftbp/include)
 
 execute_process(
   COMMAND ${CMAKE_SOURCE_DIR}/utils/test/testlist_to_fypp

--- a/test/src/dftbp/api/mm/CMakeLists.txt
+++ b/test/src/dftbp/api/mm/CMakeLists.txt
@@ -2,8 +2,8 @@ set(projectdir ${PROJECT_SOURCE_DIR})
 set(builddir ${CMAKE_CURRENT_BINARY_DIR})
 set(srcdir ${CMAKE_CURRENT_SOURCE_DIR})
 
-# execute_process is verbatim, therefore ";" must be replaced with " "
-string(REGEX REPLACE ";" " " releasename "${RELEASE}")
+# execute_process is verbatim, therefore ";" must be removed
+string(REGEX REPLACE ";" "" releasename "${RELEASE}")
 
 add_subdirectory(testers)
 

--- a/test/src/dftbp/api/mm/CMakeLists.txt
+++ b/test/src/dftbp/api/mm/CMakeLists.txt
@@ -2,13 +2,9 @@ set(projectdir ${PROJECT_SOURCE_DIR})
 set(builddir ${CMAKE_CURRENT_BINARY_DIR})
 set(srcdir ${CMAKE_CURRENT_SOURCE_DIR})
 
-# execute_process is verbatim, therefore ";" must be removed
-string(REGEX REPLACE ";" "" releasename "${RELEASE}")
-
 add_subdirectory(testers)
 
-set(fypp_flags ${FYPP_CONFIG_FLAGS} -I${projectdir}/src/dftbp/include
-  -DRELEASE=\"'${releasename}'\")
+set(fypp_flags ${FYPP_CONFIG_FLAGS} -I${projectdir}/src/dftbp/include)
 
 execute_process(
   COMMAND ${projectdir}/utils/test/testlist_to_fypp

--- a/test/src/dftbp/api/pyapi/CMakeLists.txt
+++ b/test/src/dftbp/api/pyapi/CMakeLists.txt
@@ -8,7 +8,7 @@ execute_process(
   OUTPUT_FILE ${builddir}/_pyapi_tests.fypp)
 
 set(fypp_flags ${FYPP_CONFIG_FLAGS})
-list(APPEND fypp_flags -I${projectdir}/src/dftbp/include -DRELEASE="'${releasename}'")
+list(APPEND fypp_flags -I${projectdir}/src/dftbp/include)
 
 execute_process(
   COMMAND ${FYPP} ${fypp_flags} -DMPI_PROCS=${TEST_MPI_PROCS} -DOMP_THREADS=${TEST_OMP_THREADS}


### PR DESCRIPTION
Python 3.12 raises DeprecationWarning to SyntaxWarning for '\ ', so avoids generating these in the RELEASE.