### PR TITLE
Refactor makeDensityMtx*Blacs to unify calls

### DIFF
--- a/src/dftbp/dftb/densitymatrix.F90
+++ b/src/dftbp/dftb/densitymatrix.F90
@@ -33,9 +33,6 @@ module dftbp_dftb_densitymatrix
   private
 
   public :: TDensityMatrix, TDensityMatrix_init, transformDualSpaceToBvKRealSpace
-#:if WITH_SCALAPACK
-  public :: makeDensityMtxRealBlacs, makeDensityMtxCplxBlacs
-#:endif
 
 
   !> Holds density matrix related data and control variables
@@ -80,11 +77,21 @@ module dftbp_dftb_densitymatrix
     procedure, private :: getDensityMatrix_real
     procedure, private :: getDensityMatrix_cmplx
     generic :: getDensityMatrix => getDensityMatrix_real, getDensityMatrix_cmplx
+  #:if WITH_SCALAPACK
+    procedure, private :: getDensityMatrix_real_blacs
+    procedure, private :: getDensityMatrix_cmplx_blacs
+    generic :: getDensityMatrix => getDensityMatrix_real_blacs, getDensityMatrix_cmplx_blacs
+  #:endif
 
     !> Returns the energy weighted density matrix
     procedure, private :: getEDensityMatrix_real
     procedure, private :: getEDensityMatrix_cmplx
     generic :: getEDensityMatrix => getEDensityMatrix_real, getEDensityMatrix_cmplx
+  #:if WITH_SCALAPACK
+    procedure, private :: getEDensityMatrix_real_blacs
+    procedure, private :: getEDensityMatrix_cmplx_blacs
+    generic :: getEDensityMatrix => getEDensityMatrix_real_blacs, getEDensityMatrix_cmplx_blacs
+  #:endif
 
   end type TDensityMatrix
 
@@ -335,6 +342,134 @@ contains
     end select
 
   end subroutine getEDensityMatrix_cmplx
+
+
+#:if WITH_SCALAPACK
+  !> Returns the distributed real density matrix
+  subroutine getDensityMatrix_real_blacs(this, myBlacs, desc, densityMatrix, eigenvecs, filling,&
+      & errStatus)
+
+    !> Instance
+    class(TDensityMatrix), intent(in) :: this
+
+    !> BLACS grid information
+    type(blacsgrid), intent(in) :: myBlacs
+
+    !> Matrix descriptor
+    integer, intent(in) :: desc(:)
+
+    !> Resulting density matrix
+    real(dp), intent(inout) :: densityMatrix(:,:)
+
+    !> Eigenvectors of the system
+    real(dp), intent(inout) :: eigenvecs(:,:)
+
+    !> Occupation numbers of the orbitals
+    real(dp), intent(in) :: filling(:)
+
+    !> Error status
+    type(TStatus), intent(out) :: errStatus
+
+    call makeDensityMtxRealBlacs(myBlacs, desc, filling, eigenvecs, densityMatrix)
+
+  end subroutine getDensityMatrix_real_blacs
+
+
+!> Returns the distributed real energy weighted density matrix
+  subroutine getEDensityMatrix_real_blacs(this, myBlacs, desc, egyDensityMatrix, eigenvecs,&
+      & filling, eigenvals, errStatus)
+
+    !> Instance
+    class(TDensityMatrix), intent(in) :: this
+
+    !> BLACS grid information
+    type(blacsgrid), intent(in) :: myBlacs
+
+    !> Matrix descriptor
+    integer, intent(in) :: desc(:)
+
+    !> Resulting density matrix
+    real(dp), intent(inout) :: egyDensityMatrix(:,:)
+
+    !> Eigenvectors of the system
+    real(dp), intent(inout) :: eigenvecs(:,:)
+
+    !> Occupation numbers of the orbitals
+    real(dp), intent(in) :: filling(:)
+
+    !> Eigenvalues of the system
+    real(dp), intent(in) :: eigenvals(:)
+
+    !> Error status
+    type(TStatus), intent(out) :: errStatus
+
+    call makeDensityMtxRealBlacs(myBlacs, desc, filling, eigenvecs, egyDensityMatrix, eigenvals)
+
+  end subroutine getEDensityMatrix_real_blacs
+
+
+  !> Returns the distributed complex density matrix
+  subroutine getDensityMatrix_cmplx_blacs(this, myBlacs, desc, densityMatrix, eigenvecs, filling,&
+      & errStatus)
+
+    !> Instance
+    class(TDensityMatrix), intent(in) :: this
+
+    !> BLACS grid information
+    type(blacsgrid), intent(in) :: myBlacs
+
+    !> Matrix descriptor
+    integer, intent(in) :: desc(:)
+
+    !> Resulting density matrix
+    complex(dp), intent(inout) :: densityMatrix(:,:)
+
+    !> Eigenvectors of the system
+    complex(dp), intent(inout) :: eigenvecs(:,:)
+
+    !> Occupation numbers of the orbitals
+    real(dp), intent(in) :: filling(:)
+
+    !> Error status
+    type(TStatus), intent(out) :: errStatus
+
+    call makeDensityMtxCplxBlacs(myBlacs, desc, filling, eigenvecs, densityMatrix)
+
+  end subroutine getDensityMatrix_cmplx_blacs
+
+
+  !> Returns the distributed complex energy weighted density matrix
+  subroutine getEDensityMatrix_cmplx_blacs(this, myBlacs, desc, egyDensityMatrix, eigenvecs,&
+      & filling, eigenvals, errStatus)
+
+    !> Instance
+    class(TDensityMatrix), intent(in) :: this
+
+    !> BLACS grid information
+    type(blacsgrid), intent(in) :: myBlacs
+
+    !> Matrix descriptor
+    integer, intent(in) :: desc(:)
+
+    !> Resulting density matrix
+    complex(dp), intent(inout) :: egyDensityMatrix(:,:)
+
+    !> Eigenvectors of the system
+    complex(dp), intent(inout) :: eigenvecs(:,:)
+
+    !> Occupation numbers of the orbitals
+    real(dp), intent(in) :: filling(:)
+
+    !> Eigenvalues of the system
+    real(dp), intent(in) :: eigenvals(:)
+
+    !> Error status
+    type(TStatus), intent(out) :: errStatus
+
+    call makeDensityMtxCplxBlacs(myBlacs, desc, filling, eigenvecs, egyDensityMatrix, eigenvals)
+
+  end subroutine getEDensityMatrix_cmplx_blacs
+#:endif
 
 
   !> Transforms dense, square density matrix for all spins/k-points to real-space (BvK cell).

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -125,7 +125,6 @@ module dftbp_dftbplus_main
 #:endif
   use dftbp_transport_negfvars, only : TTransPar
 #:if WITH_SCALAPACK
