### PR TITLE
Start of results tagging for linresp

### DIFF
--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -1679,10 +1679,10 @@ contains
       call calculateLinRespExcitations(env, this%linearResponse, this%parallelKS, this%scc,&
           & this%qOutput, this%q0, this%ints, this%eigvecsReal, this%eigen(:,1,:),&
           & this%filling(:,1,:), this%coord, this%species, this%speciesName, this%orb,&
-          & this%skHamCont, this%skOverCont, autotestTag, this%taggedWriter, this%runId,&
-          & this%neighbourList, this%nNeighbourSK, this%denseDesc, this%iSparseStart,&
-          & this%img2CentCell, this%tWriteAutotest, this%tCasidaForces, this%tLinRespZVect,&
-          & this%tPrintExcitedEigvecs, this%tPrintEigvecsTxt, this%nonSccDeriv,&
+          & this%skHamCont, this%skOverCont, autotestTag, resultsTag, this%taggedWriter,&
+          & this%runId, this%neighbourList, this%nNeighbourSK, this%denseDesc, this%iSparseStart,&
+          & this%img2CentCell, this%tWriteAutotest, this%tWriteResultsTag, this%tCasidaForces,&
+          & this%tLinRespZVect, this%tPrintExcitedEigvecs, this%tPrintEigvecsTxt, this%nonSccDeriv,&
           & this%dftbEnergy(1), this%energiesCasida, this%SSqrReal, this%rhoSqrReal,&
           & this%densityMatrix%deltaRhoOut, this%excitedDerivs, this%naCouplings, this%occNatural,&
           & this%hybridXc)
@@ -5423,10 +5423,10 @@ contains
   !> Do the linear response excitation calculation.
   subroutine calculateLinRespExcitations(env, linearResponse, parallelKS, sccCalc, qOutput, q0,&
       & ints, eigvecsReal, eigen, filling, coord, species, speciesName, orb, skHamCont,&
-      & skOverCont, autotestTag, taggedWriter, runId, neighbourList, nNeighbourSk, denseDesc,&
-      & iSparseStart, img2CentCell, tWriteAutotest, tForces, tLinRespZVect, tPrintExcEigvecs,&
-      & tPrintExcEigvecsTxt, nonSccDeriv, dftbEnergy, energies, work, rhoSqrReal, deltaRhoOut,&
-      & excitedDerivs, naCouplings, occNatural, hybridXc)
+      & skOverCont, autotestTag, resultsTag, taggedWriter, runId, neighbourList, nNeighbourSk,&
+      & denseDesc, iSparseStart, img2CentCell, tWriteAutotest, tWriteResultsTag, tForces,&
+      & tLinRespZVect, tPrintExcEigvecs, tPrintExcEigvecsTxt, nonSccDeriv, dftbEnergy, energies,&
+      & work, rhoSqrReal, deltaRhoOut, excitedDerivs, naCouplings, occNatural, hybridXc)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
@@ -5479,6 +5479,9 @@ contains
     !> File name for regression data
     character(*), intent(in) :: autotestTag
 
+    !> File name for machine readable output data
+    character(*), intent(in) :: resultsTag
+
     !> Tagged writer
     type(TTaggedWriter), intent(inout) :: taggedWriter
 
@@ -5502,6 +5505,9 @@ contains
 
     !> Should regression test data be written
     logical, intent(in) :: tWriteAutotest
+
+    !> Should output data be written to tagged file
+    logical, intent(in) :: tWriteResultsTag
 
     !> Forces to be calculated in the excited state
     logical, intent(in) :: tForces
@@ -5550,7 +5556,7 @@ contains
     integer, pointer :: pSpecies0(:)
     integer :: iSpin, nSpin, nAtom
     logical :: tSpin
-    type(TFileDescr) :: fdAutotest
+    Type(TFileDescr) :: fdAutotest, fdResults
 
     nAtom = size(qOutput, dim=2)
     nSpin = size(eigen, dim=2)
@@ -5586,15 +5592,18 @@ contains
     if (tWriteAutotest) then
       call openFile(fdAutotest, autotestTag, mode="a")
     end if
