### PR TITLE
Standalone ELPA integration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,10 @@ Added
 
 - Pairwise bond populations, bond energies and Mayer bond orders
 
+- Direct integration of ELPA (requires version 2022.05.001 or later)
+  with optional MPI redistribution to a lower number of ranks for all
+  ELPA calls
+
 
 Changed
 -------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,18 @@ else()
   list(APPEND FYPP_FLAGS -DELSI_VERSION=0)
 endif()
 
+if(WITH_ELPA AND NOT TARGET elpa::elpa)
+  set(ELPA_MIN_VERSION "2022.05.001")
+  find_package(elpa ${ELPA_MIN_VERSION} REQUIRED)
+  if(elpa_VERSION VERSION_GREATER "2023.05.001")
+    list(APPEND FYPP_FLAGS -DELPA_HAS_SETUP_GPU)
+  endif()
+
+  if(WITH_GPU)
+    find_package(CUDAToolkit REQUIRED)
+  endif()
+endif()
+
 if(WITH_PLUMED)
   find_package(CustomPlumed REQUIRED)
   list(APPEND PKG_CONFIG_REQUIRES plumed)

--- a/cmake/DftbPlusUtils.cmake
+++ b/cmake/DftbPlusUtils.cmake
@@ -102,6 +102,10 @@ function (dftbp_add_fypp_defines fyppflags)
     list(APPEND _fyppflags -DWITH_PEXSI)
   endif()
 
+  if(WITH_ELPA)
+    list(APPEND _fyppflags -DWITH_ELPA)
+  endif()
+
   if(WITH_GPU)
     list(APPEND _fyppflags -DWITH_GPU)
   endif()
@@ -207,8 +211,12 @@ function (dftbp_ensure_config_consistency)
     message(FATAL_ERROR "Building with PEXSI requires MPI-parallel build and ELSI enabled")
   endif()
 
-  if(WITH_GPU AND WITH_MPI AND NOT WITH_ELSI)
-    message(FATAL_ERROR "GPU support in MPI-parallelized applications requires the ELSI library (built with GPU support)")
+  if(WITH_ELPA AND NOT WITH_MPI)
+    message(FATAL_ERROR "Building with ELPA requires MPI-parallel build enabled")
+  endif()
+
+  if(WITH_GPU AND WITH_MPI AND (NOT WITH_ELSI) AND (NOT WITH_ELPA))
+    message(FATAL_ERROR "GPU support in MPI-parallelized applications requires ELSI or ELPA (built with GPU support)")
   endif()
 
   if(INSTANCE_SAFE_BUILD)

--- a/cmake/Modules/Findelpa.cmake
+++ b/cmake/Modules/Findelpa.cmake
@@ -1,0 +1,55 @@
+# Distributed under the OSI-approved BSD 3-Clause License.
+#
+# Copyright (C) 2025  DFTB+ developers group
+#
+
+#[=======================================================================[.rst:
+Findelpa
+--------
+
+Finds the ELPA library
+
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported target, if found:
+
+``elpa::elpa``
+  The ELPA library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module will define the following variable:
+
+``ELPA_FOUND``
+  True if the system has the ELPA library
+
+``ELPA_VERSION``
+  Detected version of the library
+
+#]=======================================================================]
+
+if(NOT TARGET elpa::elpa)
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(ELPA QUIET elpa)
+  if(ELPA_FOUND)
+    message(STATUS "Found 'elpa' via pkg-config")
+
+    add_library(elpa::elpa INTERFACE IMPORTED)
+    target_link_libraries(
+      elpa::elpa
+      INTERFACE
+      "${ELPA_LINK_LIBRARIES}"
+    )
+    target_include_directories(
+      elpa::elpa
+      INTERFACE
+      "${ELPA_INCLUDE_DIRS}/modules"
+    )
+
+    # DFTB+ checks for the lowercase variable name
+    set(elpa_VERSION "${ELPA_VERSION}")
+  endif()
+endif()

--- a/config.cmake
+++ b/config.cmake
@@ -18,8 +18,10 @@ option(WITH_GPU "Whether DFTB+ should support GPU-acceleration" FALSE)
 # requires the ELSI library built with GPU support.
 
 option(WITH_ELSI "Whether DFTB+ with MPI-parallelism should use the ELSI libraries" FALSE)
-# Works only with MPI-parallel build. If WITH_GPU was selected above, the ELSI library must be
-# enabled (and must have been built with GPU support).
+# Works only with MPI-parallel build.
+
+option(WITH_ELPA "Whether DFTB+ with MPI-parallelism should use the ELPA library" FALSE)
+# Works only with MPI-parallel build.
 
 option(WITH_TRANSPORT "Whether transport via libNEGF should be included." FALSE)
 # Works only when building static libraries (see option BUILD_SHARED_LIBS)

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -2508,22 +2508,42 @@ It accepts following options:
 \subsubsection{ELPA}
 
 The ELPA solver provides an efficient and scalable diagonaliser, which is also
-able to utilise GPUs (provided the ELSI library was compiled with GPU support).
+able to utilise GPUs. It can be included standalone or via the ELSI library.
 It accepts following options
 
 \begin{ptable}
   \kw{Autotune} & l& & No & \\
+  \kw{AutotuneFile} & s& Autotune = Yes & "elpa\_autotune\_state.out" & \\
   \kw{Gpu}    & l& & No & \\
   \kw{Mode} & i& & 2 & \\
+  \kw{PreferElsi} & l& & No & \\
+  \kw{RedistributeFactor} & i& & 1 & \\
+  \kw{RedistributeRanks} & p& RedistributeFactor = 1 & \cb & \\
   \kw{Sparse} & l& & No & \\
 \end{ptable}
 \begin{description}
-\item[\is{Autotune}] Whether ELPAs autotune capability should be used to
+\item[\is{Autotune}] Whether ELPA's autotune capability should be used to
   optimise performance (default: \is{No})
+\item[\is{AutotuneFile}] The ELPA autotune state is stored in this file.
+  If present at startup, the autotuning process is resumed using its previous
+  state. (default: \is{elpa\_autotune\_state.out})
 \item[\is{Gpu}] Whether ELPA should use available GPUs (default: \is{No}). Note,
   that you can only enable this option, if \dftbp{} was built with GPU support.
 \item[\is{Mode}] ELPA operation mode (possible values: \is{1}, \is{2},
   default: \is{2}). Mode 2 is supposed to be more efficient for large problems.
+  Mode 1 is strongly recommended if \is{Gpu = Yes}.
+\item[\is{PreferElsi}] Whether to call ELPA using the ELSI interface. This
+  setting is only relevant if \dftbp{} was built and linked with the ELSI
+  library.
+\item[\is{RedistributeFactor}] Call ELPA with a reduced number of MPI ranks. The
+  total number of ranks is devided by \is{RedistributeFactor}, that is, only
+  every \is{RedistributeFactor}th rank participates in ELPA calls
+  (must be greater or equal to \is{1}, default: \is{1}). The matrix
+  will be redistributed accordingly from its full block-cyclic distribution to
+  a new distribution on the selected subset of ranks. This feature is not
+  available if ELPA is included via the ELSI library.
+\item[\is{RedistributeRanks}] Explicit list of MPI ranks to be used to call
+  ELPA, for example, \is{\{0, 2\}}. The matrix will be redistributed accordingly.
 \item[\is{Sparse}] Whether the sparse matrix interface of ELPA should be used or
   the dense one (default: dense). The sparse interface does not reduce memory
   usage and is mainly for testing purposes.
@@ -2532,7 +2552,7 @@ It accepts following options
 Example:\invparskip
 \begin{verbatim}
   Solver = ELPA {
-    Mode = 2
+    Mode = 1
     Autotune = Yes
     Gpu = Yes
   }

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -2514,22 +2514,42 @@ It accepts following options:
 \subsubsection{ELPA}
 
 The ELPA solver provides an efficient and scalable diagonaliser, which is also
-able to utilise GPUs (provided the ELSI library was compiled with GPU support).
+able to utilise GPUs. It can be included standalone or via the ELSI library.
 It accepts following options
 
 \begin{ptable}
   \kw{Autotune} & l& & No & \\
+  \kw{AutotuneFile} & s& Autotune = Yes & "elpa\_autotune\_state.out" & \\
   \kw{Gpu}    & l& & No & \\
   \kw{Mode} & i& & 2 & \\
+  \kw{PreferElsi} & l& & No & \\
+  \kw{RedistributeFactor} & i& & 1 & \\
+  \kw{RedistributeRanks} & p& RedistributeFactor = 1 & \cb & \\
   \kw{Sparse} & l& & No & \\
 \end{ptable}
 \begin{description}
-\item[\is{Autotune}] Whether ELPAs autotune capability should be used to
+\item[\is{Autotune}] Whether ELPA's autotune capability should be used to
   optimise performance (default: \is{No})
+\item[\is{AutotuneFile}] The ELPA autotune state is stored in this file.
+  If present at startup, the autotuning process is resumed using its previous
+  state. (default: \is{elpa\_autotune\_state.out})
 \item[\is{Gpu}] Whether ELPA should use available GPUs (default: \is{No}). Note,
   that you can only enable this option, if \dftbp{} was built with GPU support.
 \item[\is{Mode}] ELPA operation mode (possible values: \is{1}, \is{2},
   default: \is{2}). Mode 2 is supposed to be more efficient for large problems.
+  Mode 1 is strongly recommended if \is{Gpu = Yes}.
+\item[\is{PreferElsi}] Whether to call ELPA using the ELSI interface. This
+  setting is only relevant if \dftbp{} was built and linked with the ELSI
+  library.
+\item[\is{RedistributeFactor}] Call ELPA with a reduced number of MPI ranks. The
+  total number of ranks is devided by \is{RedistributeFactor}, that is, only
+  every \is{RedistributeFactor}th rank participates in ELPA calls
+  (must be greater or equal to \is{1}, default: \is{1}). The matrix
+  will be redistributed accordingly from its full block-cyclic distribution to
+  a new distribution on the selected subset of ranks. This feature is not
+  available if ELPA is included via the ELSI library.
+\item[\is{RedistributeRanks}] Explicit list of MPI ranks to be used to call
+  ELPA, for example, \is{\{0, 2\}}. The matrix will be redistributed accordingly.
 \item[\is{Sparse}] Whether the sparse matrix interface of ELPA should be used or
   the dense one (default: dense). The sparse interface does not reduce memory
   usage and is mainly for testing purposes.
@@ -2538,7 +2558,7 @@ It accepts following options
 Example:\invparskip
 \begin{verbatim}
   Solver = ELPA {
-    Mode = 2
+    Mode = 1
     Autotune = Yes
     Gpu = Yes
   }

