### PR TITLE
Enable CI optimiser tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -112,6 +112,7 @@ Fixed
 
 - Geometry error for periodic structures with open boundary contacts
 
+- Enable CI test cases and fix a parser bug
 
 24.1 (2024-02-12)
 =================

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -5278,6 +5278,12 @@ contains
             allocate(this%excitedDerivs(3, this%nAtom, 1))
         end if
         this%isCIopt = this%linearResponse%isCIopt
+        if (this%isCIopt) then
+          ! Currently always using Bearpark algorithm:
+          write(stdOut, "('Conical Intersection finder:',T30,A)") 'Bearpark'
+          write(stdOut, format2Ue) "CI finder level shift", this%linearResponse%energyShiftCI, 'H',&
+              & Hartree__eV * this%linearResponse%energyShiftCI, 'eV'
+        end if
       end if
     end if
 

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -5178,8 +5178,10 @@ contains
         call detailedError(child2, "Invalid diagonaliser method '" // char(buffer) // "'")
       end select
 
-      call getChildValue(child, "OptimiserCI", child2, "", child=child3, allowEmptyValue=.true.)
+      call renameChildren(child, "OptimizerCI", "OptimiserCI")
+      call getChild(child, "OptimiserCI", child2, requested=.false.)
       if (associated(child2)) then
+        call getChildValue(child, "OptimiserCI", child2, child=child3)
         call getNodeName(child2, buffer)
         select case(char(buffer))
         case ("bearpark")

--- a/test/app/dftb+/tests
+++ b/test/app/dftb+/tests
@@ -447,6 +447,9 @@ timedep/NO-Stratmann                   #? MPI_PROCS <= 4
 timedep/propadiene_OscWindow-Stratmann #? MPI_PROCS <= 4
 timedep/C60_OscWindow                  #? WITH_ARPACK and MPI_PROCS <= 4
 
+timedep/Furan-CIopt                    #? WITH_ARPACK and not WITH_MPI
+timedep/Furan-CIopt-LC                 #? not WITH_MPI
+
 dftb+u/Fe4                             #? MPI_PROCS <= 2
 dftb+u/Fe4_read                        #? MPI_PROCS <= 2
 geoopt/Cchain_lattice_lbfgs            #? MPI_PROCS <= 1


### PR DESCRIPTION
Also:
* Fix parser for cases of dummy and missing optimisation methods
* Allow for US spelling in keywords
* Print some user information about what the code is doing

Note, the shift being set is not actually used internally in the algorithm