+    if (tWriteResultsTag) then
+      call openFile(fdResults, resultsTag, mode="a")
+    end if
     if (tLinRespZVect) then
       if (tPrintExcEigVecs) then
         allocate(naturalOrbs(orb%nOrb, orb%nOrb, 1))
       end if
       call LinResp_addGradients(env, tSpin, linearResponse, denseDesc, eigvecsReal, eigen,&
           & work, filling, coord(:,:nAtom), sccCalc, dQAtom, pSpecies0, neighbourList%iNeighbour,&
-          & img2CentCell, orb, skHamCont, skOverCont, fdAutotest, taggedWriter, hybridXc,&
-          & dftbEnergy%Eexcited, energies, excitedDerivs, naCouplings, nonSccDeriv, rhoSqrReal,&
-          & deltaRhoOut, occNatural, naturalOrbs)
+          & img2CentCell, orb, skHamCont, skOverCont, fdAutotest, fdResults, taggedWriter,&
+          & hybridXc, dftbEnergy%Eexcited, energies, excitedDerivs, naCouplings, nonSccDeriv,&
+          & rhoSqrReal, deltaRhoOut, occNatural, naturalOrbs)
       if (tPrintExcEigvecs) then
         call writeRealEigvecs(env, runId, neighbourList, nNeighbourSK, denseDesc, iSparseStart,&
             & img2CentCell, pSpecies0, speciesName, orb, ints%overlap, parallelKS, &
@@ -5603,7 +5612,8 @@ contains
     else
       call linResp_calcExcitations(env, linearResponse, tSpin, denseDesc, eigvecsReal, eigen, work,&
           & filling, coord(:,:nAtom), sccCalc, dQAtom, pSpecies0, neighbourList%iNeighbour,&
-          & img2CentCell, orb, fdAutotest, taggedWriter, hybridXc, dftbEnergy%Eexcited, energies)
+          & img2CentCell, orb, fdAutotest, fdResults, taggedWriter, hybridXc, dftbEnergy%Eexcited,&
+          & energies)
     end if
     dftbEnergy%Etotal = dftbEnergy%Etotal + dftbEnergy%Eexcited
     dftbEnergy%EMermin = dftbEnergy%EMermin + dftbEnergy%Eexcited

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -1694,10 +1694,10 @@ contains
       call calculateLinRespExcitations(env, this%linearResponse, this%parallelKS, this%scc,&
           & this%qOutput, this%q0, this%ints, this%eigvecsReal, this%eigen(:,1,:),&
           & this%filling(:,1,:), this%coord, this%species, this%speciesName, this%orb,&
-          & this%skHamCont, this%skOverCont, autotestTag, this%taggedWriter, this%runId,&
-          & this%neighbourList, this%nNeighbourSK, this%denseDesc, this%iSparseStart,&
-          & this%img2CentCell, this%tWriteAutotest, this%tCasidaForces, this%tLinRespZVect,&
-          & this%tPrintExcitedEigvecs, this%tPrintEigvecsTxt, this%nonSccDeriv,&
+          & this%skHamCont, this%skOverCont, autotestTag, resultsTag, this%taggedWriter,&
+          & this%runId, this%neighbourList, this%nNeighbourSK, this%denseDesc, this%iSparseStart,&
+          & this%img2CentCell, this%tWriteAutotest, this%tWriteResultsTag, this%tCasidaForces,&
+          & this%tLinRespZVect, this%tPrintExcitedEigvecs, this%tPrintEigvecsTxt, this%nonSccDeriv,&
           & this%dftbEnergy(1), this%energiesCasida, this%SSqrReal, this%rhoSqrReal,&
           & this%densityMatrix%deltaRhoOut, this%excitedDerivs, this%naCouplings, this%occNatural,&
           & this%hybridXc)
@@ -5766,10 +5766,10 @@ contains
   !> Do the linear response excitation calculation.
   subroutine calculateLinRespExcitations(env, linearResponse, parallelKS, sccCalc, qOutput, q0,&
       & ints, eigvecsReal, eigen, filling, coord, species, speciesName, orb, skHamCont,&
-      & skOverCont, autotestTag, taggedWriter, runId, neighbourList, nNeighbourSk, denseDesc,&
-      & iSparseStart, img2CentCell, tWriteAutotest, tForces, tLinRespZVect, tPrintExcEigvecs,&
-      & tPrintExcEigvecsTxt, nonSccDeriv, dftbEnergy, energies, work, rhoSqrReal, dRhoOut,&
-      & excitedDerivs, naCouplings, occNatural, hybridXc)
+      & skOverCont, autotestTag, resultsTag, taggedWriter, runId, neighbourList, nNeighbourSk,&
+      & denseDesc, iSparseStart, img2CentCell, tWriteAutotest, tWriteResultsTag, tForces,&
+      & tLinRespZVect, tPrintExcEigvecs, tPrintExcEigvecsTxt, nonSccDeriv, dftbEnergy, energies,&
+      & work, rhoSqrReal, dRhoOut, excitedDerivs, naCouplings, occNatural, hybridXc)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
@@ -5822,6 +5822,9 @@ contains
     !> File name for regression data
     character(*), intent(in) :: autotestTag
 
