### PR TITLE
MPI implementation for the excited states forces and non-adiabatic coupling vectors.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -89,3 +89,5 @@ contributed to DFTB+ :
 * Bo Thomsen (Japan Atomic Energy Agency, Japan)
 
 * Victor Yu (Duke University, USA)
+
+* Gonzalo Díaz Mirón (International Centre for Theoretical Physics, Italy)

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -5494,11 +5494,6 @@ contains
     end if
 
     if (this%isLinResp) then
-      if (withMpi) then
-        if (this%tLinRespZVect) then
-          call error("Excited state gradients do not work with MPI yet")
-        end if
-      end if
       if (this%tLinRespZVect) then
         allocate(this%rhoSqrReal(sqrHamSize, sqrHamSize, this%nSpin))
       end if
@@ -6178,12 +6173,6 @@ contains
     character(lc) :: tmpStr
 
     @:ASSERT(allocated(input%ctrl%lrespini))
-
-    if (withMpi) then
-      if (.not. all(input%ctrl%lrespini%indNACouplings == 0)) then
-        call error("Non-adiabatic coupling vectors not available under MPI")
-      end if
-    end if
 
     if (.not. tSccCalc) then
       call error("Linear response excitation requires SCC=Yes")

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -6125,14 +6125,6 @@ contains
       call error("Non-collinear spin only available for hybrids with molecular systems at present.")
     end if
 
-    if (this%isHybLinResp .and. hybridXcInp%hybridXcType == hybridXcFunc%cam) then
-      call error("General CAM functionals not currently implemented for linear response.")
-    end if
-
-    if (this%isHybLinResp .and. hybridXcInp%hybridXcType == hybridXcFunc%hyb) then
-      call error("Global hybrid functionals not currently implemented for linear response.")
-    end if
-
   end subroutine ensureHybridXcReqs
 
 

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -137,6 +137,7 @@ module dftbp_dftbplus_main
   use dftbp_extlibs_mpifx, only : MPI_MAX, MPI_SUM, mpifx_allreduceip, mpifx_bcast
   use dftbp_extlibs_scalapackfx, only : blacsfx_gemr2d, pblasfx_phemm, pblasfx_psymm,&
       & pblasfx_ptran, pblasfx_ptranc, scalafx_pposv
+  use dftbp_math_scalafxext, only : phermatinv, psymmatinv, distrib2replicated
 #:endif
 #:if WITH_SOCKETS
   use dftbp_dftbplus_mainio, only : receiveGeometryFromSocket
@@ -1753,7 +1754,7 @@ contains
               & this%naCouplings, this%energiesCasida)
         else if (this%tCasidaForces) then
           if(this%linearResponse%tNaCoupling) then
-            call writeExcitedStateForces(excFrcOut, this%derivs, this%excitedDerivs, &
+            call writeExcitedStateForces(env, excFrcOut, this%derivs, this%excitedDerivs, &
                 & this%linearResponse%indNACouplings)
           else
             this%derivs(:,:) = this%derivs + this%excitedDerivs(:,:,1)        
@@ -4095,9 +4096,22 @@ contains
       ! delta-density, therefore we store it separately for now)
       if (allocated(rhoSqrReal)) then
         if (.not. allocated(densityMatrix%deltaRhoOut)) then
-          rhoSqrReal(:,:, iSpin) = work
+        #:if WITH_SCALAPACK
+          call distrib2replicated(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr,&
+               &  work(:,:), rhoSqrReal(:,:,iSpin))
+        #:else
+          rhoSqrReal(:,:, iSpin) = work(:,:)
+        #:endif
+
         else
+
+        #:if WITH_SCALAPACK
+          call distrib2replicated(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr,&
+              & densityMatrix%deltaRhoOut(:,:,iSpin), rhoSqrReal(:,:,iSpin))
+        #:else
           rhoSqrReal(:,:, iSpin) = densityMatrix%deltaRhoOut(:,:,iSpin)
+        #:endif
+
         end if
       end if
 
@@ -5705,7 +5719,7 @@ contains
       & ints, eigvecsReal, eigen, filling, coord, species, speciesName, orb, skHamCont,&
       & skOverCont, autotestTag, taggedWriter, runId, neighbourList, nNeighbourSk, denseDesc,&
       & iSparseStart, img2CentCell, tWriteAutotest, tForces, tLinRespZVect, tPrintExcEigvecs,&
-      & tPrintExcEigvecsTxt, nonSccDeriv, dftbEnergy, energies, work, rhoSqrReal, deltaRhoOut,&
+      & tPrintExcEigvecsTxt, nonSccDeriv, dftbEnergy, energies, work, rhoSqrReal, dRhoOut,&
       & excitedDerivs, naCouplings, occNatural, hybridXc)
 
     !> Environment settings
@@ -5811,7 +5825,7 @@ contains
     real(dp), intent(inout), allocatable :: rhoSqrReal(:,:,:)
 
     !> Difference density matrix (vs. uncharged atoms) in dense form
-    real(dp), intent(inout), allocatable :: deltaRhoOut(:,:,:)
+    real(dp), intent(in), allocatable :: dRhoOut(:,:,:)
 
     !> Excited state energy derivatives per state with respect to atomic coordinates
     real(dp), intent(inout), allocatable :: excitedDerivs(:,:,:)
@@ -5825,8 +5839,7 @@ contains
     !> Data for hybrid xc-functional calculation
     class(THybridXcFunc), allocatable, intent(inout) :: hybridXc
 
-    real(dp), allocatable :: dQAtom(:,:)
-    real(dp), allocatable :: naturalOrbs(:,:,:)
+    real(dp), allocatable :: deltaRhoOut(:,:,:), dQAtom(:,:), naturalOrbs(:,:,:)
     integer, pointer :: pSpecies0(:)
     integer :: iSpin, nSpin, nAtom
     logical :: tSpin
@@ -5840,6 +5853,11 @@ contains
     dftbEnergy%Eexcited = 0.0_dp
     allocate(dQAtom(nAtom, nSpin))
     dQAtom(:,:) = sum(qOutput(:,:,:) - q0(:,:,:), dim=1)
+
+    ! Avoid overwriting deltaRhoOut
+    if (allocated(dRhoOut)) then
+        deltaRhoOut = dRhoOut
+    endif
 
   #:if WITH_SCALAPACK
 
@@ -5856,11 +5874,6 @@ contains
     if (allocated(rhoSqrReal)) then
       do iSpin = 1, nSpin
         call adjointLowerTriangle(rhoSqrReal(:,:,iSpin))
-      end do
-    end if
-    if (tForces .and. allocated(hybridXc)) then
-      do iSpin = 1, nSpin
-        call adjointLowerTriangle(deltaRhoOut(:,:, iSpin))
       end do
     end if
     if (tWriteAutotest) then

--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -6234,8 +6234,12 @@ contains
 
   end subroutine writeMdftbEnergies
 
+
   !> Write excited state forces
-  subroutine writeExcitedStateForces(fileName, derivs, excitedDerivs, indNACouplings)
+  subroutine writeExcitedStateForces(env, fileName, derivs, excitedDerivs, indNACouplings)
+
+    !> Environment settings
+    type(TEnvironment), intent(in) :: env
 
     !> File name
     character(*), intent(in) :: fileName
@@ -6251,6 +6255,10 @@ contains
 
     type(TFileDescr) :: fd
     integer :: ii, iAt, offSet
+
+  #:if WITH_MPI
+    if (.not. env%mpi%tGlobalLead) return
+  #:endif
 
     offSet = indNACouplings(1)
     call openFile(fd, fileName, mode="w")
@@ -6276,6 +6284,7 @@ contains
     enddo
 
     call closeFile(fd)
+
   end subroutine writeExcitedStateForces
   
 end module dftbp_dftbplus_mainio

--- a/src/dftbp/timedep/linrespgrad.F90
+++ b/src/dftbp/timedep/linrespgrad.F90
@@ -11,6 +11,7 @@
 !!
 !! Note: This module is NOT instance safe it uses a common block to communicate with ARPACK
 module dftbp_timedep_linrespgrad
+  use, intrinsic :: iso_fortran_env, only : int64
   use dftbp_common_accuracy, only : dp, elecTolMax, lc, rsp
   use dftbp_common_constants, only : au__Debye, cExchange, Hartree__eV
   use dftbp_common_environment, only : globalTimers, TEnvironment
@@ -30,7 +31,8 @@ module dftbp_timedep_linrespgrad
   use dftbp_math_blasroutines, only : gemm, hemv, symm
   use dftbp_math_degeneracy, only : TDegeneracyFind, TDegeneracyFind_init
   use dftbp_math_eigensolver, only : heev
-  use dftbp_math_matrixops, only : calcMatrixSqrt, makeSimilarityTrans, orthonormalizeVectors
+  use dftbp_math_matrixops, only : adjointLowerTriangle, calcMatrixSqrt, makeSimilarityTrans,&
+      & orthonormalizeVectors
   use dftbp_math_sorting, only : index_heap_sort, merge_sort
   use dftbp_timedep_linrespcommon, only : actionAminusB, actionAplusB, calcTransitionDipoles,&
       & dipselect, excitedDipoleOut, excitedQOut, getExcSpin, getSPExcitations, getSqrOcc,&
@@ -45,7 +47,7 @@ module dftbp_timedep_linrespgrad
 #:if WITH_SCALAPACK
   use dftbp_extlibs_mpifx, only : mpifx_bcast
   use dftbp_extlibs_scalapackfx, only : pblasfx_psymm
-
+  use dftbp_math_scalafxext, only : distrib2replicated
 #:endif
 
   implicit none
@@ -186,6 +188,9 @@ contains
     real(dp), allocatable :: t(:,:,:), rhs(:), woo(:,:), wvv(:,:), wov(:)
     real(dp), allocatable :: eval(:), transitionDipoles(:,:)
     integer, allocatable :: win(:), getIA(:,:), getIJ(:,:), getAB(:,:)
+
+    !> MPI Global array
+    real(dp), allocatable :: VecGlb(:,:)
 
     !> Array from pairs of single particles states to compound index - should replace with a more
     !> compact data structure in the cases where there are oscilator windows
@@ -670,6 +675,8 @@ contains
 
     ! Calculate Furche vectors and transition density matrix for various properties
     if (tZVector) then
+      write(stdOut,'(A)')
+      write(stdOut,'(A)') '>> Excited State gradient calculation'
 
       call env%globalTimer%startTimer(globalTimers%lrZVector)
 
@@ -737,25 +744,38 @@ contains
           omega = sqrt(eval(iLev))
 
           ! solve for Z and W to get excited state density matrix
-          call getZVectorEqRHS(env, this, rpa, transChrg, sym, denseDesc, species0, grndEigVal,&
-            & ovrXev, grndEigVecs, gammaMat, lrGamma, omega, xpy(:,iLev), xmy(:,iLev), rhs, t, wov,&
-            & woo, wvv)
+          call getZVectorEqRHS(env, orb, this, rpa, transChrg, sym, denseDesc, species0,&
+              & grndEigVal, ovrXev, grndEigVecs, gammaMat, lrGamma, omega, xpy(:,iLev),&
+              & xmy(:,iLev), rhs, t, wov, woo, wvv)
 
           call solveZVectorPrecond(env, orb, this, rpa, transChrg, denseDesc, species0, ovrXev,&
-            & grndEigVecs, gammaMat, lrGamma, rhs)
+              & grndEigVecs, gammaMat, lrGamma, rhs)
 
-          call calcWVectorZ(env, this, rpa, transChrg, denseDesc, species0, ovrXev, grndEigVecs,&
-            & grndEigVal, gammaMat, lrGamma, rhs, wov, woo, wvv)
+          call calcWVectorZ(env, orb, this, rpa, transChrg, denseDesc, species0, ovrXev,&
+              & grndEigVecs, grndEigVal, gammaMat, lrGamma, rhs, wov, woo, wvv)
 
-          call calcPMatrix(rpa, t, rhs, pc)
+          call calcPMatrix(env, rpa, t, rhs, pc)
 
           call writeCoeffs(pc, grndEigVecs, filling, this%writeCoeffs, this%tGrndState, occNatural,&
-            & naturalOrbs)
+              & naturalOrbs)
 
           do iSpin = 1, nSpin
             ! Make MO to AO transformation of the excited density matrix
+          #:if WITH_SCALAPACK
+            allocate(VecGlb(norb,norb))
+            call distrib2replicated(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr,&
+                & grndEigVecs(:,:,iSpin), VecGlb(:,:))
+
+            call makeSimilarityTrans(pc(:,:,iSpin), VecGlb(:,:))
+
+            call distrib2replicated(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, SSqr, VecGlb)
+
+            call getExcMulliken(denseDesc, pc(:,:,iSpin), VecGlb, dqex(:,iSpin))
+            deallocate(VecGlb)
+          #:else
             call makeSimilarityTrans(pc(:,:,iSpin), grndEigVecs(:,:,iSpin))
             call getExcMulliken(denseDesc, pc(:,:,iSpin), SSqr, dqex(:,iSpin))
+          #:endif
           end do
 
           if (this%tWriteDensityMatrix) then
@@ -779,6 +799,8 @@ contains
       end if
 
       if (this%tNaCoupling) then
+        write(stdOut,'(A)') ' '
+        write(stdOut,'(A)') '>> Non Adiabatic Coupling Vectors calculation'
 
         call env%globalTimer%startTimer(globalTimers%lrNAC)
 
@@ -805,14 +827,27 @@ contains
               xpym(:) = xpy(:,mCoupLev)
               xmym(:) = xmy(:,mCoupLev)
               omegaDif = sqrt(eval(mCoupLev))
-              call grndToExcDensityMatrices(env, this, rpa, transChrg, denseDesc, sym, species0,&
-                  & ovrXev, grndEigVecs, grndEigVal, gammaMat, lrGamma, omegaDif, pc, xpym, xmym,&
-                  & wov, woo)
+              call grndToExcDensityMatrices(env, orb, this, rpa, transChrg, denseDesc, sym,&
+                  & species0, ovrXev, grndEigVecs, grndEigVal, gammaMat, lrGamma, omegaDif, pc,&
+                  & xpym, xmym, wov, woo)
 
               do iSpin = 1, nSpin
                 ! Make MO to AO transformation of the excited density matrix
+              #:if WITH_SCALAPACK
+                allocate(VecGlb(norb,norb))
+                call distrib2replicated(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr,&
+                    & grndEigVecs(:,:,iSpin), VecGlb(:,:))
+
+                call makeSimilarityTrans(pc(:,:,iSpin), VecGlb(:,:))
+
+                call distrib2replicated(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, SSqr, VecGlb)
+
+                call getExcMulliken(denseDesc, pc(:,:,iSpin), VecGlb, dqex(:,iSpin))
+                deallocate(VecGlb)
+              #:else
                 call makeSimilarityTrans(pc(:,:,iSpin), grndEigVecs(:,:,iSpin))
                 call getExcMulliken(denseDesc, pc(:,:,iSpin), SSqr, dqex(:,iSpin))
+              #:endif
               end do
 
               ! For 0-n couplings, the standard force routine can be used, where
@@ -839,22 +874,35 @@ contains
 
               ! compute + component of RHS for Z-vector eq. in the NaCoupling case
               ! also computes the + components of W and T
