### PR TITLE
VelocityVerlet: optional forces print in XYZ  MD trajectory output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Added
 - Option (FromParameters) to automatically set spin-constants for xTB
   models
 
+- VelocityVerlet: new PrintTrajectoryForces option to append fx fy fz to
+  OutputPrefix.xyz (units: eV/Angstrom).
+
 
 Changed
 -------

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -863,6 +863,7 @@ file \verb|md.out| (see appendix \ref{sec:md.out}).
   \kw{KeepStationary} & l & & Yes & \\
   \kw{Thermostat} & m &  & - & \pref{sec:dftbp.Thermostat} \\
   \kw{OutputPrefix} &s & & "geo\_end" & \\
+  \kw{WriteTrajectoryForces} & l & & No & \\
   \kw{MDRestartFrequency} & i & & 1 & \\
   \kw{Velocities} & (3r)* & & - & \\
   \kw{Barostat} & m & Periodic = Yes & - & \pref{sec:dftbp.Barostat}\\
@@ -891,6 +892,13 @@ selection expressions, as described in appendix \ref{sec:index_selection}.
 
 \item[\is{OutputPrefix}] Prefix of the geometry files containing the
   final structure.
+
+\item[\is{WriteTrajectoryForces}] If set to \is{Yes}, per-atom forces are
+  appended to the VelocityVerlet trajectory output (\is{OutputPrefix}.xyz) as
+  columns 9--11 (\verb|fx fy fz|). Default: \is{No}. If absent or set to
+  \is{No}, the trajectory format remains unchanged. Force units are
+  eV/\AA, converted from internal force units in detailed.out. This option is independent of
+  \is{Analysis/PrintForces}.
 
 \item[\is{MDRestartFrequency}] Interval that the current geometry and
   velocities are written to the XYZ format geometry file and md.out

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -510,6 +510,9 @@ module dftbp_dftbplus_initprogram
     !> Are forces being returned
     logical :: tPrintForces
 
+    !> Should per-atom forces be written into the MD trajectory file
+    logical :: writeTrajectoryForces
+
     !> Number of moved atoms
     integer :: nMovedAtom
 
@@ -1978,6 +1981,7 @@ contains
     this%tAppendGeo = input%ctrl%tAppendGeo
     this%isSccConvRequired = input%ctrl%isSccConvRequired
     this%tMD = input%ctrl%tMD
+    this%writeTrajectoryForces = input%ctrl%writeTrajectoryForces
     if (this%tMD) this%mdOutput = input%ctrl%mdOutput
     this%tDerivs = input%ctrl%tDerivs
     this%tPrintMulliken = input%ctrl%tPrintMulliken

--- a/src/dftbp/dftbplus/inputdata.F90
+++ b/src/dftbp/dftbplus/inputdata.F90
@@ -288,6 +288,9 @@ module dftbp_dftbplus_inputdata
     !> Molecular dynamics
     logical :: tMD = .false.
 
+    !> Write per-atom forces in MD trajectory output
+    logical :: writeTrajectoryForces = .false.
+
     !> Molecular dynamics data to be recorded as it is accumulated
     type(TMDOutput), allocatable :: mdOutput
 

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -1760,7 +1760,8 @@ contains
         call writeCurrentGeometry(this%geoOutFile, this%pCoord0Out, this%tLatOpt, this%tMd,&
             & this%tAppendGeo.and.iGeoStep>0, this%tFracCoord, this%tPeriodic, this%tHelical,&
             & this%tPrintMulliken, this%species0, this%speciesName, this%latVec, this%origin,&
-            & iGeoStep, iLatGeoStep, this%nSpin, this%qOutput, this%velocities)
+            & iGeoStep, iLatGeoStep, this%nSpin, this%qOutput, this%velocities, .false.,&
+            & this%derivs)
       endif
     end if
     if (len(trim(this%extendedGeomFile)) > 0) then