+    !> File name for machine readable output data
+    character(*), intent(in) :: resultsTag
+
     !> Tagged writer
     type(TTaggedWriter), intent(inout) :: taggedWriter
 
@@ -5845,6 +5848,9 @@ contains
 
     !> Should regression test data be written
     logical, intent(in) :: tWriteAutotest
+
+    !> Should output data be written to tagged file
+    logical, intent(in) :: tWriteResultsTag
 
     !> Forces to be calculated in the excited state
     logical, intent(in) :: tForces
@@ -5892,7 +5898,7 @@ contains
     integer, pointer :: pSpecies0(:)
     integer :: iSpin, nSpin, nAtom
     logical :: tSpin
-    type(TFileDescr) :: fdAutotest
+    Type(TFileDescr) :: fdAutotest, fdResults
 
     nAtom = size(qOutput, dim=2)
     nSpin = size(eigen, dim=2)
@@ -5928,15 +5934,18 @@ contains
     if (tWriteAutotest) then
       call openFile(fdAutotest, autotestTag, mode="a")
     end if
+    if (tWriteResultsTag) then
+      call openFile(fdResults, resultsTag, mode="a")
+    end if
     if (tLinRespZVect) then
       if (tPrintExcEigVecs) then
         allocate(naturalOrbs(orb%nOrb, orb%nOrb, 1))
       end if
       call LinResp_addGradients(env, tSpin, linearResponse, denseDesc, eigvecsReal, eigen,&
           & work, filling, coord(:,:nAtom), sccCalc, dQAtom, pSpecies0, neighbourList%iNeighbour,&
-          & img2CentCell, orb, skHamCont, skOverCont, fdAutotest, taggedWriter, hybridXc,&
-          & dftbEnergy%Eexcited, energies, excitedDerivs, naCouplings, nonSccDeriv, rhoSqrReal,&
-          & deltaRhoOut, occNatural, naturalOrbs)
+          & img2CentCell, orb, skHamCont, skOverCont, fdAutotest, fdResults, taggedWriter,&
+          & hybridXc, dftbEnergy%Eexcited, energies, excitedDerivs, naCouplings, nonSccDeriv,&
+          & rhoSqrReal, deltaRhoOut, occNatural, naturalOrbs)
       if (tPrintExcEigvecs) then
         call writeRealEigvecs(env, runId, neighbourList, nNeighbourSK, denseDesc, iSparseStart,&
             & img2CentCell, pSpecies0, speciesName, orb, ints%overlap, parallelKS, &
@@ -5945,7 +5954,8 @@ contains
     else
       call linResp_calcExcitations(env, linearResponse, tSpin, denseDesc, eigvecsReal, eigen, work,&
           & filling, coord(:,:nAtom), sccCalc, dQAtom, pSpecies0, neighbourList%iNeighbour,&
-          & img2CentCell, orb, fdAutotest, taggedWriter, hybridXc, dftbEnergy%Eexcited, energies)
+          & img2CentCell, orb, fdAutotest, fdResults, taggedWriter, hybridXc, dftbEnergy%Eexcited,&
+          & energies)
     end if
     dftbEnergy%Etotal = dftbEnergy%Etotal + dftbEnergy%Eexcited
     dftbEnergy%EMermin = dftbEnergy%EMermin + dftbEnergy%Eexcited

--- a/src/dftbp/timedep/linresp.F90
+++ b/src/dftbp/timedep/linresp.F90
@@ -263,7 +263,7 @@ contains
   !> Wrapper to call the actual linear response routine for excitation energies
   subroutine linResp_calcExcitations(env, this, tSpin, denseDesc, eigVec, eigVal, SSqrReal,&
       & filling, coords0, sccCalc, dqAt, species0, iNeighbour, img2CentCell, orb,&
-      & fdTagged, taggedWriter, hybridXc, excEnergy, allExcEnergies)
+      & fdAutotest, fdResults, taggedWriter, hybridXc, excEnergy, allExcEnergies)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
@@ -310,8 +310,11 @@ contains
     !> Data type with atomic orbital information
     type(TOrbitals), intent(in) :: orb
 