-              call getNadiaZvectorEqRHS(env, this, rpa, transChrg, sym, denseDesc, species0,&
+              call getNadiaZvectorEqRHS(env, orb, this, rpa, transChrg, sym, denseDesc, species0,&
                   & grndEigVal, ovrXev, grndEigVecs, gammaMat, lrGamma, omegaAvg, xpy(:,nCoupLev),&
                   & xmy(:,nCoupLev), xpy(:,mCoupLev), xmy(:,mCoupLev), rhs, t, wov, woo, wvv)
 
               call solveZVectorPrecond(env, orb, this, rpa, transChrg, denseDesc, species0, ovrXev,&
                   & grndEigVecs, gammaMat, lrGamma, rhs)
 
-              call calcWVectorZ(env, this, rpa, transChrg, denseDesc, species0, ovrXev,&
+              call calcWVectorZ(env, orb, this, rpa, transChrg, denseDesc, species0, ovrXev,&
                   & grndEigVecs, grndEigVal, gammaMat, lrGamma, rhs, wov, woo, wvv)
 
-              call calcPMatrix(rpa, t, rhs, pc)
+              call calcPMatrix(env, rpa, t, rhs, pc)
 
               do iSpin = 1, nSpin
                 ! Make MO to AO transformation of the excited density matrix
+              #:if WITH_SCALAPACK
+                allocate(VecGlb(norb,norb))
+                call distrib2replicated(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr,&
+                    & grndEigVecs(:,:,iSpin), VecGlb(:,:))
+
+                call makeSimilarityTrans(pc(:,:,iSpin), VecGlb(:,:))
+
+                call distrib2replicated(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, SSqr, VecGlb)
+
+                call getExcMulliken(denseDesc, pc(:,:,iSpin), VecGlb, dqex(:,iSpin))
+                deallocate(VecGlb)
+              #:else
                 call makeSimilarityTrans(pc(:,:,iSpin), grndEigVecs(:,:,iSpin))
                 call getExcMulliken(denseDesc, pc(:,:,iSpin), SSqr, dqex(:,iSpin))
+              #:endif
               end do
 
               call addNadiaGradients(env, orb, this, rpa, transChrg, hybridXc, denseDesc, sym,&
@@ -885,8 +933,6 @@ contains
       call env%globalTimer%stopTimer(globalTimers%lrZVector)
 
     end if
-
-    call env%globalTimer%stopTimer(globalTimers%lrZVector)
 
     ! Omega has possibly been overwritten for CI optimization or NA couplings, but should always
     ! refer to nstat
@@ -1528,11 +1574,14 @@ contains
 
   !> Build right hand side of the equation for the Z-vector and those parts of the W-vectors which
   !! do not depend on Z.
-  subroutine getZVectorEqRHS(env, lr, rpa, transChrg, sym, denseDesc, species0, grndEigVal,&
+  subroutine getZVectorEqRHS(env, orb, lr, rpa, transChrg, sym, denseDesc, species0, grndEigVal,&
       & ovrXev, grndEigVecs, gammaMat, lrGamma, omega, xpy, xmy, rhs, t, wov, woo, wvv)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
+
+    !> Data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
 
     !> Data structure for linear response
     type(TLinResp), intent(in) :: lr
@@ -1592,6 +1641,7 @@ contains
     real(dp), intent(out) :: wvv(:,:)
 
     integer :: i, j, a, b, ias, ibs, abs, ij, ab, jas, ijs, s, nSpin, soo(2), svv(2), nOrb, nxov
+    integer :: iGlobal, fGlobal
     real(dp), allocatable :: xpyq(:), qTr(:), gamxpyq(:), qgamxpyq(:,:), gamqt(:)
     real(dp), allocatable :: xpyqds(:), gamxpyqds(:)
     real(dp), allocatable :: vecHvvXpY(:), vecHvvXmY(:), vecHooXpY(:), vecHooXmY(:)
@@ -1600,7 +1650,9 @@ contains
     logical :: tSpin
 
     nxov = size(rhs)
-    nOrb = size(ovrXev, dim=1)
+    nOrb = orb%nOrb
+
+    call distributeRangeInChunks(env, 1, nxov, iGlobal, fGlobal)
 
     allocate(xpyq(lr%nAtom))
     allocate(qTr(lr%nAtom))
@@ -1620,6 +1672,7 @@ contains
     svv(:) = [0, rpa%nxvv_ud(1)]
 
     allocate(qgamxpyq(max(maxval(rpa%nxoo_ud), maxval(rpa%nxvv_ud)), size(rpa%nocc_ud)))
+    qgamxpyq(:,:) = 0.0_dp
 
     if (nSpin == 2) then
       tSpin = .true.
@@ -1632,7 +1685,7 @@ contains
     ! Build t_ab = 0.5 * sum_i (X+Y)_ia (X+Y)_ib + (X-Y)_ia (X-Y)_ib
     ! and w_ab = Q_ab with Q_ab as in (B16) but with corrected sign.
     ! factor 1 / (1 + delta_ab) follows later
-    do ias = 1, nxov
+    do ias = iGlobal, fGlobal
       call indxov(rpa%win, ias, rpa%getIA, i, a, s)
 
       ! BA: is T_aa = 0?
@@ -1672,24 +1725,31 @@ contains
 
     end do
 
+    call assembleChunks(env, t)
+    call assembleChunks(env, wvv)
+
     ! xpyq = Q * xpy
     xpyq(:) = 0.0_dp
     call transChrg%qMatVec(env, denseDesc, ovrXev, grndEigVecs, rpa%getIA, rpa%win, xpy, xpyq)
 
     if (.not. tSpin) then  ! ---- spin-unpolarized case ----
+      call distributeRangeInChunks(env, 1, rpa%nxvv_ud(1), iGlobal, fGlobal)
+
       ! qgamxpyq(ab) = sum_jc K_ab,jc (X+Y)_jc
       if (sym == "S") then
         call hemv(gamxpyq, gammaMat,  xpyq)
-        do ab = 1, rpa%nxvv_ud(1)
+        do ab = iGlobal, fGlobal
           qTr(:) = transChrg%qTransAB(ab, env, denseDesc, ovrXev, grndEigVecs, rpa%getAB)
           qgamxpyq(ab, 1) = 2.0_dp * sum(qTr * gamxpyq)
         end do
       else ! triplet case
-        do ab = 1, rpa%nxvv_ud(1)
+        do ab = iGlobal, fGlobal
           qTr(:) = transChrg%qTransAB(ab, env, denseDesc, ovrXev, grndEigVecs, rpa%getAB)
           qgamxpyq(ab, 1) = 2.0_dp * sum(qTr * xpyq * lr%spinW(species0))
         end do
       end if
+
+      call assembleChunks(env, qgamxpyq)
 
     else  ! ---- spin-polarized case -----
 
@@ -1703,18 +1763,25 @@ contains
         else
           fact = -1.0_dp
         end if
-        do ab = 1, rpa%nxvv_ud(s)
+
+        call distributeRangeInChunks(env, 1, rpa%nxvv_ud(s), iGlobal, fGlobal)
+
+        do ab = iGlobal, fGlobal
           qTr(:) = transChrg%qTransAB(ab + svv(s), env, denseDesc, ovrXev, grndEigVecs, rpa%getAB)
           qgamxpyq(ab, s) = sum(qTr * gamxpyq)
           !magnetization part
           qgamxpyq(ab, s) = qgamxpyq(ab, s) + fact * sum(qTr * xpyqds * lr%spinW(species0))
         end do
+
       end do
+      call assembleChunks(env, qgamxpyq)
 
     end if
 
+    call distributeRangeInChunks(env, 1, nxov, iGlobal, fGlobal)
+
     ! rhs(ia) -= Qia = sum_b (X+Y)_ib * qgamxpyq(ab))
-    do ias = 1, nxov
+    do ias = iGlobal, fGlobal
       call indxov(rpa%win, ias, rpa%getIA, i, a, s)
 
       do b = rpa%nocc_ud(s) + 1, a
@@ -1729,22 +1796,26 @@ contains
     end do
 
     ! -rhs = -rhs - sum_j (X + Y)_ja H + _ij[X + Y]
+    qgamxpyq(:,:) = 0.0_dp
     if (.not. tSpin) then  ! ---- spin-unpolarized case ----
+      call distributeRangeInChunks(env, 1, rpa%nxoo_ud(1), iGlobal, fGlobal)
 
       if (sym == "S") then
-        do ij = 1, rpa%nxoo_ud(1)
+        do ij = iGlobal, fGlobal
           qgamxpyq(ij, 1) = 0.0_dp
           qTr(:) = transChrg%qTransIJ(ij, env, denseDesc, ovrXev, grndEigVecs, rpa%getIJ)
           ! qgamxpyq(ij) = sum_kb K_ij,kb (X+Y)_kb
           qgamxpyq(ij, 1) = 2.0_dp * sum(qTr * gamxpyq)
         end do
       else
-        do ij = 1, rpa%nxoo_ud(1)
+        do ij = iGlobal, fGlobal
           qgamxpyq(ij, 1) = 0.0_dp
           qTr(:) = transChrg%qTransIJ(ij, env, denseDesc, ovrXev, grndEigVecs, rpa%getIJ)
           qgamxpyq(ij, 1) = 2.0_dp * sum(qTr * xpyq * lr%spinW(species0))
         end do
       end if
+
+      call assembleChunks(env, qgamxpyq)
 
     else  ! ---- spin-polarized case -----
 
@@ -1754,7 +1825,8 @@ contains
         else
           fact = -1.0_dp
         end if
-        do ij = 1, rpa%nxoo_ud(s)
+        call distributeRangeInChunks(env, 1, rpa%nxoo_ud(s), iGlobal, fGlobal)
+        do ij = iGlobal, fGlobal
           qgamxpyq(ij, s) = 0.0_dp
           qTr(:) = transChrg%qTransIJ(ij + soo(s), env, denseDesc, ovrXev, grndEigVecs, rpa%getIJ)
           qgamxpyq(ij, s) = sum(qTr * gamxpyq)
@@ -1763,11 +1835,15 @@ contains
         end do
       end do
 
+      call assembleChunks(env, qgamxpyq)
+
     end if
+
+    call distributeRangeInChunks(env, 1, nxov, iGlobal, fGlobal)
 
     ! rhs(ia) += Qai = sum_j (X+Y)_ja qgamxpyq(ij)
     ! add Qai to Wia as well.
-    do ias = 1, nxov
+    do ias = iGlobal, fGlobal
       call indxov(rpa%win, ias, rpa%getIA, i, a, s)
       do j = i, rpa%nocc_ud(s)
         jas = rpa%iaTrans(j, a, s)
@@ -1783,6 +1859,9 @@ contains
       end do
     end do
 
+    call assembleChunks(env, rhs)
+    call assembleChunks(env, wov)
+
     ! gamxpyq(iAt2) = sum_ij q_ij(iAt2) T_ij
     gamxpyq(:) = 0.0_dp
     if (tSpin) then
@@ -1795,7 +1874,10 @@ contains
       else
         fact = -1.0_dp
       end if
-      do ij = 1, rpa%nxoo_ud(s)
+
+      call distributeRangeInChunks(env, 1, rpa%nxoo_ud(s), iGlobal, fGlobal)
+
+      do ij = iGlobal, fGlobal
         i = rpa%getIJ(ij + soo(s), 1)
         j = rpa%getIJ(ij + soo(s), 2)
         qTr(:) = transChrg%qTransIJ(ij + soo(s), env, denseDesc, ovrXev, grndEigVecs, rpa%getIJ)
@@ -1813,8 +1895,10 @@ contains
         end if
       end do
 
+      call distributeRangeInChunks(env, 1, rpa%nxvv_ud(s), iGlobal, fGlobal)
+
       ! gamxpyq(iAt2) += sum_ab q_ab(iAt2) T_ab
-      do ab = 1, rpa%nxvv_ud(s)
+      do ab = iGlobal, fGlobal
         a = rpa%getAB(ab + svv(s), 1)
         b = rpa%getAB(ab + svv(s), 2)
         qTr(:) = transChrg%qTransAB(ab + svv(s), env, denseDesc, ovrXev, grndEigVecs, rpa%getAB)
@@ -1834,8 +1918,15 @@ contains
 
     end do
 
+    call assembleChunks(env, gamxpyq)
+    if (tSpin) then
+      call assembleChunks(env, gamxpyqds)
+    end if
+
+
     ! gamqt(iAt1) = sum_iAt2 gamma_iAt1,iAt2 gamxpyq(iAt2)
     call hemv(gamqt, gammaMat, gamxpyq)
+
 
     ! rhs -= sum_q^ia(iAt1) gamxpyq(iAt1)
     if (.not. tSpin) then
@@ -1855,7 +1946,10 @@ contains
       else
         fact = -1.0_dp
       end if
-      do ij = 1, rpa%nxoo_ud(s)
+
+      call distributeRangeInChunks(env, 1, rpa%nxoo_ud(s), iGlobal, fGlobal)
+
+      do ij = iGlobal, fGlobal
         qTr(:) = transChrg%qTransIJ(ij + soo(s), env, denseDesc, ovrXev, grndEigVecs, rpa%getIJ)
         if (.not. tSpin) then
           woo(ij,s) = woo(ij,s) + 4.0_dp * sum(qTr * gamqt)
@@ -1876,19 +1970,27 @@ contains
       allocate(vecHovT(nxov))
       allocate(vecHooT(sum(rpa%nxoo_ud)))
 
-      call getHvvXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma,  1, xpy,&
+      call getHvvXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma,  1, xpy,&
           & vecHvvXpY)
 
-      call getHvvXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, -1, xmy,&
+      call getHvvXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, -1, xmy,&
           & vecHvvXmY)
 
-      call getHooXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma,  1, xpy,&
+      call getHooXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma,  1, xpy,&
           & vecHooXpY)
 
-      call getHooXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, -1, xmy,&
+      call getHooXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, -1, xmy,&
           & vecHooXmY)
 
-      call getHovT(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, t, vecHovT)
+      call getHovT(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, t,&
+          & vecHovT)
+
+      !TODO: i can not parallelized this because i had to do the assemble of rhs before
+      ! in order to get gamqt (see before), if i dont do the assemble then gamqt is wrong.
+      ! A possible solution is to move all the block of gamqt and the rhs before that to the end
+      ! after the hybridxc section, then do the assemble of rsh and then calculate gamqt and the
+      ! other eq of rhs
+      ! call distributeRangeInChunks(env, 1, nxov, iGlobal, fGlobal)
 
       do ias = 1, nxov
 
@@ -1917,15 +2019,18 @@ contains
             wov(ias) = wov(ias) - cExchange * xmy(jas) * vecHooXmY(ijs)
           end if
         end do
-       rhs(ias) = rhs(ias) - cExchange * vecHovT(ias)
+        rhs(ias) = rhs(ias) - cExchange * vecHovT(ias)
 
       end do
 
-      call getHooT(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, t, vecHooT)
+      call getHooT(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, t,&
+          & vecHooT)
+
+      call distributeRangeInChunks(env, 1, rpa%nxoo_ud(s), iGlobal, fGlobal)
 
       ! Array woo should be made 1D
       do s = 1, nSpin
-        do ij = 1, rpa%nxoo_ud(s)
+        do ij = iGlobal, fGlobal
           i = rpa%getIJ(ij + soo(s), 1)
           j = rpa%getIJ(ij + soo(s), 2)
           ijs = rpa%iaTrans(i, j, s)
@@ -1934,6 +2039,8 @@ contains
       end do
 
     endif
+
+    call assembleChunks(env, woo)
 
   end subroutine getZVectorEqRHS
 
@@ -1978,15 +2085,17 @@ contains
     !> On entry -R, on exit Z
     real(dp), intent(inout) :: rhs(:)
 
-    integer :: nxov, iGlobal, fGlobal
-    integer :: ia, kk, i, a, s, iis, aas
+    ! NOTE: For very large systems, nxov (or nxov**2) may exceed the 32-bit
+    ! integer range. To avoid integer overflow I use 64-bit integers.
+    integer(int64) :: kk, nxov
+
+    integer :: iGlobal, fGlobal
+    integer :: ia, i, a, s, iis, aas
     real(dp), allocatable :: qTr(:), qTmp(:), P(:)
     real(dp) :: rhs2(size(rhs)), rkm1(size(rhs)), zkm1(size(rhs)), pkm1(size(rhs)), apk(size(rhs))
     real(dp) :: rs, alphakm1, tmp1, tmp2, bkm1
 
