### PR TITLE
Error propagation

### DIFF
--- a/app/dftb+/dftbplus.F90
+++ b/app/dftb+/dftbplus.F90
@@ -9,7 +9,9 @@
 
 program dftbplus
   use dftbp_common_environment, only : TEnvironment, TEnvironment_init
-  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv
+  use dftbp_common_exception, only : TEarlyExit, TException, TGeneralError, TInputError,&
+      & TInternalError, TModelError, TSystemError
+  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv, stdOut0
   use dftbp_common_release, only : releaseName, releaseYear
   use dftbp_dftbplus_hsdhelpers, only : parseHsdInput
   use dftbp_dftbplus_initprogram, only : TDftbPlusMain
@@ -19,24 +21,84 @@ program dftbplus
   implicit none
 
   type(TEnvironment) :: env
+  type(TException), allocatable :: exc
   type(TInputData), allocatable :: input
   type(TDftbPlusMain), allocatable, target :: main
+  integer :: exitCode
 
   call initGlobalEnv()
-  call printDftbHeader(releaseName, releaseYear)
-  allocate(input)
-  call parseHsdInput(input)
   call TEnvironment_init(env)
-  allocate(main)
-  call main%initProgramVariables(input, env)
-  deallocate(input)
-  call runDftbPlus(main, env)
-  call main%destructProgramVariables()
-  deallocate(main)
-#:if WITH_MAGMA
-  call magmaf_finalize()
-#:endif
-  call env%destruct()
+
+  try: block
+    call printDftbHeader(releaseName, releaseYear)
+
+    allocate(input)
+    call parseHsdInput(exc, input)
+    if (allocated(exc)) exit try
+
+    allocate(main)
+    call main%initProgramVariables(exc, env, input)
+    deallocate(input)
+    if (allocated(exc)) exit try
+
+    call runDftbPlus(main, exc, env)
+    call main%destructProgramVariables()
+    deallocate(main)
+  #:if WITH_MAGMA
+    call magmaf_finalize()
+  #:endif
+  end block try
+
+  call handleException(exc, exitCode)
+  call env%destruct(writeTimings=(exitCode == 0))
   call destructGlobalEnv()
+  if (exitCode /= 0) error stop exitCode, quiet=.true.
+
+contains
+
+  !> Handle eventual exception
+  subroutine handleException(exc, exitCode)
+
+    !> Exception, might be unallocated, if no exception occured.
+    type(TException), allocatable, intent(inout) :: exc
+
+    !> Exit code the program should generate
+    integer, intent(out) :: exitCode
+
+    logical :: withPropagationPath
+
+    withPropagationPath = .false.
+    exitCode = 0
+    if (allocated(exc)) then
+      select type (cause => exc%cause)
+      class is (TInputError)
+        write(stdOut0, "(/, a, /)") "*** Input error occured! ***"
+        exitCode = 2
+      class is (TModelError)
+        write(stdOut0, "(/, a, /)") "*** Model error occured! ***"
+        exitCode = 3
+      class is (TSystemError)
+        write(stdOut0, "(/, a, /)") "*** System error occured! ***"
+        exitCode = 4
+      class is (TInternalError)
+        write(stdOut0, "(/, a, /)") "*** Internal error occured (please file a bug report)! ***"
+        exitCode = 100
+        withPropagationPath = .true.
+      ! TGeneralError is superclass of all other errors, must be checked after specific ones
+      class is (TGeneralError)
+        write(stdOut0, "(/, a, /)") "*** Error occured ***"
+        exitCode = 1
+      class is (TEarlyExit)
+        exitCode = 0
+      class default
+        write(stdOut0, "(/, a, /)") "*** Unknown error occured (please file a bug report)!"
+        exitCode = 200
+        withPropagationPath = .true.
+      end select
+      call exc%writeTo(stdOut0, withPropagationPath=withPropagationPath)
+      call exc%deactivate()
+    end if
+
+  end subroutine handleException
 
 end program dftbplus