-  use dftbp_dftb_densitymatrix, only : makeDensityMtxCplxBlacs, makeDensityMtxRealBlacs
   use dftbp_dftb_hybridxc, only : getFullFromDistributed, scatterFullToDistributed
   use dftbp_dftb_populations, only : denseMullikenRealBlacs,&
       & denseSubtractDensityOfAtomsRealNonperiodicBlacs,&
@@ -3938,8 +3937,9 @@ contains
 
     #:if WITH_SCALAPACK
       if (.not. allocated(densityMatrix%deltaRhoOut)) then
-        call makeDensityMtxRealBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr,&
-            & filling(:,iSpin), eigvecs(:,:,iKS), work)
+        call densityMatrix%getDensityMatrix(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, work,&
+            & eigvecs(:,:,iKS), filling(:,iSpin), errStatus)
+        @:PROPAGATE_ERROR(errStatus)
         call env%globalTimer%startTimer(globalTimers%denseToSparse)
         if (tHelical) then
           call packRhoHelicalRealBlacs(env%blacs, denseDesc, work, neighbourList%iNeighbour,&
@@ -3950,8 +3950,9 @@ contains
         end if
         call env%globalTimer%stopTimer(globalTimers%denseToSparse)
       else
-        call makeDensityMtxRealBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr,&
-            & filling(:,iSpin), eigvecs(:,:,iKS), densityMatrix%deltaRhoOut(:,:,iKS))
+        call densityMatrix%getDensityMatrix(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr,&
+            & densityMatrix%deltaRhoOut(:,:,iKS), eigvecs(:,:,iKS), filling(:,iSpin), errStatus)
+        @:PROPAGATE_ERROR(errStatus)
         call env%globalTimer%startTimer(globalTimers%denseToSparse)
         if (tHelical) then
           call packRhoHelicalRealBlacs(env%blacs, denseDesc, densityMatrix%deltaRhoOut(:,:,iKS),&
@@ -4128,8 +4129,9 @@ contains
       iK = parallelKS%localKS(1, iKS)
       iSpin = parallelKS%localKS(2, iKS)
     #:if WITH_SCALAPACK
-      call makeDensityMtxCplxBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,iK&
-          &,iSpin), eigvecs(:,:,iKS), work)
+      call densityMatrix%getDensityMatrix(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, work,&
+          & eigvecs(:,:,iKS), filling(:,iK,iSpin), errStatus)
+      @:PROPAGATE_ERROR(errStatus)
       call env%globalTimer%startTimer(globalTimers%denseToSparse)
       if (tHelical) then
         call packRhoHelicalCplxBlacs(env%blacs, denseDesc, work, kPoint(:,iK), kWeight(iK),&
@@ -4311,8 +4313,9 @@ contains
       iK = parallelKS%localKS(1, iKS)
 
     #:if WITH_SCALAPACK
-      call makeDensityMtxCplxBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,iK),&
-          & eigvecs(:,:,iKS), work)
+      call densityMatrix%getDensityMatrix(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, work,&
+          & eigvecs(:,:,iKS), filling(:,iK), errStatus)
+      @:PROPAGATE_ERROR(errStatus)
     #:else
       call densityMatrix%getDensityMatrix(work, eigvecs(:,:,iKS), filling(:,iK), errStatus)
       @:PROPAGATE_ERROR(errStatus)
