### PR TITLE
Fix input parsing bug in Override*BC tags

### DIFF
--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -6800,6 +6800,8 @@ contains
     character(lc) :: strTmp
     character(1), parameter :: sDirs(3) = ['x','y','z']
 
+    call getChild(pNode, "none", pNode2, requested=.false.)
+    if (associated(pNode2)) return
     do iBC = 1, size(availableConditions)
       bctype = availableConditions(iBC)
       call getChild(pNode, trim(bcPoissonNames(bctype)), pNode2, requested=.false.)


### PR DESCRIPTION
`OverrideBulkBC = None {}` was recjected after 8e68bcb0 leading to test failure.