--- a/src/dftbp/CMakeLists.txt
+++ b/src/dftbp/CMakeLists.txt
@@ -125,6 +125,13 @@ if(WITH_ELSI)
   endif()
 endif()
 
+if(WITH_ELPA)
+  target_link_libraries(dftbplus PUBLIC elpa::elpa)
+  if(WITH_GPU)
+    target_link_directories(dftbplus PUBLIC ${CUDAToolkit_LIBRARY_DIR})
+  endif()
+endif()
+
 if(WITH_PLUMED)
   target_link_libraries(dftbplus PRIVATE Plumed::Plumed)
 endif()

--- a/src/dftbp/dftbplus/eigenvects.F90
+++ b/src/dftbp/dftbplus/eigenvects.F90
@@ -242,15 +242,20 @@ contains
       call scalafx_psygvr(HSqr, desc, SSqr, desc, eigenVals, eigenVecs, desc, uplo="L", jobz="V",&
           & skipchol=electronicSolver%hasCholesky(iCholesky))
     case(electronicSolverTypes%elpa)
-      if (electronicSolver%elsi%tWriteHS) then
-        call elsi_write_mat_real(electronicSolver%elsi%rwHandle, "ELSI_Hreal.bin", HSqr)
-        call elsi_write_mat_real(electronicSolver%elsi%rwHandle, "ELSI_Sreal.bin", SSqr)
-        call elsi_finalize_rw(electronicSolver%elsi%rwHandle)
-        call cleanShutdown("Finished dense matrix write")
+      if (electronicSolver%isElpaStandalone) then
+        call electronicSolver%elpa%solve(HSqr, SSqr, eigenVals, eigenVecs,&
+            & electronicSolver%hasCholesky(iCholesky))
+      else
+        if (electronicSolver%elsi%tWriteHS) then
+          call elsi_write_mat_real(electronicSolver%elsi%rwHandle, "ELSI_Hreal.bin", HSqr)
+          call elsi_write_mat_real(electronicSolver%elsi%rwHandle, "ELSI_Sreal.bin", SSqr)
+          call elsi_finalize_rw(electronicSolver%elsi%rwHandle)
+          call cleanShutdown("Finished dense matrix write")
+        end if
+        ! ELPA solver, returns eigenstates
+        ! note, this only factorises overlap on first call - no skipchol equivalent
+        call elsi_ev_real(electronicSolver%elsi%handle, HSqr, SSqr, eigenVals, eigenVecs)
       end if
-      ! ELPA solver, returns eigenstates
-      ! note, this only factorises overlap on first call - no skipchol equivalent
-      call elsi_ev_real(electronicSolver%elsi%handle, HSqr, SSqr, eigenVals, eigenVecs)
 
     case default
       @:RAISE_ERROR(errStatus, -1, "Unknown eigensolver")
@@ -328,15 +333,20 @@ contains
           & skipchol=electronicSolver%hasCholesky(iCholesky))
 
     case(electronicSolverTypes%elpa)
-      if (electronicSolver%elsi%tWriteHS) then
-        call elsi_write_mat_complex(electronicSolver%elsi%rwHandle, "ELSI_Hcmplx.bin", HSqr)
-        call elsi_write_mat_complex(electronicSolver%elsi%rwHandle, "ELSI_Scmplx.bin", SSqr)
-        call elsi_finalize_rw(electronicSolver%elsi%rwHandle)
-        call cleanShutdown("Finished dense matrix write")
+      if (electronicSolver%isElpaStandalone) then
+        call electronicSolver%elpa%solve(HSqr, SSqr, eigenVals, eigenVecs,&
+            & electronicSolver%hasCholesky(iCholesky))
+      else
+        if (electronicSolver%elsi%tWriteHS) then
+          call elsi_write_mat_complex(electronicSolver%elsi%rwHandle, "ELSI_Hcmplx.bin", HSqr)
+          call elsi_write_mat_complex(electronicSolver%elsi%rwHandle, "ELSI_Scmplx.bin", SSqr)
+          call elsi_finalize_rw(electronicSolver%elsi%rwHandle)
+          call cleanShutdown("Finished dense matrix write")
+        end if
+        ! ELPA solver, returns eigenstates
+        ! note, this only factorises overlap on first call - no skipchol equivalent
+        call elsi_ev_complex(electronicSolver%elsi%handle, HSqr, SSqr, eigenVals, eigenVecs)
       end if
-      ! ELPA solver, returns eigenstates
-      ! note, this only factorises overlap on first call - no skipchol equivalent
-      call elsi_ev_complex(electronicSolver%elsi%handle, HSqr, SSqr, eigenVals, eigenVecs)
 
     case default
       @:RAISE_ERROR(errStatus, -1, "Unknown eigensolver")

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -78,8 +78,10 @@ module dftbp_dftbplus_initprogram
   use dftbp_elecsolvers_dmsolvertypes, only : densityMatrixTypes
   use dftbp_elecsolvers_elecsolvers, only : electronicSolverTypes, TElectronicSolver,&
       & TElectronicSolver_init
+  use dftbp_elecsolvers_elpa, only : TElpa_final, TElpa_init
   use dftbp_elecsolvers_elsisolver, only : TElsiSolver_final, TElsiSolver_init
   use dftbp_extlibs_arpack, only : withArpack
+  use dftbp_extlibs_elpa, only : withElpa
   use dftbp_extlibs_elsiiface, only : withELSI
   use dftbp_extlibs_plumed, only : TPlumedCalc, TPlumedCalc_init, withPlumed
   use dftbp_extlibs_poisson, only : TPoissonInput
@@ -1744,7 +1746,7 @@ contains
     call ensureSolverCompatibility(input%ctrl%solver%iSolver, this%kPoint, input%ctrl%parallelOpts,&
         & this%nIndepSpin, this%tempElec, input%ctrl%isASICallbackEnabled)
     nBufferedCholesky = countBufferedCholesky_(this%tRealHS, this%parallelKS%nLocalKS)
-    call TElectronicSolver_init(this%electronicSolver, input%ctrl%solver%iSolver, nBufferedCholesky)
+    call TElectronicSolver_init(this%electronicSolver, input%ctrl%solver, nBufferedCholesky)
 
     if (input%ctrl%isNonAufbau) then
       ! for the moment, as this has not been derived
@@ -2072,12 +2074,17 @@ contains
       ! Would be using the ELSI matrix writing mechanism, so set this as always false
       this%tWriteHS = .false.
 