@@ -6421,8 +6424,9 @@ contains
       case(forceTypes%orig)
         ! Original (non-consistent) scheme
       #:if WITH_SCALAPACK
-        call makeDensityMtxRealBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,1,iS),&
-            & eigvecsReal(:,:,iKS), work, eigen(:,1,iS))
+        call densityMatrix%getEDensityMatrix(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, work,&
+            & eigvecsReal(:,:,iKS), filling(:,1,iS), eigen(:,1,iS), errStatus)
+        @:PROPAGATE_ERROR(errStatus)
       #:else
         call densityMatrix%getEDensityMatrix(work, eigvecsReal(:,:,iKS), filling(:,1,iS),&
             & eigen(:,1,iS), errStatus)
@@ -6440,8 +6444,9 @@ contains
           call unpackHSRealBlacs(env%blacs, ints%hamiltonian(:,iS), neighbourList%iNeighbour,&
               & nNeighbourSK, iSparseStart, img2CentCell, denseDesc, work)
         end if
-        call makeDensityMtxRealBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,1,iS),&
-            & eigVecsReal(:,:,iKS), work2)
+        call densityMatrix%getDensityMatrix(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, work2,&
+            & eigVecsReal(:,:,iKS), filling(:,1,iS), errStatus)
+        @:PROPAGATE_ERROR(errStatus)
         call pblasfx_psymm(work2, denseDesc%blacsOrbSqr, work, denseDesc%blacsOrbSqr,&
             & eigvecsReal(:,:,iKS), denseDesc%blacsOrbSqr, side="L")
         call pblasfx_psymm(work2, denseDesc%blacsOrbSqr, eigvecsReal(:,:,iKS),&
@@ -6468,8 +6473,9 @@ contains
       case(forceTypes%dynamicTFinite)
         ! Correct force for XLBOMD for T <> 0K (DHS^-1 + S^-1HD)
       #:if WITH_SCALAPACK
-        call makeDensityMtxRealBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,1,iS),&
-            & eigVecsReal(:,:,iKS), work)
+        call densityMatrix%getDensityMatrix(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, work,&
+            & eigVecsReal(:,:,iKS), filling(:,1,iS), errStatus)
+        @:PROPAGATE_ERROR(errStatus)
         if (tHelical) then
           call unpackHSHelicalRealBlacs(env%blacs, ints%hamiltonian(:,iS),&
               & neighbourlist%iNeighbour, nNeighbourSK, iSparseStart, img2CentCell, orb, species,&
@@ -6654,8 +6660,9 @@ contains
       case(forceTypes%orig)
         ! Original (non-consistent) scheme
       #:if WITH_SCALAPACK
-        call makeDensityMtxCplxBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr,&
-            & filling(:,iK,iS), eigvecsCplx(:,:,iKS), work, eigen(:,iK,iS))
+        call densityMatrix%getEDensityMatrix(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, work,&
+            & eigvecsCplx(:,:,iKS), filling(:,iK,iS), eigen(:,iK,iS), errStatus)
+        @:PROPAGATE_ERROR(errStatus)
       #:else
         call densityMatrix%getEDensityMatrix(work, eigvecsCplx(:,:,iKS), filling(:,iK,iS),&
             & eigen(:,iK, iS), errStatus)
@@ -6674,8 +6681,9 @@ contains
               & neighbourList%iNeighbour, nNeighbourSK, iCellVec, cellVec, iSparseStart,&
               & img2CentCell, denseDesc, work)
         end if