-    ! Need to change this for MPI, currently routine works on full RPA vectors
-    iGlobal = 1
-    fGlobal = rpa%nxov_rd
+    call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
 
     nxov = rpa%nxov_rd
     allocate(qTr(lr%nAtom))
@@ -1994,8 +2103,8 @@ contains
 
     ! diagonal preconditioner
     ! P^-1 = 1 / (A+B)_ia,ia (diagonal of the supermatrix sum A+B)
-    allocate(P(nxov))
-    do ia = 1, nxov
+    allocate(P(nxov)); P(:) = 0.0_dp
+    do ia = iGlobal, fGlobal
       qTr(:) = transChrg%qTransIA(ia, env, denseDesc, ovrXev, grndEigVecs, rpa%getIA, rpa%win)
       call hemv(qTmp, gammaMat, qTr)
       if (.not. lr%tSpin) then
@@ -2021,16 +2130,22 @@ contains
       P(ia) = 1.0_dp / rs
     end do
 
+    call assembleChunks(env, P)
+
     ! Free some space, before entering the actionAplusB routine
     deallocate(qTr)
 
     ! unit vector as initial guess solution
     rhs2(:) = 1.0_dp / sqrt(real(nxov,dp))
+    rkm1(:) = 0.0_dp
 
     ! action of matrix on vector
     ! we need the singlet action even for triplet excitations!
     call actionAplusB(iGlobal, fGlobal, env, orb, lr, rpa, transChrg, 'S', denseDesc, species0,&
-        & ovrXev, grndEigVecs, gammaMat, .true., rhs2, rkm1, lrGamma)
+        & ovrXev, grndEigVecs, gammaMat, .true., rhs2(iGlobal:fGlobal), rkm1(iGlobal:fGlobal),&
+        & lrGamma)
+
+    call assembleChunks(env, rkm1)
 
     rkm1(:) = rhs - rkm1
     zkm1(:) = P * rkm1
@@ -2040,8 +2155,12 @@ contains
     do kk = 1, nxov**2
 
       ! action of matrix on vector
+      apk = 0.0_dp
       call actionAplusB(iGlobal, fGlobal, env, orb, lr, rpa, transChrg, 'S', denseDesc, species0,&
-          & ovrXev, grndEigVecs, gammaMat, .true., pkm1, apk, lrGamma)
+          & ovrXev, grndEigVecs, gammaMat, .true., pkm1(iGlobal:fGlobal), apk(iGlobal:fGlobal),&
+          & lrGamma)
+
+      call assembleChunks(env, apk)
 
       tmp1 = dot_product(rkm1, zkm1)
       tmp2 = dot_product(pkm1, apk)
@@ -2080,11 +2199,14 @@ contains
 
   !> Calculate Z-dependent parts of the W-vectors and divide diagonal elements of W_ij and W_ab by
   !! 2.
-  subroutine calcWvectorZ(env, lr, rpa, transChrg, denseDesc, species0, ovrXev, grndEigVecs,&
+  subroutine calcWvectorZ(env, orb, lr, rpa, transChrg, denseDesc, species0, ovrXev, grndEigVecs,&
       & grndEigVal, gammaMat, lrGamma, zz, wov, woo, wvv)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
+
+    !> Data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
 
     !> Data structure for linear response
     type(TLinResp), intent(in) :: lr
@@ -2129,8 +2251,9 @@ contains
     real(dp), intent(inout) :: wvv(:,:)
 
     integer :: nSpin, soo(2), svv(2)
-    integer :: ij, ias, ijs, ab, i, j, a, b, s
+    integer :: ij, ias, ijs, ab, i, j, a, b, s, iGlobal, fGlobal
     real(dp), allocatable :: qTr(:), gamxpyq(:), zq(:), zqds(:), vecHooZ(:)
+    real(dp), allocatable :: wovLoc(:), wooLoc(:,:), wvvLoc(:,:)
     real(dp) :: fact
 
     nSpin = size(grndEigVal, dim=2)
@@ -2146,11 +2269,18 @@ contains
       allocate(zqds(lr%nAtom))
     end if
 
+    ! MPI local arrays
+    call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
+    allocate(wovLoc(rpa%nxov_rd)); wovLoc = 0.0_dp
+
     ! Adding missing epsilon_i * Z_ia term to W_ia
-    do ias = 1, rpa%nxov_rd
+    do ias = iGlobal, fGlobal
       call indxov(rpa%win, ias, rpa%getIA, i, a, s)
-      wov(ias) = wov(ias) + zz(ias) * grndEigVal(i, s)
+      wovLoc(ias) = zz(ias) * grndEigVal(i, s)
     end do
+    call assembleChunks(env, wovLoc)
+    wov = wov + wovLoc
+    deallocate(wovLoc)
 
     ! Missing sum_kb 4 K_ijkb Z_kb term in W_ij: zq(iAt1) = sum_kb q^kb(iAt1) Z_kb
     zq(:) = 0.0_dp
@@ -2162,6 +2292,9 @@ contains
       call transChrg%qMatVecDs(env, denseDesc, ovrXev, grndEigVecs, rpa%getIA, rpa%win, zz, zqds)
     end if
 
+    ! MPI local arrays
+    allocate(wooLoc(size(woo, dim=1),nSpin)); wooLoc = 0.0_dp
+
     ! sum_iAt1 qTr(iAt1) gamxpyq(iAt1)
     do s = 1, nSpin
       if (s == 1) then
@@ -2169,14 +2302,16 @@ contains
       else
         fact = -1.0_dp
       end if
-      do ij = 1, rpa%nxoo_ud(s)
+      call distributeRangeInChunks(env, 1, rpa%nxoo_ud(s), iGlobal, fGlobal)
+
+      do ij = iGlobal, fGlobal
         qTr(:) = transChrg%qTransIJ(ij + soo(s), env, denseDesc, ovrXev, grndEigVecs, rpa%getIJ)
         ! W contains 1/2 for i == j.
         if (.not. lr%tSpin) then
-          woo(ij,s) = woo(ij,s) + 4.0_dp * sum(qTr * gamxpyq)
+          wooLoc(ij,s) = woo(ij,s) + 4.0_dp * sum(qTr * gamxpyq)
         else
-          woo(ij,s) = woo(ij,s) + 2.0_dp * sum(qTr * gamxpyq)
-          woo(ij,s) = woo(ij,s) + 2.0_dp * fact * sum(qTr * zqds * lr%spinW(species0))
+          wooLoc(ij,s) = woo(ij,s) + 2.0_dp * sum(qTr * gamxpyq)
+          wooLoc(ij,s) = wooLoc(ij,s) + 2.0_dp * fact * sum(qTr * zqds * lr%spinW(species0))
         end if
       end do
     end do
@@ -2184,16 +2319,17 @@ contains
     if (rpa%tHybridXc) then
 
       allocate(vecHooZ(sum(rpa%nxoo_ud)))
-      call getHooXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, 1, zz,&
+      call getHooXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, 1, zz,&
           & vecHooZ)
 
       ! Array woo should be made 1D
       do s = 1, nSpin
-        do ij = 1, rpa%nxoo_ud(s)
+        call distributeRangeInChunks(env, 1, rpa%nxoo_ud(s), iGlobal, fGlobal)
+        do ij = iGlobal, fGlobal
           i = rpa%getIJ(ij + soo(s), 1)
           j = rpa%getIJ(ij + soo(s), 2)
           ijs = rpa%iaTrans(i, j, s)
-          woo(ij,s) = woo(ij,s) + cExchange * vecHooZ(ijs)
+          wooLoc(ij,s) = wooLoc(ij,s) + cExchange * vecHooZ(ijs)
         end do
       end do
 
@@ -2201,25 +2337,40 @@ contains
 
     ! Divide diagonal elements of W_ij by 2.
     do s = 1, nSpin
-      do ij = 1, rpa%nxoo_ud(s)
+      call distributeRangeInChunks(env, 1, rpa%nxoo_ud(s), iGlobal, fGlobal)
+      do ij = iGlobal, fGlobal
         i = rpa%getIJ(ij + soo(s), 1)
         j = rpa%getIJ(ij + soo(s), 2)
         if (i == j) then
-          woo(ij,s) = 0.5_dp * woo(ij,s)
+          wooLoc(ij,s) = 0.5_dp * wooLoc(ij,s)
         end if
       end do
     end do
 
+    call assembleChunks(env, wooLoc)
+    woo = wooLoc
+    deallocate(wooLoc)
+
+    ! MPI local arrays
+    allocate(wvvLoc(size(wvv, dim=1),nSpin)); wvvLoc = 0.0_dp
+
     ! Divide diagonal elements of W_ab by 2.
     do s = 1, nSpin
-      do ab = 1, rpa%nxvv_ud(s)
+      call distributeRangeInChunks(env, 1, rpa%nxvv_ud(s), iGlobal, fGlobal)
+
+      do ab = iGlobal, fGlobal
         a = rpa%getAB(ab + svv(s), 1)
         b = rpa%getAB(ab + svv(s), 2)
+        wvvLoc(ab,s) = wvv(ab,s)
         if (a == b) then
-          wvv(ab,s) = 0.5_dp * wvv(ab,s)
+          wvvLoc(ab,s) = 0.5_dp * wvv(ab,s)
         end if
       end do
     end do
+
+    call assembleChunks(env, wvvLoc)
+    wvv = wvvLoc
+    deallocate(wvvLoc)
 
   end subroutine calcWvectorZ
 
@@ -2402,12 +2553,13 @@ contains
     real(dp), allocatable :: overlap(:,:), lrGammaOrb(:,:), gammaLongRangePrime(:,:,:)
     real(dp), allocatable :: PS(:,:,:), DS(:,:,:), SPS(:,:,:), SDS(:,:,:), SX(:,:,:)
     real(dp), allocatable :: XS(:,:,:), SXS(:,:,:), SY(:,:,:), YS(:,:,:), SYS(:,:,:)
+    real(dp), allocatable :: deltaRhoGlobal(:,:,:), grndEigVecsGlobal(:,:,:)
     real(dp) :: tmp1, tmp2, tmp3, tmp4, tmp6, tmp8, tmp9, tmp10, rab
     real(dp) :: diffvec(3), dgab(3), tmpVec(3), tmp3a, tmp3b, tmprs, tmprs2, tmps(2)
     integer, allocatable :: species(:)
     integer :: ia, i, j, a, b, ab, ij, m, n, mu, nu, xyz, iAt1, iAt2, ka
     integer :: indalpha, indalpha1, indbeta, indbeta1, soo(2), svv(2)
-    integer :: iSp1, iSp2, iSpin, nSpin, nOrb
+    integer :: iSp1, iSp2, iSpin, nSpin, nOrb, iGlobal, fGlobal
 
     nSpin = size(grndEigVecs, dim=3)
     nOrb = orb%nOrb
@@ -2425,6 +2577,10 @@ contains
     allocate(Dens(nOrb, nOrb))
     Dens(:,:) = sum(rhoSqr, dim=3)
 
+    ! NOTE: probably this is not necessary, we need to check
+    ! Symmetrize RhoSqr
+    call adjointLowerTriangle(Dens)
+
     allocate(dH0(orb%mOrb, orb%mOrb, 3))
     allocate(dSo(orb%mOrb, orb%mOrb, 3))
 
@@ -2439,6 +2595,9 @@ contains
       allocate(xpyqds(lr%nAtom))
       allocate(tmp11(nSpin))
 
+      !FIXME: here nOrb is the global value but rhoSqr has dimension of nOrb local
+      !TODO: The test NH forces does not run even for single process.
+      ! NOTE: I think now, with the last BUGFIX, this should be correct
       allocate(SpinDens(nOrb,nOrb))
       SpinDens(:,:) = rhoSqr(:,:,1) - rhoSqr(:,:,2)
 
@@ -2447,6 +2606,19 @@ contains
       dsigma(2) = -1.0_dp
       dm(:) = dq_ud(:,2)
     end if
+
+    ! Convert local arrays to global
+    allocate(grndEigVecsGlobal(norb,norb,size(grndEigVecs,dim=3)))
+  #:if WITH_SCALAPACK
+
+    do iSpin = 1, nSpin
+      call distrib2replicated(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, &
+                           &  grndEigVecs(:,:,iSpin), grndEigVecsGlobal(:,:,iSpin))
+    enddo
+  #:else
+
+    grndEigVecsGlobal = grndEigVecs
+  #:endif
 
     if (rpa%tHybridXc) then
       allocate(xmycc(nOrb, nOrb, nSpin))
@@ -2466,17 +2638,30 @@ contains
       allocate(lrGammaOrb(nOrb, nOrb))
       allocate(gammaLongRangePrime(3, lr%nAtom, lr%nAtom))
 
-      ! Symmetrize deltaRho
-      do mu = 1, nOrb
-        do nu = mu + 1, nOrb
-          deltaRho(mu,nu,:) = deltaRho(nu,mu,:)
+      ! Convert local arrays to global
+      allocate(deltaRhoGlobal(norb,norb,size(deltaRho,dim=3)))
+    #:if WITH_SCALAPACK
+
+      do iSpin = 1, nSpin
+        call distrib2replicated(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, &
+                             &  deltaRho(:,:,iSpin), deltaRhoGlobal(:,:,iSpin))
+      enddo
+    #:else
+
+      deltaRhoGlobal = deltaRho
+    #:endif
+
+      ! Symmetrize deltaRhoGlobal
+      do mu = 1, size(deltaRhoGlobal, dim=1)
+        do nu = mu + 1, size(deltaRhoGlobal, dim=2)
+          deltaRhoGlobal(mu,nu,:) = deltaRhoGlobal(nu,mu,:)
         end do
       end do
 
       ! Compute long-range gamma derivative
-      gammaLongRangePrime(:,:,:) = 0._dp
-      call hybridXc%getCentralCellSpecies(species)
-      do iAt1 = 1, lr%nAtom
+      call distributeRangeInChunks(env, 1, lr%nAtom, iGlobal, fGlobal)
+      gammaLongRangePrime(:,:,:) = 0.0_dp
+      do iAt1 = iGlobal, fGlobal
         do iAt2 = 1, lr%nAtom
           if (iAt1 /= iAt2) then
             call getDirectionalCamGammaPrimeValue(hybridXc, tmpVec, iAt1, iAt2)
@@ -2484,6 +2669,7 @@ contains
           end if
         end do
       end do
