### PR TITLE
Move versionMap to more logical oldCompat

### DIFF
--- a/src/dftbp/dftbplus/oldcompat.F90
+++ b/src/dftbp/dftbplus/oldcompat.F90
@@ -11,6 +11,7 @@
 !> Note: parserVersion is set in parser.F90
 module dftbp_dftbplus_oldcompat
   use dftbp_common_accuracy, only : dp, lc
+  use dftbp_common_release, only : TVersionMap
   use dftbp_extlibs_xmlf90, only : char, destroyNode, destroyNodeList, fnode, fnodeList, getItem1,&
       & getLength, getNodeName, removeChild, string
   use dftbp_io_charmanip, only : i2c, newline, tolower
@@ -22,7 +23,23 @@ module dftbp_dftbplus_oldcompat
   implicit none
 
   private
-  public :: convertOldHSD
+  public :: convertOldHSD, minVersion, parserVersion, versionMaps
+
+
+  !> Actual input version <-> parser version maps (must be updated at every public release)
+  type(TVersionMap), parameter :: versionMaps(*) = [&
+      & TVersionMap("25.1", 14),&
+      & TVersionMap("24.1", 14), TVersionMap("23.1", 13), TVersionMap("22.2", 12),&
+      & TVersionMap("22.1", 11), TVersionMap("21.2", 10), TVersionMap("21.1", 9),&
+      & TVersionMap("20.2", 9), TVersionMap("20.1", 8), TVersionMap("19.1", 7),&
+      & TVersionMap("18.2", 6), TVersionMap("18.1", 5), TVersionMap("17.1", 5)]
+
+  !> Version of the oldest parser for which compatibility is still maintained
+  integer, parameter :: minVersion = 1
+
+  !> Version of the current parser (as latest version)
+  integer, parameter :: parserVersion = maxval(versionMaps(:)%parserVersion)
+
 
 contains
 

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -16,7 +16,6 @@ module dftbp_dftbplus_parser
   use dftbp_common_filesystem, only : findFile, getParamSearchPaths, joinPathsPrettyErr
   use dftbp_common_globalenv, only : abortProgram, stdout, withMpi, withScalapack
   use dftbp_common_hamiltoniantypes, only : hamiltonianTypes
-  use dftbp_common_release, only : TVersionMap
   use dftbp_common_status, only : TStatus
   use dftbp_common_unitconversion, only : angularUnits, chargeUnits, dipoleUnits, EFieldUnits,&
       & energyUnits, forceUnits, freqUnits, lengthUnits, massUnits, pressureUnits, timeUnits,&
@@ -46,7 +45,7 @@ module dftbp_dftbplus_parser
   use dftbp_dftbplus_input_geoopt, only : readGeoOptInput
   use dftbp_dftbplus_inputconversion, only : transformpdosregioninfo
   use dftbp_dftbplus_inputdata, only : TBlacsOpts, TControl, THybridXcInp, TInputData, TSlater
-  use dftbp_dftbplus_oldcompat, only : convertOldHSD
+  use dftbp_dftbplus_oldcompat, only : convertOldHSD, minVersion, parserVersion, versionMaps
   use dftbp_dftbplus_specieslist, only : readSpeciesList
   use dftbp_elecsolvers_elecsolvers, only : electronicSolverTypes, providesEigenvalues
   use dftbp_extlibs_arpack, only : withArpack
@@ -122,20 +121,6 @@ module dftbp_dftbplus_parser
     !> HSD output?
     logical :: tWriteHSD
   end type TParserFlags
-
-  !> Actual input version <-> parser version maps (must be updated at every public release)
-  type(TVersionMap), parameter :: versionMaps(*) = [&
-      & TVersionMap("25.1", 14),&
-      & TVersionMap("24.1", 14), TVersionMap("23.1", 13), TVersionMap("22.2", 12),&
-      & TVersionMap("22.1", 11), TVersionMap("21.2", 10), TVersionMap("21.1", 9),&
-      & TVersionMap("20.2", 9), TVersionMap("20.1", 8), TVersionMap("19.1", 7),&
-      & TVersionMap("18.2", 6), TVersionMap("18.1", 5), TVersionMap("17.1", 5)]
-
-  !> Version of the oldest parser for which compatibility is still maintained
-  integer, parameter :: minVersion = 1
-
-  !> Version of the current parser (as latest version)
-  integer, parameter :: parserVersion = maxval(versionMaps(:)%parserVersion)
 
 
 contains

--- a/utils/srcmanip/set_version
+++ b/utils/srcmanip/set_version
@@ -129,7 +129,7 @@ def _warn_about_manual_changes():
 Make sure to check that the table in doc/dftb+/manual/releases.tex has been
 updated.
 
-Make sure to update input version table in src/dftbp/dftbplus/parser.F90
+Make sure to update input version map table in src/dftbp/dftbplus/oldcompat.F90
 """
     print(txt)
 


### PR DESCRIPTION
As this needs to be updated in sync with changes to the compatibility routines when old behaviour changes.