### PR TITLE
Revert Cholesky counting logic

### DIFF
--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -1683,7 +1683,7 @@ contains
 
     call ensureSolverCompatibility(input%ctrl%solver%iSolver, this%kPoint, input%ctrl%parallelOpts,&
         & this%nIndepSpin, this%tempElec)
-    nBufferedCholesky = countBufferedCholesky_(this%nKPoint, this%parallelKS%nLocalKS)
+    nBufferedCholesky = countBufferedCholesky_(this%tRealHS, this%parallelKS%nLocalKS)
     call TElectronicSolver_init(this%electronicSolver, input%ctrl%solver%iSolver, nBufferedCholesky)
 
     if (input%ctrl%isNonAufbau) then
@@ -7306,11 +7306,11 @@ contains
   end subroutine initRepulsive_
 
 
-  ! Decides how many Cholesky-decompositions should be buffered
-  pure function countBufferedCholesky_(nKPoints, nLocalKS) result(nBufferedCholesky)
+  !> Decides how many Cholesky-decompositions should be buffered
+  pure function countBufferedCholesky_(tRealHS, nLocalKS) result(nBufferedCholesky)
 
-    !> Total number of k-points
-    integer, intent(in) :: nKPoints
+    !> Is this a real valued (in real space) calculation
+    logical, intent(in) :: tRealHS
 
     !> Number of locally stored spin/k-points
     integer, intent(in) :: nLocalKS
@@ -7318,7 +7318,7 @@ contains
     !> Resulting number of Cholesky-factored overlap matrices to be stored
     integer :: nBufferedCholesky
 
-    if (nKPoints == 1) then
+    if (tRealHS) then
       nBufferedCholesky = 1
     else
       nBufferedCholesky = nLocalKS


### PR DESCRIPTION
To be re-implemeted in a later PR to reuse factorisation between spin channels, which requires a loop reordering of the local spin and k-points array of compound index iKS over both.