-    !> File id for tagging information
-    type(TFileDescr), intent(in) :: fdTagged
+    !> File id for tagging information for regression system
+    type(TFileDescr), intent(in) :: fdAutotest
+
+    !> File id for tagged results output
+    type(TFileDescr), intent(in) :: fdResults
 
     !> Tagged writer
     type(TTaggedWriter), intent(inout) :: taggedWriter
@@ -328,8 +331,8 @@ contains
     if (this%tInit) then
       @:ASSERT(size(orb%nOrbAtom) == this%nAtom)
       call LinRespGrad_old(env, this, denseDesc, eigVec, eigVal, sccCalc, dqAt, coords0,&
-          & SSqrReal, filling, species0, iNeighbour, img2CentCell, orb, fdTagged, taggedWriter,&
-          & hybridXc, excEnergy, allExcEnergies)
+          & SSqrReal, filling, species0, iNeighbour, img2CentCell, orb, fdAutotest, fdResults,&
+          & taggedWriter, hybridXc, excEnergy, allExcEnergies)
     else
       call error('Internal error: Illegal routine call to LinResp_calcExcitations.')
     end if
@@ -340,8 +343,8 @@ contains
   !> Wrapper to call linear response calculations of excitations and forces in excited states
   subroutine LinResp_addGradients(env, tSpin, this, denseDesc, eigVec, eigVal, SSqrReal, filling,&
       & coords0, sccCalc, dqAt, species0, iNeighbour, img2CentCell, orb, skHamCont, skOverCont,&
-      & fdTagged, taggedWriter, hybridXc, excEnergy, allExcEnergies, excgradient, nacv, derivator,&
-      & rhoSqr, deltaRho, occNatural, naturalOrbs)
+      & fdAutotest, fdResults, taggedWriter, hybridXc, excEnergy, allExcEnergies, excgradient,&
+      & nacv, derivator, rhoSqr, deltaRho, occNatural, naturalOrbs)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
@@ -404,7 +407,10 @@ contains
     real(dp), intent(inout), allocatable :: deltaRho(:,:,:)
 
     !> File descriptor for tagged data
-    type(TFileDescr), intent(in) :: fdTagged
+    type(TFileDescr), intent(in) :: fdAutotest
+
+    !> File id for tagged results information
+    type(TFileDescr), intent(in) :: fdResults
 
     !> Tagged writer
     type(TTaggedWriter), intent(inout) :: taggedWriter
@@ -445,16 +451,17 @@ contains
 
       if (allocated(occNatural)) then
         call LinRespGrad_old(env, this, denseDesc, eigVec, eigVal, sccCalc, dqAt, coords0,&
-            & SSqrReal, filling, species0, iNeighbour, img2CentCell, orb, fdTagged, taggedWriter,&
-            & hybridXc, excEnergy, allExcEnergies, deltaRho=deltaRho, shift=shiftPerAtom,&
-            & skHamCont=skHamCont, skOverCont=skOverCont, excgrad=excgradient, nacv=nacv,&
-            & derivator=derivator, rhoSqr=rhoSqr, occNatural=occNatural, naturalOrbs=naturalOrbs)
+            & SSqrReal, filling, species0, iNeighbour, img2CentCell, orb, fdAutotest, fdResults,&
+            & taggedWriter, hybridXc, excEnergy, allExcEnergies, deltaRho=deltaRho,&
+            & shift=shiftPerAtom, skHamCont=skHamCont, skOverCont=skOverCont, excgrad=excgradient,&
+            & nacv=nacv, derivator=derivator, rhoSqr=rhoSqr, occNatural=occNatural,&
+            & naturalOrbs=naturalOrbs)
       else
-         call LinRespGrad_old(env, this, denseDesc, eigVec, eigVal, sccCalc, dqAt, coords0,&
-            & SSqrReal, filling, species0, iNeighbour, img2CentCell, orb, fdTagged, taggedWriter,&
-            & hybridXc, excEnergy, allExcEnergies, deltaRho=deltaRho, shift=shiftPerAtom,&
-            & skHamCont=skHamCont, skOverCont=skOverCont, excgrad=excgradient, nacv=nacv,&
-            & derivator=derivator, rhoSqr=rhoSqr)
+        call LinRespGrad_old(env, this, denseDesc, eigVec, eigVal, sccCalc, dqAt, coords0,&
+            & SSqrReal, filling, species0, iNeighbour, img2CentCell, orb, fdAutotest, fdResults,&
+            & taggedWriter, hybridXc, excEnergy, allExcEnergies, deltaRho=deltaRho,&
+            & shift=shiftPerAtom, skHamCont=skHamCont, skOverCont=skOverCont, excgrad=excgradient,&
+            & nacv=nacv, derivator=derivator, rhoSqr=rhoSqr)
       end if
 
     else

