### PR TITLE
Use toml for the ford settings

### DIFF
--- a/doc/dftb+/ford/dftbplus-project-file.md
+++ b/doc/dftb+/ford/dftbplus-project-file.md
@@ -1,30 +1,15 @@
-macro:
-        DEBUG=0
-        WITH_MPI=1
-        WITH_ARPACK=1
-        WITH_DFTD3=1
-        WITH_SOCKETS=1
-        RELEASE=24.1
-preprocess: true
-src_dir:
-        ../../../app/dftb+
-        ../../../app/modes
-        ../../../app/waveplot
-        ../../../app/misc
-output_dir: ./doc
-project_github: https://github.com/dftbplus/dftbplus
-project_website: http://www.dftbplus.org
-summary: The DFTB+ package for fast quantum mechanical atomistic simulations
-author: The DFTB+ developers group
-preprocessor: ../../../external/fypp/bin/fypp
-include: ../../../src/dftbp/include
-         ../../../external/dftd4refs
-predocmark: >
-display: public
-         protected
-proc_internals: false
-source: true
-graph: true
-search: false
-license: by
-warn: true
+## Information
+The most recent features are described in the (open access) [DFTB+ paper](https://doi.org/10.1063/1.5143190).
+
+Consult the following resources for documentation:
+
+- [Step-by-step instructions with selected examples (DFTB+ Recipes)](http://dftbplus-recipes.readthedocs.io/)
+- [Reference manual describing all features (DFTB+ Manual)](https://github.com/dftbplus/dftbplus/releases/latest/download/manual.pdf)
+
+## Contributing
+New features, bug fixes, documentation, tutorial examples, and code testing are welcome in the DFTB+ developer community!
+
+The project is [hosted on GitHub](https://github.com/dftbplus/).  
+Please check [CONTRIBUTING.rst](https://github.com/elv3rs/dftbplus/blob/main/CONTRIBUTING.rst) and the [DFTB+ Developers Guide](https://dftbplus-develguide.readthedocs.io/) for guidelines.
+
+We look forward to your pull request!

--- a/doc/dftb+/ford/fpm.toml
+++ b/doc/dftb+/ford/fpm.toml
@@ -1,0 +1,42 @@
+[extra.ford]
+macro = [
+    "DEBUG=0",
+    "WITH_MPI=1",
+    "WITH_ARPACK=1",
+    "WITH_DFTD3=1",
+    "WITH_SOCKETS=1",
+    "RELEASE=24.1"
+]
+
+preprocess = true
+preprocessor = "../../../external/fypp/bin/fypp"
+
+src_dir = [
+    "../../../app/dftb+",
+    "../../../app/modes",
+    "../../../app/waveplot",
+    "../../../app/misc"
+]
+include = [
+    "../../../src/dftbp/include",
+    "../../../external/dftd4refs"
+]
+output_dir = "./doc"
+
+project = "DFTB+"
+project_github = "https://github.com/dftbplus/dftbplus"
+project_website = "http://www.dftbplus.org"
+version = 24.1
+
+summary = "DFTB+ is a software package for carrying out fast quantum mechanical atomistic calculations based on the Density Functional Tight Binding method."
+author = "The DFTB+ developers group"
+license = "lgpl"
+doc_license = "by"
+
+predocmark = ">"
+display = ["public", "protected"]
+proc_internals = false
+source = true
+graph = true
+search = false
+warn = true


### PR DESCRIPTION
## Update Ford Configuration to Use TOML

With the introduction of TOML support in Ford version 7.0, it is now recommended to specify the Project Options in the `[extra.ford]` section of an `fpm.toml` file.

This change migrates the settings from the markdown project file to an equivalent TOML configuration. The Ford invocation remains unchanged and continues to simply be:

```
ford dftbplus-project-file.md
```

To avoid having the main project file be completely devoid of content, I copied over some material from the project README.

Closes #1659.