-      call TElsiSolver_init(this%electronicSolver%elsi, input%ctrl%solver%elsi, env,&
-          & this%denseDesc%fullSize, this%nEl, this%iDistribFn, this%nSpin,&
-          & this%parallelKS%localKS(2, 1), this%nKPoint, this%parallelKS%localKS(1, 1),&
+      call TElsiSolver_init(this%electronicSolver%elsi, input%ctrl%solver%elsi,&
+          & input%ctrl%solver%elpa, env, this%denseDesc%fullSize, this%nEl, this%iDistribFn,&
+          & this%nSpin, this%parallelKS%localKS(2, 1), this%nKPoint, this%parallelKS%localKS(1, 1),&
           & this%kWeight(this%parallelKS%localKS(1, 1)), input%ctrl%tWriteHS,&
           & this%electronicSolver%providesElectronEntropy)
 
+    end if
+
+    if (this%electronicSolver%isElpaStandalone) then
+      call TElpa_init(this%electronicSolver%elpa, env, input%ctrl%solver%elpa,&
+          & this%denseDesc%fullSize, input%ctrl%timingLevel)
     end if
 
     if (this%deltaDftb%isNonAufbau .and. .not.this%electronicSolver%providesEigenvals) then
@@ -5013,6 +5020,10 @@ contains
       call TElsiSolver_final(this%electronicSolver%elsi)
     end if
 
+    if (this%electronicSolver%isElpaStandalone) then
+      call TElpa_final(this%electronicSolver%elpa)
+    end if
+
     if (this%tProjEigenvecs) then
       call destruct(this%iOrbRegion)
       call destruct(this%regionLabels)
@@ -5812,11 +5823,17 @@ contains
           & This should be fixed soon.")
     end if
 
+    if (iSolver == electronicSolverTypes%elpa .and. .not. withElpa .and. .not. withELSI) then
+      call error("This binary was not compiled with ELSI or ELPA support enabled")
+    end if
+
     tElsiSolver = any(iSolver ==&
         & [electronicSolverTypes%elpa, electronicSolverTypes%omm, electronicSolverTypes%pexsi,&
         & electronicSolverTypes%ntpoly, electronicSolverTypes%elpadm])
     if (.not. withELSI .and. tElsiSolver) then
-      call error("This binary was not compiled with ELSI support enabled")
+      if (iSolver /= electronicSolverTypes%elpa .or. .not. withElpa) then
+        call error("This binary was not compiled with ELSI support enabled")
+      end if
     end if
 
     nKPoint = size(kPoints, dim=2)

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -78,8 +78,10 @@ module dftbp_dftbplus_initprogram
   use dftbp_elecsolvers_dmsolvertypes, only : densityMatrixTypes
   use dftbp_elecsolvers_elecsolvers, only : electronicSolverTypes, TElectronicSolver,&
       & TElectronicSolver_init
+  use dftbp_elecsolvers_elpa, only : TElpa_final, TElpa_init
   use dftbp_elecsolvers_elsisolver, only : TElsiSolver_final, TElsiSolver_init
   use dftbp_extlibs_arpack, only : withArpack
+  use dftbp_extlibs_elpa, only : withElpa
   use dftbp_extlibs_elsiiface, only : withELSI
   use dftbp_extlibs_plumed, only : TPlumedCalc, TPlumedCalc_init, withPlumed
   use dftbp_extlibs_poisson, only : TPoissonInput
@@ -1760,7 +1762,7 @@ contains
     call ensureSolverCompatibility(input%ctrl%solver%iSolver, this%kPoint, input%ctrl%parallelOpts,&
         & this%nIndepSpin, this%tempElec, input%ctrl%isASICallbackEnabled)
     nBufferedCholesky = countBufferedCholesky_(this%tRealHS, this%parallelKS%nLocalKS)
-    call TElectronicSolver_init(this%electronicSolver, input%ctrl%solver%iSolver, nBufferedCholesky)
+    call TElectronicSolver_init(this%electronicSolver, input%ctrl%solver, nBufferedCholesky)
 
     if (input%ctrl%isNonAufbau) then
       ! for the moment, as this has not been derived
@@ -2100,12 +2102,17 @@ contains
       ! Would be using the ELSI matrix writing mechanism, so set this as always false
       this%tWriteHS = .false.
 
-      call TElsiSolver_init(this%electronicSolver%elsi, input%ctrl%solver%elsi, env,&
-          & this%denseDesc%fullSize, this%nEl, this%iDistribFn, this%nSpin,&
-          & this%parallelKS%localKS(2, 1), this%nKPoint, this%parallelKS%localKS(1, 1),&
+      call TElsiSolver_init(this%electronicSolver%elsi, input%ctrl%solver%elsi,&
+          & input%ctrl%solver%elpa, env, this%denseDesc%fullSize, this%nEl, this%iDistribFn,&
+          & this%nSpin, this%parallelKS%localKS(2, 1), this%nKPoint, this%parallelKS%localKS(1, 1),&
           & this%kWeight(this%parallelKS%localKS(1, 1)), input%ctrl%tWriteHS,&
           & this%electronicSolver%providesElectronEntropy)
 
+    end if
+
+    if (this%electronicSolver%isElpaStandalone) then
+      call TElpa_init(this%electronicSolver%elpa, env, input%ctrl%solver%elpa,&
+          & this%denseDesc%fullSize, input%ctrl%timingLevel)
     end if
 
     if (this%deltaDftb%isNonAufbau .and. .not.this%electronicSolver%providesEigenvals) then
@@ -5112,6 +5119,10 @@ contains
       call TElsiSolver_final(this%electronicSolver%elsi)
     end if
 
+    if (this%electronicSolver%isElpaStandalone) then
+      call TElpa_final(this%electronicSolver%elpa)
+    end if
+
     if (this%tProjEigenvecs) then
       call destruct(this%iOrbRegion)
       call destruct(this%regionLabels)
@@ -5907,11 +5918,17 @@ contains
           & This should be fixed soon.")
     end if
 
+    if (iSolver == electronicSolverTypes%elpa .and. .not. withElpa .and. .not. withELSI) then
+      call error("This binary was not compiled with ELSI or ELPA support enabled")
+    end if
+
     tElsiSolver = any(iSolver ==&
         & [electronicSolverTypes%elpa, electronicSolverTypes%omm, electronicSolverTypes%pexsi,&
         & electronicSolverTypes%ntpoly, electronicSolverTypes%elpadm])
     if (.not. withELSI .and. tElsiSolver) then
-      call error("This binary was not compiled with ELSI support enabled")
+      if (iSolver /= electronicSolverTypes%elpa .or. .not. withElpa) then
+        call error("This binary was not compiled with ELSI support enabled")
+      end if
     end if
 
     nKPoint = size(kPoints, dim=2)

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -49,6 +49,7 @@ module dftbp_dftbplus_parser
   use dftbp_dftbplus_specieslist, only : readSpeciesList
   use dftbp_elecsolvers_elecsolvers, only : electronicSolverTypes, providesEigenvalues
   use dftbp_extlibs_arpack, only : withArpack
+  use dftbp_extlibs_elpa, only : withElpa
   use dftbp_extlibs_elsiiface, only : withELSI, withPEXSI
   use dftbp_extlibs_plumed, only : withPlumed
   use dftbp_extlibs_poisson, only : TPoissonInfo, withPoisson
@@ -2632,6 +2633,7 @@ contains
 
     type(fnode), pointer :: value1, child
     type(string) :: buffer, modifier
+    type(TListInt) :: elpaRedistributeRanks
 
     integer :: iTmp
 
@@ -2661,22 +2663,55 @@ contains
 
     case ("elpa")
       allocate(ctrl%solver%elsi)
-      call getChildValue(value1, "Sparse", ctrl%solver%elsi%elsiCsr, .false.)
+      allocate(ctrl%solver%elpa)
+      call getChildValue(value1, "Sparse", ctrl%solver%elsi%elsiCsr, .false., child=child)
       if (ctrl%solver%elsi%elsiCsr) then
         ctrl%solver%isolver = electronicSolverTypes%elpadm
+        #:if WITH_ELPA and not WITH_ELSI
+          call detailedError(child, "The sparse interface is not supported if ELPA is directly&
+              & included without using the ELSI interface")
+        #:endif
       else
         ctrl%solver%isolver = electronicSolverTypes%elpa
       end if
       ctrl%solver%elsi%iSolver = ctrl%solver%isolver
-      call getChildValue(value1, "Mode", ctrl%solver%elsi%elpaSolver, 2)
-      call getChildValue(value1, "Autotune", ctrl%solver%elsi%elpaAutotune, .false.)
-      call getChildValue(value1, "Gpu", ctrl%solver%elsi%elpaGpu, .false., child=child)
+      call getChildValue(value1, "PreferElsi", ctrl%solver%elpa%preferElsi, .false.)
+      call getChildValue(value1, "Mode", ctrl%solver%elpa%solver, 2)
+      call getChildValue(value1, "Autotune", ctrl%solver%elpa%autotune, .false.)
+      call getChildValue(value1, "AutotuneFile", buffer, "elpa_autotune_state.out")
+      ctrl%solver%elpa%autotuneFile = trim(unquote(char(buffer)))
+      call getChildValue(value1, "Gpu", ctrl%solver%elpa%gpu, .false., child=child)
       #:if not WITH_GPU
-        if (ctrl%solver%elsi%elpaGpu) then
+        if (ctrl%solver%elpa%gpu) then
           call detailedError(child, "DFTB+ must be compiled with GPU support in order to enable&
               & the GPU acceleration for the ELPA solver")
         end if
       #:endif
+      call getChildValue(value1, "RedistributeFactor", ctrl%solver%elpa%redistributeFactor, 1,&
+          & child=child)
+      #:if not WITH_ELPA
+        if (ctrl%solver%elpa%redistributeFactor /= 1) then
+          call detailedError(child, "Matrix redistribution is only possible if ELPA is directly&
+              & included without using the ELSI interface")
+        end if
+      #:endif
+
+      call getChild(value1, "RedistributeRanks", child=child, requested=.false.)
+      if (associated(child)) then
+      #:if not WITH_ELPA
+        call detailedError(child, "Matrix redistribution is only possible if ELPA is directly&
+            & included without using the ELSI interface")
+      #:endif
+        if (ctrl%solver%elpa%redistributeFactor /= 1) then
+          call detailedError(child, "RedistributeFactor and RedistributeRanks must not be specified&
+              & at the same time")
+        end if
+        call init(elpaRedistributeRanks)
+        call getChildValue(child, "", elpaRedistributeRanks)
+        allocate(ctrl%solver%elpa%redistributeRanks(len(elpaRedistributeRanks)))
+        call asArray(elpaRedistributeRanks, ctrl%solver%elpa%redistributeRanks)
+        call destruct(elpaRedistributeRanks)
+      end if
 
     case ("omm")
       ctrl%solver%isolver = electronicSolverTypes%omm
@@ -2769,10 +2804,15 @@ contains
     if (ctrl%solver%isolver == electronicSolverTypes%pexsi .and. .not.withPEXSI) then
       call error("Not compiled with PEXSI support via ELSI")
     end if
-    if (any(ctrl%solver%isolver == [electronicSolverTypes%elpa, electronicSolverTypes%omm,&
-        & electronicSolverTypes%pexsi, electronicSolverTypes%ntpoly])) then
+    if (any(ctrl%solver%isolver == [electronicSolverTypes%omm, electronicSolverTypes%pexsi,&
+        & electronicSolverTypes%ntpoly])) then
       if (.not.withELSI) then
         call error("Not compiled with ELSI supported solvers")
+      end if
+    end if
+    if (ctrl%solver%isolver == electronicSolverTypes%elpa) then
+      if (.not.withELSI .and. .not.withElpa) then
+        call error("Not compiled with ELSI or ELPA support")
       end if
     end if
 

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -50,6 +50,7 @@ module dftbp_dftbplus_parser
   use dftbp_dftbplus_specieslist, only : readSpeciesList
   use dftbp_elecsolvers_elecsolvers, only : electronicSolverTypes, providesEigenvalues
   use dftbp_extlibs_arpack, only : withArpack
+  use dftbp_extlibs_elpa, only : withElpa
   use dftbp_extlibs_elsiiface, only : withELSI, withPEXSI
   use dftbp_extlibs_plumed, only : withPlumed
   use dftbp_extlibs_poisson, only : TPoissonInfo, withPoisson
@@ -2758,6 +2759,7 @@ contains
 
     type(fnode), pointer :: value1, child
     type(string) :: buffer, modifier
+    type(TListInt) :: elpaRedistributeRanks
 
     integer :: iTmp
 
@@ -2787,22 +2789,55 @@ contains
 
     case ("elpa")
       allocate(ctrl%solver%elsi)
-      call getChildValue(value1, "Sparse", ctrl%solver%elsi%elsiCsr, .false.)
+      allocate(ctrl%solver%elpa)
+      call getChildValue(value1, "Sparse", ctrl%solver%elsi%elsiCsr, .false., child=child)
       if (ctrl%solver%elsi%elsiCsr) then
         ctrl%solver%isolver = electronicSolverTypes%elpadm
+        #:if WITH_ELPA and not WITH_ELSI
+          call detailedError(child, "The sparse interface is not supported if ELPA is directly&
+              & included without using the ELSI interface")
+        #:endif
       else
         ctrl%solver%isolver = electronicSolverTypes%elpa
       end if
       ctrl%solver%elsi%iSolver = ctrl%solver%isolver
-      call getChildValue(value1, "Mode", ctrl%solver%elsi%elpaSolver, 2)
-      call getChildValue(value1, "Autotune", ctrl%solver%elsi%elpaAutotune, .false.)
-      call getChildValue(value1, "Gpu", ctrl%solver%elsi%elpaGpu, .false., child=child)
+      call getChildValue(value1, "PreferElsi", ctrl%solver%elpa%preferElsi, .false.)
+      call getChildValue(value1, "Mode", ctrl%solver%elpa%solver, 2)
+      call getChildValue(value1, "Autotune", ctrl%solver%elpa%autotune, .false.)
+      call getChildValue(value1, "AutotuneFile", buffer, "elpa_autotune_state.out")
+      ctrl%solver%elpa%autotuneFile = trim(unquote(char(buffer)))
+      call getChildValue(value1, "Gpu", ctrl%solver%elpa%gpu, .false., child=child)
       #:if not WITH_GPU
-        if (ctrl%solver%elsi%elpaGpu) then
+        if (ctrl%solver%elpa%gpu) then
           call detailedError(child, "DFTB+ must be compiled with GPU support in order to enable&
               & the GPU acceleration for the ELPA solver")
         end if
       #:endif
+      call getChildValue(value1, "RedistributeFactor", ctrl%solver%elpa%redistributeFactor, 1,&
+          & child=child)
+      #:if not WITH_ELPA
+        if (ctrl%solver%elpa%redistributeFactor /= 1) then
+          call detailedError(child, "Matrix redistribution is only possible if ELPA is directly&
+              & included without using the ELSI interface")
+        end if
+      #:endif
+
+      call getChild(value1, "RedistributeRanks", child=child, requested=.false.)
+      if (associated(child)) then
+      #:if not WITH_ELPA
+        call detailedError(child, "Matrix redistribution is only possible if ELPA is directly&
+            & included without using the ELSI interface")
+      #:endif
+        if (ctrl%solver%elpa%redistributeFactor /= 1) then
+          call detailedError(child, "RedistributeFactor and RedistributeRanks must not be specified&
+              & at the same time")
+        end if
+        call init(elpaRedistributeRanks)
+        call getChildValue(child, "", elpaRedistributeRanks)
+        allocate(ctrl%solver%elpa%redistributeRanks(len(elpaRedistributeRanks)))
+        call asArray(elpaRedistributeRanks, ctrl%solver%elpa%redistributeRanks)
+        call destruct(elpaRedistributeRanks)
+      end if
 
     case ("omm")
       ctrl%solver%isolver = electronicSolverTypes%omm
@@ -2895,10 +2930,15 @@ contains
     if (ctrl%solver%isolver == electronicSolverTypes%pexsi .and. .not.withPEXSI) then
       call error("Not compiled with PEXSI support via ELSI")
     end if
-    if (any(ctrl%solver%isolver == [electronicSolverTypes%elpa, electronicSolverTypes%omm,&
-        & electronicSolverTypes%pexsi, electronicSolverTypes%ntpoly])) then
+    if (any(ctrl%solver%isolver == [electronicSolverTypes%omm, electronicSolverTypes%pexsi,&
+        & electronicSolverTypes%ntpoly])) then
       if (.not.withELSI) then
         call error("Not compiled with ELSI supported solvers")
+      end if
+    end if
+    if (ctrl%solver%isolver == electronicSolverTypes%elpa) then
+      if (.not.withELSI .and. .not.withElpa) then
+        call error("Not compiled with ELSI or ELPA support")
       end if
     end if
 

--- a/src/dftbp/elecsolvers/CMakeLists.txt
+++ b/src/dftbp/elecsolvers/CMakeLists.txt
@@ -4,6 +4,7 @@ set(sources-fpp
   ${curdir}/dmsolvertypes.F90
   ${curdir}/elecsolvers.F90
   ${curdir}/elecsolvertypes.F90
+  ${curdir}/elpa.F90
   ${curdir}/elsicsc.F90
   ${curdir}/elsisolver.F90)
 

--- a/src/dftbp/elecsolvers/elecsolvers.F90
+++ b/src/dftbp/elecsolvers/elecsolvers.F90
@@ -11,7 +11,10 @@
 module dftbp_elecsolvers_elecsolvers
   use dftbp_common_accuracy, only : dp, lc
   use dftbp_elecsolvers_elecsolvertypes, only : electronicSolverTypes
+  use dftbp_elecsolvers_elpa, only : TElpa, TElpaInp
   use dftbp_elecsolvers_elsisolver, only : TElsiSolver, TElsiSolverInp
+  use dftbp_extlibs_elpa, only : withElpa
+  use dftbp_extlibs_elsiiface, only: withElsi
   implicit none
 
   private
@@ -28,6 +31,9 @@ module dftbp_elecsolvers_elecsolvers
     !> Input for the ELSI solver
     type(TElsiSolverInp), allocatable :: elsi
 
+    !> Input for the ELPA solver
+    type(TElpaInp), allocatable :: elpa
+
   end type TElectronicSolverInp
 
 
@@ -40,6 +46,9 @@ module dftbp_elecsolvers_elecsolvers
 
     !> Whether it is an ELSI solver
     logical, public :: isElsiSolver = .false.
+
+    !> Whether we use ELPA without ELSI
+    logical, public :: isElpaStandalone
 
     !> Whether the solver provides eigenvalues
     logical, public :: providesEigenvals = .false.
@@ -59,6 +68,9 @@ module dftbp_elecsolvers_elecsolvers
 
     !> Data for ELSI solvers
     type(TElsiSolver), public, allocatable :: elsi
+
+    !> Data for ELPA solver
+    type(TElpa), public, allocatable :: elpa
 
     !> Are Choleskii factors already available for the overlap matrix
     logical, public, allocatable :: hasCholesky(:)
@@ -89,22 +101,39 @@ module dftbp_elecsolvers_elecsolvers
 contains
 
   !> Initializes an electronic solver
-  subroutine TElectronicSolver_init(this, iSolver, nCholesky)
+  subroutine TElectronicSolver_init(this, solverInp, nCholesky)
 
     !> Instance.
     type(TElectronicSolver), intent(out) :: this
 
-    !> Solver type to be used.
-    integer, intent(in) :: iSolver
+    !> Input data for the solver.
+    type(TElectronicSolverInp), intent(in) :: solverInp
 
     !> Number of Cholesky-decompositions which will be buffered.
     integer, intent(in) :: nCholesky
 
-    this%iSolver = iSolver
+    logical :: preferElsi
+
+    this%iSolver = solverInp%iSolver
 
     this%isElsiSolver = any(this%iSolver ==&
         & [electronicSolverTypes%elpa, electronicSolverTypes%omm, electronicSolverTypes%pexsi,&
         & electronicSolverTypes%ntpoly, electronicSolverTypes%elpadm])
+
+    preferElsi = .false.
+    if (allocated(solverInp%elpa)) then
+      preferElsi = solverInp%elpa%preferElsi
+    end if
+
+    if (this%iSolver == electronicSolverTypes%elpa .and. withElpa .and.&
+        & .not. (withElsi .and. preferElsi)) then
+      !> If ELPA should be used and we have the ELPA library included directly (without ELSI),
+      !> do not call ELSI.
+      this%isElsiSolver = .false.
+      this%isElpaStandalone = .true.
+    else
+      this%isElpaStandalone = .false.
+    end if
 
     !> Eigenvalues for hamiltonian available
     this%providesEigenvals = providesEigenvalues(this%iSolver)
@@ -142,6 +171,10 @@ contains
 
     if (this%isElsiSolver) then
       allocate(this%elsi)
+    end if
+
+    if (this%isElpaStandalone) then
+      allocate(this%elpa)
     end if
 
   end subroutine TElectronicSolver_init
@@ -217,6 +250,9 @@ contains
 
     case(electronicSolverTypes%magmaGvd)
       write(buffer, "(A)") "Divide and Conquer (MAGMA GPU version)"
+
+    case(electronicSolverTypes%elpa)
+      write(buffer, "(A)") "ELPA"
 
     case default
       write(buffer, "(A,I0,A)") "Invalid electronic solver! (iSolver = ", this%iSolver, ")"

--- a/src/dftbp/elecsolvers/elecsolvertypes.F90
+++ b/src/dftbp/elecsolvers/elecsolvertypes.F90
@@ -24,8 +24,10 @@ module dftbp_elecsolvers_elecsolvertypes
     integer :: divideandconquer = 2
     integer :: relativelyrobust = 3
 
-    ! elsi provided solvers
+    ! either provided by elsi or included standalone
     integer :: elpa = 4
+
+    ! elsi provided solvers
     integer :: omm = 5
     integer :: pexsi = 6
     integer :: dummy1 = 7

--- a/src/dftbp/elecsolvers/elecsolvertypes.F90
+++ b/src/dftbp/elecsolvers/elecsolvertypes.F90
@@ -24,8 +24,10 @@ module dftbp_elecsolvers_elecsolvertypes
     integer :: divideandconquer = 2
     integer :: relativelyrobust = 3
 
-    ! elsi provided solvers
+    ! either provided by elsi or included standalone
     integer :: elpa = 4
+
+    ! elsi provided solvers
     integer :: omm = 5
     integer :: pexsi = 6
     integer :: unused1 = 7

--- a/src/dftbp/elecsolvers/elpa.F90
+++ b/src/dftbp/elecsolvers/elpa.F90
@@ -1,0 +1,613 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2025  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+#:include 'common.fypp'
+
+!> Contains the interface to the ELPA solver
+module dftbp_elecsolvers_elpa
+  use dftbp_common_accuracy, only : dp
+  use dftbp_common_environment, only : TEnvironment
+#:if WITH_ELPA
+  use dftbp_extlibs_elpa, only : elpa_allocate, elpa_autotune_deallocate, elpa_autotune_t,&
+      & elpa_deallocate, elpa_init, elpa_t, elpa_uninit, ELPA_AUTOTUNE_DOMAIN_COMPLEX,&
+      & ELPA_AUTOTUNE_DOMAIN_REAL, ELPA_AUTOTUNE_FAST, ELPA_AUTOTUNE_MEDIUM, ELPA_OK,&
+      & ELPA_SOLVER_1STAGE, ELPA_SOLVER_2STAGE
+#:else
+  use dftbp_extlibs_elpa, only : elpa_autotune_t, elpa_t
+#:endif
+#:if WITH_MPI
+  use dftbp_extlibs_mpifx, only : mpifx_bcast, mpifx_comm
+#:endif
+#:if WITH_SCALAPACK
+  use dftbp_extlibs_scalapackfx, only : blacsfx_gemr2d, blacsgrid, scalafx_getdescriptor,&
+      & scalafx_numroc, CTXT_, DLEN_
+#:endif
+  use dftbp_io_message, only : error
+  implicit none
+
+  private
+  public :: TElpaInp
+  public :: TElpa, TElpa_init, TElpa_final
+
+
+  !> Input data for the ELPA solver
+  type :: TElpaInp
+
+    !> Choice of ELPA solver
+    integer :: solver = 2
+
+    !> Enable ELPA autotuning
+    logical :: autotune = .false.
+
+    !> Name of the autotuning state file
+    character(:), allocatable :: autotuneFile
+
+    !> Enable GPU usage in ELPA
+    logical :: gpu = .false.
+
+    !> Whether to use the ELSI library for calling ELPA
+    logical :: preferElsi = .false.
+
+    !> On what fraction of the original number of ranks to redistribute the matrix
+    integer :: redistributeFactor = 1
+
+    !> Explicit list of ranks to be used for redistribution
+    integer, allocatable :: redistributeRanks(:)
+
+  end type TElpaInp
+
+
+  !> ELPA solver state
+  type :: TElpa
+    private
+
+    !> Handle of the ELPA instance
+    class(elpa_t), pointer :: handle => null()
+
+    !> Handle of the ELPA autotuning
+    class(elpa_autotune_t), pointer :: autotune => null()
+
+    !> Whether GPUs are enabled
+    logical :: gpu = .false.
+
+    !> Whether to print ELPA's timing information an the end
+    logical :: printTimings = .false.
+
+    !> Whether we are currently autotuning
+    logical :: autotuning = .false.
+
+    !> Name of the autotuning state file
+    character(:), allocatable :: autotuneFile
+
+    !> Whether we should redistribute the matrix each call
+    logical :: redistributing = .false.
+
+    !> Whether the current process holds parts of the redistributed matrix and joins ELPA calls
+    logical :: joinElpaCalls = .true.
+
+    !> Global size of the square matrix
+    integer :: matrixSize
+
+    !> Number of rows in the local matrix
+    integer :: matrixLocalRows = 1
+
+    !> Number of columns in the local matrix
+    integer :: matrixLocalColumns = 1
+
+  #:if WITH_SCALAPACK
+    !> BLACS grid to use for redistribution
+    type(blacsgrid) :: redistributeGrid
+  #:endif
+
+  #:if WITH_MPI
+    !> MPI communicator to use for redistribution
+    type(mpifx_comm) :: redistributeComm
+
+    !> MPI communicator of all ranks in the current group
+    type(mpifx_comm) :: groupComm
+  #:endif
+
+    !> MPI rank number of redistributeComm%leadrank in the groupComm communicator
+    integer :: redistributeLead
+
+    !> BLACS context
+    integer :: contextOrig
+
+  #:if WITH_SCALAPACK
+    !> Original  descriptor of the matrix
+    integer :: descOrig(DLEN_)
+
+    !> Descriptor to be used in ELPA, possibly redistributed
+    integer :: desc(DLEN_)
+  #:endif
+
+    !> First matrix used for redistribution
+    real(dp), allocatable :: matrixReal1(:,:)
+
+    !> Second matrix used for redistribution
+    real(dp), allocatable :: matrixReal2(:,:)
+
+    !> Eigenvector storage used for redistribution
+    real(dp), allocatable :: eigenvectorsReal(:,:)
+
+    !> First matrix used for redistribution
+    complex(dp), allocatable :: matrixComplex1(:,:)
+
+    !> Second matrix used for redistribution
+    complex(dp), allocatable :: matrixComplex2(:,:)
+
+    !> Eigenvector storage used for redistribution
+    complex(dp), allocatable :: eigenvectorsComplex(:,:)
+
+  contains
+
+    procedure, private :: TElpa_solveReal
+    procedure, private :: TElpa_solveComplex
+    generic :: solve => TElpa_solveReal, TElpa_solveComplex
+  #:if WITH_ELPA
+    procedure, private :: setConfig => Telpa_setConfig
+    procedure, private :: initConfig => Telpa_initConfig
+    procedure, private :: initRedistribute => Telpa_initRedistribute
+  #:endif
+
+  end type TElpa
+
+contains
+
+
+  !> Initialise the ELPA solver
+  subroutine TElpa_init(this, env, inp, nBasisFn, timingLevel)
+
+    !> Instance
+    type(TElpa), intent(out) :: this
+
+    !> Environment settings
+    type(TEnvironment), intent(in) :: env
+
+    !> Input structure read from config file
+    type(TElpaInp), intent(inout) :: inp
+
+    !> Number of orbitals in the system
+    integer, intent(in) :: nBasisFn
+
+    !> Timing level read from config file
+    integer, intent(in) :: timingLevel
+
+    integer :: na_rows, na_cols
+    integer :: status
+
+  #:if WITH_ELPA
+
+    this%matrixSize = nBasisFn
+    this%contextOrig = env%blacs%orbitalGrid%ctxt
+
+    call scalafx_getdescriptor(env%blacs%orbitalGrid, this%matrixSize, this%matrixSize,&
+        & env%blacs%rowBlockSize, env%blacs%columnBlockSize, this%descOrig)
+
+    if (env%blacs%rowBlockSize /= env%blacs%columnBlockSize) then
+      call error("Error during ELPA initialization: different block sizes for rows and columns")
+    end if
+
+    status = elpa_init(20220510) ! minimum ELPA version is 2022.05.001
+    if (status /= ELPA_OK) then
+      call error("ELPA error: elpa_init failed")
+    end if
+
+    if (inp%redistributeFactor /= 1 .or. allocated(inp%redistributeRanks)) then
+      call this%initRedistribute(inp%redistributeFactor, inp%redistributeRanks, env%mpi%groupComm)
+
+      if (.not. this%joinElpaCalls) then
+        this%desc(:) = 0
+        this%desc(CTXT_) = -1
+        return
+      end if
+    end if
+
+    this%handle => elpa_allocate(status)
+    if (status /= ELPA_OK) then
+      call error("ELPA error: elpa_allocate failed")
+    end if
+
+    if (this%redistributing) then
+      call this%initConfig(this%redistributeGrid, this%redistributeComm, env%blacs%rowBlockSize)
+    else
+      call this%initConfig(env%blacs%orbitalGrid, env%mpi%groupComm, env%blacs%rowBlockSize)
+    end if
+
+    if (timingLevel < 0) then
+      call this%setConfig("timings", 1)
+      if (this%redistributing) then
+        this%printTimings = this%redistributeComm%lead
+      else
+        this%printTimings = env%mpi%groupComm%lead
+      end if
+    end if
+
+    status = this%handle%setup()
+    if (status /= ELPA_OK) then
+      call error("ELPA error: elpa_setup failed")
+    end if
+
+    if (inp%gpu) then
+      call this%setConfig("nvidia-gpu", 1)
+
+    #:if ELPA_HAS_SETUP_GPU
+      status = this%handle%setup_gpu()
+      if (status /= ELPA_OK) then
+        call error("ELPA error: elpa_setup_gpu failed")
+      end if
+    #:endif
+      this%gpu = .true.
+    end if
+
+    if (inp%autotune) then
+      this%autotuning = .true.
+      this%autotuneFile = inp%autotuneFile
+    else
+      select case (inp%solver)
+        case (1)
+          call this%setConfig("solver", ELPA_SOLVER_1STAGE)
+        case (2)
+          call this%setConfig("solver", ELPA_SOLVER_2STAGE)
+        case default
+          call error("Invalid solver choice for ELPA")
+      end select
+    end if
+
+  #:else
+    call error("Internal error: TElpa_init() called despite missing ELPA support")
+  #:endif
+
+  end subroutine TElpa_init
+
+
+#:if WITH_ELPA
+  !> Initialize ELPA settings
+  subroutine TElpa_initConfig(this, grid, comm, nblk)
+
+    !> Instance
+    class(TElpa), intent(inout) :: this
+
+    !> BLACS grid to use in ELPA
+    type(blacsgrid), intent(in) :: grid
+
+    !> MPI communicator to use in ELPA
+    type(mpifx_comm), intent(in) :: comm
+
+    !> BLACS block size
+    integer, intent(in) :: nblk
+
+    call scalafx_getdescriptor(grid, this%matrixSize, this%matrixSize, nblk, nblk, this%desc)
+
+    this%matrixLocalRows = scalafx_numroc(this%matrixSize, nblk, grid%myrow, grid%leadrow,&
+        & grid%nrow)
+    this%matrixLocalColumns = scalafx_numroc(this%matrixSize, nblk, grid%mycol, grid%leadcol,&
+        & grid%ncol)
+
+    call this%setConfig("na", this%matrixSize)
+    call this%setConfig("nev", this%matrixSize)
+    call this%setConfig("nblk", nblk)
+    call this%setConfig("local_nrows", this%matrixLocalRows)
+    call this%setConfig("local_ncols", this%matrixLocalColumns)
+    call this%setConfig("mpi_comm_parent", comm%id)
+    call this%setConfig("blacs_context", grid%ctxt)
+    call this%setConfig("process_row", grid%myrow)
+    call this%setConfig("process_col", grid%mycol)
+
+  end subroutine TElpa_initConfig
+
+
+  !> Initialize matrix redistribution
+  subroutine TElpa_initRedistribute(this, nprocStep, ranks, groupComm)
+
+    !> Instance
+    class(TElpa), intent(inout) :: this
+
+    !> How many processes to choose from the group communicator
+    !> nprocStep == 2 means: select every second rank
+    integer, intent(in) :: nprocStep
+
+    !> Which processes to choose from the group communicator
+    integer, allocatable, intent(inout) :: ranks(:)
+
+    !> Group communicator from which a new communicator will be created
+    type(mpifx_comm), intent(in) :: groupComm
+
+    integer :: np_rows, np_cols, row, col
+    integer :: nprocs, splitkey, rankkey, iproc
+    integer :: status
+    integer, allocatable :: gridmap(:,:)
+
+    if (.not. allocated(ranks)) then
+      if (nprocStep < 1 .or. modulo(groupComm%size, nprocStep) /= 0) then
+        call error("Invalid value for number of processes in ELPA redistribution")
+      end if
+
+      nprocs = groupComm%size / nprocStep
+      allocate(ranks(nprocs))
+      ranks(1) = groupComm%leadrank
+      do iproc = 2, nprocs
+        ranks(iproc) = ranks(iproc - 1) + nprocStep
+      end do
+    end if
+
+    nprocs = size(ranks)
+
+    do iproc = 1, nprocs
+      if (ranks(iproc) < 0 .or. ranks(iproc) >= groupComm%size) then
+        call error("Invalid value for rank in ELPA redistribution")
+      end if
+    end do
+
+    do np_rows = nint(sqrt(real(nprocs))), 2, -1
+      if (mod(nprocs, np_rows) == 0) exit
+    enddo
+    np_cols = nprocs / np_rows
+
+    allocate(gridmap(np_rows, np_cols))
+
+    splitkey = 0
+    rankkey = 0
+    iproc = 1
+    do row = 1, np_rows
+      do col = 1, np_cols
+        gridmap(row, col) = ranks(iproc)
+        if (ranks(iproc) == groupComm%rank) then
+          splitkey = 1
+        end if
+        iproc = iproc + 1
+      end do
+    end do
+
+    call this%redistributeGrid%initmappedgrids(gridmap)
+
+    if (splitkey == 1) then
+      rankkey = this%redistributeGrid%iproc
+    end if
+
+    call groupComm%split(splitkey, rankkey, this%redistributeComm, status)
+    if (status /= 0) then
+      call error("Error during communicator setup for ELPA redistribution")
+    end if
+
+    this%joinElpaCalls = splitkey == 1
+    this%redistributing = .true.
+    this%redistributeLead = ranks(1)
+    this%groupComm = groupComm
+
+  end subroutine TElpa_initRedistribute
+
+
+  !> Set ELPA flags with error handling
+  subroutine TElpa_setConfig(this, name, val)
+
+    !> Instance
+    class(TElpa), intent(inout) :: this
+
+    !> Name of the flag
+    character(*), intent(in) :: name
+
+    !> Value of the flag
+    integer, intent(in) :: val
+
+    integer :: status
+
+    call this%handle%set(name, val, status)
+    if (status /= ELPA_OK) then
+      call error("Error during ELPA initialization: setting " // name // " failed")
+    end if
+
+  end subroutine TElpa_setConfig
+#:endif
+
+
+  !> Finalize the ELPA solver
+  subroutine TElpa_final(this)
+
+    !> Instance
+    type(TElpa), intent(inout) :: this
+
+    integer :: status
+
+  #:if WITH_ELPA
+
+    if (this%redistributing) then
+      call this%redistributeGrid%destruct()
+      call this%redistributeComm%free()
+
+      if (allocated(this%matrixReal1)) then
+        deallocate(this%matrixReal1)
+      end if
+      if (allocated(this%matrixReal2)) then
+        deallocate(this%matrixReal2)
+      end if
+      if (allocated(this%eigenvectorsReal)) then
+        deallocate(this%eigenvectorsReal)
+      end if
+      if (allocated(this%matrixComplex1)) then
+        deallocate(this%matrixComplex1)
+      end if
+      if (allocated(this%matrixComplex2)) then
+        deallocate(this%matrixComplex2)
+      end if
+      if (allocated(this%eigenvectorsComplex)) then
+        deallocate(this%eigenvectorsComplex)
+      end if
+    end if
+
+    if (associated(this%autotune)) then
+      call elpa_autotune_deallocate(this%autotune, status)
+      if (status /= ELPA_OK) then
+        call error("ELPA error: elpa_autotune_deallocate failed")
+      end if
+    end if
+
+    if (associated(this%handle)) then
+      if (this%printTimings) then
+        call this%handle%print_times("ELPA generalized_eigenvectors")
+        if (this%redistributing) then
+          call this%handle%print_times("ELPA redistribute")
+        end if
+      end if
+
+      call elpa_deallocate(this%handle, status)
+      if (status /= ELPA_OK) then
+        call error("ELPA error: elpa_deallocate failed")
+      end if
+    end if
+
+    call elpa_uninit(status)
+    if (status /= ELPA_OK) then
+      call error("ELPA error: elpa_uninit failed")
+    end if
+
+  #:else
+    call error("Internal error: TElpa_final() called despite missing ELPA support")
+  #:endif
+
+  end subroutine TElpa_final
+
+
+#:for DTYPE, NAME in [('complex', 'Complex'), ('real', 'Real')]
+  !> Solve the eigenproblem (${DTYPE}$ case)
+  subroutine TElpa_solve${NAME}$(this, HSqr, SSqr, eigenVals, eigenVecs, hasCholesky)
+
+    !> Instance
+    class(TElpa), intent(inout) :: this
+
+    !> Hamiltonian
+    ${DTYPE}$(dp), intent(inout) :: HSqr(:,:)
+
+    !> Overlap matrix
+    ${DTYPE}$(dp), intent(inout) :: SSqr(:,:)
+
+    !> Eigenvalues
+    real(dp), intent(out) :: eigenVals(:)
+
+    !> Eigenvectors
+    ${DTYPE}$(dp), intent(out) :: eigenVecs(:,:)
+
+    !> Whether the S matrix already contains the Cholesky decomposition
+    logical, intent(in) :: hasCholesky
+
+    integer :: status
+    logical :: unfinished, previousStateExists
+
+  #:if WITH_ELPA
+
+    previousStateExists = .false.
+    if (this%autotuning .and. this%joinElpaCalls) then
+      if (.not. associated(this%autotune)) then
+        if (this%gpu) then
+          this%autotune => this%handle%autotune_setup(ELPA_AUTOTUNE_MEDIUM,&
+              & ELPA_AUTOTUNE_DOMAIN_${DTYPE.upper()}$, status)
+        else
+          this%autotune => this%handle%autotune_setup(ELPA_AUTOTUNE_FAST,&
+              & ELPA_AUTOTUNE_DOMAIN_${DTYPE.upper()}$, status)
+        end if
+        if (status /= ELPA_OK) then
+          call error("elpa error: elpa_autotune_setup failed")
+        end if
+
+        inquire(file=this%autotuneFile, exist=previousStateExists)
+      end if
+
+      unfinished = this%handle%autotune_step(this%autotune, status)
+      if (status /= ELPA_OK) then
+        call error("ELPA error: elpa_autotune_step failed")
+      end if
+
+      if (previousStateExists) then
+        call this%handle%autotune_load_state(this%autotune, this%autotuneFile, status)
+        if (status /= ELPA_OK) then
+          call error("ELPA error: elpa_autotune_load_state failed")
+        end if
+      end if
+
+      call this%handle%autotune_save_state(this%autotune, this%autotuneFile, status)
+      if (status /= ELPA_OK) then
+        call error("ELPA error: elpa_autotune_save_state failed")
+      end if
+
+      if (.not. unfinished) then
+        call this%handle%autotune_set_best(this%autotune, status)
+        if (status /= ELPA_OK) then
+          call error("ELPA error: elpa_autotune_set_best failed")
+        end if
+
+        this%autotuning = .false.
+      end if
+    end if
+
+    if (this%redistributing) then
+      if (.not. allocated(this%matrix${NAME}$1)) then
+        allocate(this%matrix${NAME}$1(this%matrixLocalRows, this%matrixLocalColumns))
+      end if
+      if (.not. allocated(this%matrix${NAME}$2)) then
+        allocate(this%matrix${NAME}$2(this%matrixLocalRows, this%matrixLocalColumns))
+      end if
+      if (.not. allocated(this%eigenvectors${NAME}$)) then
+        allocate(this%eigenvectors${NAME}$(this%matrixLocalRows, this%matrixLocalColumns))
+      end if
+
+      if (this%joinElpaCalls) then
+        call this%handle%timer_start("ELPA redistribute")
+      end if
+      call blacsfx_gemr2d(this%matrixSize, this%matrixSize, HSqr, 1, 1, this%descOrig,&
+          & this%matrix${NAME}$1, 1, 1, this%desc, this%contextOrig)
+      call blacsfx_gemr2d(this%matrixSize, this%matrixSize, SSqr, 1, 1, this%descOrig,&
+          & this%matrix${NAME}$2, 1, 1, this%desc, this%contextOrig)
+      if (this%joinElpaCalls) then
+        call this%handle%timer_stop("ELPA redistribute")
+      end if
+
+      if (this%joinElpaCalls) then
+        call this%handle%timer_start("ELPA generalized_eigenvectors")
+        call this%handle%generalized_eigenvectors(this%matrix${NAME}$1, this%matrix${NAME}$2,&
+            & eigenVals, this%eigenvectors${NAME}$, hasCholesky, status)
+        call this%handle%timer_stop("ELPA generalized_eigenvectors")
+
+        if (status /= ELPA_OK) then
+          call error("ELPA error: generalized_eigenvectors failed")
+        end if
+      end if
+
+      if (this%joinElpaCalls) then
+        call this%handle%timer_start("ELPA redistribute")
+      end if
+      if (.not. hasCholesky) then
+        call blacsfx_gemr2d(this%matrixSize, this%matrixSize, this%matrix${NAME}$2, 1, 1,&
+            & this%desc, SSqr, 1, 1, this%descOrig, this%contextOrig)
+      end if
+      call blacsfx_gemr2d(this%matrixSize, this%matrixSize, this%eigenvectors${NAME}$, 1, 1,&
+          & this%desc, eigenVecs, 1, 1, this%descOrig, this%contextOrig)
+      call mpifx_bcast(this%groupComm, eigenVals, this%redistributeLead)
+      if (this%joinElpaCalls) then
+        call this%handle%timer_stop("ELPA redistribute")
+      end if
+    else
+      call this%handle%timer_start("ELPA generalized_eigenvectors")
+      call this%handle%generalized_eigenvectors(HSqr, SSqr, eigenVals, eigenVecs, hasCholesky,&
+          & status)
+      call this%handle%timer_stop("ELPA generalized_eigenvectors")
+
+      if (status /= ELPA_OK) then
+        call error("ELPA error: generalized_eigenvectors failed")
+      end if
+    end if
+
+  #:else
+    eigenVals(:) = 0._dp
+    eigenVecs(:,:) = 0._dp
+    call error("Internal error: TElpa_solve${NAME}$() called despite missing ELPA support")
+  #:endif
+
+  end subroutine TElpa_solve${NAME}$
+#:endfor
+
+
+end module dftbp_elecsolvers_elpa

--- a/src/dftbp/elecsolvers/elsisolver.F90
+++ b/src/dftbp/elecsolvers/elsisolver.F90
@@ -20,6 +20,7 @@ module dftbp_elecsolvers_elsisolver
   use dftbp_dftb_spin, only : ud2qm
   use dftbp_dftb_spinorbit, only : addOnsiteSpinOrbitHam, getOnsiteSpinOrbitEnergy
   use dftbp_elecsolvers_elecsolvertypes, only : electronicSolverTypes
+  use dftbp_elecsolvers_elpa, only : TElpaInp
   use dftbp_elecsolvers_elsicsc, only : TElsiCsc
   use dftbp_extlibs_elsiiface, only : elsi_handle, elsi_rw_handle
   use dftbp_io_message, only : cleanshutdown, error, warning
@@ -61,15 +62,6 @@ module dftbp_elecsolvers_elsisolver
 
     !> Choice of the solver
     integer :: iSolver
-
-    !> Choice of ELPA solver
-    integer :: elpaSolver = 2
-
-    !> Enable ELPA autotuning
-    logical :: elpaAutotune = .false.
-
-    !> Enable GPU usage in ELPA
-    logical :: elpaGpu = .false.
 
     !> Iterations of ELPA solver before OMM minimization
     integer :: ommIterationsElpa = 5
@@ -301,14 +293,17 @@ contains
 
 
   !> Initialise ELSI solver
-  subroutine TElsiSolver_init(this, inp, env, nBasisFn, nEl, iDistribFn, nSpin, iSpin, nKPoint,&
-      & iKPoint, kWeight, tWriteHS, providesElectronEntropy)
+  subroutine TElsiSolver_init(this, inp, inpElpa, env, nBasisFn, nEl, iDistribFn, nSpin, iSpin,&
+      & nKPoint, iKPoint, kWeight, tWriteHS, providesElectronEntropy)
 
     !> control structure for solvers, including ELSI data
     class(TElsiSolver), intent(out) :: this
 
     !> input structure for ELSI
     type(TElsiSolverInp), intent(in) :: inp
+
+    !> input structure for ELPA
+    type(TElpaInp), intent(in) :: inpElpa
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -451,13 +446,13 @@ contains
     end if
 
     ! ELPA settings
-    this%elpaSolverOption = inp%elpaSolver
-    if (inp%elpaAutotune) then
+    this%elpaSolverOption = inpElpa%solver
+    if (inpElpa%autotune) then
       this%elpaAutotune = 1
     else
       this%elpaAutotune = 0
     end if
-    if (inp%elpaGpu) then
+    if (inpElpa%gpu) then
       this%elpaGpu = 1
     else
       this%elpaGpu = 0

--- a/src/dftbp/elecsolvers/elsisolver.F90
+++ b/src/dftbp/elecsolvers/elsisolver.F90
@@ -20,6 +20,7 @@ module dftbp_elecsolvers_elsisolver
   use dftbp_dftb_spin, only : ud2qm
   use dftbp_dftb_spinorbit, only : addOnsiteSpinOrbitHam, getOnsiteSpinOrbitEnergy
   use dftbp_elecsolvers_elecsolvertypes, only : electronicSolverTypes
+  use dftbp_elecsolvers_elpa, only : TElpaInp
   use dftbp_elecsolvers_elsicsc, only : TElsiCsc
   use dftbp_extlibs_elsiiface, only : elsi_handle, elsi_rw_handle
   use dftbp_io_message, only : cleanshutdown, error, warning
@@ -80,15 +81,6 @@ module dftbp_elecsolvers_elsisolver
 
     !> Choice of the solver
     integer :: iSolver
-
-    !> Choice of ELPA solver
-    integer :: elpaSolver = 2
-
-    !> Enable ELPA autotuning
-    logical :: elpaAutotune = .false.
-
-    !> Enable GPU usage in ELPA
-    logical :: elpaGpu = .false.
 
     !> Iterations of ELPA solver before OMM minimization
     integer :: ommIterationsElpa = 5
@@ -320,14 +312,17 @@ contains
 
 
   !> Initialise ELSI solver
-  subroutine TElsiSolver_init(this, inp, env, nBasisFn, nEl, iDistribFn, nSpin, iSpin, nKPoint,&
-      & iKPoint, kWeight, tWriteHS, providesElectronEntropy)
+  subroutine TElsiSolver_init(this, inp, inpElpa, env, nBasisFn, nEl, iDistribFn, nSpin, iSpin,&
+      & nKPoint, iKPoint, kWeight, tWriteHS, providesElectronEntropy)
 
     !> control structure for solvers, including ELSI data
     class(TElsiSolver), intent(out) :: this
 
     !> input structure for ELSI
     type(TElsiSolverInp), intent(in) :: inp
+
+    !> input structure for ELPA
+    type(TElpaInp), intent(in) :: inpElpa
 
     !> Environment settings
     type(TEnvironment), intent(in) :: env
@@ -470,13 +465,13 @@ contains
     end if
 
     ! ELPA settings
-    this%elpaSolverOption = inp%elpaSolver
-    if (inp%elpaAutotune) then
+    this%elpaSolverOption = inpElpa%solver
+    if (inpElpa%autotune) then
       this%elpaAutotune = 1
     else
       this%elpaAutotune = 0
     end if
-    if (inp%elpaGpu) then
+    if (inpElpa%gpu) then
       this%elpaGpu = 1
     else
       this%elpaGpu = 0

--- a/src/dftbp/extlibs/CMakeLists.txt
+++ b/src/dftbp/extlibs/CMakeLists.txt
@@ -6,6 +6,7 @@ set(sources-fpp
   ${curdir}/chimes.F90
   ${curdir}/ddcosmo.F90
   ${curdir}/dftd4refs.F90
+  ${curdir}/elpa.F90
   ${curdir}/elsiiface.F90
   ${curdir}/lapack.F90
   ${curdir}/lebedev.F90

--- a/src/dftbp/extlibs/elpa.F90
+++ b/src/dftbp/extlibs/elpa.F90
@@ -1,0 +1,42 @@
+!--------------------------------------------------------------------------------------------------!
+!  DFTB+: general package for performing fast atomistic simulations                                !
+!  Copyright (C) 2006 - 2025  DFTB+ developers group                                               !
+!                                                                                                  !
+!  See the LICENSE file for terms of usage and distribution.                                       !
+!--------------------------------------------------------------------------------------------------!
+
+#:include 'common.fypp'
+
+
+!> Interface wrapper for the ELPA library
+!>
+module dftbp_extlibs_elpa
+#:if WITH_ELPA
+  use elpa, only : elpa_allocate, elpa_autotune_deallocate, elpa_autotune_t, elpa_deallocate,&
+      & elpa_init, elpa_t, elpa_uninit, ELPA_AUTOTUNE_DOMAIN_COMPLEX, ELPA_AUTOTUNE_DOMAIN_REAL,&
+      & ELPA_AUTOTUNE_FAST, ELPA_AUTOTUNE_MEDIUM, ELPA_OK, ELPA_SOLVER_1STAGE, ELPA_SOLVER_2STAGE
+#:endif
+  implicit none
+  private
+
+  public :: elpa_t, withElpa
+  public :: elpa_autotune_t
+#:if WITH_ELPA
+  public :: elpa_allocate, elpa_deallocate
+  public :: elpa_init, elpa_uninit
+  public :: elpa_autotune_deallocate
+  public :: ELPA_OK
+  public :: ELPA_SOLVER_1STAGE, ELPA_SOLVER_2STAGE
+  public :: ELPA_AUTOTUNE_FAST, ELPA_AUTOTUNE_MEDIUM
+  public :: ELPA_AUTOTUNE_DOMAIN_REAL, ELPA_AUTOTUNE_DOMAIN_COMPLEX
+#:else
+  type elpa_t
+  end type
+  type elpa_autotune_t
+  end type
+#:endif
+
+  !> Whether code was built with ELPA support
+  logical, parameter :: withElpa = #{if WITH_ELPA}# .true. #{else}# .false. #{endif}#
+
+end module dftbp_extlibs_elpa

--- a/src/dftbp/extlibs/scalapackfx.F90
+++ b/src/dftbp/extlibs/scalapackfx.F90
@@ -11,12 +11,12 @@
 module dftbp_extlibs_scalapackfx
 #:if WITH_SCALAPACK
   use libscalapackfx_module, only : blacsfx_gemr2d, blacsfx_gsum, blacsgrid, blocklist, CSRC_,&
-      & DLEN_, linecomm, M_, MB_, N_, NB_, pblasfx_pgemm, pblasfx_phemm, pblasfx_psymm,&
-      & pblasfx_psymv, pblasfx_ptran, pblasfx_ptranc, pblasfx_ptranu, RSRC_, scalafx_addg2l, scalafx_addl2g,&
-      & scalafx_cpg2l, scalafx_cpl2g, scalafx_getdescriptor, scalafx_getlocalshape,&
-      & scalafx_indxl2g, scalafx_infog2l, scalafx_islocal, scalafx_pgetri, scalafx_pgetrf, scalafx_phegv,&
-      & scalafx_phegvd, scalafx_phegvr, scalafx_pposv, scalafx_ppotrf, scalafx_ppotri,&
-      & scalafx_psygv, scalafx_psygvd, scalafx_psygvr, size
+      & CTXT_, DLEN_, linecomm, M_, MB_, N_, NB_, pblasfx_pgemm, pblasfx_phemm, pblasfx_psymm,&
+      & pblasfx_psymv, pblasfx_ptran, pblasfx_ptranc, pblasfx_ptranu, RSRC_, scalafx_addg2l,&
+      & scalafx_addl2g, scalafx_cpg2l, scalafx_cpl2g, scalafx_getdescriptor, scalafx_getlocalshape,&
+      & scalafx_indxl2g, scalafx_infog2l, scalafx_islocal, scalafx_numroc, scalafx_pgetri,&
+      & scalafx_pgetrf, scalafx_phegv, scalafx_phegvd, scalafx_phegvr, scalafx_pposv,&
+      & scalafx_ppotrf, scalafx_ppotri, scalafx_psygv, scalafx_psygvd, scalafx_psygvr, size
 #:endif
   implicit none
   public

--- a/src/dftbp/extlibs/scalapackfx.F90
+++ b/src/dftbp/extlibs/scalapackfx.F90
@@ -11,13 +11,13 @@
 module dftbp_extlibs_scalapackfx
 #:if WITH_SCALAPACK
   use libscalapackfx_module, only : blacsfx_gemr2d, blacsfx_gsum, blacsgrid, blocklist, CSRC_,&
-      & DLEN_, linecomm, M_, MB_, N_, NB_, pblasfx_pgemm, pblasfx_phemm, pblasfx_psymm,&
+      & CTXT_, DLEN_, linecomm, M_, MB_, N_, NB_, pblasfx_pgemm, pblasfx_phemm, pblasfx_psymm,&
       & pblasfx_psymv, pblasfx_psyrk, pblasfx_ptran, pblasfx_ptranc, pblasfx_ptranu, RSRC_,&
-      & scalafx_addg2l, scalafx_addl2g,&
-      & scalafx_cpg2l, scalafx_cpl2g, scalafx_getdescriptor, scalafx_getlocalshape,&
-      & scalafx_indxl2g, scalafx_infog2l, scalafx_islocal, scalafx_pgetri, scalafx_pgetrf, scalafx_phegv,&
-      & scalafx_phegvd, scalafx_phegvr, scalafx_pposv, scalafx_ppotrf, scalafx_ppotri,&
-      & scalafx_psygv, scalafx_psygvd, scalafx_psygvr, size
+      & scalafx_addg2l, scalafx_addl2g, scalafx_cpg2l, scalafx_cpl2g, scalafx_getdescriptor,&
+      & scalafx_getlocalshape, scalafx_indxl2g, scalafx_infog2l, scalafx_islocal, scalafx_pgetri,&
+      & scalafx_pgetrf, scalafx_phegv, scalafx_phegvd, scalafx_phegvr, scalafx_pposv,&
+      & scalafx_ppotrf, scalafx_numroc, scalafx_ppotri, scalafx_psygv, scalafx_psygvd,&
+      & scalafx_psygvr, size
 #:endif
   implicit none
   public

--- a/src/dftbp/include/common.fypp
+++ b/src/dftbp/include/common.fypp
@@ -21,6 +21,7 @@
 #:set WITH_MAGMA = defined('WITH_MAGMA')
 #:set WITH_ELSI = defined('WITH_ELSI')
 #:set WITH_PEXSI = defined('WITH_PEXSI') and WITH_ELSI
+#:set WITH_ELPA = defined('WITH_ELPA')
 #:set WITH_SCALAPACK = defined('WITH_SCALAPACK')
 #:set WITH_MBD = defined('WITH_MBD')
 #:set WITH_SOCKETS = defined('WITH_SOCKETS')
@@ -38,6 +39,8 @@
 #:set EMULATE_F08_MATH = defined('EMULATE_F08_MATH')
 #:set INSTANCE_SAFE_BUILD = defined('INSTANCE_SAFE_BUILD')
 #:set WITH_CXX = defined('WITH_CXX')
+#:set ELPA_HAS_SETUP_GPU = defined('ELPA_HAS_SETUP_GPU')
+
 
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 #! ASSERT and DEBUG related macros

--- a/test/app/dftb+/tests
+++ b/test/app/dftb+/tests
@@ -60,8 +60,8 @@ helical/10-0CtubeC_10_origin           #? MPI_PROCS == 1
 helical/10-0CtubeC_10_sampled          #? MPI_PROCS == 1
 helical/1000-0-C_1000                  #? MPI_PROCS == 1
 helical/C6H6_stack                     #? MPI_PROCS == 1
-helical/10-0Ctube_ELPA                 #? WITH_ELSI and MPI_PROCS <= 8 and MPI_PROCS % 2 == 0 and OMP_THREADS == 1
-helical/C6H6_stack_ELPA                #? WITH_ELSI and MPI_PROCS == 1 and OMP_THREADS == 1
+helical/10-0Ctube_ELPA                 #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 8 and MPI_PROCS % 2 == 0 and OMP_THREADS == 1
+helical/C6H6_stack_ELPA                #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS == 1 and OMP_THREADS == 1
 helical/10-0Ctube_PEXSI                #? WITH_PEXSI and MPI_PROCS <= 8 and MPI_PROCS % 4 == 0 and OMP_THREADS == 1 and ELSI_VERSION > 2.5
 
 dispersion/2C6H6_MBD                   #? WITH_MBD and MPI_PROCS <= 4
@@ -233,14 +233,14 @@ mdftb/NH4+H2O_RotTran1                 #? MPI_PROCS <= 2
 mdftb/NH4+H2O_RotTran2                 #? MPI_PROCS <= 2
 mdftb/NH4+H2O_RotTran3                 #? OMP_THREADS <= 4 and MPI_PROCS <= 2
 
-solvers/GaAs_2_ELPA2                   #? WITH_ELSI and MPI_PROCS == 8 and OMP_THREADS == 1
-solvers/Si32C32_ELPA1                  #? WITH_ELSI and MPI_PROCS <= 4 and OMP_THREADS == 1
-solvers/Si32C32_ELPA2                  #? WITH_ELSI and MPI_PROCS <= 4 and OMP_THREADS == 1
-solvers/Fe4_ELPA_2group                #? WITH_ELSI and MPI_PROCS <= 4 and MPI_PROCS % 2 == 0 and OMP_THREADS == 1
-solvers/Si384_ELPA1                    #? WITH_ELSI and MPI_PROCS <= 4 and OMP_THREADS == 1
-solvers/Si384_ELPA2                    #? WITH_ELSI and MPI_PROCS <= 4 and OMP_THREADS == 1
-solvers/SiC64+V_ELPA2                  #? WITH_ELSI and MPI_PROCS <= 16 and MPI_PROCS % 4 == 0 and OMP_THREADS == 1
-solvers/Si256C256_ELPA_GPU             #? WITH_ELSI and MPI_PROCS <= 16 and MPI_PROCS % 4 == 0 and OMP_THREADS == 1 and WITH_GPU
+solvers/GaAs_2_ELPA2                   #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS == 8 and OMP_THREADS == 1
+solvers/Si32C32_ELPA1                  #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 4 and OMP_THREADS == 1
+solvers/Si32C32_ELPA2                  #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 4 and OMP_THREADS == 1
+solvers/Fe4_ELPA_2group                #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 4 and MPI_PROCS % 2 == 0 and OMP_THREADS == 1
+solvers/Si384_ELPA1                    #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 4 and OMP_THREADS == 1
+solvers/Si384_ELPA2                    #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 4 and OMP_THREADS == 1
+solvers/SiC64+V_ELPA2                  #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 16 and MPI_PROCS % 4 == 0 and OMP_THREADS == 1
+solvers/Si256C256_ELPA_GPU             #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 16 and MPI_PROCS % 4 == 0 and OMP_THREADS == 1 and WITH_GPU
 
 solvers/ice_OMM                        #? WITH_ELSI and MPI_PROCS <= 4 and OMP_THREADS == 1
 solvers/ice_NTPoly                     #? WITH_ELSI and MPI_PROCS <= 4 and OMP_THREADS == 1

--- a/test/app/dftb+/tests
+++ b/test/app/dftb+/tests
@@ -62,8 +62,8 @@ helical/10-0CtubeC_10_origin           #? MPI_PROCS == 1
 helical/10-0CtubeC_10_sampled          #? MPI_PROCS == 1
 helical/1000-0-C_1000                  #? MPI_PROCS == 1
 helical/C6H6_stack                     #? MPI_PROCS == 1
-helical/10-0Ctube_ELPA                 #? WITH_ELSI and MPI_PROCS <= 8 and MPI_PROCS % 2 == 0 and OMP_THREADS == 1
-helical/C6H6_stack_ELPA                #? WITH_ELSI and MPI_PROCS == 1 and OMP_THREADS == 1
+helical/10-0Ctube_ELPA                 #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 8 and MPI_PROCS % 2 == 0 and OMP_THREADS == 1
+helical/C6H6_stack_ELPA                #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS == 1 and OMP_THREADS == 1
 helical/10-0Ctube_PEXSI                #? WITH_PEXSI and MPI_PROCS <= 8 and MPI_PROCS % 4 == 0 and OMP_THREADS == 1 and ELSI_VERSION > 2.5
 
 dispersion/2C6H6_MBD                   #? WITH_MBD and MPI_PROCS <= 4
@@ -235,14 +235,14 @@ mdftb/NH4+H2O_RotTran1                 #? MPI_PROCS <= 2
 mdftb/NH4+H2O_RotTran2                 #? MPI_PROCS <= 2
 mdftb/NH4+H2O_RotTran3                 #? OMP_THREADS <= 4 and MPI_PROCS <= 2
 
-solvers/GaAs_2_ELPA2                   #? WITH_ELSI and MPI_PROCS == 8 and OMP_THREADS == 1
-solvers/Si32C32_ELPA1                  #? WITH_ELSI and MPI_PROCS <= 4 and OMP_THREADS == 1
-solvers/Si32C32_ELPA2                  #? WITH_ELSI and MPI_PROCS <= 4 and OMP_THREADS == 1
-solvers/Fe4_ELPA_2group                #? WITH_ELSI and MPI_PROCS <= 4 and MPI_PROCS % 2 == 0 and OMP_THREADS == 1
-solvers/Si384_ELPA1                    #? WITH_ELSI and MPI_PROCS <= 4 and OMP_THREADS == 1
-solvers/Si384_ELPA2                    #? WITH_ELSI and MPI_PROCS <= 4 and OMP_THREADS == 1
-solvers/SiC64+V_ELPA2                  #? WITH_ELSI and MPI_PROCS <= 16 and MPI_PROCS % 4 == 0 and OMP_THREADS == 1
-solvers/Si256C256_ELPA_GPU             #? WITH_ELSI and MPI_PROCS <= 16 and MPI_PROCS % 4 == 0 and OMP_THREADS == 1 and WITH_GPU
+solvers/GaAs_2_ELPA2                   #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS == 8 and OMP_THREADS == 1
+solvers/Si32C32_ELPA1                  #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 4 and OMP_THREADS == 1
+solvers/Si32C32_ELPA2                  #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 4 and OMP_THREADS == 1
+solvers/Fe4_ELPA_2group                #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 4 and MPI_PROCS % 2 == 0 and OMP_THREADS == 1
+solvers/Si384_ELPA1                    #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 4 and OMP_THREADS == 1
+solvers/Si384_ELPA2                    #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 4 and OMP_THREADS == 1
+solvers/SiC64+V_ELPA2                  #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 16 and MPI_PROCS % 4 == 0 and OMP_THREADS == 1
+solvers/Si256C256_ELPA_GPU             #? (WITH_ELSI or WITH_ELPA) and MPI_PROCS <= 16 and MPI_PROCS % 4 == 0 and OMP_THREADS == 1 and WITH_GPU
 
 solvers/ice_OMM                        #? WITH_ELSI and MPI_PROCS <= 4 and OMP_THREADS == 1
 solvers/ice_NTPoly                     #? WITH_ELSI and MPI_PROCS <= 4 and OMP_THREADS == 1

--- a/utils/export/dftbplus-config.cmake.in
+++ b/utils/export/dftbplus-config.cmake.in
@@ -7,6 +7,7 @@ set(DftbPlus_WITH_GPU @WITH_GPU@)
 set(DftbPlus_WITH_MAGMA @WITH_MAGMA@)
 set(DftbPlus_WITH_ELSI @WITH_ELSI@)
 set(DftbPlus_ELSI_WITH_PEXSI @ELSI_WITH_PEXSI@)
+set(DftbPlus_WITH_ELPA @WITH_ELPA@)
 set(DftbPlus_WITH_TRANSPORT @WITH_TRANSPORT@)
 set(DftbPlus_WITH_POISSON @WITH_POISSON@)
 set(DftbPlus_WITH_TBLITE @WITH_TBLITE@)
@@ -56,6 +57,10 @@ if(NOT TARGET DftbPlus::DftbPlus)
 
   if(DftbPlus_WITH_ELSI AND NOT TARGET elsi::elsi)
     find_dependency(elsi)
+  endif()
+
+  if(DftbPlus_WITH_ELPA AND NOT TARGET elpa::elpa)
+    find_dependency(elpa)
   endif()
 
   if(DftbPlus_WITH_MAGMA AND NOT TARGET Magma::Magma)


### PR DESCRIPTION
Include ELPA directly without the ELSI library. Additionally implements new "redistribute" feature, which allows DFTB+ to be launched with a higher number of MPI ranks than used for the actual ELPA call. This is useful for GPU runs.
Documentation has been updated accordingly.