+      call assembleChunks(env,gammaLongRangePrime)
 
       ! Symmetrize S (can't we get S from caller?)
       call getSqrS(coord0, lr%nAtom, skOverCont, orb, denseDesc%iAtomStart, species0, overlap)
@@ -2528,18 +2714,22 @@ contains
     !
     ! xpycc(mu,nu) = sum_ia (X+Y)_ia grndEigVecs(mu,i) grndEigVecs(nu,a)
     ! xpycc(mu, nu) += sum_ia (X+Y)_ia grndEigVecs(mu,a) grndEigVecs(nu,i)
+
+    call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
     xpycc(:,:,:) = 0.0_dp
-    do ia = 1, rpa%nxov_rd
+    do ia = iGlobal, fGlobal
       call indxov(rpa%win, ia, rpa%getIA, i, a, iSpin)
       ! should replace with DSYR2 call :
       do nu = 1, nOrb
         do mu = 1, nOrb
           xpycc(mu,nu,iSpin) = xpycc(mu,nu,iSpin) + xpy(ia) *&
-              & ( grndEigVecs(mu,i,iSpin)*grndEigVecs(nu,a,iSpin)&
-              & + grndEigVecs(mu,a,iSpin)*grndEigVecs(nu,i,iSpin) )
+              & ( grndEigVecsGlobal(mu,i,iSpin)*grndEigVecsGlobal(nu,a,iSpin)&
+              & + grndEigVecsGlobal(mu,a,iSpin)*grndEigVecsGlobal(nu,i,iSpin) )
         end do
       end do
     end do
+    call assembleChunks(env, xpycc)
+
 
     if (rpa%tHybridXc) then
 
@@ -2547,21 +2737,25 @@ contains
       xmycc(:,:,:) = 0.0_dp
       xpyas(:,:,:) = 0.0_dp
       xmyas(:,:,:) = 0.0_dp
-      do ia = 1, rpa%nxov_rd
+      call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
+      do ia = iGlobal, fGlobal
         call indxov(rpa%win, ia, rpa%getIA, i, a, iSpin)
         ! should replace with DSYR2 call:
         do nu = 1, nOrb
           do mu = 1, nOrb
             xmycc(mu,nu,iSpin) = xmycc(mu,nu,iSpin) + xmy(ia) *&
-                & ( grndEigVecs(mu,i,iSpin) * grndEigVecs(nu,a,iSpin)&
-                & + grndEigVecs(mu,a,iSpin) * grndEigVecs(nu,i,iSpin) )
+                & ( grndEigVecsGlobal(mu,i,iSpin) * grndEigVecsGlobal(nu,a,iSpin)&
+                & + grndEigVecsGlobal(mu,a,iSpin) * grndEigVecsGlobal(nu,i,iSpin) )
             xpyas(mu,nu,iSpin) = xpyas(mu,nu,iSpin) + xpy(ia) *&
-                & grndEigVecs(mu,i,iSpin) * grndEigVecs(nu,a,iSpin)
+                & grndEigVecsGlobal(mu,i,iSpin) * grndEigVecsGlobal(nu,a,iSpin)
             xmyas(mu,nu,iSpin) = xmyas(mu,nu,iSpin) + xmy(ia) *&
-                & grndEigVecs(mu,i,iSpin) * grndEigVecs(nu,a,iSpin)
+                & grndEigVecsGlobal(mu,i,iSpin) * grndEigVecsGlobal(nu,a,iSpin)
           end do
         end do
       end do
+      call assembleChunks(env, xmycc)
+      call assembleChunks(env, xpyas)
+      call assembleChunks(env, xmyas)
 
       ! Account for normalization of S/T versus spin-polarized X+/-Y
       ! We have (X+Y)^S = 1/sqrt(2) [(X+Y)_up + (X+Y)_dn]
@@ -2574,7 +2768,8 @@ contains
       do iSpin = 1, nSpin
         call symm(PS(:,:,iSpin), 'R', overlap, pc(:,:,iSpin), 'U', 1.0_dp, 0.0_dp, nOrb, nOrb)
         call symm(SPS(:,:,iSpin), 'L', overlap, PS(:,:,iSpin), 'U', 1.0_dp, 0.0_dp, nOrb, nOrb)
-        call symm(DS(:,:,iSpin), 'R', overlap, deltaRho(:,:,iSpin), 'U', 1.0_dp, 0.0_dp, nOrb, nOrb)
+        call symm(DS(:,:,iSpin), 'R', overlap, deltaRhoGlobal(:,:,iSpin), 'U', 1.0_dp, 0.0_dp,&
+            & nOrb, nOrb)
         call symm(SDS(:,:,iSpin), 'L', overlap, DS(:,:,iSpin), 'U', 1.0_dp, 0.0_dp, nOrb, nOrb)
         call symm(XS(:,:,iSpin), 'R', overlap, xpyas(:,:,iSpin), 'U', 1.0_dp, 0.0_dp, nOrb, nOrb)
         call symm(SX(:,:,iSpin), 'L', overlap, xpyas(:,:,iSpin), 'U', 1.0_dp, 0.0_dp, nOrb, nOrb)
@@ -2592,17 +2787,17 @@ contains
 
     ! calculate the occ-occ part
     wcc(:,:,:) = 0.0_dp
-
     do iSpin = 1, nSpin
-      do ij = 1, rpa%nxoo_ud(iSpin)
+      call distributeRangeInChunks(env, 1, rpa%nxoo_ud(iSpin), iGlobal, fGlobal)
+      do ij = iGlobal, fGlobal
         i = rpa%getIJ(ij + soo(iSpin), 1)
         j = rpa%getIJ(ij + soo(iSpin), 2)
         ! replace with DSYR2 call :
         do mu = 1, nOrb
           do nu = 1, nOrb
             wcc(mu,nu,iSpin) = wcc(mu,nu,iSpin) + woo(ij,iSpin) *&
-                & ( grndEigVecs(mu,i,iSpin)*grndEigVecs(nu,j,iSpin)&
-                & + grndEigVecs(mu,j,iSpin)*grndEigVecs(nu,i,iSpin) )
+                & ( grndEigVecsGlobal(mu,i,iSpin)*grndEigVecsGlobal(nu,j,iSpin)&
+                & + grndEigVecsGlobal(mu,j,iSpin)*grndEigVecsGlobal(nu,i,iSpin) )
           end do
         end do
 
@@ -2610,34 +2805,36 @@ contains
     end do
 
     ! calculate the occ-virt part : the same way as for xpycc
-    do ia = 1, rpa%nxov_rd
+    call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
+    do ia = iGlobal, fGlobal
       call indxov(rpa%win, ia, rpa%getIA, i, a, iSpin)
       ! again replace with DSYR2 call :
       do nu = 1, nOrb
         do mu = 1, nOrb
           wcc(mu,nu,iSpin) = wcc(mu,nu,iSpin) + wov(ia) *&
-              & ( grndEigVecs(mu,i,iSpin)*grndEigVecs(nu,a,iSpin)&
-              & + grndEigVecs(mu,a,iSpin)*grndEigVecs(nu,i,iSpin) )
+              & ( grndEigVecsGlobal(mu,i,iSpin)*grndEigVecsGlobal(nu,a,iSpin)&
+              & + grndEigVecsGlobal(mu,a,iSpin)*grndEigVecsGlobal(nu,i,iSpin) )
         end do
       end do
     end do
 
     ! calculate the virt - virt part
     do iSpin = 1, nSpin
-      do ab = 1, rpa%nxvv_ud(iSpin)
+      call distributeRangeInChunks(env, 1, rpa%nxvv_ud(iSpin), iGlobal, fGlobal)
+      do ab = iGlobal, fGlobal
         a = rpa%getAB(ab + svv(iSpin), 1)
         b = rpa%getAB(ab + svv(iSpin), 2)
         ! replace with DSYR2 call :
         do mu = 1, nOrb
           do nu = 1, nOrb
             wcc(mu,nu,iSpin) = wcc(mu,nu,iSpin) + wvv(ab,iSpin) *&
-                & ( grndEigVecs(mu,a,iSpin)*grndEigVecs(nu,b,iSpin)&
-                & + grndEigVecs(mu,b,iSpin)*grndEigVecs(nu,a,iSpin) )
+                & ( grndEigVecsGlobal(mu,a,iSpin)*grndEigVecsGlobal(nu,b,iSpin)&
+                & + grndEigVecsGlobal(mu,b,iSpin)*grndEigVecsGlobal(nu,a,iSpin) )
           end do
         end do
-
       end do
     end do
+    call assembleChunks(env, wcc)
 
     ! now calculating the force complexity : nOrb * nOrb * 3
 
@@ -2697,26 +2894,39 @@ contains
           do iSpin = 1, nSpin
             do mu = indAlpha, indAlpha1
               do nu = indBeta, indBeta1
-                tmprs = tmprs +&
-          & ( 2.0_dp * (PS(mu,nu,iSpin) * DS(nu,mu,iSpin) + PS(nu,mu,iSpin) * DS(mu,nu,iSpin)) +&
-          &   SPS(mu,nu,iSpin) * deltaRho(mu,nu,iSpin) + SPS(nu,mu,iSpin) * deltaRho(nu,mu,iSpin) +&
-          &   pc(mu,nu,iSpin) * SDS(mu,nu,iSpin) + pc(nu,mu,iSpin) * SDS(nu,mu,iSpin) )
+                tmprs = tmprs&
+                    & + 2.0_dp * (PS(mu,nu,iSpin) * DS(nu,mu,iSpin)&
+                    & + PS(nu,mu,iSpin) * DS(mu,nu,iSpin))&
+                    & + SPS(mu,nu,iSpin) * deltaRhoGlobal(mu,nu,iSpin)&
+                    & + SPS(nu,mu,iSpin) * deltaRhoGlobal(nu,mu,iSpin)&
+                    & + pc(mu,nu,iSpin) * SDS(mu,nu,iSpin) + pc(nu,mu,iSpin) * SDS(nu,mu,iSpin)
+
                 tmprs = tmprs + 2.0_dp *&
-          & ( xpyas(mu,nu,iSpin) * SXS(mu,nu,iSpin) + xpyas(nu,mu,iSpin) * SXS(nu,mu,iSpin) +&
-          &   SX(mu,nu,iSpin) * XS(mu,nu,iSpin) + SX(nu,mu,iSpin) * XS(nu,mu,iSpin) )
+                    & ( xpyas(mu,nu,iSpin) * SXS(mu,nu,iSpin)&
+                    & + xpyas(nu,mu,iSpin) * SXS(nu,mu,iSpin)&
+                    & + SX(mu,nu,iSpin) * XS(mu,nu,iSpin)&
+                    & + SX(nu,mu,iSpin) * XS(nu,mu,iSpin) )
+
                 tmprs = tmprs +&
-          & ( XS(mu,nu,iSpin) * XS(nu,mu,iSpin) + XS(nu,mu,iSpin) * XS(mu,nu,iSpin) +&
-          &   SXS(mu,nu,iSpin) * xpyas(nu,mu,iSpin) + SXS(nu,mu,iSpin) * xpyas(mu,nu,iSpin) +&
-          &   xpyas(mu,nu,iSpin) * SXS(nu,mu,iSpin) + xpyas(nu,mu,iSpin) * SXS(mu,nu,iSpin) +&
-          &   SX(mu,nu,iSpin) * SX(nu,mu,iSpin) + SX(nu,mu,iSpin) * SX(mu,nu,iSpin) )
+                    & ( XS(mu,nu,iSpin) * XS(nu,mu,iSpin) + XS(nu,mu,iSpin) * XS(mu,nu,iSpin)&
+                    & + SXS(mu,nu,iSpin) * xpyas(nu,mu,iSpin)&
+                    & + SXS(nu,mu,iSpin) * xpyas(mu,nu,iSpin)&
+                    & + xpyas(mu,nu,iSpin) * SXS(nu,mu,iSpin)&
+                    & + xpyas(nu,mu,iSpin) * SXS(mu,nu,iSpin)&
+                    & + SX(mu,nu,iSpin) * SX(nu,mu,iSpin) + SX(nu,mu,iSpin) * SX(mu,nu,iSpin) )
+
                 tmprs = tmprs + 2.0_dp *&
-          & ( xmyas(mu,nu,iSpin) * SYS(mu,nu,iSpin) + xmyas(nu,mu,iSpin) * SYS(nu,mu,iSpin) +&
-          &   SY(mu,nu,iSpin) * YS(mu,nu,iSpin) + SY(nu,mu,iSpin) * YS(nu,mu,iSpin) )
+                    & ( xmyas(mu,nu,iSpin) * SYS(mu,nu,iSpin)&
+                    & + xmyas(nu,mu,iSpin) * SYS(nu,mu,iSpin)&
+                    & + SY(mu,nu,iSpin) * YS(mu,nu,iSpin) + SY(nu,mu,iSpin) * YS(nu,mu,iSpin) )
+
                 tmprs = tmprs -&
-          & ( YS(mu,nu,iSpin) * YS(nu,mu,iSpin) + YS(nu,mu,iSpin) * YS(mu,nu,iSpin) +&
-          &   SYS(mu,nu,iSpin) * xmyas(nu,mu,iSpin) + SYS(nu,mu,iSpin) * xmyas(mu,nu,iSpin) +&
-          &   xmyas(mu,nu,iSpin) * SYS(nu,mu,iSpin) + xmyas(nu,mu,iSpin) * SYS(mu,nu,iSpin) +&
-          &   SY(mu,nu,iSpin) * SY(nu,mu,iSpin) + SY(nu,mu,iSpin) * SY(mu,nu,iSpin) )
+                    & ( YS(mu,nu,iSpin) * YS(nu,mu,iSpin) + YS(nu,mu,iSpin) * YS(mu,nu,iSpin)&
+                    & + SYS(mu,nu,iSpin) * xmyas(nu,mu,iSpin)&
+                    & + SYS(nu,mu,iSpin) * xmyas(mu,nu,iSpin)&
+                    & + xmyas(mu,nu,iSpin) * SYS(nu,mu,iSpin)&
+                    & + xmyas(nu,mu,iSpin) * SYS(mu,nu,iSpin)&
+                    & + SY(mu,nu,iSpin) * SY(nu,mu,iSpin) + SY(nu,mu,iSpin) * SY(mu,nu,iSpin) )
               end do
             end do
           end do
@@ -2765,25 +2975,35 @@ contains
                   tmprs = 0.0_dp
                   do ka = 1, nOrb
                     tmprs = tmprs +&
-            & ( PS(mu,ka,iSpin) * deltaRho(nu,ka,iSpin) + PS(nu,ka,iSpin) * deltaRho(mu,ka,iSpin) +&
-            &   pc(mu,ka,iSpin) * DS(nu,ka,iSpin) + pc(nu,ka,iSpin) * DS(mu,ka,iSpin) ) *&
-            &  (lrGammaOrb(mu,ka) + lrGammaOrb(nu,ka))
+                        & ( PS(mu,ka,iSpin) * deltaRhoGlobal(nu,ka,iSpin)&
+                        & + PS(nu,ka,iSpin) * deltaRhoGlobal(mu,ka,iSpin)&
+                        & + pc(mu,ka,iSpin) * DS(nu,ka,iSpin) + pc(nu,ka,iSpin) * DS(mu,ka,iSpin) )&
+                        & * (lrGammaOrb(mu,ka) + lrGammaOrb(nu,ka))
                     tmprs = tmprs +&
-            & ( xpyas(mu,ka,iSpin) * XS(nu,ka,iSpin) + xpyas(ka,mu,iSpin) * SX(ka,nu,iSpin) +&
-            &   xpyas(nu,ka,iSpin) * XS(mu,ka,iSpin) + xpyas(ka,nu,iSpin) * SX(ka,mu,iSpin) )*&
-            &  (lrGammaOrb(mu,ka) + lrGammaOrb(nu,ka))
+                        & ( xpyas(mu,ka,iSpin) * XS(nu,ka,iSpin)&
+                        & + xpyas(ka,mu,iSpin) * SX(ka,nu,iSpin)&
+                        & + xpyas(nu,ka,iSpin) * XS(mu,ka,iSpin)&
+                        & + xpyas(ka,nu,iSpin) * SX(ka,mu,iSpin) )&
+                        & * (lrGammaOrb(mu,ka) + lrGammaOrb(nu,ka))
                     tmprs = tmprs +&
-            & ( xmyas(mu,ka,iSpin) * YS(nu,ka,iSpin) + xmyas(ka,mu,iSpin) * SY(ka,nu,iSpin) +&
-            &   xmyas(nu,ka,iSpin) * YS(mu,ka,iSpin) + xmyas(ka,nu,iSpin) * SY(ka,mu,iSpin) ) *&
-            &  (lrGammaOrb(mu,ka) + lrGammaOrb(nu,ka))
+                        & ( xmyas(mu,ka,iSpin) * YS(nu,ka,iSpin)&
+                        & + xmyas(ka,mu,iSpin) * SY(ka,nu,iSpin)&
+                        & + xmyas(nu,ka,iSpin) * YS(mu,ka,iSpin)&
+                        & + xmyas(ka,nu,iSpin) * SY(ka,mu,iSpin) )&
+                        & * (lrGammaOrb(mu,ka) + lrGammaOrb(nu,ka))
+
                     tmprs = tmprs +&
-            & ( XS(mu,ka,iSpin) * xpyas(ka,nu,iSpin) + XS(nu,ka,iSpin) * xpyas(ka,mu,iSpin) +&
-            &   xpyas(mu,ka,iSpin) * SX(ka,nu,iSpin) + xpyas(nu,ka,iSpin) * SX(ka,mu,iSpin)) *&
-            &  (lrGammaOrb(mu,ka) + lrGammaOrb(nu,ka))
+                        & ( XS(mu,ka,iSpin) * xpyas(ka,nu,iSpin)&
+                        & + XS(nu,ka,iSpin) * xpyas(ka,mu,iSpin)&
+                        & + xpyas(mu,ka,iSpin) * SX(ka,nu,iSpin)&
+                        & + xpyas(nu,ka,iSpin) * SX(ka,mu,iSpin))&
+                        & * (lrGammaOrb(mu,ka) + lrGammaOrb(nu,ka))
                     tmprs = tmprs -&
-            & ( YS(mu,ka,iSpin) * xmyas(ka,nu,iSpin) + YS(nu,ka,iSpin) * xmyas(ka,mu,iSpin) +&
-            &   xmyas(mu,ka,iSpin) * SY(ka,nu,iSpin) + xmyas(nu,ka,iSpin) * SY(ka,mu,iSpin)) *&
-            &  (lrGammaOrb(mu,ka) + lrGammaOrb(nu,ka))
+                        & ( YS(mu,ka,iSpin) * xmyas(ka,nu,iSpin)&
+                        & + YS(nu,ka,iSpin) * xmyas(ka,mu,iSpin)&
+                        & + xmyas(mu,ka,iSpin) * SY(ka,nu,iSpin)&
+                        & + xmyas(nu,ka,iSpin) * SY(ka,mu,iSpin))&
+                        & * (lrGammaOrb(mu,ka) + lrGammaOrb(nu,ka))
                   end do
                   ! Factor of 2 for spin-polarized calculations
                   tmprs2 = tmprs2 + cExchange * nSpin * dSo(n,m,xyz) * tmprs
@@ -3164,7 +3384,10 @@ contains
 
   !> Create transition density matrix in MO basis P = T + 1/2 Z symmetric (paper has T + Z
   !! asymmetric) (Zab = Zij = 0, Tia = 0).
-  subroutine calcPMatrix(rpa, t, rhs, pc)
+  subroutine calcPMatrix(env, rpa, t, rhs, pc)
+
+    !> Environment settings
+    type(TEnvironment), intent(inout) :: env
 
     !> Run time parameters of the Casida routine
     type(TCasidaParameter), intent(in) :: rpa
@@ -3178,15 +3401,18 @@ contains
     !> Resulting excited state density matrix
     real(dp), intent(out) :: pc(:,:,:)
 
-    integer :: ias, i, a, s, nSpin
+    integer :: ias, i, a, s, nSpin, iGlobal, fGlobal
 
     nSpin = size(pc, dim=3)
 
+    call distributeRangeInChunks(env, 1, size(rhs), iGlobal, fGlobal)
+
     pc(:,:,:) = 0.0_dp
-    do ias = 1, size(rhs)
+    do ias = iGlobal, fGlobal
       call indxov(rpa%win, ias, rpa%getIA, i, a, s)
       pc(i,a,s) = rhs(ias)
     end do
+    call assembleChunks(env, pc)
 
     do s = 1, nSpin
       pc(:,:,s) = 0.5_dp * ( pc(:,:,s) + transpose(pc(:,:,s)) )
@@ -3199,11 +3425,14 @@ contains
 
   !> Computes H^+/-_pq [V] as defined in Furche JCP 117 7433 (2002) eq. 20
   !! Here p/q are virtual orbitals and V is either X+Y or X-Y
-  subroutine getHvvXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, ipm, XorY,&
-      & vecHvv)
+  subroutine getHvvXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, ipm,&
+      & XorY, vecHvv)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
+
+    !> Data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
 
     !> Data structure for linear response
     type(TLinResp), intent(in) :: lr
