### PR TITLE
Skip bin files in year update

### DIFF
--- a/utils/srcmanip/change_header_year
+++ b/utils/srcmanip/change_header_year
@@ -29,6 +29,7 @@ IGNORED_FILES = [
     "*.mgf",
     "*.egg",
     "*.skf",
+    "*.bin",
 ]
 
 


### PR DESCRIPTION
As these can a) contain characters that break the scrip and b) do not have the year header in plain text.