--- a/src/dftbp/timedep/linresp.F90
+++ b/src/dftbp/timedep/linresp.F90
@@ -296,7 +296,7 @@ contains
   !> Wrapper to call the actual linear response routine for excitation energies
   subroutine linResp_calcExcitations(env, this, tSpin, denseDesc, eigVec, eigVal, SSqrReal,&
       & filling, coords0, sccCalc, dqAt, species0, iNeighbour, img2CentCell, orb,&
-      & fdTagged, taggedWriter, hybridXc, excEnergy, allExcEnergies)
+      & fdAutotest, fdResults, taggedWriter, hybridXc, excEnergy, allExcEnergies)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
@@ -343,8 +343,11 @@ contains
     !> Data type with atomic orbital information
     type(TOrbitals), intent(in) :: orb
 
-    !> File id for tagging information
-    type(TFileDescr), intent(in) :: fdTagged
+    !> File id for tagging information for regression system
+    type(TFileDescr), intent(in) :: fdAutotest
+
+    !> File id for tagged results output
+    type(TFileDescr), intent(in) :: fdResults
 
     !> Tagged writer
     type(TTaggedWriter), intent(inout) :: taggedWriter
@@ -361,8 +364,8 @@ contains
     if (this%tInit) then
       @:ASSERT(size(orb%nOrbAtom) == this%nAtom)
       call LinRespGrad_old(env, this, denseDesc, eigVec, eigVal, sccCalc, dqAt, coords0,&
-          & SSqrReal, filling, species0, iNeighbour, img2CentCell, orb, fdTagged, taggedWriter,&
-          & hybridXc, excEnergy, allExcEnergies)
+          & SSqrReal, filling, species0, iNeighbour, img2CentCell, orb, fdAutotest, fdResults,&
+          & taggedWriter, hybridXc, excEnergy, allExcEnergies)
     else
       call error('Internal error: Illegal routine call to LinResp_calcExcitations.')
     end if
@@ -373,8 +376,8 @@ contains
   !> Wrapper to call linear response calculations of excitations and forces in excited states
   subroutine LinResp_addGradients(env, tSpin, this, denseDesc, eigVec, eigVal, SSqrReal, filling,&
       & coords0, sccCalc, dqAt, species0, iNeighbour, img2CentCell, orb, skHamCont, skOverCont,&
-      & fdTagged, taggedWriter, hybridXc, excEnergy, allExcEnergies, excgradient, nacv, derivator,&
-      & rhoSqr, deltaRho, occNatural, naturalOrbs)
+      & fdAutotest, fdResults, taggedWriter, hybridXc, excEnergy, allExcEnergies, excgradient,&
+      & nacv, derivator, rhoSqr, deltaRho, occNatural, naturalOrbs)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
@@ -437,7 +440,10 @@ contains
     real(dp), intent(inout), allocatable :: deltaRho(:,:,:)
 
     !> File descriptor for tagged data
-    type(TFileDescr), intent(in) :: fdTagged
+    type(TFileDescr), intent(in) :: fdAutotest
+
+    !> File id for tagged results information
+    type(TFileDescr), intent(in) :: fdResults
 
     !> Tagged writer
     type(TTaggedWriter), intent(inout) :: taggedWriter
@@ -478,16 +484,17 @@ contains
 
       if (allocated(occNatural)) then
         call LinRespGrad_old(env, this, denseDesc, eigVec, eigVal, sccCalc, dqAt, coords0,&
-            & SSqrReal, filling, species0, iNeighbour, img2CentCell, orb, fdTagged, taggedWriter,&
-            & hybridXc, excEnergy, allExcEnergies, deltaRho=deltaRho, shift=shiftPerAtom,&
-            & skHamCont=skHamCont, skOverCont=skOverCont, excgrad=excgradient, nacv=nacv,&
-            & derivator=derivator, rhoSqr=rhoSqr, occNatural=occNatural, naturalOrbs=naturalOrbs)
+            & SSqrReal, filling, species0, iNeighbour, img2CentCell, orb, fdAutotest, fdResults,&
+            & taggedWriter, hybridXc, excEnergy, allExcEnergies, deltaRho=deltaRho,&
+            & shift=shiftPerAtom, skHamCont=skHamCont, skOverCont=skOverCont, excgrad=excgradient,&
+            & nacv=nacv, derivator=derivator, rhoSqr=rhoSqr, occNatural=occNatural,&
+            & naturalOrbs=naturalOrbs)
       else