@@ -3236,17 +3465,19 @@ contains
     real(dp), intent(out) :: vecHvv(:)
 
     real(dp), allocatable :: qIJ(:), gqIJ(:), qX(:,:), Gq(:,:)
-    integer :: i, a, b, s, ias, ibs, abs, nOrb
+    integer :: i, a, b, s, ias, ibs, abs, nOrb, iGlobal, fGlobal
 
-    nOrb = size(ovrXev, dim=1)
+    nOrb = orb%nOrb
 
     allocate(qIJ(lr%nAtom))
     allocate(gqIJ(lr%nAtom))
     allocate(qX(lr%nAtom, rpa%nxov_rd))
     allocate(Gq(lr%nAtom, rpa%nxov_rd))
 
+    call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
+
     qX(:,:) = 0.0_dp
-    do ias = 1, rpa%nxov_rd
+    do ias = iGlobal, fGlobal
       call indXov(rpa%win, ias, rpa%getIA, i, a, s)
       do b = rpa%nocc_ud(s) + 1, nOrb
         ibs = rpa%iaTrans(i, b, s)
@@ -3257,14 +3488,19 @@ contains
     end do
 
     Gq(:,:) = 0.0_dp
-    do ias = 1, rpa%nxov_rd
+    do ias = iGlobal, fGlobal
       qIJ(:) = transChrg%qTransIA(ias, env, denseDesc, ovrXev, grndEigVecs, rpa%getIA, rpa%win)
       call hemv(gqIJ, lrGamma, qIJ, uplo='U')
       Gq(:,ias) = gqIJ(:)
     end do
 
+    call assembleChunks(env,qX)
+    call assembleChunks(env,Gq)
+
+    call distributeRangeInChunks(env, 1, sum(rpa%nxvv_ud), iGlobal, fGlobal)
+
     vecHvv(:) = 0.0_dp
-    do abs = 1, sum(rpa%nxvv_ud)
+    do abs = iGlobal, fGlobal
       a = rpa%getAB(abs, 1)
       b = rpa%getAB(abs, 2)
       s = rpa%getAB(abs, 3)
@@ -3276,16 +3512,21 @@ contains
       end do
     end do
 
+    call assembleChunks(env,vecHvv)
+
   end subroutine getHvvXY
 
 
   !> Computes H^+/-_pq [V] as defined in Furche JCP 117 7433 (2002) eq. 20
   !! Here p/q are occupied orbitals and V is either X+Y or X-Y
-  subroutine getHooXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, ipm, XorY,&
-      & vecHoo)
+  subroutine getHooXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, ipm,&
+      & XorY, vecHoo)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
+
+    !> Data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
 
     !> Data structure for linear response
     type(TLinResp), intent(in) :: lr
@@ -3318,17 +3559,19 @@ contains
     real(dp), intent(out) :: vecHoo(:)
 
     real(dp), allocatable :: qIJ(:), gqIJ(:), qX(:,:), Gq(:,:)
-    integer :: i, j, a, s, ias, jas, ijs, nOrb
+    integer :: i, j, a, s, ias, jas, ijs, nOrb, iGlobal, fGlobal
 
-    nOrb = size(ovrXev, dim=1)
+    nOrb = orb%nOrb
 
     allocate(qIJ(lr%nAtom))
     allocate(gqIJ(lr%nAtom))
     allocate(qX(lr%nAtom, rpa%nxov_rd))
     allocate(Gq(lr%nAtom, rpa%nxov_rd))
 
+    call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
+
     qX(:,:) = 0.0_dp
-    do ias = 1, rpa%nxov_rd
+    do ias = iGlobal, fGlobal
       call indXov(rpa%win, ias, rpa%getIA, i, a, s)
       do j = 1, rpa%nocc_ud(s)
         jas = rpa%iaTrans(j, a, s)
@@ -3339,15 +3582,20 @@ contains
     end do
 
     Gq(:,:) = 0.0_dp
-    do ias = 1, rpa%nxov_rd
+    do ias = iGlobal, fGlobal
       call indXov(rpa%win, ias, rpa%getIA, i, a, s)
       qIJ(:) = transChrg%qTransIA(ias, env, denseDesc, ovrXev, grndEigVecs, rpa%getIA, rpa%win)
       call hemv(gqIJ, lrGamma, qIJ, uplo='U')
       Gq(:,ias) = gqIJ
     end do
 
+    call assembleChunks(env,qX)
+    call assembleChunks(env,Gq)
+
+    call distributeRangeInChunks(env, 1, sum(rpa%nxoo_ud), iGlobal, fGlobal)
+
     vecHoo(:) = 0.0_dp
-    do ijs = 1, sum(rpa%nxoo_ud)
+    do ijs = iGlobal, fGlobal
       i = rpa%getIJ(ijs, 1)
       j = rpa%getIJ(ijs, 2)
       s = rpa%getIJ(ijs, 3)
@@ -3359,15 +3607,21 @@ contains
       end do
     end do
 
+    call assembleChunks(env,vecHoo)
+
   end subroutine getHooXY
 
 
   !> Computes H^+/-_pq [T] as defined in Furche JCP 117 7433 (2002) eq. 20
   !! Here p is an occupied MO and q is a virtual one, T is the relaxed difference density
-  subroutine getHovT(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, t, vecHovT)
+  subroutine getHovT(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, t,&
+      & vecHovT)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
+
+    !> Data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
 
     !> Data structure for linear response
     type(TLinResp), intent(in) :: lr
@@ -3397,9 +3651,9 @@ contains
     real(dp), intent(out) :: vecHovT(:)
 
     real(dp), allocatable :: qIJ(:), gqIJ(:), qX(:,:), Gq(:,:)
-    integer :: i, j, a, b, s, ias, ibs, abs, ijs, jas, nOrb, iMx
+    integer :: i, j, a, b, s, ias, ibs, abs, ijs, jas, nOrb, iMx, iGlobal, fGlobal
 
-    nOrb = size(ovrXev, dim=1)
+    nOrb = orb%nOrb
 
     allocate(qIJ(lr%nAtom))
     allocate(gqIJ(lr%nAtom))
@@ -3407,8 +3661,10 @@ contains
     iMx = max(sum(rpa%nxoo_ud), sum(rpa%nxvv_ud))
     allocate(Gq(lr%nAtom, iMx))
 
+    call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
+
     qX(:,:) = 0.0_dp
-    do ias = 1, rpa%nxov_rd
+    do ias = iGlobal, fGlobal
       call indXov(rpa%win, ias, rpa%getIA, i, a, s)
       do b = rpa%nocc_ud(s) + 1, nOrb
         ibs = rpa%iaTrans(i, b, s)
@@ -3417,15 +3673,21 @@ contains
       end do
     end do
 
+    call assembleChunks(env,qX)
+    call distributeRangeInChunks(env, 1, sum(rpa%nxvv_ud), iGlobal, fGlobal)
+
     Gq(:,:) = 0.0_dp
-    do abs = 1, sum(rpa%nxvv_ud)
+    do abs = iGlobal, fGlobal
       qIJ(:) = transChrg%qTransAB(abs, env, denseDesc, ovrXev, grndEigVecs, rpa%getAB)
       call hemv(gqIJ, lrGamma, qIJ, uplo='U')
       Gq(:,abs) = gqIJ
     end do
 
+    call assembleChunks(env,Gq)
+    call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
+
     vecHovT(:) = 0.0_dp
-    do ias = 1, rpa%nxov_rd
+    do ias = iGlobal, fGlobal
       call indXov(rpa%win, ias, rpa%getIA, i, a, s)
       do b = rpa%nocc_ud(s) + 1, nOrb
         ibs = rpa%iaTrans(i, b, s)
@@ -3435,7 +3697,7 @@ contains
     end do
 
     qX(:,:) = 0.0_dp
-    do ias = 1, rpa%nxov_rd
+    do ias = iGlobal, fGlobal
       call indXov(rpa%win, ias, rpa%getIA, i, a, s)
       do j = 1, rpa%nocc_ud(s)
         jas = rpa%iaTrans(j, a, s)
@@ -3444,8 +3706,11 @@ contains
       end do
     end do
 
+    call assembleChunks(env,qX)
+    call distributeRangeInChunks(env, 1, sum(rpa%nxoo_ud), iGlobal, fGlobal)
+
     Gq(:,:) = 0.0_dp
-    do ijs = 1, sum(rpa%nxoo_ud)
+    do ijs = iGlobal, fGlobal
       i = rpa%getIJ(ijs, 1)
       j = rpa%getIJ(ijs, 2)
       s = rpa%getIJ(ijs, 3)
@@ -3454,7 +3719,10 @@ contains
       Gq(:,ijs) = gqIJ
     end do
 
-    do ias = 1, rpa%nxov_rd
+    call assembleChunks(env,Gq)
+    call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
+
+    do ias = iGlobal, fGlobal
       call indXov(rpa%win, ias, rpa%getIA, i, a, s)
       do j = 1, rpa%nocc_ud(s)
         jas = rpa%iaTrans(j, a, s)
@@ -3463,15 +3731,21 @@ contains
       end do
     end do
 
+    call assembleChunks(env,vecHovT)
+
   end subroutine getHovT
 
 
   !> Computes H^+/-_pq [T] as defined in Furche JCP 117 7433 (2002) eq. 20
   !! Here p/q are occupied MO, T is the relaxed difference density
-  subroutine getHooT(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, t, vecHooT)
+  subroutine getHooT(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, t,&
+      & vecHooT)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
+
+    !> Data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
 
     !> Data structure for linear response
     type(TLinResp), intent(in) :: lr
@@ -3502,9 +3776,9 @@ contains
 
     real(dp), allocatable :: qIJ(:), gqIJ(:), qX(:,:), Gq(:,:), qXa(:,:,:)
     integer :: nOrb, iSpin, nSpin, iMx, soo(2)
-    integer :: i, j, k, a, b, s, ij, ias, ibs, ijs, jas, iks, jks
+    integer :: i, j, k, a, b, s, ij, ias, ibs, ijs, jas, iks, jks, iGlobal, fGlobal
 
-    nOrb = size(ovrXev, dim=1)
+    nOrb = orb%nOrb
     nSpin = size(t, dim=3)
     soo(:) = [0, rpa%nxoo_ud(1)]
 
@@ -3514,8 +3788,10 @@ contains
     allocate(qX(lr%nAtom, iMx))
     allocate(Gq(lr%nAtom, iMx))
 
+    call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
+
     qX(:,:) = 0.0_dp
-    do ias = 1, rpa%nxov_rd
+    do ias = iGlobal, fGlobal
       call indXov(rpa%win, ias, rpa%getIA, i, a, s)
       do b = rpa%nocc_ud(s) + 1, nOrb
         ibs = rpa%iaTrans(i, b, s)
@@ -3525,14 +3801,19 @@ contains
     end do
 
     Gq(:,:) = 0.0_dp
-    do ias = 1, rpa%nxov_rd
+    do ias = iGlobal, fGlobal
       qIJ(:) = transChrg%qTransIA(ias, env, denseDesc, ovrXev, grndEigVecs, rpa%getIA, rpa%win)
       call hemv(gqIJ, lrGamma, qIJ, uplo='U')
       Gq(:,ias) = gqIJ
     end do
 
+    call assembleChunks(env,qX)
+    call assembleChunks(env,Gq)
+
+    call distributeRangeInChunks(env, 1, sum(rpa%nxoo_ud), iGlobal, fGlobal)
+
     vecHooT(:) = 0.0_dp
-    do ijs = 1, sum(rpa%nxoo_ud)
+    do ijs = iGlobal, fGlobal
       i = rpa%getIJ(ijs, 1)
       j = rpa%getIJ(ijs, 2)
       s = rpa%getIJ(ijs, 3)
@@ -3546,19 +3827,23 @@ contains
     deallocate(qX)
 
     Gq(:,:) = 0.0_dp
-    do ijs = 1, sum(rpa%nxoo_ud)
+    do ijs = iGlobal, fGlobal
       qIJ = transChrg%qTransIJ(ijs, env, denseDesc, ovrXev, grndEigVecs, rpa%getIJ)
       call hemv(gqIJ, lrGamma, qIJ, uplo='U')
       Gq(:,ijs) = gqIJ(:)
     end do
 
