### PR TITLE
Concurrent branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,6 @@ env:
   HOMEBREW_NO_INSTALL_CLEANUP: "ON"
   BUILD_DIR: _build
   INSTALL_DIR: _install
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   CMAKE_OPTIONS: >-
     -DWITH_API=true
     -DWITH_SDFTD3=true
@@ -62,7 +61,7 @@ jobs:
         version: [13]
 
     concurrency:
-      group: ${{ env.BRANCH_NAME }}-${{ matrix.os }}-${{ matrix.mpi }}
+      group: ${{ github.head_ref || github.ref_name }}-${{ matrix.os }}-${{ matrix.mpi }}
       cancel-in-progress: true
 
     steps:
@@ -215,7 +214,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     concurrency:
-      group: ${{ env.BRANCH_NAME }}-intel
+      group: ${{ github.head_ref || github.ref_name }}-intel
       cancel-in-progress: true
 
     env:


### PR DESCRIPTION
Should avoid separate branches cancelling each other in actions if the regression is running simultaneously. Multiple copies of the same branch should still only have the most recent action running.