-         call LinRespGrad_old(env, this, denseDesc, eigVec, eigVal, sccCalc, dqAt, coords0,&
-            & SSqrReal, filling, species0, iNeighbour, img2CentCell, orb, fdTagged, taggedWriter,&
-            & hybridXc, excEnergy, allExcEnergies, deltaRho=deltaRho, shift=shiftPerAtom,&
-            & skHamCont=skHamCont, skOverCont=skOverCont, excgrad=excgradient, nacv=nacv,&
-            & derivator=derivator, rhoSqr=rhoSqr)
+        call LinRespGrad_old(env, this, denseDesc, eigVec, eigVal, sccCalc, dqAt, coords0,&
+            & SSqrReal, filling, species0, iNeighbour, img2CentCell, orb, fdAutotest, fdResults,&
+            & taggedWriter, hybridXc, excEnergy, allExcEnergies, deltaRho=deltaRho,&
+            & shift=shiftPerAtom, skHamCont=skHamCont, skOverCont=skOverCont, excgrad=excgradient,&
+            & nacv=nacv, derivator=derivator, rhoSqr=rhoSqr)
       end if
 
     else

--- a/src/dftbp/timedep/linrespgrad.F90
+++ b/src/dftbp/timedep/linrespgrad.F90
@@ -88,9 +88,9 @@ contains
   !> This subroutine analytically calculates excitations and gradients of excited state energies
   !! based on Time Dependent DFRT
   subroutine LinRespGrad_old(env, this, denseDesc, grndEigVecs, grndEigVal, sccCalc, dq, coord0,&
-      & SSqr, filling, species0, iNeighbour, img2CentCell, orb, fdTagged, taggedWriter, hybridXc,&
-      & omega, allOmega, deltaRho, shift, skHamCont, skOverCont, excgrad, nacv, derivator, rhoSqr,&
-      & occNatural, naturalOrbs)
+      & SSqr, filling, species0, iNeighbour, img2CentCell, orb, fdAutoTest, fdResults,&
+      & taggedWriter, hybridXc, omega, allOmega, deltaRho, shift, skHamCont, skOverCont, excgrad,&
+      & nacv, derivator, rhoSqr, occNatural, naturalOrbs)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
@@ -133,8 +133,11 @@ contains
     !> Data type for atomic orbital information
     type(TOrbitals), intent(in) :: orb
 
-    !> File descriptor for the tagged data output
-    type(TFileDescr), intent(in) :: fdTagged
+    !> File descriptor for the tagged regression data output
+    type(TFileDescr), intent(in) :: fdAutoTest
+
+    !> File descriptor for tagged results information
+    type(TFileDescr), intent(in) :: fdResults
 
     !> Tagged writer
     type(TTaggedWriter), intent(inout) :: taggedWriter
@@ -564,7 +567,7 @@ contains
         call openFile(fdXPlusY, XplusYOut // '.DAT', mode="w")
       else
         call openFile(fdXPlusY, XplusYOut // '.BIN', mode="wb")
-      end if 
+      end if
     end if
 
     if (this%writeTrans) then
@@ -634,7 +637,7 @@ contains
       ! Transition charges for state nstat
       if (this%writeTransQ) then
         call getAndWriteTransitionCharges(env, this, rpa, transChrg, sym, denseDesc, ovrXev,&
-            & grndEigVecs, xpy, fdTransQ, fdTagged, taggedWriter)
+            & grndEigVecs, xpy, fdTransQ, fdAutoTest, fdResults, taggedWriter)
       end if
 
       if (this%tSpin) then
@@ -642,12 +645,13 @@ contains
         call getExcSpin(env, orb, rpa, denseDesc, Ssq, xpy, filling, ovrXev, grndEigVecs)
 
         call writeExcitations(this, rpa, sym, osz, eval, xpy, fdXPlusY, this%writeXplusYAscii,&
-            & fdTrans, fdTransDip, transitionDipoles, fdTagged, taggedWriter, fdExc, Ssq)
+            & fdTrans, fdTransDip, transitionDipoles, fdAutoTest, fdResults, taggedWriter, fdExc,&
+            & Ssq)
 
       else
 
         call writeExcitations(this, rpa, sym, osz, eval, xpy, fdXPlusY, this%writeXplusYAscii,&
-            & fdTrans, fdTransDip, transitionDipoles, fdTagged, taggedWriter, fdExc)
+            & fdTrans, fdTransDip, transitionDipoles, fdAutoTest, fdResults, taggedWriter, fdExc)
 
       end if
 