+    call assembleChunks(env,Gq)
+
     ! For qXa_ijs = sum_k q_iks t(j,k,s), we need both qXa_ijs and qXa_jis
     ! Need for a spin loop, don't think this can be simplified
     do iSpin = 1, nSpin
 
+      call distributeRangeInChunks(env, 1, rpa%nocc_ud(iSpin), iGlobal, fGlobal)
+
       allocate(qXa(lr%nAtom, rpa%nocc_ud(iSpin), rpa%nocc_ud(iSpin)))
       qXa(:,:,:) = 0.0_dp
-      do i = 1, rpa%nocc_ud(iSpin)
+      do i = iGlobal, fGlobal
         do k = 1, rpa%nocc_ud(iSpin)
           iks = rpa%iaTrans(i, k, iSpin)
           qIJ(:) = transChrg%qTransIJ(iks, env, denseDesc, ovrXev, grndEigVecs, rpa%getIJ)
@@ -3568,7 +3853,11 @@ contains
         end do
       end do
 
-      do ij = 1, rpa%nxoo_ud(iSpin)
+      call assembleChunks(env,qXa)
+
+      call distributeRangeInChunks(env, 1, rpa%nxoo_ud(iSpin), iGlobal, fGlobal)
+
+      do ij = iGlobal, fGlobal
         i = rpa%getIJ(ij + soo(iSpin), 1)
         j = rpa%getIJ(ij + soo(iSpin), 2)
         ijs = rpa%iaTrans(i, j, iSpin)
@@ -3580,6 +3869,8 @@ contains
       deallocate(qXa)
 
     end do
+
+    call assembleChunks(env,vecHooT)
 
   end subroutine getHooT
 
@@ -3720,11 +4011,14 @@ contains
   !! See TCA 140 34 (2020) and JCP 132 044107 (2010)
   !! Actually omega * W is computed
   !! TODO: Spin-polarized systems
-  subroutine grndToExcDensityMatrices(env, lr, rpa, transChrg, denseDesc, sym, species0, ovrXev,&
-      & grndEigVecs, grndEigVal, frGamma, lrGamma, omega, pc, xpy, xmy, wov, woo)
+  subroutine grndToExcDensityMatrices(env, orb, lr, rpa, transChrg, denseDesc, sym, species0,&
+      & ovrXev, grndEigVecs, grndEigVal, frGamma, lrGamma, omega, pc, xpy, xmy, wov, woo)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
+
+    !> Data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
 
     !> Data structure for linear response
     type(TLinResp), intent(in) :: lr
@@ -3778,10 +4072,9 @@ contains
     real(dp), intent(out) :: woo(:,:)
 
     real(dp), allocatable :: p(:), vecHoo(:)
-    integer :: soo(2), i, a, s, ias, j, ij, ijs, nSpin, nOrb
+    integer :: soo(2), i, a, s, ias, j, ij, ijs, nSpin, iGlobal, fGlobal
 
 
-    nOrb = size(ovrXev, dim=1)
     nSpin = size(rpa%nocc_ud)
 
     allocate(p(rpa%nxov_rd))
@@ -3794,9 +4087,12 @@ contains
     wov(:) = 0.0_dp
     woo(:,:) = 0.0_dp
 
+    ! MPI distribution indexes
+    call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
+
     ! "Fake" density matrix for non-adiabatic coupling [Furche JCP 132 044107 (2010)]
     ! Restricted KS: P = 2 P^up ; (X+Y) = sqrt(2) (X+Y)^up
-    do ias = 1, rpa%nxov_rd
+    do ias = iGlobal, fGlobal
       call indxov(rpa%win, ias, rpa%getIA, i, a, s)
       p(ias) = sqrt(2.0_dp) * xpy(ias)
       wov(ias) = grndEigVal(i, s) * p(ias) + omega * xmy(ias) / sqrt(2.0_dp)
@@ -3804,16 +4100,22 @@ contains
 
     ! Define P symmetrically (similar to treatment of excited state gradients)
     pc(:,:,:) = 0.0_dp
-    do ias = 1, rpa%nxov_rd
+    do ias = iGlobal, fGlobal
       call indxov(rpa%win, ias, rpa%getIA, i, a, s)
       pc(i,a,s) = 0.5_dp * p(ias)
       pc(a,i,s) = 0.5_dp * p(ias)
     end do
+
+    call assembleChunks(env,p)
+    call assembleChunks(env,pc)
+    call assembleChunks(env,wov)
+
     call getHplusXYfr(env, lr, rpa, transChrg, denseDesc, sym, species0, ovrXev, grndEigVecs,&
         & frGamma, p, vecHoo=vecHoo)
 
     do s = 1, nSpin
-      do ij = 1, rpa%nxoo_ud(s)
+      call distributeRangeInChunks(env, 1, rpa%nxoo_ud(s), iGlobal, fGlobal)
+      do ij = iGlobal, fGlobal
         i = rpa%getIJ(ij + soo(s), 1)
         j = rpa%getIJ(ij + soo(s), 2)
         ijs = rpa%iaTrans(i, j, s)
@@ -3823,10 +4125,12 @@ contains
     end do
 
     if (rpa%tHybridXc) then
-      call getHooXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, 1, p, vecHoo)
+      call getHooXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, 1, p,&
+          & vecHoo)
 
       do s = 1, nSpin
-        do ij = 1, rpa%nxoo_ud(s)
+        call distributeRangeInChunks(env, 1, rpa%nxoo_ud(s), iGlobal, fGlobal)
+        do ij = iGlobal, fGlobal
           i = rpa%getIJ(ij + soo(s), 1)
           j = rpa%getIJ(ij + soo(s), 2)
           ijs = rpa%iaTrans(i, j, s)
@@ -3837,7 +4141,8 @@ contains
 
     ! Divide diagonal elements of W_ij by 2.
     do s = 1, nSpin
-      do ij = 1, rpa%nxoo_ud(s)
+      call distributeRangeInChunks(env, 1, rpa%nxoo_ud(s), iGlobal, fGlobal)
+      do ij = iGlobal, fGlobal
         i = rpa%getIJ(ij + soo(s), 1)
         j = rpa%getIJ(ij + soo(s), 2)
         if (i == j) then
@@ -3845,6 +4150,7 @@ contains
         end if
       end do
     end do
+    call assembleChunks(env,woo)
 
   end subroutine grndToExcDensityMatrices
 
@@ -3853,12 +4159,15 @@ contains
   !! do not depend on Z. Modified version of getZVectorEqRHS for state-to-state NA couplings.
   !! Furche PCCP 21 18999 (2019)
   !! Here the + (symmetric) part of RHS, T and (omega_m-omega_n) * W (stored as W) is computed.
-  subroutine getNadiaZVectorEqRHS(env, lr, rpa, transChrg, sym, denseDesc, species0, grndEigVal,&
-      & ovrXev, grndEigVecs, gammaMat, lrGamma, omegaAvg, xpyn, xmyn, xpym, xmym, rhs, t, wov, woo,&
-      & wvv)
+  subroutine getNadiaZVectorEqRHS(env, orb, lr, rpa, transChrg, sym, denseDesc, species0,&
+      & grndEigVal, ovrXev, grndEigVecs, gammaMat, lrGamma, omegaAvg, xpyn, xmyn, xpym, xmym, rhs,&
+      & t, wov, woo, wvv)
 
     !> Environment settings
     type(TEnvironment), intent(inout) :: env
+
+    !> Data type for atomic orbital information
+    type(TOrbitals), intent(in) :: orb
 
     !> Data structure for linear response
     type(TLinResp), intent(in) :: lr
@@ -3928,12 +4237,12 @@ contains
     real(dp), allocatable :: vecHvvXorY(:), vecHooXorY(:), vecHovT(:), vecHvvT(:)
     real(dp), allocatable :: vecHvvXpY(:), vecHvvXmY(:), vecHooXpY(:), vecHooXmY(:)
     real(dp), allocatable :: vecHooT(:)
-    integer :: nxov
+    integer :: nxov, iGlobal, fGlobal
     integer :: i, j, a, b, ias, ibs, abs, ij, ab, jas, ijs, s, nSpin, soo(2), svv(2), nOrb
     real(dp) :: ptmp1, ptmp2, tmp3, tmp4, tmp1
 
     nxov = size(rhs)
-    nOrb = size(ovrXev, dim=1)
+    nOrb = orb%nOrb
 
     allocate(xpyq(lr%nAtom))
     allocate(qTr(lr%nAtom))
@@ -3961,10 +4270,12 @@ contains
       allocate(gamxpyqds(lr%nAtom))
     end if
 
+    call distributeRangeInChunks(env, 1, nxov, iGlobal, fGlobal)
+
     ! Build state-to-state 1TDM and W (eq. 42 in Furche PCCP)
     ! We are symmetrizing the non-symmetric T of Furche
     ! Factor 1 / (1 + delta_ab) for W follows later
-    do ias = 1, nxov
+    do ias = iGlobal, fGlobal
       call indxov(rpa%win, ias, rpa%getIA, i, a, s)
 
       ! BA: is T_aa = 0?
@@ -4019,11 +4330,13 @@ contains
 
     end do
 
+    call assembleChunks(env, t)
+
     ! Terms for (P+-Q) of form (X+Y)^m_ib H^+_ab[(X+Y)^n]
     call getHplusXYfr(env, lr, rpa, transChrg, denseDesc, sym, species0, ovrXev, grndEigVecs,&
         & gammaMat, xpyn, vecHoo=vecHooXorY, vecHvv=vecHvvXorY)
 
-    do ias = 1, nxov
+    do ias = iGlobal, fGlobal
       call indxov(rpa%win, ias, rpa%getIA, i, a, s)
       do b = rpa%nocc_ud(s) + 1, a
         abs = rpa%iaTrans(a, b, s)
@@ -4056,7 +4369,7 @@ contains
     call getHplusXYfr(env, lr, rpa, transChrg, denseDesc, sym, species0, ovrXev, grndEigVecs,&
         & gammaMat, xpym, vecHoo=vecHooXorY, vecHvv=vecHvvXorY)
 
-    do ias = 1, nxov
+    do ias = iGlobal, fGlobal
       call indxov(rpa%win, ias, rpa%getIA, i, a, s)
       do b = rpa%nocc_ud(s) + 1, a
         abs = rpa%iaTrans(a, b, s)
@@ -4093,14 +4406,15 @@ contains
     call getHplusMfr(env, lr, rpa, transChrg, denseDesc, species0, ovrXev, grndEigVecs, gammaMat,&
         & 3, t, vecHovT)
 
-    rhs = rhs - vecHovT
+    rhs(iGlobal:fGlobal) = rhs(iGlobal:fGlobal) - vecHovT(iGlobal:fGlobal)
 
     ! Woo^+ += 0.5 * H^+_ij[T+Z] / Omega_mn, Z part computed later
     call getHplusMfr(env, lr, rpa, transChrg, denseDesc, species0, ovrXev, grndEigVecs, gammaMat,&
         & 1, t, vecHooT)
 
     do s = 1, nSpin
-      do ij = 1, rpa%nxoo_ud(s)
+      call distributeRangeInChunks(env, 1, rpa%nxoo_ud(s), iGlobal, fGlobal)
+      do ij = iGlobal, fGlobal
         ijs = ij + soo(s)
         woo(ij,s) = woo(ij,s) + vecHooT(ijs)
       end do
@@ -4114,19 +4428,20 @@ contains
       allocate(vecHooXmY(sum(rpa%nxoo_ud)))
 
       ! Long-range part of H^+[(X+Y)^n] or H^-[(X-Y)^n] for occ-occ and vir-vir comp. of H
-      call getHvvXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma,  1, xpyn,&
-          & vecHvvXpY)
+      call getHvvXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma,  1,&
+          & xpyn, vecHvvXpY)
 
-      call getHvvXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, -1, xmyn,&
-          & vecHvvXmY)
+      call getHvvXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, -1,&
+          & xmyn, vecHvvXmY)
 
-      call getHooXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma,  1, xpyn,&
-          & vecHooXpY)
+      call getHooXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma,  1,&
+          & xpyn, vecHooXpY)
 
-      call getHooXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, -1, xmyn,&
-          & vecHooXmY)
+      call getHooXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, -1,&
+          & xmyn, vecHooXmY)
 
-      do ias = 1, nxov
+      call distributeRangeInChunks(env, 1, nxov, iGlobal, fGlobal)
+      do ias = iGlobal, fGlobal
 
         call indXov(rpa%win, ias, rpa%getIA, i, a, s)
         do b = rpa%nocc_ud(s) + 1, nOrb
@@ -4160,19 +4475,19 @@ contains
       ! Now n <-> m
 
       ! Long-range part of H^+[(X+Y)^n] or H^-[(X-Y)^n] for occ-occ and vir-vir comp. of H
-      call getHvvXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, 1, xpym,&
+      call getHvvXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, 1, xpym,&
           & vecHvvXpY)
 
-      call getHvvXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, -1, xmym,&
-          & vecHvvXmY)
+      call getHvvXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, -1,&
+          & xmym, vecHvvXmY)
 
-      call getHooXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma,  1, xpym,&
-          & vecHooXpY)
+      call getHooXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma,  1,&
+          & xpym, vecHooXpY)
 
-      call getHooXY(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, -1, xmym,&
-          & vecHooXmY)
+      call getHooXY(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, -1,&
+          & xmym, vecHooXmY)
 
-      do ias = 1, nxov
+      do ias = iGlobal, fGlobal
 
         call indXov(rpa%win, ias, rpa%getIA, i, a, s)
         do b = rpa%nocc_ud(s) + 1, nOrb
@@ -4204,21 +4519,29 @@ contains
       end do
 
       ! -RHS^+ += - H^+_ia[T^+]
-      call getHovT(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, t, vecHovT)
+      call getHovT(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, t,&
+          & vecHovT)
 
-      rhs(:) = rhs - cExchange * vecHovT
+      rhs(iGlobal:fGlobal) = rhs(iGlobal:fGlobal) - cExchange * vecHovT(iGlobal:fGlobal)
 
       ! Woo^+ += 0.5 * H^+_ij[T+Z] / Omega_mn, Z part computed later
-      call getHooT(env, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, t, vecHooT)
+      call getHooT(env, orb, lr, rpa, transChrg, denseDesc, ovrXev, grndEigVecs, lrGamma, t,&
+          & vecHooT)
 
       do s = 1, nSpin
-        do ij = 1, rpa%nxoo_ud(s)
+        call distributeRangeInChunks(env, 1, rpa%nxoo_ud(s), iGlobal, fGlobal)
+        do ij = iGlobal, fGlobal
           ijs = ij + soo(s)
           woo(ij, s) = woo(ij, s) + cExchange * vecHooT(ijs)
         end do
       end do
 
     endif
+
+    call assembleChunks(env, rhs)
+    call assembleChunks(env, woo)
+    call assembleChunks(env, wov)
+    call assembleChunks(env, wvv)
 
   end subroutine getNadiaZvectorEqRHS
 
@@ -4371,13 +4694,14 @@ contains
     real(dp), allocatable :: overlap(:,:), lrGammaOrb(:,:), gammaLongRangePrime(:,:,:)
     real(dp), allocatable :: PS(:,:,:), DS(:,:,:), SPS(:,:,:), SDS(:,:,:), SX(:,:,:,:)
     real(dp), allocatable :: XS(:,:,:,:), SXS(:,:,:,:), SY(:,:,:,:), YS(:,:,:,:), SYS(:,:,:,:)
+    real(dp), allocatable :: deltaRhoGlobal(:,:,:), grndEigVecsGlobal(:,:,:)
     real(dp), allocatable :: xpy(:,:), xmy(:,:)
     real(dp) :: tmp1, tmp2, tmp3, tmp4, tmp6, tmp8, tmp9, tmp10, rab
     real(dp) :: diffvec(3), dgab(3), tmpVec(3), tmp3a, tmp3b, tmprs, tmprs2, tmps(2)
     integer, allocatable :: species(:)
     integer :: ia, i, j, a, b, ab, ij, m, n, mu, nu, xyz, iAt1, iAt2, ka
     integer :: indalpha, indalpha1, indbeta, indbeta1, soo(2), svv(2)
