### PR TITLE
RecomputeAfterDensity

### DIFF
--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -1368,6 +1368,7 @@ To select the DFTB Hamiltonian you must set \is{Hamiltonian =
   \kw{SCCTolerance} &r& SCC = Yes & 1e-5 &  \\
   \kw{MaxSCCIterations} &i& SCC = Yes & 100 & \\
   \kw{ConvergentSccOnly} & l & SCC = Yes & \is{Yes}\\
+  \kw{RecomputeAfterDensity} & l & & Yes & \\
   \kw{EwaldParameter} & r & Periodic = Yes SCC = Yes & 0.0 & \\
   \kw{EwaldTolerance} & r & Periodic = Yes SCC = Yes & 1e-9 & \\
   \kw{ShellResolvedSCC} & l & SCC = Yes & No & \\
@@ -1436,6 +1437,17 @@ To select the DFTB Hamiltonian you must set \is{Hamiltonian =
 \item[\is{ConvergentSccOnly}] If true, requires that the SCC cycle converges
   before proceeding to subsequent stages of the calculation (forces, analysis,
   etc.).
+
+\item[\is{RecomputeAfterDensity}] When set to \is{Yes} the
+  electrostatic potentials is updated with the newly computed DM and
+  atomic charges. This is done in order to make the electrostatic
+  energy consistent and forces variational.  It can be set to \is{No}
+  in transport calculations to avoid an unnecessary invocation of the
+  Poisson solver, when energy and forces are not relevant.  It should
+  also be set to \is{No} when the user would like to perform a
+  fixed-charge calculation with charges that are initialized from an
+  external file. In this case also set \is{MaxSCCIterations=1} and
+  \is{ReadInitialCharges=Yes}.
 
 \item[\is{EwaldParameter}] Sets the dimensionless parameter $\alpha$
   in the Ewald electrostatic summation for periodic calculations. This

--- a/doc/dftb+/manual/transport.tex
+++ b/doc/dftb+/manual/transport.tex
@@ -631,7 +631,6 @@ Cartesian axes, $x$, $y$, $z$.
   \kw{BoundaryRegion} & m & & global\{\} &  \pref{Boundary Conditions} \\
   \kw{Gate} & m & & none\{\} & \pref{Electrostatic Gates} \\
   \kw{MaxParallelNodes} & m & & none\{\} & \pref{Parallelisations} \\
-  \kw{RecomputeAfterDensity} & l & & No & \\
   \kw{PoissonThickness} & r & contacts = 1 & &\\
 \end{ptableh}
 
@@ -678,12 +677,6 @@ Cartesian axes, $x$, $y$, $z$.
   the Poisson equation (default value 10$^{-6}$).
 \item[\is{MaxPoissonIterations}] Defines the maximum number of iterations allowed
   for the solver.
-\item[\is{RecomputeAfterDensity}] When set to \is{Yes}, Poisson's equation is
-  solved again after the density matrix is created in order to make the
-  electrostatic energy consistent with the newly updated charges.  In transport
-  calculations it is set to \is{No} by default in order to avoid the extra time
-  spent on the Poisson step. This does not affect the SCC loop or other
-  calculations apart from the electronic energy and forces.
 \item[\is{PoissonThickness}] In the special case of a single contact (cases like
   the end of semi-infinite wires or surfaces of crystals), the thickness of the
   Poisson box normal to the surface of the contact can be set with this command.

--- a/src/dftbp/dftbplus/inputdata.F90
+++ b/src/dftbp/dftbplus/inputdata.F90
@@ -568,7 +568,9 @@ module dftbp_dftbplus_inputdata
     type(TReksInp) :: reksInp
 
     !> Whether Scc should be updated with the output charges (obtained after diagonalization)
-    !> Could be set to .false. to prevent costly recalculations (e.g. when using Poisson-solver)
+    !! Could be set to .false. to prevent costly recalculations (e.g. when using Poisson-solver)
+    !! It can also be set to .false. in case of fixed-charge calculations
+    !! (e.g. when setting MaxSCCIterations=1;   ReadInitialCharges=Yes)
     logical :: updateSccAfterDiag = .true.
 
     !> Write cavity information as COSMO file

--- a/src/dftbp/dftbplus/oldcompat.F90
+++ b/src/dftbp/dftbplus/oldcompat.F90
@@ -28,7 +28,7 @@ module dftbp_dftbplus_oldcompat
 
   !> Actual input version <-> parser version maps (must be updated at every public release)
   type(TVersionMap), parameter :: versionMaps(*) = [&
-      & TVersionMap("25.1", 14),&
+      & TVersionMap("26.1", 15), TVersionMap("25.1", 14),&
       & TVersionMap("24.1", 14), TVersionMap("23.1", 13), TVersionMap("22.2", 12),&
       & TVersionMap("22.1", 11), TVersionMap("21.2", 10), TVersionMap("21.1", 9),&
       & TVersionMap("20.2", 9), TVersionMap("20.1", 8), TVersionMap("19.1", 7),&
@@ -101,6 +101,9 @@ contains
       case (13)
         call convert_13_14(root)
         version = 14
+      case (14)
+        call convert_14_15(root)
+        version = 15
       end select
     end do
 
@@ -937,6 +940,40 @@ contains
     end if
 
   end subroutine convert_13_14
+
+  !> Converts input from version 14 to 15. (Version 18 February 2026)
+  subroutine convert_14_15(root)
+
+    !> Root tag of the HSD-tree
+    type(fnode), pointer :: root
+
+    type(fnode), pointer :: ch1, ch2, par, hamil, dummy
+    logical :: isRecomputed
+
+    ! Move RecomputeAfterDensity to the Hamiltonian block.
+    ! The normal default is RecomputeAfterDensity=.true.
+    ! Check if Poisson block is present. If NOT RecomputeAfterDensity will take the new default.
+    call getDescendant(root, "Hamiltonian/DFTB/Electrostatics/Poisson", ch1, parent=par)
+    if (associated(ch1))  then
+      call getDescendant(root, "Hamiltonian/DFTB/Electrostatics/Poisson/RecomputeAfterDensity", &
+          & ch1, parent=par)
+      if (associated(ch1)) then
+        call getChildValue(par, "RecomputeAfterDensity", isRecomputed)
+        call detailedWarning(ch1, "Keyword Moved to Hamiltonian {} block.")
+        dummy => removeChild(par, ch1)
+        call destroyNode(ch1)
+      else
+         isRecomputed = .false.
+      end if
+      ! Check if the tag is already present and issue an error.
+      call getDescendant(root, "Hamiltonian/DFTB/RecomputeAfterDensity", ch1)
+      if (associated(ch1)) call detailedError(ch1, "RecomputeAfterDensity is already present.")
+      call getDescendant(root, "Hamiltonian/DFTB", hamil)
+      call setChildValue(hamil, "RecomputeAfterDensity", isRecomputed, child=ch2)
+      call setUnprocessed(ch2)
+    end if
+
+  end subroutine convert_14_15
 
 
   !> Update values in the DftD3 block to match behaviour of v6 parser

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -2151,9 +2151,9 @@ contains
       #:block REQUIRES_COMPONENT('Poisson-solver', WITH_POISSON)
         ctrl%tPoisson = .true.
         #:if WITH_TRANSPORT
-          call readPoisson(value1, poisson, geo%tPeriodic, tp, geo%latVecs, ctrl%updateSccAfterDiag)
+          call readPoisson(value1, poisson, geo%tPeriodic, tp, geo%latVecs)
         #:else
-          call readPoisson(value1, poisson, geo%tPeriodic, geo%latVecs, ctrl%updateSccAfterDiag)
+          call readPoisson(value1, poisson, geo%tPeriodic, geo%latVecs)
         #:endif
       #:endblock
 
@@ -3278,6 +3278,10 @@ contains
 
     ! self consistency required or not to proceed
     call getChildValue(node, "ConvergentSCCOnly", ctrl%isSccConvRequired, .true.)
+    
+    call getChildValue(node, "RecomputeAfterDensity", ctrl%updateSccAfterDiag, .true.)
+
+    call getChildValue(node, "RecomputeAfterDensity", ctrl%updateSccAfterDiag, .true.)
 
   end subroutine readSccOptions
 
@@ -6488,9 +6492,9 @@ contains
 
   !> Read in Poisson related data
 #:if WITH_TRANSPORT
-  subroutine readPoisson(pNode, poisson, tPeriodic, transpar, latVecs, updateSccAfterDiag)
+  subroutine readPoisson(pNode, poisson, tPeriodic, transpar, latVecs)
 #:else
-  subroutine readPoisson(pNode, poisson, tPeriodic, latVecs, updateSccAfterDiag)
+  subroutine readPoisson(pNode, poisson, tPeriodic, latVecs)
 #:endif
 
     !> Input tree
@@ -6509,9 +6513,6 @@ contains
 
     !> Lattice vectors if periodic
     real(dp), allocatable, intent(in) :: latVecs(:,:)
-
-    !> Whether Scc should be updated with the output charges (obtained after diagonalisation)
-    logical, intent(out) :: updateSccAfterDiag
 
     type(fnode), pointer :: pTmp, pTmp2, pChild, field
     type(string) :: buffer, modifier
@@ -6582,7 +6583,6 @@ contains
     call getChildValue(pNode, "PoissonAccuracy", poisson%poissAcc, 1.0e-6_dp)
     call getChildValue(pNode, "BuildBulkPotential", poisson%bulkBC, .true.)
     call getChildValue(pNode, "ReadOldBulkPotential", poisson%readBulkPot, .false.)
-    call getChildValue(pNode, "RecomputeAfterDensity", updateSccAfterDiag, .false.)
     call getChildValue(pNode, "MaxPoissonIterations", poisson%maxPoissIter, 60)
 
     poisson%overrideBC(:) = poissonBCsEnum%periodic

--- a/test/app/dftb+/poisson/CH4-poisson/dftb_in.hsd
+++ b/test/app/dftb+/poisson/CH4-poisson/dftb_in.hsd
@@ -32,7 +32,7 @@ Prefix = {slakos/origin/mio-1-1/}
     readoldbulkpotential = no
     boundaryregion = global {}
     poissonaccuracy = 1e-7
-    recomputeafterdensity = no 
+    RecomputeAfterDensity = No 
   }
   
 } 

--- a/test/app/dftb+/transport/CH4-poisson/dftb_in.hsd
+++ b/test/app/dftb+/transport/CH4-poisson/dftb_in.hsd
@@ -32,7 +32,7 @@ Prefix = {slakos/origin/mio-1-1/}
     readoldbulkpotential = no
     boundaryregion = global {}
     poissonaccuracy = 1e-7
-    recomputeafterdensity = no 
+    Recomputeafterdensity = No 
   }
   
 

--- a/test/app/dftb+/transport/graphene3T/dftb_in.hsd
+++ b/test/app/dftb+/transport/graphene3T/dftb_in.hsd
@@ -246,10 +246,10 @@ Hamiltonian = DFTB {
     AtomDensityTolerance = 1e-005
     CutoffCheck = Yes
     Verbosity = 51
-    RecomputeAfterDensity = No
     MaxPoissonIterations = 60
     OverrideBulkBC = none {}
     Gate = none {}
+    RecomputeAfterDensity = No
   }
 
   ElectricField = {}


### PR DESCRIPTION
I moved the existent option for the Poisson solver "RecomputeAfterDensity" to the main dftb Hamiltonian block of options. In this way the option is available in general, also when the gamma-functional is used.
Rationale:
In el-phonon scattering calculations we have published works using fixed-charges. This is obtained by setting MaxSCCIterations=1 and readInitialCharges=Yes. 
We want the Forces to be computed with the initialized charges, not those recomputed from the new DM, especially when atoms are displaced. In practice the option is useful whenever the user would like to run calculations with **fixed** atomic charges. 
The option is also useful in the context of transport+gammafunctional (to come).  