@@ -2081,7 +2082,7 @@ contains
         call writeCurrentGeometry(this%geoOutFile, this%pCoord0Out, .false., .true., .true.,&
             & this%tFracCoord, this%tPeriodic, this%tHelical, this%tPrintMulliken, this%species0,&
             & this%speciesName, this%latVec, this%origin, iGeoStep, iLatGeoStep, this%nSpin,&
-            & this%qOutput, this%velocities)
+            & this%qOutput, this%velocities, this%writeTrajectoryForces, this%derivs)
       end if
       if (len(trim(this%extendedGeomFile)) > 0) then
         call writeExtendedGeometry(trim(this%extendedGeomFile), .false., .true., .true.,&

--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -15,7 +15,8 @@
 !> Various I/O routines for the main program.
 module dftbp_dftbplus_mainio
   use dftbp_common_accuracy, only : dp, lc, mc, sc
-  use dftbp_common_constants, only : au__Debye, au__pascal, au__V_m, Bohr__AA, Boltzmann, gfac,&
+  use dftbp_common_constants, only : au__Debye, au__fs, au__pascal, au__V_m, Bohr__AA, Boltzmann,&
+      & gfac,&
       & Hartree__eV, quaternionName, spinName
   use dftbp_common_environment, only : TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
@@ -4426,7 +4427,7 @@ contains
   !> Write current geometry to disc
   subroutine writeCurrentGeometry(geoOutFile, pCoord0Out, tLatOpt, tMd, tAppendGeo, tFracCoord,&
       & tPeriodic, tHelical, tPrintMulliken, species0, speciesName, latVec, origin, iGeoStep,&
-      & iLatGeoStep, nSpin, qOutput, velocities)
+      & iLatGeoStep, nSpin, qOutput, velocities, writeTrajectoryForces, derivs)
 
     !> File for geometry output
     character(*), intent(in) :: geoOutFile
@@ -4482,8 +4483,13 @@ contains
     !> Atomic velocities
     real(dp), intent(in), allocatable :: velocities(:,:)
 
+    !> Should per-atom forces be printed in the trajectory
+    logical, intent(in) :: writeTrajectoryForces
+
+    !> Energy derivatives with respect to atomic coordinates
+    real(dp), intent(in), allocatable :: derivs(:,:)
+
     integer :: nAtom
-    integer :: ii, jj
     character(lc) :: comment, fname
 
     nAtom = size(pCoord0Out, dim=2)
@@ -4499,24 +4505,109 @@ contains
 
     call geometryComment_(comment, tLatOpt, tMd, iGeoStep, iLatGeoStep)
 
-    if (tPrintMulliken) then
-      ! For non-colinear spin without velocities write magnetisation into the velocity field
-      if (nSpin == 4 .and. .not. allocated(velocities)) then
-        call writeXYZFormat(fname, pCoord0Out, species0, speciesName,&
-            & charges=sum(qOutput(:,:,1), dim=1),&
-            & vectors=transpose(sum(qOutput(:,:,2:4), dim=1)), comment=comment,&
-            & append=tAppendGeo)
+    if (writeTrajectoryForces) then
+      @:ASSERT(allocated(velocities))
+      @:ASSERT(allocated(derivs))
+      if (tPrintMulliken) then
+        call writeXYZFormatWithForces_(fname, pCoord0Out, species0, speciesName, velocities,&
+            & -derivs(:, 1:nAtom), comment, tAppendGeo, charges=sum(qOutput(:,:,1), dim=1))
       else
-        call writeXYZFormat(fname, pCoord0Out, species0, speciesName,&
-            & charges=sum(qOutput(:,:,1),dim=1), velocities=velocities, comment=comment,&
-            & append=tAppendGeo)
+        call writeXYZFormatWithForces_(fname, pCoord0Out, species0, speciesName, velocities,&
+            & -derivs(:, 1:nAtom), comment, tAppendGeo)
       end if
     else
-      call writeXYZFormat(fname, pCoord0Out, species0, speciesName, velocities=velocities,&
-          & comment=comment, append=tAppendGeo)
+      if (tPrintMulliken) then
+        ! For non-colinear spin without velocities write magnetisation into the velocity field
+        if (nSpin == 4 .and. .not. allocated(velocities)) then
+          call writeXYZFormat(fname, pCoord0Out, species0, speciesName,&
+              & charges=sum(qOutput(:,:,1), dim=1),&
+              & vectors=transpose(sum(qOutput(:,:,2:4), dim=1)), comment=comment,&
+              & append=tAppendGeo)
+        else
+          call writeXYZFormat(fname, pCoord0Out, species0, speciesName,&
+              & charges=sum(qOutput(:,:,1),dim=1), velocities=velocities, comment=comment,&
+              & append=tAppendGeo)
+        end if
+      else
+        call writeXYZFormat(fname, pCoord0Out, species0, speciesName, velocities=velocities,&
+            & comment=comment, append=tAppendGeo)
+      end if
     end if
 
   end subroutine writeCurrentGeometry