-    integer :: iSp1, iSp2, iSpin, nSpin, iState, nOrb
+    integer :: iSp1, iSp2, iSpin, nSpin, iState, nOrb, iGlobal, fGlobal
 
     nSpin = size(grndEigVecs, dim=3)
     nOrb = orb%nOrb
@@ -4418,6 +4742,10 @@ contains
       xpyqds = 0.0_dp
       allocate(tmp11(nSpin))
 
+      ! FIXME: here nOrb is the global value but rhoSqr has dimension of nOrb local
+      ! TODO: nOrb is the global but rhoSqr has the dimension of nOrb local
+      !      The test NH forces does not run even for single process.
+      ! NOTE: I think now, with the last BUGFIX, this should be correct
       allocate(SpinDens(nOrb, nOrb))
       SpinDens(:,:) = rhoSqr(:,:,1) - rhoSqr(:,:,2)
 
@@ -4426,6 +4754,19 @@ contains
       dsigma(2) = -1.0_dp
       dm(:) = dq_ud(:,2)
     end if
+
+    ! Convert local arrays to global
+    allocate(grndEigVecsGlobal(norb,norb,size(grndEigVecs,dim=3)))
+  #:if WITH_SCALAPACK
+
+    do iSpin = 1, nSpin
+      call distrib2replicated(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, &
+                           &  grndEigVecs(:,:,iSpin), grndEigVecsGlobal(:,:,iSpin))
+    enddo
+  #:else
+
+    grndEigVecsGlobal = grndEigVecs
+  #:endif
 
     if (rpa%tHybridXc) then
       allocate(xmycc(nOrb, nOrb, nSpin, 2))
@@ -4445,17 +4786,30 @@ contains
       allocate(lrGammaOrb(nOrb, nOrb))
       allocate(gammaLongRangePrime(3, lr%nAtom, lr%nAtom))
 
-      ! Symmetrize deltaRho
-      do mu = 1, nOrb
-        do nu = mu + 1, nOrb
-          deltaRho(mu,nu,:) = deltaRho(nu,mu,:)
+      allocate(deltaRhoGlobal(norb,norb,size(deltaRho,dim=3)))
+    #:if WITH_SCALAPACK
+
+      ! Convert local arrays to global
+      do iSpin = 1, nSpin
+        call distrib2replicated(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, &
+                             &  deltaRho(:,:,iSpin), deltaRhoGlobal(:,:,iSpin))
+      enddo
+    #:else
+
+      deltaRhoGlobal = deltaRho
+    #:endif
+
+      ! Symmetrize deltaRhoGlobal
+      do mu = 1, size(deltaRhoGlobal, dim=1)
+        do nu = mu + 1, size(deltaRhoGlobal, dim=2)
+          deltaRhoGlobal(mu,nu,:) = deltaRhoGlobal(nu,mu,:)
         end do
       end do
 
       ! Compute long-range gamma derivative
+      call distributeRangeInChunks(env, 1, lr%nAtom, iGlobal, fGlobal)
       gammaLongRangePrime(:,:,:) = 0.0_dp
-      call hybridXc%getCentralCellSpecies(species)
-      do iAt1 = 1, lr%nAtom
+      do iAt1 = iGlobal, fGlobal
         do iAt2 = 1, lr%nAtom
           if (iAt1 /= iAt2) then
             call getDirectionalCamGammaPrimeValue(hybridXc, tmpVec, iAt1, iAt2)
@@ -4463,6 +4817,7 @@ contains
           end if
         end do
       end do
+      call assembleChunks(env,gammaLongRangePrime)
 
       ! Symmetrize S (can't we get S from caller?)
       call getSqrS(coord0, lr%nAtom, skOverCont, orb, denseDesc%iAtomStart, species0, overlap)
@@ -4509,19 +4864,21 @@ contains
       !
       ! xpycc(mu,nu) = sum_ia (X+Y)_ia grndEigVecs(mu,i) grndEigVecs(nu,a)
       ! xpycc(mu, nu) += sum_ia (X+Y)_ia grndEigVecs(mu,a) grndEigVecs(nu,i)
+      call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
       xpycc(:,:,:,iState) = 0.0_dp
-      do ia = 1, rpa%nxov_rd
+      do ia = iGlobal, fGlobal
         call indxov(rpa%win, ia, rpa%getIA, i, a, iSpin)
         ! Should replace with DSYR2 call:
         do nu = 1, nOrb
           do mu = 1, nOrb
             xpycc(mu,nu,iSpin,iState) = xpycc(mu,nu,iSpin,iState) + xpy(ia,iState)&
-                & * (grndEigVecs(mu,i,iSpin)*grndEigVecs(nu,a,iSpin)&
-                & + grndEigVecs(mu,a,iSpin)*grndEigVecs(nu,i,iSpin))
+                & * (grndEigVecsGlobal(mu,i,iSpin)*grndEigVecsGlobal(nu,a,iSpin)&
+                & + grndEigVecsGlobal(mu,a,iSpin)*grndEigVecsGlobal(nu,i,iSpin))
           end do
         end do
       end do
     end do
+    call assembleChunks(env, xpycc)
 
     if (rpa%tHybridXc) then
 
@@ -4529,23 +4886,27 @@ contains
       xpyas(:,:,:,:) = 0.0_dp
       xmyas(:,:,:,:) = 0.0_dp
 
+      call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
       do iState = 1,2
         ! Asymmetric contribution: xmycc_as = sum_ias (X-Y)_ias c_mas c_nis
-        do ia = 1, rpa%nxov_rd
+        do ia = iGlobal, fGlobal
           call indxov(rpa%win, ia, rpa%getIA, i, a, iSpin)
           ! Should replace with DSYR2 call:
           do nu = 1, nOrb
             do mu = 1, nOrb
                xmycc(mu,nu,iSpin,iState) = xmycc(mu,nu,iSpin,iState) + xmy(ia,iState) *&
-                & ( grndEigVecs(mu,i,iSpin) * grndEigVecs(nu,a,iSpin)&
-                & + grndEigVecs(mu,a,iSpin) * grndEigVecs(nu,i,iSpin) )
+                & ( grndEigVecsGlobal(mu,i,iSpin) * grndEigVecsGlobal(nu,a,iSpin)&
+                & + grndEigVecsGlobal(mu,a,iSpin) * grndEigVecsGlobal(nu,i,iSpin) )
                xpyas(mu,nu,iSpin,iState) = xpyas(mu,nu,iSpin,iState) + xpy(ia,iState) *&
-                & grndEigVecs(mu,i,iSpin) * grndEigVecs(nu,a,iSpin)
+                & grndEigVecsGlobal(mu,i,iSpin) * grndEigVecsGlobal(nu,a,iSpin)
                xmyas(mu,nu,iSpin,iState) = xmyas(mu,nu,iSpin,iState) + xmy(ia,iState) *&
-                & grndEigVecs(mu,i,iSpin) * grndEigVecs(nu,a,iSpin)
+                & grndEigVecsGlobal(mu,i,iSpin) * grndEigVecsGlobal(nu,a,iSpin)
             end do
           end do
         end do
+        call assembleChunks(env, xmycc(:,:,:,iState))
+        call assembleChunks(env, xpyas(:,:,:,iState))
+        call assembleChunks(env, xmyas(:,:,:,iState))
 
         ! Account for normalization of S/T versus spin-polarized X+/-Y
         ! We have (X+Y)^S = 1/sqrt(2) [(X+Y)_up + (X+Y)_dn]
@@ -4558,8 +4919,8 @@ contains
         do iSpin = 1, nSpin
           call symm(PS(:,:,iSpin), 'R', overlap, pc(:,:,iSpin), 'U', 1.0_dp, 0.0_dp, nOrb, nOrb)
           call symm(SPS(:,:,iSpin), 'L', overlap, PS(:,:,iSpin), 'U', 1.0_dp, 0.0_dp, nOrb, nOrb)
-          call symm(DS(:,:,iSpin), 'R', overlap, deltaRho(:,:,iSpin), 'U', 1.0_dp, 0.0_dp, nOrb,&
-              & nOrb)
+          call symm(DS(:,:,iSpin), 'R', overlap, deltaRhoGlobal(:,:,iSpin), 'U', 1.0_dp, 0.0_dp,&
+              & nOrb, nOrb)
           call symm(SDS(:,:,iSpin), 'L', overlap, DS(:,:,iSpin), 'U', 1.0_dp, 0.0_dp, nOrb, nOrb)
           call symm(XS(:,:,iSpin,iState), 'R', overlap, xpyas(:,:,iSpin,iState), 'U', 1.0_dp,&
               & 0.0_dp, nOrb, nOrb)
@@ -4585,52 +4946,53 @@ contains
 
     ! Calculate the occ-occ part
     wcc(:,:,:) = 0.0_dp
-
     do iSpin = 1, nSpin
-      do ij = 1, rpa%nxoo_ud(iSpin)
+      call distributeRangeInChunks(env, 1, rpa%nxoo_ud(iSpin), iGlobal, fGlobal)
+      do ij = iGlobal, fGlobal
         i = rpa%getIJ(ij + soo(iSpin), 1)
         j = rpa%getIJ(ij + soo(iSpin), 2)
         ! Replace with DSYR2 call:
         do mu = 1, nOrb
           do nu = 1, nOrb
             wcc(mu,nu,iSpin) = wcc(mu,nu,iSpin) + woo(ij,iSpin) *&
-                & ( grndEigVecs(mu,i,iSpin)*grndEigVecs(nu,j,iSpin)&
-                & + grndEigVecs(mu,j,iSpin)*grndEigVecs(nu,i,iSpin) )
+                & ( grndEigVecsGlobal(mu,i,iSpin)*grndEigVecsGlobal(nu,j,iSpin)&
+                & + grndEigVecsGlobal(mu,j,iSpin)*grndEigVecsGlobal(nu,i,iSpin) )
           end do
         end do
-
       end do
     end do
 
     ! Calculate the occ-virt part: the same way as for xpycc
-    do ia = 1, rpa%nxov_rd
+    call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
+    do ia = iGlobal, fGlobal
       call indxov(rpa%win, ia, rpa%getIA, i, a, iSpin)
       ! Again replace with DSYR2 call:
       do nu = 1, nOrb
         do mu = 1, nOrb
           wcc(mu,nu,iSpin) = wcc(mu,nu,iSpin) + wov(ia) *&
-              & ( grndEigVecs(mu,i,iSpin)*grndEigVecs(nu,a,iSpin)&
-              & + grndEigVecs(mu,a,iSpin)*grndEigVecs(nu,i,iSpin) )
+              & ( grndEigVecsGlobal(mu,i,iSpin)*grndEigVecsGlobal(nu,a,iSpin)&
+              & + grndEigVecsGlobal(mu,a,iSpin)*grndEigVecsGlobal(nu,i,iSpin) )
         end do
       end do
     end do
 
     ! Calculate the virt - virt part
     do iSpin = 1, nSpin
-      do ab = 1, rpa%nxvv_ud(iSpin)
+      call distributeRangeInChunks(env, 1, rpa%nxvv_ud(iSpin), iGlobal, fGlobal)
+      do ab = iGlobal, fGlobal
         a = rpa%getAB(ab + svv(iSpin), 1)
         b = rpa%getAB(ab + svv(iSpin), 2)
         ! Replace with DSYR2 call:
         do mu = 1, nOrb
           do nu = 1, nOrb
             wcc(mu,nu,iSpin) = wcc(mu,nu,iSpin) + wvv(ab,iSpin) *&
-                & ( grndEigVecs(mu,a,iSpin)*grndEigVecs(nu,b,iSpin)&
-                & + grndEigVecs(mu,b,iSpin)*grndEigVecs(nu,a,iSpin) )
+                & ( grndEigVecsGlobal(mu,a,iSpin)*grndEigVecsGlobal(nu,b,iSpin)&
+                & + grndEigVecsGlobal(mu,b,iSpin)*grndEigVecsGlobal(nu,a,iSpin) )
           end do
         end do
-
       end do
     end do
+    call assembleChunks(env, wcc)
 
     ! Now calculating the force complexity : nOrb * nOrb * 3
 
@@ -4693,8 +5055,8 @@ contains
                 tmprs = tmprs +&
                     & ( 2.0_dp * (PS(mu,nu,iSpin) * DS(nu,mu,iSpin)&
                     & + PS(nu,mu,iSpin) * DS(mu,nu,iSpin))&
-                    & + SPS(mu,nu,iSpin) * deltaRho(mu,nu,iSpin)&
-                    & + SPS(nu,mu,iSpin) * deltaRho(nu,mu,iSpin)&
+                    & + SPS(mu,nu,iSpin) * deltaRhoGlobal(mu,nu,iSpin)&
+                    & + SPS(nu,mu,iSpin) * deltaRhoGlobal(nu,mu,iSpin)&
                     & + pc(mu,nu,iSpin) * SDS(mu,nu,iSpin)&
                     & + pc(nu,mu,iSpin) * SDS(nu,mu,iSpin) )
 
@@ -4805,8 +5167,8 @@ contains
                   tmprs = 0.0_dp
                   do ka = 1, nOrb
                     tmprs = tmprs + (lrGammaOrb(mu,ka) + lrGammaOrb(nu,ka)) *&
-                        & ( PS(mu,ka,iSpin) * deltaRho(nu,ka,iSpin)&
-                        & + PS(nu,ka,iSpin) * deltaRho(mu,ka,iSpin)&
+                        & ( PS(mu,ka,iSpin) * deltaRhoGlobal(nu,ka,iSpin)&
+                        & + PS(nu,ka,iSpin) * deltaRhoGlobal(mu,ka,iSpin)&
                         & + pc(mu,ka,iSpin) * DS(nu,ka,iSpin)&
                         & + pc(nu,ka,iSpin) * DS(mu,ka,iSpin) )
                     tmprs = tmprs + 0.5_dp * (lrGammaOrb(mu,ka) + lrGammaOrb(nu,ka)) *&
@@ -4915,7 +5277,7 @@ contains
     !> Output vector H[V] virtual-virtual
     real(dp), optional, intent(out) :: vecHvv(:)
 
-    integer :: nSpin, ab, s, abs, svv(2), ij, ijs, soo(2)
+    integer :: nSpin, ab, s, abs, svv(2), ij, ijs, soo(2), iGlobal, fGlobal
     real(dp) :: fact
     real(dp), allocatable  :: xpyq(:), gamxpyq(:), qTr(:), xpyqds(:), gamxpyqds(:)
 
@@ -4942,13 +5304,15 @@ contains
       if (sym == "S") then
         call hemv(gamxpyq, frGamma, xpyq)
         if (present(vecHvv)) then
-          do ab = 1, rpa%nxvv_ud(1)
+          call distributeRangeInChunks(env, 1, rpa%nxvv_ud(1), iGlobal, fGlobal)
+          do ab = iGlobal, fGlobal
             qTr(:) = transChrg%qTransAB(ab, env, denseDesc, ovrXev, grndEigVecs, rpa%getAB)
             vecHvv(ab) = 2.0_dp * sum(qTr * gamxpyq)
           end do
         end if
         if (present(vecHoo)) then
-          do ij = 1, rpa%nxoo_ud(1)
+          call distributeRangeInChunks(env, 1, rpa%nxoo_ud(1), iGlobal, fGlobal)
+          do ij = iGlobal, fGlobal
             qTr(:) = transChrg%qTransIJ(ij, env, denseDesc, ovrXev, grndEigVecs, rpa%getIJ)
             ! vecHoo(ij) = sum_kb K_ij,kb (X+Y)_kb
             vecHoo(ij) = 2.0_dp * sum(qTr * gamxpyq)
@@ -4956,13 +5320,15 @@ contains
         end if
       else ! Triplet case
         if (present(vecHvv)) then
-          do ab = 1, rpa%nxvv_ud(1)
+          call distributeRangeInChunks(env, 1, rpa%nxvv_ud(1), iGlobal, fGlobal)
+          do ab = iGlobal, fGlobal
             qTr(:) = transChrg%qTransAB(ab, env, denseDesc, ovrXev, grndEigVecs, rpa%getAB)
             vecHvv(ab) = 2.0_dp * sum(qTr * xpyq * lr%spinW(species0))
           end do
         end if
         if (present(vecHoo)) then
-          do ij = 1, rpa%nxoo_ud(1)
+          call distributeRangeInChunks(env, 1, rpa%nxoo_ud(1), iGlobal, fGlobal)
+          do ij = iGlobal, fGlobal
             qTr(:) = transChrg%qTransIJ(ij, env, denseDesc, ovrXev, grndEigVecs, rpa%getIJ)
             vecHoo(ij) = 2.0_dp * sum(qTr * xpyq * lr%spinW(species0))
           end do
@@ -4985,7 +5351,8 @@ contains
           fact = -1.0_dp
         end if
         if (present(vecHvv)) then
-          do ab = 1, rpa%nxvv_ud(s)
+          call distributeRangeInChunks(env, 1, rpa%nxvv_ud(s), iGlobal, fGlobal)
+          do ab = iGlobal, fGlobal
             abs = ab + svv(s)
             qTr(:) = transChrg%qTransAB(abs, env, denseDesc, ovrXev, grndEigVecs, rpa%getAB)
             vecHvv(abs) = sum(qTr * gamxpyq)
@@ -4994,7 +5361,8 @@ contains
           end do
         end if
         if (present(vecHoo)) then
-          do ij = 1, rpa%nxoo_ud(s)
+          call distributeRangeInChunks(env, 1, rpa%nxoo_ud(s), iGlobal, fGlobal)
+          do ij = iGlobal, fGlobal
             ijs = ij + soo(s)
             qTr(:) = transChrg%qTransIJ(ijs, env, denseDesc, ovrXev, grndEigVecs, rpa%getIJ)
             vecHoo(ijs) = sum(qTr * gamxpyq)
@@ -5004,6 +5372,13 @@ contains
         end if
       end do
 
+    end if
+
+    if (present(vecHoo)) then
+      call assembleChunks(env, vecHoo)
+    end if
+    if (present(vecHvv)) then
+      call assembleChunks(env, vecHvv)
     end if
 
   end subroutine getHplusXYfr
@@ -5055,7 +5430,7 @@ contains
     !> Output vector H[M]
     real(dp), intent(out) :: vecH(:)
 
-    integer :: nSpin, ab, i, j, a, b, s, svv(2), ij, soo(2), ias
+    integer :: nSpin, ab, i, j, a, b, s, svv(2), ij, soo(2), ias, iGlobal, fGlobal
     real(dp), dimension(2) :: spinFactor = [1.0_dp, -1.0_dp]
     real(dp), allocatable  :: xpyq(:), gamxpyq(:), qTr(:), xpyqds(:), gamxpyqds(:)
     real(dp), allocatable  :: gamqt(:)
@@ -5088,7 +5463,8 @@ contains
     end if
 
     do s = 1, nSpin
-      do ij = 1, rpa%nxoo_ud(s)
+      call distributeRangeInChunks(env, 1, rpa%nxoo_ud(s), iGlobal, fGlobal)
+      do ij = iGlobal, fGlobal
         i = rpa%getIJ(ij + soo(s), 1)
         j = rpa%getIJ(ij + soo(s), 2)
         qTr(:) = transChrg%qTransIJ(ij + soo(s), env, denseDesc, ovrXev, grndEigVecs, rpa%getIJ)
@@ -5105,8 +5481,9 @@ contains
         end if
       end do
 
+      call distributeRangeInChunks(env, 1, rpa%nxvv_ud(s), iGlobal, fGlobal)
       ! gamxpyq(iAt2) += sum_ab q_ab(iAt2) M_ab
-      do ab = 1, rpa%nxvv_ud(s)
+      do ab = iGlobal, fGlobal
         a = rpa%getAB(ab + svv(s), 1)
         b = rpa%getAB(ab + svv(s), 2)
         qTr(:) = transChrg%qTransAB(ab + svv(s), env, denseDesc, ovrXev, grndEigVecs, rpa%getAB)
@@ -5126,8 +5503,9 @@ contains
 
     end do
 
+    call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
     ! gamxpyq(iAt2) += sum_ab q_ab(iAt2) M_ia
-    do ias = 1, rpa%nxov_rd
+    do ias = iGlobal, fGlobal
       i = rpa%getIA(ias, 1)
       a = rpa%getIA(ias, 2)
       s = rpa%getIA(ias, 3)
@@ -5138,12 +5516,18 @@ contains
       end if
     end do
 
+    call assembleChunks(env, gamxpyq)
+    if (lr%tSpin) then
+      call assembleChunks(env, gamxpyqds)
+    end if
+
     ! gamqt(iAt1) = sum_iAt2 gamma_iAt1,iAt2 gamxpyq(iAt2)
     call hemv(gamqt, frGamma, gamxpyq)
 
     if (iMode == 1) then
       do s = 1, nSpin
-        do ij = 1, rpa%nxoo_ud(s)
+        call distributeRangeInChunks(env, 1, rpa%nxoo_ud(s), iGlobal, fGlobal)
+        do ij = iGlobal, fGlobal
           i = rpa%getIJ(ij + soo(s), 1)
           j = rpa%getIJ(ij + soo(s), 2)
           qTr(:) = transChrg%qTransIJ(ij + soo(s), env, denseDesc, ovrXev, grndEigVecs, rpa%getIJ)
@@ -5158,7 +5542,8 @@ contains
       end do
     else if (iMode == 2) then
       do s = 1, nSpin
-        do ab = 1, rpa%nxvv_ud(s)
+        call distributeRangeInChunks(env, 1, rpa%nxvv_ud(s), iGlobal, fGlobal)
+        do ab = iGlobal, fGlobal
           a = rpa%getAB(ab + svv(s), 1)
           b = rpa%getAB(ab + svv(s), 2)
           qTr(:) = transChrg%qTransAB(ab + svv(s), env, denseDesc, ovrXev, grndEigVecs, rpa%getAB)
@@ -5172,7 +5557,8 @@ contains
         end do
       end do
     else
-      do ias = 1, rpa%nxov_rd
+      call distributeRangeInChunks(env, 1, rpa%nxov_rd, iGlobal, fGlobal)
+      do ias = iGlobal, fGlobal
         i = rpa%getIA(ias, 1)
         a = rpa%getIA(ias, 2)
         s = rpa%getIA(ias, 3)
@@ -5186,6 +5572,7 @@ contains
         end if
       end do
     end if
+    call assembleChunks(env, vecH)
 
   end subroutine getHplusMfr
 

--- a/src/dftbp/timedep/transcharges.F90
+++ b/src/dftbp/timedep/transcharges.F90
@@ -623,7 +623,7 @@ contains
   !> minus Transition charges left produced with a vector Q * v for spin down
   !> sum_ias q_ias V_ias delta_s,  where delta_s = 1 for spin up and delta_s = -1 for spin down
   subroutine TTransCharges_qMatVecDs(this, env, denseDesc, sTimesGrndEigVecs, grndEigVecs, getia,&
-      & win, vector, qProduct)
+      & win, vector, qProduct, indexOffSet)
 
     !> Instance of the transition charge object
     class(TTransCharges), intent(in) :: this
@@ -652,29 +652,55 @@ contains
     !> Product on exit
     real(dp), intent(inout) :: qProduct(:)
 
+    !> Offset of vector index (optional) which determines orbital pair
+    integer, intent(in), optional :: indexOffSet
+
     real(dp), allocatable :: qij(:)
-    integer :: ii, jj, ij, kk
+    integer :: ii, jj, ij, kk, iOff, iGlb, fGlb
     logical :: updwn
 
-    allocate(qij(this%nAtom))
+    ! RPA vectors are distributed for MPI: size(vector) < nOcc*nVir
+    if (present(indexOffSet)) then
+      iOff = indexOffSet
+    else
+      iOff = 0
+    endif
+    iGlb = iOff + 1
+    fGlb = iOff + size(vector)
 
-    !!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(ij,ii,jj,kk,updwn,qij)&
-    !!$OMP& SCHEDULE(RUNTIME) REDUCTION(+:qProduct)
-    do ij = 1, this%nTransitions
-      kk = win(ij)
-      ii = getia(kk, 1)
-      jj = getia(kk, 2)
-      updwn = (kk <= this%nMatUp)
-      qij(:) = transq(ii, jj, env, denseDesc, updwn, sTimesGrndEigVecs, grndEigVecs)
-      if (updwn) then
-        qProduct(:) = qProduct + qij * vector(ij)
-      else
-        qProduct(:) = qProduct - qij * vector(ij)
-      end if
-    end do
-    !!$OMP END PARALLEL DO
+    if (this%tCacheChargesOccVir) then
+      do ij = 1, size(vector)
+        kk = win(iOff+ij)
+        updwn = (kk <= this%nMatUp)
 
-    deallocate(qij)
+        if (updwn) then
+          qProduct(:) = qProduct + this%qCacheOccVir(:,ij) * vector(ij)
+        else
+          qProduct(:) = qProduct - this%qCacheOccVir(:,ij) * vector(ij)
+        end if
+      end do
+
+    else
+      allocate(qij(this%nAtom))
+
+      !!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(ij,ii,jj,kk,updwn,qij)&
+      !!$OMP& SCHEDULE(RUNTIME) REDUCTION(+:qProduct)
+      do ij = 1, this%nTransitions
+        kk = win(iOff+ij)
+        ii = getia(kk, 1)
+        jj = getia(kk, 2)
+        updwn = (kk <= this%nMatUp)
+        qij(:) = transq(ii, jj, env, denseDesc, updwn, sTimesGrndEigVecs, grndEigVecs)
+        if (updwn) then
+          qProduct(:) = qProduct + qij * vector(ij)
+        else
+          qProduct(:) = qProduct - qij * vector(ij)
+        end if
+      end do
+      !!$OMP END PARALLEL DO
+
+      deallocate(qij)
+    endif
 
   end subroutine TTransCharges_qMatVecDs
 
@@ -684,7 +710,7 @@ contains
   !! R_ias = delta_s sum_A q_A^(ias) V_A,  where delta_s = 1 for spin up and delta_s = -1 for spin
   !! down
   subroutine TTransCharges_qVecMatDs(this, env, denseDesc, sTimesGrndEigVecs, grndEigVecs, getia,&
-      & win, vector, qProduct)
+      & win, vector, qProduct, indexOffSet)
 
     !> Instance of the transition charge object
     class(TTransCharges), intent(in) :: this