--- a/src/dftbp/common/CMakeLists.txt
+++ b/src/dftbp/common/CMakeLists.txt
@@ -9,6 +9,7 @@ set(sources-fpp
   ${curdir}/constants.F90
   ${curdir}/envcheck.F90
   ${curdir}/environment.F90
+  ${curdir}/exception.F90
   ${curdir}/file.F90
   ${curdir}/filesystem.F90
   ${curdir}/globalenv.F90

--- a/src/dftbp/common/environment.F90
+++ b/src/dftbp/common/environment.F90
@@ -186,12 +186,20 @@ contains
 
 
   !> Finalizes the environment.
-  subroutine TEnvironment_destruct(this)
+  subroutine TEnvironment_destruct(this, writeTimings)
 
     !> Instance
     class(TEnvironment), intent(inout) :: this
 
-    if (allocated(this%globalTimer)) then
+    !> Whether timings should be written (default: .true.)
+    logical, optional, intent(in) :: writeTimings
+
+    logical :: writeTimings_
+
+    writeTimings_ = .true.
+    if (present(writeTimings)) writeTimings_ = writeTimings
+
+    if (writeTimings_ .and. allocated(this%globalTimer)) then
       call this%globalTimer%writeTimings()
     end if
 

--- a/src/dftbp/common/exception.F90
+++ b/src/dftbp/common/exception.F90
@@ -1,0 +1,273 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2025  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+#:include 'common.fypp'
+
+!> Implements a status object to indicate possible errors.
+module dftbp_common_exception
+  use, intrinsic :: iso_fortran_env, only : stdErr => error_unit
+  implicit none
+
+  private
+  public :: TException, TException_create
+  public :: TExceptionCause
+  public :: TEarlyExit, TGeneralError, TInputError, TModelError, TSystemError, TInternalError
+
+
+  !> Represents an exception propagation path item
+  type :: TPathItem
+    character(:), allocatable :: file
+    integer :: line = 0
+    type(TPathItem), allocatable :: next
+  end type TPathItem
+
+
+  !> Represents the propagation path obtained during exception propagation
+  type :: TPropagationPath
+    type(TPathItem), allocatable :: lastItem
+  contains
+    procedure :: addItem => TPropagationPath_addItem
+    procedure :: writeTo => TPropagationPath_writeTo
+  end type TPropagationPath
+
+
+  !> Represents the details about why the exception was triggered
+  type, abstract :: TExceptionCause
+  contains
+    procedure(TExceptionCause_asChar), deferred :: asChar
+  end type TExceptionCause
+
+
+  abstract interface
+    !> Character representation of the exception details
+    function TExceptionCause_asChar(this) result(str)
+      import :: TExceptionCause
+      implicit none
+
+      !> Instance
+      class(TExceptionCause), intent(in) :: this
+
+      !> Character representation of the cause
+      character(:), allocatable :: str
+
+    end function TExceptionCause_asChar
+  end interface
+
+
+  !> Represents an exception
+  type :: TException
+    type(TPropagationPath) :: propagationPath
+    class(TExceptionCause), allocatable :: cause
+    logical :: active = .true.
+  contains
+    procedure, non_overridable :: addLocation => TException_addLocation
+    procedure, non_overridable :: writeTo => TException_writeTo
+    procedure, non_overridable :: deactivate => TException_deactivate
+    final :: TException_final
+  end type TException
+
+
+  !> General error, base class for more specific error classes.
+  !!
+  !! Avoid if possible and use more specific sub-classes instead.
+  !!
+  type, extends(TExceptionCause) :: TGeneralError
+    character(:), allocatable :: message
+  contains
+    procedure :: asChar => TGeneralError_asChar
+  end type TGeneralError
+
+
+  !> Error raised due to invalid input (either syntactically or semantically incorrect)
+  type, extends(TGeneralError) :: TInputError
+  end type TInputError
+
+
+  !> The model set up is not solvable (e.g. singular, non-convergent, etc.)
+  type, extends(TGeneralError) :: TModelError
+  end type TModelError
+
+
+  !> Unrecoverable system error (e.g. I/O or memory problems)
+  type, extends(TGeneralError) :: TSystemError
+  end type TSystemError
+
+
+  !> Internal error (which in optimal case should never occur)
+  type, extends(TGeneralError) :: TInternalError
+  end type TInternalError
+
+
+  !> Normal but early termination (can be used to propagate up early termination as an exception)
+  type, extends(TExceptionCause) :: TEarlyExit
+  contains
+    procedure :: asChar => TEarlyExit_asChar
+  end type TEarlyExit
+
+
+  !> Whether program should stop, if an exception was active when going out of scope
+  logical, parameter :: stopOnActiveException = ${FORTRAN_LOGICAL(DEBUG > 0)}$
+
+
+contains
+
+  !> Creates (allocates and initializes) an exception
+  subroutine TException_create(this, cause, file, line)
+
+    !> Instance
+    type(TException), allocatable, intent(out) :: this
+
+    !> Cause of the exception
+    class(TExceptionCause), intent(in) :: cause
+
+    !> File where the exception had been triggered
+    character(*), optional, intent(in) :: file
+
+    !> Line where the exception had been triggered
+    integer, optional, intent(in) :: line
+
+    allocate(this)
+    this%cause = cause
+    call this%propagationPath%addItem(file, line)
+
+  end subroutine TException_create
+
+
+  !> Finalizer of the exception, might stop the code, if the exception is still active
+  subroutine TException_final(this)
+
+    !> Instance
+    type(TException), intent(inout) :: this
+
+    if (stopOnActiveException .and. this%active) then
+      write(stdErr, "(a)") "*** Unhandled exception went out of scope ***"
+      call this%writeTo(stdErr, withPropagationPath=.true.)
+      error stop 255
+    end if
+
+  end subroutine TException_final
+
+
+  !> Deactivates an exception, so that no error stop occurs, if it goes out of scope
+  subroutine TException_deactivate(this)
+    class(TException), intent(inout) :: this
+
+    this%active = .false.
+
+  end subroutine TException_deactivate
+
+
+  !> Appends an additional location to the propagation path of the exception
+  subroutine TException_addLocation(this, file, line)
+
+    !> Instance
+    class(TException), intent(inout) :: this
+
+    !> File name
+    character(*), optional, intent(in) :: file
+
+    !> Line number
+    integer, optional, intent(in) :: line
+
+    call this%propagationPath%addItem(file=file, line=line)
+
+  end subroutine TException_addLocation
+
+
+  !> Writes the exception to a file unit
+  subroutine TException_writeTo(this, unit, withPropagationPath)
+
+    !> Instance
+    class(TException), intent(in) :: this
+
+    !> File unit
+    integer, intent(in) :: unit
+
+    !> Whether the exception propagation path should also be written
+    logical, optional :: withPropagationPath
+
+    if (present(withPropagationPath)) then
+      if (withPropagationPath) call this%propagationPath%writeTo(unit)
+    end if
+    write(unit, "(a)") this%cause%asChar()
+
+  end subroutine TException_writeTo
+
+
+  !> Adds a new path item to the propagation path
+  subroutine TPropagationPath_addItem(this, file, line)
+
+    !> Instance
+    class(TPropagationPath), intent(inout) :: this
+
+    !> File where the exception had been propagated
+    character(*), optional, intent(in) :: file
+
+    !> Line where the exception had been propagated
+    integer, optional, intent(in) :: line
+
+    type(TPathItem), allocatable :: item
+
+    item = TPathItem(file=file, line=line)
+    if (allocated(this%lastItem)) call move_alloc(this%lastItem, item%next)
+    call move_alloc(item, this%lastItem)
+
+  end subroutine TPropagationPath_addItem
+
+
+  !> Writes the propagation path to a file
+  subroutine TPropagationPath_writeTo(this, unit)
+
+    !> Instance
+    class(TPropagationPath), target, intent(in) :: this
+
+    !> File unit
+    integer, intent(in) :: unit
+
+    type(TPathItem), pointer :: pItem
+
+    if (.not. allocated(this%lastItem)) return
+    pItem => this%lastItem
+    do
+      write(unit, "(a, 1x, a)") "File:", pItem%file
+      write(unit, "(a, 1x, i0)") "Line:", pItem%line
+      if (.not. allocated(pItem%next)) exit
+      write(unit, "(a)") "|"
+      pItem => pItem%next
+    end do
+
+  end subroutine TPropagationPath_writeTo
+
+
+  !> Returns the character representation of the exception cause
+  function TGeneralError_asChar(this) result(str)
+
+    !> Instance
+    class(TGeneralError), intent(in) :: this
+
+    !> Character representation of the cause
+    character(:), allocatable :: str
+
+    str = this%message
+
+  end function TGeneralError_asChar
+
+
+  !> Returns the character representation of the exception cause
+  function TEarlyExit_asChar(this) result(msg)
+
+    !> Instance
+    class(TEarlyExit), intent(in) :: this
+
+    !> !> Character representation of the cause
+    character(:), allocatable :: msg
+
+    msg = "Terminating program."
+
+  end function TEarlyExit_asChar
+
+end module dftbp_common_exception

--- a/src/dftbp/dftbplus/hsdhelpers.F90
+++ b/src/dftbp/dftbplus/hsdhelpers.F90
@@ -10,6 +10,7 @@
 !> HSD-parsing related helper routines.
 module dftbp_dftbplus_hsdhelpers
   use dftbp_common_globalenv, only : stdOut, tIoProc
+  use dftbp_common_exception, only : TException
   use dftbp_dftbplus_inputdata, only : TInputData
   use dftbp_dftbplus_parser, only : parseHsdTree, readHsdFile, rootTag, TParserFlags
   use dftbp_extlibs_xmlf90, only : destroyNode, fnode
@@ -32,7 +33,10 @@ module dftbp_dftbplus_hsdhelpers
 contains
 
   !> Parses input file and returns initialised input structure
-  subroutine parseHsdInput(input)
+  subroutine parseHsdInput(exc, input)
+
+    !> Exception
+    type(TException), allocatable, intent(out) :: exc
 
     !> Input data parsed from the input file
     type(TInputData), intent(out) :: input

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -17,6 +17,7 @@ module dftbp_dftbplus_initprogram
       & Hartree__kJ_mol, pi, shellNames
   use dftbp_common_envcheck, only : checkStackSize
   use dftbp_common_environment, only : globalTimers, TEnvironment
+  use dftbp_common_exception, only : TException
   use dftbp_common_file, only : clearFile, setDefaultBinaryAccess, TFileDescr
   use dftbp_common_globalenv, only : stdOut, withMpi
   use dftbp_common_hamiltoniantypes, only : hamiltonianTypes
@@ -1181,16 +1182,20 @@ contains
 
 
   !> Initializes the variables in the module based on the parsed input
-  subroutine initProgramVariables(this, input, env)
+  subroutine initProgramVariables(this, exc, env, input)
 
     !> Instance
     class(TDftbPlusMain), intent(inout), target :: this
 
-    !> Holds the parsed input data.
-    type(TInputData), intent(inout), target :: input
+    !> Exception (allocated if an exception had been raised)
+    type(TException), allocatable, intent(out) :: exc
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
+
+    !> Holds the parsed input data.
+    type(TInputData), intent(inout), target :: input
+
 
     ! Geometry optimiser related local variables
 

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -13,6 +13,7 @@ module dftbp_dftbplus_main
   use dftbp_common_accuracy, only : dp, elecTolMax, tolSameDist
   use dftbp_common_constants, only : pi
   use dftbp_common_environment, only : globalTimers, TEnvironment
+  use dftbp_common_exception, only : TException, TEarlyExit, TGeneralError
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
   use dftbp_common_globalenv, only : stdOut, withMpi
   use dftbp_common_hamiltoniantypes, only : hamiltonianTypes
@@ -70,7 +71,7 @@ module dftbp_dftbplus_main
       & writeDetailedOut1, writeDetailedOut10, writeDetailedOut2, writeDetailedOut2dets,&
       & writeDetailedOut3, writeDetailedOut4, writeDetailedOut5, writeDetailedOut6,&
       & writeDetailedOut7, writeDetailedOut8, writeDetailedOut9, writeDetailedXml,&
-      & writeEigenVectors, writeEsp, writeFinalDriverstatus, writeHessianout, writehsandstop,&
+      & writeEigenVectors, writeEsp, writeFinalDriverstatus, writeHessianout, writeHS,&
       & writeMdOut1, writeMdOut2, writeProjectedEigenvectors, writeRealEigvecs,&
       & writeReksDetailedOut1, writeResultsTag
   use dftbp_dftbplus_outputfiles, only : autotestTag, bandOut, bornChargesOut, bornDerivativesOut,&
@@ -150,10 +151,13 @@ module dftbp_dftbplus_main
 contains
 
   !> The main DFTB program itself
-  subroutine runDftbPlus(this, env)
+  subroutine runDftbPlus(this, exc, env)
 
     !> Global variables
     type(TDftbPlusMain), intent(inout) :: this
+
+    !> Exception
+    type(TException), allocatable, intent(out) :: exc
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
@@ -233,10 +237,12 @@ contains
               & this%iEqBlockOnSite, this%iEqBlockOnSiteLS)
         end if
 