+
+
+  !> Writes XYZ geometry with Mulliken charge, velocity and force columns.
+  subroutine writeXYZFormatWithForces_(fileName, coords, species, speciesNames, velocities, forces,&
+      & comment, append, charges)
+
+    !> File name to write to
+    character(*), intent(in) :: fileName
+
+    !> Coordinates in atomic units
+    real(dp), intent(in) :: coords(:,:)
+
+    !> Species of atoms
+    integer, intent(in) :: species(:)
+
+    !> Species names
+    character(*), intent(in) :: speciesNames(:)
+
+    !> Velocities for each atom
+    real(dp), intent(in) :: velocities(:,:)
+
+    !> Forces for each atom (in atomic units)
+    real(dp), intent(in) :: forces(:,:)
+
+    !> Comment for the XYZ frame header
+    character(*), intent(in) :: comment
+
+    !> Whether to append to existing file
+    logical, intent(in) :: append
+
+    !> Optional Mulliken charges
+    real(dp), intent(in), optional :: charges(:)
+
+    type(TFileDescr) :: fd
+    character(1) :: mode
+    integer :: ii, nAtom, nSpecies
+    real(dp) :: forceConv
+
+    nAtom = size(coords, dim=2)
+    nSpecies = maxval(species)
+    forceConv = Hartree__eV / Bohr__AA
+    @:ASSERT(size(coords, dim=1) == 3)
+    @:ASSERT(size(species) == nAtom)
+    @:ASSERT(size(speciesNames) == nSpecies)
+    @:ASSERT(all(shape(velocities) == [3, nAtom]))
+    @:ASSERT(all(shape(forces) == [3, nAtom]))
+    if (present(charges)) then
+      @:ASSERT(size(charges) == nAtom)
+    end if
+
+    if (append) then
+      mode = "a"
+    else
+      mode = "w"
+    end if
+
+    call openFile(fd, fileName, mode=mode)
+    write(fd%unit, "(I0)") nAtom
+    write(fd%unit, "(A)") trim(comment)
+
+    if (present(charges)) then
+      write(fd%unit, "(A5,10F16.8)") (trim(speciesNames(species(ii))), coords(:, ii) * Bohr__AA,&
+          & charges(ii), velocities(:, ii) * Bohr__AA / au__fs * 1000.0_dp,&
+          & forces(:, ii) * forceConv, ii = 1, nAtom)
+    else
+      write(fd%unit, "(A5,9F16.8)") (trim(speciesNames(species(ii))), coords(:, ii) * Bohr__AA,&
+          & velocities(:, ii) * Bohr__AA / au__fs * 1000.0_dp, forces(:, ii) * forceConv,&
+          & ii = 1, nAtom)
+    end if
+
+    call closeFile(fd)
+
+  end subroutine writeXYZFormatWithForces_
 
 
   !> Write geometry including periodic images to disc

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -643,6 +643,7 @@ contains
 
       call getChildValue(node, "OutputPrefix", buffer2, "geo_end")
       ctrl%outFile = unquote(char(buffer2))
+      call getChildValue(node, "WriteTrajectoryForces", ctrl%writeTrajectoryForces, .false.)
 
       call getChildValue(node, "Plumed", ctrl%tPlumed, default=.false., child=child)
       if (ctrl%tPlumed .and. .not. withPlumed) then


### PR DESCRIPTION
* Adds PrintTrajectoryForces = Yes/No (default No) to Driver = VelocityVerlet to append forces to ${OutputPrefix}.xyz.
* When enabled, atom lines include fx fy fz as columns 9–11 (after velocities), units (Hartree/bohr) match internal forces (detailed.out).
* Independent of Analysis = { PrintForces = Yes }, which is unchanged.
* No output change when keyword is absent/No.
* Tested with MD example: verified 8 vs 11 columns and final-step force match to detailed.out.