@@ -922,8 +926,8 @@ contains
         call fixNACVPhase(nacv)
 
         if (this%writeNacv) then
-          call writeNACV(this%indNACouplings(1), this%indNACouplings(2), fdTagged, taggedWriter,&
-              & nacv)
+          call writeNACV(this%indNACouplings(1), this%indNACouplings(2), fdAutoTest, fdResults,&
+              & taggedWriter, nacv)
         end if
 
         call env%globalTimer%stopTimer(globalTimers%lrNAC)
@@ -3182,7 +3186,7 @@ contains
   !> Write out transitions from ground to excited state along with single particle transitions and
   !! dipole strengths.
   subroutine writeExcitations(lr, rpa, sym, osz, eval, xpy, fdXPlusY, writeXplusYAscii, fdTrans, &
-      & fdTransDip, transitionDipoles, fdTagged, taggedWriter, fdExc, Ssq)
+      & fdTransDip, transitionDipoles, fdAutoTest, fdResults, taggedWriter, fdExc, Ssq)
 
     !> Data structure for linear response
     type(TLinResp), intent(in) :: lr
@@ -3217,8 +3221,11 @@ contains
     !> File unit for transitions
     type(TFileDescr), intent(in) :: fdTrans
 
-    !> File unit for tagged output (> -1 for write out)
-    type(TFileDescr), intent(in) :: fdTagged
+    !> File unit for regression tagged output
+    type(TFileDescr), intent(in) :: fdAutoTest
+
+    !> File unit for tagged data output
+    type(TFileDescr), intent(in) :: fdResults
 
     !> Tagged writer
     type(TTaggedWriter), intent(inout) :: taggedWriter
@@ -3386,36 +3393,55 @@ contains
     deallocate(wvec)
     deallocate(wvin)
 
-    if (fdTagged%isConnected()) then
+    if (fdAutoTest%isConnected() .or. fdResults%isConnected()) then
 
       call TDegeneracyFind_init(degeneracyFind, elecTolMax)
       call degeneracyFind%degeneracyTest(eval, tDegenerate)
       if (.not.tDegenerate) then
-        call taggedWriter%write(fdTagged%unit, tagLabels%excEgy, eval)
-        call taggedWriter%write(fdTagged%unit, tagLabels%excOsc, osz)
-        ! Since the transition dipole file exists, transition dipoles had been calculated
-        if (fdTransDip%isConnected()) then
-          call taggedWriter%write(fdTagged%unit, tagLabels%excDipole,&
-              & sqrt(sum(transitionDipoles**2,dim=2)))
+        if (fdAutoTest%isConnected()) then
+          call taggedWriter%write(fdAutoTest%unit, tagLabels%excEgy, eval)
+          call taggedWriter%write(fdAutoTest%unit, tagLabels%excOsc, osz)
         end if
+        if (fdResults%isConnected()) then
+          call taggedWriter%write(fdResults%unit, tagLabels%excEgy, eval)
+          call taggedWriter%write(fdResults%unit, tagLabels%excOsc, osz)
+        end if
+        if (fdTransDip%isConnected()) then
+          ! Since the transition dipole file exists, transition dipoles have been calculated
+          if (fdAutoTest%isConnected()) call taggedWriter%write(fdAutoTest%unit,&
+              & tagLabels%excDipole, sqrt(sum(transitionDipoles**2,dim=2)))
+          if (fdResults%isConnected()) call taggedWriter%write(fdResults%unit,&
+              & tagLabels%excDipole, sqrt(sum(transitionDipoles**2,dim=2)))
+        end if
+
       else
+
         degenerate = DegeneracyFind%degenerateRanges()
-        call taggedWriter%write(fdTagged%unit, tagLabels%excEgy, eval(degenerate(1,:)))
+        if (fdAutoTest%isConnected()) call taggedWriter%write(fdAutoTest%unit, tagLabels%excEgy,&
+            & eval(degenerate(1,:)))
+        if (fdResults%isConnected()) call taggedWriter%write(fdResults%unit, tagLabels%excEgy,&
+            & eval(degenerate(1,:)))
         ! sum oscillator strength over any degenerate levels
         allocate(oDeg(DegeneracyFind%degenerateGroups()))
         do ii = 1, size(oDeg)
           oDeg(ii) = sum(osz(degenerate(1,ii):degenerate(2,ii)))
         end do