-        call makeDensityMtxCplxBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,1,iS),&
-            & eigvecsCplx(:,:,iKS), work2)
+        call densityMatrix%getDensityMatrix(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, work2,&
+            & eigvecsCplx(:,:,iKS), filling(:,1,iS), errStatus)
+        @:PROPAGATE_ERROR(errStatus)
         call pblasfx_phemm(work2, denseDesc%blacsOrbSqr, work, denseDesc%blacsOrbSqr,&
             & eigvecsCplx(:,:,iKS), denseDesc%blacsOrbSqr, side="L")
         call pblasfx_phemm(work2, denseDesc%blacsOrbSqr, eigvecsCplx(:,:,iKS),&
@@ -6700,8 +6708,9 @@ contains
       case(forceTypes%dynamicTFinite)
         ! Correct force for XLBOMD for T <> 0K (DHS^-1 + S^-1HD)
       #:if WITH_SCALAPACK
-        call makeDensityMtxCplxBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr,&
-            & filling(:,iK,iS), eigVecsCplx(:,:,iKS), work)
+        call densityMatrix%getDensityMatrix(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, work,&
+            & eigVecsCplx(:,:,iKS), filling(:,iK,iS), errStatus)
+        @:PROPAGATE_ERROR(errStatus)
         if (tHelical) then
           call unpackHSHelicalCplxBlacs(env%blacs, ints%hamiltonian(:,iS), kPoint(:,iK),&
               & neighbourlist%iNeighbour, nNeighbourSK, iCellVec, cellVec, iSparseStart,&
@@ -6875,8 +6884,9 @@ contains
     do iKS = 1, parallelKS%nLocalKS
       iK = parallelKS%localKS(1, iKS)
     #:if WITH_SCALAPACK
-      call makeDensityMtxCplxBlacs(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, filling(:,iK,1),&
-          & eigvecsCplx(:,:,iKS), work, eigen(:,iK,1))
+      call densityMatrix%getEDensityMatrix(env%blacs%orbitalGrid, denseDesc%blacsOrbSqr, work,&
+          & eigvecsCplx(:,:,iKS), filling(:,iK,1), eigen(:,iK,1), errStatus)
+      @:PROPAGATE_ERROR(errStatus)
       call packERhoPauliBlacs(env%blacs, denseDesc, work, kPoint(:,iK), kWeight(iK),&
           & neighbourList%iNeighbour, nNeighbourSK, orb%mOrb, iCellVec, cellVec, iSparseStart,&
           & img2CentCell, ERhoPrim)

--- a/src/dftbp/timedep/timeprop.F90
+++ b/src/dftbp/timedep/timeprop.F90
@@ -73,7 +73,6 @@ module dftbp_timedep_timeprop
   use dftbp_type_integral, only : TIntegral
   use dftbp_type_multipole, only : TMultipole, TMultipole_init
 #:if WITH_SCALAPACK
-  use dftbp_dftb_densitymatrix, only : makeDensityMtxRealBlacs
   use dftbp_dftb_populations, only : mulliken, denseSubtractDensityOfAtomsCmplxNonperiodicBlacs
   use dftbp_dftb_sparse2dense, only : unpackHSRealBlacs, packRhoRealBlacs
   use dftbp_extlibs_mpifx, only : MPI_SUM, mpifx_allreduceip, mpifx_bcast
@@ -2527,8 +2526,9 @@ contains
         iK = this%parallelKS%localKS(1, iKS)
         iSpin = this%parallelKS%localKS(2, iKS)
         if (this%tRealHS) then
-          call makeDensityMtxRealBlacs(env%blacs%orbitalGrid, this%denseDesc%blacsOrbSqr,&
-              & filling(:,1,iSpin), eigvecsReal(:,:,iKS), T2)
+          call densityMatrix%getDensityMatrix(env%blacs%orbitalGrid, this%denseDesc%blacsOrbSqr,&
+              & T2, eigvecsReal(:,:,iKS), filling(:,1,iSpin), errStatus)
+          @:PROPAGATE_ERROR(errStatus)
           rho(:,:,iKS) = cmplx(T2, 0, kind=dp)
           ! TODO: add here the complex case
         end if


### PR DESCRIPTION
As we have discussed some time ago, the calls to `makeDendityMtxRealBlacs` and `makeDendityMtxCplxBlacs` are not bound to the `TDensityMatrix` type. This is inconsistent if you inspect all the various subroutine signatures in the `dftbp_dftb_densitymatrix` module.
This merge request refactors this module so that all calls look somewhat similar.