-        call processGeometry(this, env, iGeoStep, iLatGeoStep, tWriteRestart, tStopScc,&
+        call processGeometry(this, exc, env, iGeoStep, iLatGeoStep, tWriteRestart, tStopScc,&
             & tExitGeoOpt, errStatus)
+        @:PROPAGATE_EXCEPTION(exc)
+        ! If error is signalized via old mechanism, convert it to exception
         if (errStatus%hasError()) then
-          call error(errStatus%message)
+          @:RAISE_EXCEPTION(exc, TGeneralError(message=errStatus%message))
         end if
 
         call postDetCharges(iDet, this%nDets, this%qOutput, this%qDets, this%qBlockDets,&
@@ -1065,11 +1071,14 @@ contains
 
 
   !> Process current geometry
-  subroutine processGeometry(this, env, iGeoStep, iLatGeoStep, tWriteRestart, tStopScc,&
+  subroutine processGeometry(this, exc, env, iGeoStep, iLatGeoStep, tWriteRestart, tStopScc,&
       & tExitGeoOpt, errStatus)
 
     !> Global variables
     type(TDftbPlusMain), intent(inout) :: this
+
+    !> Exception
+    type(TException), allocatable, intent(out) :: exc
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
@@ -1425,10 +1434,13 @@ contains
               & .and. any(this%electronicSolver%iSolver ==&
               & [electronicSolverTypes%qr, electronicSolverTypes%divideandconquer,&
               & electronicSolverTypes%relativelyrobust, electronicSolverTypes%magmaGvd])) then
-            call writeHSAndStop(env, this%tWriteHS, this%tWriteRealHS, this%tRealHS,&
-                & this%ints%overlap, this%neighbourList, this%nNeighbourSK,&
+            call writeHS(exc, env, this%tWriteHS, this%tWriteRealHS, this%tRealHS,&
+                & this%ints%overlap, this%neighbourList%iNeighbour, this%nNeighbourSK,&
                 & this%denseDesc%iAtomStart, this%iSparseStart, this%img2CentCell, this%kPoint,&
                 & this%iCellVec, this%cellVec, this%ints%hamiltonian, this%ints%iHamiltonian)
+            @:PROPAGATE_EXCEPTION(exc)
+            ! Even if writing was successfully, program should be terminated.
+            @:RAISE_EXCEPTION(exc, TEarlyExit())
           end if
 
           call convertToUpDownRepr(this%ints%hamiltonian, this%ints%iHamiltonian)
@@ -2075,6 +2087,7 @@ contains
       end if
     end function format_string
   end function stepSummary
+
 
   !> Initialises some parameters before geometry loop starts.
   subroutine initGeoOptParameters(tCoordOpt, nGeoSteps, tGeomEnd, tCoordStep, tStopDriver,&

--- a/src/dftbp/dftbplus/mainapi.F90
+++ b/src/dftbp/dftbplus/mainapi.F90
@@ -12,6 +12,7 @@ module dftbp_dftbplus_mainapi
   use dftbp_common_accuracy, only : dp, mc
   use dftbp_common_coherence, only : checkExactCoherence, checkToleranceCoherence
   use dftbp_common_environment, only : TEnvironment
+  use dftbp_common_exception, only : TException
   use dftbp_common_status, only : TStatus
   use dftbp_dftb_periodic, only : setNeighbourListOrig => setNeighbourList
   use dftbp_dftbplus_initprogram, only : initElectronNumber, initReferenceCharges, TDftbPlusMain,&
@@ -980,12 +981,12 @@ contains
 
     !> Status of operation
     type(TStatus) :: errStatus
+    type(TException), allocatable :: exc
 
     if (main%tLatticeChanged .or. main%tCoordsChanged) then
-      call processGeometry(main, env, 1, 1, .false., tStopScc, tExitGeoOpt, errStatus)
-      if (errStatus%hasError()) then
-        call error(errStatus%message)
-      end if
+      call processGeometry(main, exc, env, 1, 1, .false., tStopScc, tExitGeoOpt, errStatus)
+      if (allocated(exc)) call error(exc%cause%asChar())
+      if (errStatus%hasError()) call error(errStatus%message)
       main%tLatticeChanged = .false.
       main%tCoordsChanged = .false.
     end if

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -4062,7 +4062,11 @@ contains
     if (ctrl%iSeed < 0) then
       call detailedError(child, "Random seed must be greater or equal zero")
     end if
-    call getChildValue(node, "WriteHS", ctrl%tWriteHS, .false.)
+    call getChildValue(node, "WriteHS", ctrl%tWriteHS, default=.false., child=child)
+    if (ctrl%tWriteHS .and. withMpi) then
+      call detailedError(child, "Writing of dense H and S matrices currently only implemented for&
+          & non-MPI builds")
+    end if
     call getChildValue(node, "WriteRealHS", ctrl%tWriteRealHS, .false.)
     call renameChildren(node, "MinimizeMemoryUsage", "MinimiseMemoryUsage")
     call getChildValue(node, "MinimiseMemoryUsage", ctrl%tMinMemory, .false., child=child)

--- a/src/dftbp/include/error.fypp
+++ b/src/dftbp/include/error.fypp
@@ -105,5 +105,24 @@
 #:enddef PROPAGATE_ERROR
 
 
+#! Raises an exception
+#:def RAISE_EXCEPTION(exc, cause)
+  block
+    use dftbp_common_exception, only : TException_create
+    call TException_create(${exc}$, ${cause}$, file="${_FILE_}$", line=${_LINE_}$)
+    return
+  end block
+#:enddef RAISE_EXCEPTION
+
+
+#! Propagates an exception upwards by adding path information and returning
+#:def PROPAGATE_EXCEPTION(exc)
+  if (allocated(${exc}$)) then
+    call ${exc}$%addLocation(file="${_FILE_}$", line=${_LINE_}$)
+    return
+  end if
+#:enddef PROPAGATE_EXCEPTION
+
+
 #:endif
 #:endmute

--- a/src/dftbp/io/formatout.F90
+++ b/src/dftbp/io/formatout.F90
@@ -5,13 +5,15 @@
 !  See the LICENSE file for terms of usage and distribution.                                       !
 !--------------------------------------------------------------------------------------------------!
 
-#:include 'common.fypp'
+#:include "common.fypp"
+#:include "error.fypp"
 
 !> Contains subroutines for formatted output of data
 module dftbp_io_formatout
   use dftbp_common_accuracy, only : dp, mc
   use dftbp_common_constants, only : au__fs, Bohr__AA, pi
   use dftbp_common_environment, only : TEnvironment
+  use dftbp_common_exception, only : TException, TInternalError
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
   use dftbp_common_globalenv, only : stdOut, tIoProc, withMpi
   use dftbp_dftb_sparse2dense, only : unpackHS
@@ -428,8 +430,11 @@ contains
 
 
   !> Converts a sparse matrix to its square form and write it to a file.
-  subroutine writeSparseAsSquare_real(env, fname, sparse, iNeighbour, nNeighbourSK, iAtomStart,&
-      & iPair, img2CentCell)
+  subroutine writeSparseAsSquare_real(exc, env, fname, sparse, iNeighbour, nNeighbourSK,&
+      & iAtomStart, iPair, img2CentCell)
+
+    !> Exception
+    type(TException), allocatable, intent(out) :: exc
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -462,7 +467,7 @@ contains
     type(TFileDescr) :: fd
 
     if (withMpi) then
-      call error("Writing of HS not working with MPI yet")
+      @:RAISE_EXCEPTION(exc, TInternalError("Writing of HS not working with MPI yet"))
     end if
 
     nOrb = iAtomStart(size(nNeighbourSK) + 1) - 1
@@ -485,8 +490,11 @@ contains
 
 
   !> Converts a sparse matrix to its square form and write it to a file.
-  subroutine writeSparseAsSquare_cplx(env, fname, sparse, kPoints, iNeighbour, nNeighbourSK,&
+  subroutine writeSparseAsSquare_cplx(exc, env, fname, sparse, kPoints, iNeighbour, nNeighbourSK,&
       & iAtomStart, iPair, img2CentCell, iCellVec, cellVec)
+
+    !> Exception
+    type(TException), allocatable, intent(out) :: exc
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -528,7 +536,7 @@ contains
     integer :: iK
 
     if (withMpi) then
-      call error("Writing of HS not working with MPI yet")
+      @:RAISE_EXCEPTION(exc, TInternalError("Writing of HS not working with MPI yet"))
     end if
 
     nOrb = iAtomStart(size(nNeighbourSK) + 1) - 1


### PR DESCRIPTION
Lays the foundations for exception like error handling with manual propagation.

* Defines exception type containing exception event and propagation stack
* Exception event is polymorphic, so that different events can be distinguished if needed (and additional data might be passed).
* Early program termination (e.g. after H/S writing) can be propagated up using appropriate exception.

This PR implements up-propagation for the internal errors during H/S writing and the early exit after successful H/S writing as a proof of concept. This is needed in order to extend #1339 and remove the global variable `mpiGlobalComm` from the `globalenv` module.

* [ ] Exit codes might need some discussions, although only slightly relevant for the usual usage scenario of the code.