-        call taggedWriter%write(fdTagged%unit, tagLabels%excOsc, oDeg)
+        if (fdAutoTest%isConnected()) call taggedWriter%write(fdAutoTest%unit, tagLabels%excOsc,&
+            & oDeg)
+        if (fdResults%isConnected()) call taggedWriter%write(fdResults%unit, tagLabels%excOsc, oDeg)
         ! Since the transition dipole file exists, transition dipoles had been calculated
         if (fdTransDip%isConnected()) then
           oDeg(:) = 0.0_dp
           do ii = 1, size(oDeg)
             oDeg(ii) = sqrt(sum(transitionDipoles(degenerate(1,ii):degenerate(2,ii),:)**2))
           end do
-          call taggedWriter%write(fdTagged%unit, tagLabels%excDipole, oDeg)
+          if (fdAutoTest%isConnected()) call taggedWriter%write(fdAutoTest%unit,&
+              & tagLabels%excDipole, oDeg)
+          if (fdResults%isConnected()) call taggedWriter%write(fdResults%unit, tagLabels%excDipole,&
+              & oDeg)
         end if
       end if
+
     end if
 
   end subroutine writeExcitations
@@ -4586,7 +4612,7 @@ contains
 
 
   !> Write out non-adiabatic coupling vectors.
-  subroutine writeNACV(iLev, jLev, fdTagged, taggedWriter, nacv)
+  subroutine writeNACV(iLev, jLev, fdAutoTest, fdResults, taggedWriter, nacv)
 
     !> Start level for coupling
     integer, intent(in) :: iLev
@@ -4594,8 +4620,11 @@ contains
     !> End level for coupling
     integer, intent(in) :: jLev
 
-    !> File descriptor for the tagged data output
-    type(TFileDescr), intent(in) :: fdTagged
+    !> File descriptor for the tagged regression data
+    type(TFileDescr), intent(in) :: fdAutoTest
+
+    !> File unit for tagged data output
+    type(TFileDescr), intent(in) :: fdResults
 
     !> Tagged writer
     type(TTaggedWriter), intent(inout) :: taggedWriter
@@ -4621,7 +4650,8 @@ contains
 
     call closeFile(fdNaCoupl)
 
-    if (fdTagged%isConnected()) call taggedWriter%write(fdTagged%unit, tagLabels%nacv, nacv)
+    if (fdAutoTest%isConnected()) call taggedWriter%write(fdAutoTest%unit, tagLabels%nacv, nacv)
+    if (fdResults%isConnected()) call taggedWriter%write(fdResults%unit, tagLabels%nacv, nacv)
 
   end subroutine writeNACV
 
@@ -5735,7 +5765,7 @@ contains
   !! Initialization prevents entering this routine for triplets for which the charges
   !! would simply be zero.
   subroutine getAndWriteTransitionCharges(env, lr, rpa, transChrg, sym, denseDesc, ovrXev, &
-      & grndEigVecs, xpy, fdTransQ, fdTagged, taggedWriter)
+      & grndEigVecs, xpy, fdTransQ, fdAutoTest, fdResults, taggedWriter)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
@@ -5767,8 +5797,11 @@ contains
     !> File descriptor for ATQ.DAT
     type(TFileDescr) :: fdTransQ
 
-    !> File unit for tagged output (> -1 for write out)
-    type(TFileDescr), intent(in) :: fdTagged
+    !> File descriptor for the tagged regression data
+    type(TFileDescr), intent(in) :: fdAutoTest
+
+    !> File unit for tagged data output
+    type(TFileDescr), intent(in) :: fdResults
 
     !> Tagged writer
     type(TTaggedWriter), intent(inout) :: taggedWriter
@@ -5807,9 +5840,10 @@ contains
 
     call closeFile(fdTransQ)
 
-    if (fdTagged%isConnected()) then
-      call taggedWriter%write(fdTagged%unit, tagLabels%transQ, atomicTransQ**2)
-    end if
+    if (fdAutoTest%isConnected()) call taggedWriter%write(fdAutoTest%unit, tagLabels%transQ,&
+        & atomicTransQ**2)
+    if (fdResults%isConnected()) call taggedWriter%write(fdResults%unit, tagLabels%transQ,&
+        & atomicTransQ**2)
 
   end subroutine getAndWriteTransitionCharges
 


### PR DESCRIPTION
In addition to the existing autotest.tag files, relevant data should be written to results.tag

Closes #1652 