### PR TITLE
Cancel old github actions on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,10 @@ jobs:
         config: [Debug]
         version: [13]
 
+    concurrency:
+      group: ${{ matrix.os }}-${{ matrix.mpi }}
+      cancel-in-progress: true
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -208,6 +212,10 @@ jobs:
         config: [RelWithDebInfo]
 
     runs-on: ${{ matrix.os }}
+
+    concurrency:
+      group: intel
+      cancel-in-progress: true
 
     env:
       FC: ifx


### PR DESCRIPTION
Use concurrency in different paths in the action to stop old pulls