@@ -713,29 +739,58 @@ contains
     !> Product on exit
     real(dp), intent(inout) :: qProduct(:)
 
+    !> Offset of vector index (optional) which determines orbital pair
+    integer, intent(in), optional :: indexOffSet
+
     real(dp), allocatable :: qij(:)
-    integer :: ii, jj, ij, kk
+    integer :: ii, jj, ij, kk, iOff, iGlb, fGlb
     logical :: updwn
 
-    allocate(qij(this%nAtom))
+    ! RPA vectors are distributed for MPI: size(vector) < nOcc*nVir
+    if (present(indexOffSet)) then
+      iOff = indexOffSet
+    else
+      iOff = 0
+    end if
+    iGlb = iOff + 1
+    fGlb = iOff + size(qProduct)
 
-    !!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(ij,ii,jj,kk,updwn,qij)&
-    !!$OMP& SCHEDULE(RUNTIME)
-    do ij = 1, this%nTransitions
-      kk = win(ij)
-      ii = getia(kk, 1)
-      jj = getia(kk, 2)
-      updwn = (kk <= this%nMatUp)
-      qij(:) = transq(ii, jj, env, denseDesc, updwn, sTimesGrndEigVecs, grndEigVecs)
-      if (updwn) then
-        qProduct(ij) = qProduct(ij) + dot_product(qij, vector)
-      else
-        qProduct(ij) = qProduct(ij) - dot_product(qij, vector)
-      end if
-    end do
-    !!$OMP END PARALLEL DO
+    if (this%tCacheChargesOccVir) then
 
-    deallocate(qij)
+      do ij = 1, this%nTransitions
+        kk = win(iOff+ij)
+        updwn = (kk <= this%nMatUp)
+
+        if (updwn) then
+          qProduct(ij) = qProduct(ij) + dot_product(this%qCacheOccVir(:,ij), vector)
+        else
+          qProduct(ij) = qProduct(ij) - dot_product(this%qCacheOccVir(:,ij), vector)
+        end if
+      end do
+
+    else
+
+      allocate(qij(this%nAtom))
+
+      !!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(ij,ii,jj,kk,updwn,qij)&
+      !!$OMP& SCHEDULE(RUNTIME)
+      do ij = 1, this%nTransitions
+        kk = win(iOff+ij)
+        ii = getia(kk, 1)
+        jj = getia(kk, 2)
+        updwn = (kk <= this%nMatUp)
+        qij(:) = transq(ii, jj, env, denseDesc, updwn, sTimesGrndEigVecs, grndEigVecs)
+        if (updwn) then
+          qProduct(ij) = qProduct(ij) + dot_product(qij, vector)
+        else
+          qProduct(ij) = qProduct(ij) - dot_product(qij, vector)
+        end if
+      end do
+      !!$OMP END PARALLEL DO
+
+      deallocate(qij)
+
+    endif
 
   end subroutine TTransCharges_qVecMatDs
 

--- a/test/app/dftb+/tests
+++ b/test/app/dftb+/tests
@@ -448,7 +448,7 @@ timedep/OCH2-md                        #? WITH_ARPACK and MPI_PROCS <= 4
 timedep/C66O10N4H44_Ewindow            #? WITH_ARPACK and MPI_PROCS <= 8
 timedep/C66O10N4H44_OscWindow          #? WITH_ARPACK and MPI_PROCS <= 8
 timedep/C60_EandOsc                    #? WITH_ARPACK and MPI_PROCS <= 8
-timedep/Furan-NACV                     #? WITH_ARPACK and not WITH_MPI
+timedep/Furan-NACV                     #? WITH_ARPACK and MPI_PROCS <= 4
 timedep/Furan-NACV-LC                  #? not WITH_MPI
 
 timedep/C4H6-Singlet                   #? WITH_ARPACK and MPI_PROCS <= 4

--- a/test/app/dftb+/timedep/Furan-NACV/dftb_in.hsd
+++ b/test/app/dftb+/timedep/Furan-NACV/dftb_in.hsd
@@ -3,6 +3,7 @@ Geometry = GenFormat {
 }
 
 Driver = {}
+
 Hamiltonian = DFTB {
     SCC = Yes
     SCCTolerance = 1e-10
@@ -17,6 +18,7 @@ Hamiltonian = DFTB {
         Suffix = ".skf"
     }
 }
+
 ExcitedState {
     Casida {
         NrOfExcitations = 10
@@ -26,7 +28,6 @@ ExcitedState {
     }
 }
 
-
 Options {
     WriteAutotestTag = Yes
 }
@@ -35,5 +36,9 @@ ParserOptions {
     ParserVersion = 13
 }            
 
-
-
+Parallel {
+  # Allow OMP threads explicitely to test for hybrid parallelisation with
+  # MPI-binary. (Check the manual before using this in production runs!)
+  UseOmpThreads = Yes
+  Blacs = BlockSize { 1 } # Very small
+}


### PR DESCRIPTION
This is the first implementation of the excited-state forces and non-adiabatic coupling vector calculations performed in parallel using MPI. The code significantly improves the computational speed of both types of calculations. However, there is still a memory-related issue, as some eigenvectors are not yet distributed across the different MPI processes.

### TODO:
- [ ] Distribute the eigenvectors across the available MPI processes.
- [ ] Modify the gradient and NACV algorithms to operate on the distributed ground-state eigenvectors.