### PR TITLE
Introduce enumerated type and fix minor bug

### DIFF
--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -52,6 +52,7 @@ module dftbp_dftbplus_parser
   use dftbp_extlibs_elsiiface, only : withELSI, withPEXSI
   use dftbp_extlibs_plumed, only : withPlumed
   use dftbp_extlibs_poisson, only : TPoissonInfo, withPoisson
+  use dftbp_poisson_parameters, only : bcPoissonList, bcPoissonNames
   use dftbp_extlibs_sdftd3, only : dampingFunction, TSDFTD3Input
   use dftbp_extlibs_tblite, only : tbliteMethod
   use dftbp_extlibs_xmlf90, only : assignment(=), char, destroyNode, destroyNodeList, fnode,&
@@ -6542,16 +6543,19 @@ contains
     call getChildValue(pNode, "RecomputeAfterDensity", updateSccAfterDiag, .false.)
     call getChildValue(pNode, "MaxPoissonIterations", poisson%maxPoissIter, 60)
 
-    poisson%overrideBC(:) = 0
+    poisson%overrideBC(:) = bcPoissonList%periodic
     call getChild(pNode, "OverrideDefaultBC", pTmp, requested=.false.)
     if (associated(pTmp)) then
-      call getPoissonBoundaryConditionOverrides(pTmp, [ 1, 2 ], poisson%overrideBC)
+      call getPoissonBoundaryConditionOverrides(pTmp,&
+          & [ bcPoissonList%Dirichlet, bcPoissonList%Neumann ], poisson%overrideBC)
     end if
 
     call getChildValue(pNode, "OverrideBulkBC", pTmp, "none")
-    poisson%overrBulkBC(:) = -1
+    poisson%overrBulkBC(:) = bcPoissonList%unset
     if (associated(pTmp)) then
-      call getPoissonBoundaryConditionOverrides(pTmp, [ 0, 1, 2 ], poisson%overrBulkBC)
+      call getPoissonBoundaryConditionOverrides(pTmp,&
+          & [ bcPoissonList%Periodic, bcPoissonList%Dirichlet, bcPoissonList%Neumann ],&
+          & poisson%overrBulkBC)
     end if
 
     call getChildValue(pNode, "BoundaryRegion", pTmp, "global")
@@ -6655,26 +6659,22 @@ contains
     !> Array of boundary condition types on the 6 faces of the box, 0 for use of default
     integer, intent(inout) :: overrideBC(:)
 
-    integer, parameter :: PERIODIC_BC = 0
-    integer, parameter :: DIRICHLET_BC = 1
-    integer, parameter :: NEUMANN_BC = 2
-    character(10), parameter :: bcstr(0:2) = &
-        & [ character(10) :: "Periodic", "Dirichlet", "Neumann" ]
     integer :: bctype, iBC
     integer :: faceBC, oppositeBC
     integer :: ii
     type(TListString) :: lStr
     type(fnode), pointer :: pNode2, pChild
     character(lc) :: strTmp
+    character(1), parameter :: sDirs(3) = ['x','y','z']
 
     do iBC = 1, size(availableConditions)
       bctype = availableConditions(iBC)
-      call getChild(pNode, trim(bcstr(bctype)), pNode2, requested=.false.)
+      call getChild(pNode, trim(bcPoissonNames(bctype)), pNode2, requested=.false.)
       if (associated(pNode2)) then
         call init(lStr)
         call getChildValue(pNode2, "boundaries", lStr, child=pChild)
         if (len(lStr).gt.6) then
-          call detailedError(pChild,"boundaries must be 6 or less")
+          call detailedError(pChild,"A maximum of boundaries (or fewer) can be set")
         end if
         do ii = 1, len(lStr)
           call get(lStr, strTmp, ii)
@@ -6706,14 +6706,12 @@ contains
       end if
     end do
 
-    ! If face is set to periodic, opposite one should be the same
+    ! If a face is set to be periodic, the opposite one should be of the same type
     do ii = 1, 3
       faceBC = overrideBC(2 * ii)
       oppositeBC = overrideBC(2 * ii - 1)
-      if (faceBC == PERIODIC_BC &
-          & .and. oppositeBC /= faceBC) then
-        call detailedError(pChild, &
-            & "periodic override must be set both min max")
+      if (faceBC == bcPoissonList%Periodic .neqv. oppositeBC == bcPoissonList%Periodic) then
+        call detailedError(pChild, "Periodic override must be set both min max along "//sDirs(ii))
       end if
     end do
 

--- a/src/dftbp/extlibs/poisson.F90
+++ b/src/dftbp/extlibs/poisson.F90
@@ -19,6 +19,7 @@ module dftbp_extlibs_poisson
   use dftbp_common_environment, only : globalTimers, TEnvironment
   use dftbp_common_globalenv, only : stdOut
   use dftbp_io_message, only : error
+  use dftbp_poisson_parameters, only : bcPoissonList
   use dftbp_type_commontypes, only : TOrbitals
 #:if WITH_MPI
   use dftbp_extlibs_mpifx, only : mpifx_barrier, mpifx_bcast
@@ -628,8 +629,8 @@ contains
       dR_cont = poissoninfo%bufferLocBC
       bufferBox = poissoninfo%bufferBox
       SavePot = poissoninfo%savePotential
-      overrideBC = poissoninfo%overrideBC
-      overrBulkBC = poissoninfo%overrBulkBC
+      overrideBC(:) = poissoninfo%overrideBC
+      overrBulkBC(:) = poissoninfo%overrBulkBC
       !-----------------------------------------------------------------------------+
       ! Gate settings
       DoGate=.false.
@@ -666,9 +667,7 @@ contains
       if  (iErr /= 0) then
         call error("Unable to build box for Poisson solver")
       end if
-      if (any(overrideBC.ne.0)) then
-        period = .false.
-      end if
+      period = all(overrideBC == bcPoissonList%periodic)
       call check_parameters()
       call check_localbc()
       call write_parameters()

--- a/src/dftbp/poisson/parameters.F90
+++ b/src/dftbp/poisson/parameters.F90
@@ -109,6 +109,29 @@ module dftbp_poisson_parameters
 
   character(:), allocatable, public :: scratchfolder
 
+  !> Enumerator containing possible Poisson boundary conditions
+  type, private :: TBCPoissonEnum_
+
+    !> Unset
+    integer :: Unset = -1
+
+    !> Periodic on face
+    integer :: Periodic = 0
+
+    !> Potential specified at the cell edge
+    integer :: Dirichlet = 1
+
+    !> Derivative specified at the cell edge
+    integer :: Neumann = 2
+
+  end type TBCPoissonEnum_
+
+  !> Actual instance of the boundary condition enumerator
+  type(TBCPoissonEnum_), parameter, public :: bcPoissonList = TBCPoissonEnum_()
+
+  ! Note, order corresponds to TBCPoissonEnum_
+  character(10), parameter, public :: bcPoissonNames(-1:2) =&
+      & [ character(10) :: "Unset", "Periodic", "Dirichlet", "Neumann" ]
 
   contains
 
@@ -131,8 +154,8 @@ module dftbp_poisson_parameters
     maxiter=30
     localBC=0
     poissBC=0
-    overrideBC=0
-    overrBulkBC=-1
+    overrideBC(:) = 0
+    overrBulkBC(:) = -1
     mixed = .false.
     maxpoissiter=60
 


### PR DESCRIPTION
Use enumerated type for boundary conditions on Poisson box. Fix test for opposite faces being equivalently periodic.