### PR TITLE
Fix geometry normalize

### DIFF
--- a/src/dftbp/type/typegeometry.F90
+++ b/src/dftbp/type/typegeometry.F90
@@ -102,16 +102,16 @@ contains
       allocate(sf%species(size(oldSpecies)))
       allocate(sf%speciesNames(sf%nSpecies))
       ind = 1
-      do iSp = 1, size(oldSpeciesNames)
+      lpNewSpecies: do iSp = 1, size(oldSpeciesNames)
         if (.not. inUse(iSp)) then
-          continue
+          cycle lpNewSpecies
         end if
         sf%speciesNames(ind) = oldSpeciesNames(iSp)
         where (oldSpecies == iSp)
           sf%species = ind
         end where
         ind = ind + 1
-      end do
+      end do lpNewSpecies
     end if
 
   end subroutine Geometry_normalize


### PR DESCRIPTION
Should cycle not continue a loop if there are no atoms of this species actually present.

closes #1777