### PR TITLE
Refactor xyz file writer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,10 @@ Fixed
 
 - API include file now can also be used for C++ codes
 
+- Removed incorrect scaling factor applied to spin-vectors (only) in
+  XYZ files containing both atomic populations and noncolinear spin
+  vectors.
+
 
 25.1 (2025-12-18)
 =================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,10 @@ Fixed
 
 - API include file now can also be used for C++ codes
 
+- Removed incorrect scaling factor applied to spin-vectors (only) in
+  XYZ files containing both atomic populations and noncolinear spin
+  vectors.
+
 
 25.1 (2025-12-18)
 =================

--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -15,7 +15,7 @@
 !> Various I/O routines for the main program.
 module dftbp_dftbplus_mainio
   use dftbp_common_accuracy, only : dp, lc, mc, sc
-  use dftbp_common_constants, only : au__Debye, au__fs, au__pascal, au__V_m, Bohr__AA, Boltzmann,&
+  use dftbp_common_constants, only : au__Debye, au__pascal, au__V_m, Bohr__AA, Boltzmann,&
       & gfac, Hartree__eV, pi, quaternionName, spinName
   use dftbp_common_environment, only : TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
@@ -40,7 +40,8 @@ module dftbp_dftbplus_mainio
   use dftbp_io_charmanip, only : i2c
   use dftbp_io_commonformats, only : format1U, format1U1e, format1Ue, format2U, format2Ue,&
       & formatBorn, formatdBorn, formatGeoOut, formatHessian
-  use dftbp_io_formatout, only : writeGenFormat, writeSparse, writeSparseAsSquare, writeXYZFormat
+  use dftbp_io_formatout, only : writeGenFormat, writeSparse, writeSparseAsSquare,&
+      & writeXYZFormat
   use dftbp_io_hsdutils, only : writeChildValue
   use dftbp_io_message, only : error, warning
   use dftbp_io_taggedoutput, only : tagLabels, TTaggedWriter
@@ -4510,11 +4511,11 @@ contains
       @:ASSERT(allocated(velocities))
       @:ASSERT(allocated(derivs))
       if (tPrintMulliken) then
-        call writeXYZFormatWithForces_(fname, pCoord0Out, species0, speciesName, velocities,&
-            & -derivs(:, 1:nAtom), comment, tAppendGeo, charges=sum(qOutput(:,:,1), dim=1))
+        call writeXYZFormat(fname, pCoord0Out, species0, speciesName, charges=sum(qOutput(:,:,1),&
+            & dim=1), velocities=velocities, forces=-derivs, comment=comment, append=tAppendGeo)
       else
-        call writeXYZFormatWithForces_(fname, pCoord0Out, species0, speciesName, velocities,&
-            & -derivs(:, 1:nAtom), comment, tAppendGeo)
+        call writeXYZFormat(fname, pCoord0Out, species0, speciesName, velocities=velocities,&
+            & forces=-derivs, comment=comment, append=tAppendGeo)
       end if
     else
       if (tPrintMulliken) then
@@ -4536,79 +4537,6 @@ contains
     end if
 
   end subroutine writeCurrentGeometry
-
-
-  !> Writes XYZ geometry with Mulliken charge, velocity and force columns.
-  subroutine writeXYZFormatWithForces_(fileName, coords, species, speciesNames, velocities, forces,&
-      & comment, append, charges)
-
-    !> File name to write to
-    character(*), intent(in) :: fileName
-
-    !> Coordinates in atomic units
-    real(dp), intent(in) :: coords(:,:)
-
-    !> Species of atoms
-    integer, intent(in) :: species(:)
-
-    !> Species names
-    character(*), intent(in) :: speciesNames(:)
-
-    !> Velocities for each atom
-    real(dp), intent(in) :: velocities(:,:)
-
-    !> Forces for each atom (in atomic units)
-    real(dp), intent(in) :: forces(:,:)
-
-    !> Comment for the XYZ frame header
-    character(*), intent(in) :: comment
-
-    !> Whether to append to existing file
-    logical, intent(in) :: append
-
-    !> Optional Mulliken charges
-    real(dp), intent(in), optional :: charges(:)
-
-    type(TFileDescr) :: fd
-    character(1) :: mode
-    integer :: ii, nAtom, nSpecies
-    real(dp) :: forceConv
-
-    nAtom = size(coords, dim=2)
-    nSpecies = maxval(species)
-    forceConv = Hartree__eV / Bohr__AA
-    @:ASSERT(size(coords, dim=1) == 3)
-    @:ASSERT(size(species) == nAtom)
-    @:ASSERT(size(speciesNames) == nSpecies)
-    @:ASSERT(all(shape(velocities) == [3, nAtom]))
-    @:ASSERT(all(shape(forces) == [3, nAtom]))
-    if (present(charges)) then
-      @:ASSERT(size(charges) == nAtom)
-    end if
-
-    if (append) then
-      mode = "a"
-    else
-      mode = "w"
-    end if
-
-    call openFile(fd, fileName, mode=mode)
-    write(fd%unit, "(I0)") nAtom
-    write(fd%unit, "(A)") trim(comment)
-
-    if (present(charges)) then
-      write(fd%unit, "(A5,10F16.8)") (trim(speciesNames(species(ii))), coords(:, ii) * Bohr__AA,&
-          & charges(ii), velocities(:, ii) * Bohr__AA / au__fs * 1000.0_dp,&
-          & forces(:, ii) * forceConv, ii = 1, nAtom)
-    else
-      write(fd%unit, "(A5,9F16.8)") (trim(speciesNames(species(ii))), coords(:, ii) * Bohr__AA,&
-          & velocities(:, ii) * Bohr__AA / au__fs * 1000.0_dp, forces(:, ii) * forceConv,&
-          & ii = 1, nAtom)
-    end if
-
-    call closeFile(fd)
-
-  end subroutine writeXYZFormatWithForces_
 
 
   !> Write geometry including periodic images to disc

--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -15,7 +15,7 @@
 !> Various I/O routines for the main program.
 module dftbp_dftbplus_mainio
   use dftbp_common_accuracy, only : dp, lc, mc, sc
-  use dftbp_common_constants, only : au__Debye, au__fs, au__pascal, au__V_m, Bohr__AA, Boltzmann,&
+  use dftbp_common_constants, only : au__Debye, au__pascal, au__V_m, Bohr__AA, Boltzmann,&
       & gfac, Hartree__eV, pi, quaternionName, spinName
   use dftbp_common_environment, only : TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
@@ -40,7 +40,8 @@ module dftbp_dftbplus_mainio
   use dftbp_io_charmanip, only : i2c
   use dftbp_io_commonformats, only : format1U, format1U1e, format1Ue, format2U, format2Ue,&
       & formatBorn, formatdBorn, formatGeoOut, formatHessian
-  use dftbp_io_formatout, only : writeGenFormat, writeSparse, writeSparseAsSquare, writeXYZFormat
+  use dftbp_io_formatout, only : writeGenFormat, writeSparse, writeSparseAsSquare,&
+      & writeXYZFormat
   use dftbp_io_hsdutils, only : writeChildValue
   use dftbp_io_message, only : error, warning
   use dftbp_io_taggedoutput, only : tagLabels, TTaggedWriter
@@ -4613,11 +4614,11 @@ contains
       @:ASSERT(allocated(velocities))
       @:ASSERT(allocated(derivs))
       if (tPrintMulliken) then
-        call writeXYZFormatWithForces_(fname, pCoord0Out, species0, speciesName, velocities,&
-            & -derivs(:, 1:nAtom), comment, tAppendGeo, charges=sum(qOutput(:,:,1), dim=1))
+        call writeXYZFormat(fname, pCoord0Out, species0, speciesName, charges=sum(qOutput(:,:,1),&
+            & dim=1), velocities=velocities, forces=-derivs, comment=comment, append=tAppendGeo)
       else
-        call writeXYZFormatWithForces_(fname, pCoord0Out, species0, speciesName, velocities,&
-            & -derivs(:, 1:nAtom), comment, tAppendGeo)
+        call writeXYZFormat(fname, pCoord0Out, species0, speciesName, velocities=velocities,&
+            & forces=-derivs, comment=comment, append=tAppendGeo)
       end if
     else
       if (tPrintMulliken) then
@@ -4639,79 +4640,6 @@ contains
     end if
 
   end subroutine writeCurrentGeometry
-
-
-  !> Writes XYZ geometry with Mulliken charge, velocity and force columns.
-  subroutine writeXYZFormatWithForces_(fileName, coords, species, speciesNames, velocities, forces,&
-      & comment, append, charges)
-
-    !> File name to write to
-    character(*), intent(in) :: fileName
-
-    !> Coordinates in atomic units
-    real(dp), intent(in) :: coords(:,:)
-
-    !> Species of atoms
-    integer, intent(in) :: species(:)
-
-    !> Species names
-    character(*), intent(in) :: speciesNames(:)
-
-    !> Velocities for each atom
-    real(dp), intent(in) :: velocities(:,:)
-
-    !> Forces for each atom (in atomic units)
-    real(dp), intent(in) :: forces(:,:)
-
-    !> Comment for the XYZ frame header
-    character(*), intent(in) :: comment
-
-    !> Whether to append to existing file
-    logical, intent(in) :: append
-
-    !> Optional Mulliken charges
-    real(dp), intent(in), optional :: charges(:)
-
-    type(TFileDescr) :: fd
-    character(1) :: mode
-    integer :: ii, nAtom, nSpecies
-    real(dp) :: forceConv
-
-    nAtom = size(coords, dim=2)
-    nSpecies = maxval(species)
-    forceConv = Hartree__eV / Bohr__AA
-    @:ASSERT(size(coords, dim=1) == 3)
-    @:ASSERT(size(species) == nAtom)
-    @:ASSERT(size(speciesNames) == nSpecies)
-    @:ASSERT(all(shape(velocities) == [3, nAtom]))
-    @:ASSERT(all(shape(forces) == [3, nAtom]))
-    if (present(charges)) then
-      @:ASSERT(size(charges) == nAtom)
-    end if
-
-    if (append) then
-      mode = "a"
-    else
-      mode = "w"
-    end if
-
-    call openFile(fd, fileName, mode=mode)
-    write(fd%unit, "(I0)") nAtom
-    write(fd%unit, "(A)") trim(comment)
-
-    if (present(charges)) then
-      write(fd%unit, "(A5,10F16.8)") (trim(speciesNames(species(ii))), coords(:, ii) * Bohr__AA,&
-          & charges(ii), velocities(:, ii) * Bohr__AA / au__fs * 1000.0_dp,&
-          & forces(:, ii) * forceConv, ii = 1, nAtom)
-    else
-      write(fd%unit, "(A5,9F16.8)") (trim(speciesNames(species(ii))), coords(:, ii) * Bohr__AA,&
-          & velocities(:, ii) * Bohr__AA / au__fs * 1000.0_dp, forces(:, ii) * forceConv,&
-          & ii = 1, nAtom)
-    end if
-
-    call closeFile(fd)
-
-  end subroutine writeXYZFormatWithForces_
 
 
   !> Write geometry including periodic images to disc

--- a/src/dftbp/io/formatout.F90
+++ b/src/dftbp/io/formatout.F90
@@ -10,7 +10,7 @@
 !> Contains subroutines for formatted output of data
 module dftbp_io_formatout
   use dftbp_common_accuracy, only : dp, mc
-  use dftbp_common_constants, only : au__fs, Bohr__AA, pi
+  use dftbp_common_constants, only : au__fs, Bohr__AA, Hartree__eV, pi
   use dftbp_common_environment, only : TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
   use dftbp_common_globalenv, only : stdOut, tIoProc, withMpi
@@ -31,13 +31,6 @@ module dftbp_io_formatout
     module procedure writeGenFormat_fname
     module procedure writeGenFormat_fid
   end interface writeGenFormat
-
-
-  !> Writes geometry information in xyz format to a file
-  interface writeXYZFormat
-    module procedure writeXYZFormat_fname
-    module procedure writeXYZFormat_fid
-  end interface writeXYZFormat
 
 
   !> Writes DFTB+ type sparse matrix in square form to disc
@@ -230,8 +223,8 @@ contains
 
 
   !> Writes coordinates in the XYZ format
-  subroutine writeXYZFormat_fname(fileName, coord, species, speciesName, charges, velocities,&
-      & vectors, comment, append)
+  subroutine writeXYZFormat(fileName, coord, species, speciesName, charges, velocities, vectors,&
+      & forces, comment, append)
 
     !> File name of a file to be created
     character(len=*), intent(in) :: fileName
@@ -254,6 +247,9 @@ contains
     !> Optional array of vectors for each atom, printed unscaled
     real(dp), intent(in), optional :: vectors(:,:)
 
+    !> Optional array of forces for each atom (in atomic units)
+    real(dp), intent(in), optional :: forces(:,:)
+
     !> Optional comment for line 2 of the file
     character(len=*), intent(in), optional :: comment
 
@@ -264,11 +260,8 @@ contains
     character(1) :: mode
     logical :: append0
 
-    if (present(append)) then
-      append0 = append
-    else
-      append0 = .false.
-    end if
+    append0 = .false.
+    if (present(append)) append0 = append
 
     if (append0) then
       mode = "a"
@@ -276,18 +269,19 @@ contains
       mode = "w"
     end if
     call openFile(fd, fileName, mode=mode)
-    call writeXYZFormat(fd%unit, coord, species, speciesName, charges, velocities, vectors, comment)
+    call writeXYZFormat_fid(fd, coord, species, speciesName, charges, velocities, vectors, forces,&
+        & comment)
     call closeFile(fd)
 
-  end subroutine writeXYZFormat_fname
+  end subroutine writeXYZFormat
 
 
   !> Writes coordinates in the XYZ format with additional charges and vectors
   subroutine writeXYZFormat_fid(fd, coords, species, speciesNames, charges, velocities, vectors,&
-      & comment)
+      & forces, comment)
 
-    !> File id of an open file where output should be written
-    integer, intent(in) :: fd
+    !> Open file where output should be written
+    type(TFileDescr) :: fd
 
     !> Coordinates in atomic units
     real(dp), intent(in) :: coords(:,:)
@@ -307,16 +301,19 @@ contains
     !> Optional array of vectors for each atom, printed unscaled
     real(dp), intent(in), optional :: vectors(:,:)
 
+    !> Optional array of forces for each atom (in atomic units)
+    real(dp), intent(in), optional :: forces(:,:)
+
     !> Optional comment for line 2 of the file
     character(len=*), intent(in), optional :: comment
 
-    integer :: nAtom, nSpecies, ii
+    integer :: nAtom, nSpecies, iAt
+    real(dp), parameter :: forceConv = Hartree__eV / Bohr__AA
+    real(dp), parameter :: velocityConv = Bohr__AA * 1000.0_dp / au__fs
 
-200 format(I5)
-201 format(A5,3F16.8)
-202 format(A5,6F16.8)
-203 format(A5,4F16.8)
-204 format(A5,7F16.8)
+    character(len=*), parameter :: formatElement = "(A5)"
+    character(len=*), parameter :: formatScalar = "(F16.8)"
+    character(len=*), parameter :: formatVector = "(3F16.8)"
 
     nAtom = size(coords, dim=2)
     nSpecies = maxval(species)
@@ -328,61 +325,39 @@ contains
       @:ASSERT(size(charges) == nAtom)
     end if
     @:ASSERT(.not. (present(velocities) .and. present(vectors)))
+    @:ASSERT(.not. (present(forces) .and. present(vectors)))
     if (present(velocities)) then
-      @:ASSERT(all(shape(velocities) == (/ 3, nAtom /)))
+      @:ASSERT(all(shape(velocities) == [3, nAtom]))
     end if
     if (present(vectors)) then
-      @:ASSERT(all(shape(vectors) == (/ 3, nAtom /)))
+      @:ASSERT(all(shape(vectors) == [3, nAtom]))
+    end if
+    if (present(forces)) then
+      @:ASSERT(all(shape(forces) == [3, nAtom]))
     end if
   #:endblock DEBUG_CODE
 
-    write(fd, 200) nAtom
+    write(fd%unit, "(I5)") nAtom
     if (present(comment)) then
-      write(fd, "(A)") trim(comment)
+      write(fd%unit, "(A)") trim(comment)
     elseif (present(velocities)) then
-      write(fd, *) "Velocity in AA/ps"
+      write(fd%unit, *) "Velocity in AA/ps"
     else
-      write(fd, *) ""
+      write(fd%unit, *) ""
     end if
 
-    if (present(charges)) then
+    do iAt = 1, nAtom
 
-      if (present(velocities)) then
+      write(fd%unit, formatElement, advance="NO") trim(speciesNames(species(iAt)))
+      write(fd%unit, formatVector, advance="NO") coords(:, iAt) * Bohr__AA
+      if (present(charges)) write(fd%unit, formatScalar, advance="NO") charges(iAt)
+      if (present(velocities)) write(fd%unit, formatVector, advance="NO")&
+          & velocities(:,iAt) * velocityConv
+      if (present(forces)) write(fd%unit, formatVector, advance="NO") forces(:,iAt) * forceConv
+      if (present(vectors))  write(fd%unit, formatVector, advance="NO") vectors(:,iAt)
+      write(fd%unit, *)
 
-        write(fd, 204) (trim(speciesNames(species(ii))), coords(:, ii) * Bohr__AA,&
-            & charges(ii), velocities(:,ii) * Bohr__AA / au__fs * 1000.0_dp, ii = 1, nAtom)
-
-      else if (present(vectors)) then
-
-        write(fd, 204) (trim(speciesNames(species(ii))), coords(:, ii) * Bohr__AA,&
-            & charges(ii), vectors(:,ii) * Bohr__AA, ii = 1, nAtom)
-
-      else
-
-        write(fd, 203) (trim(speciesNames(species(ii))), coords(:, ii) * Bohr__AA, charges(ii),&
-            & ii = 1, nAtom)
-
-      end if
-
-    else
-
-      if (present(velocities)) then
-
-        write(fd, 202) (trim(speciesNames(species(ii))), coords(:, ii) * Bohr__AA,&
-            & velocities(:,ii) * Bohr__AA / au__fs * 1000.0_dp, ii = 1, nAtom)
-
-      else if (present(vectors)) then
-
-        write(fd, 202) (trim(speciesNames(species(ii))), coords(:, ii) * Bohr__AA,&
-            & vectors(:,ii), ii = 1, nAtom)
-
-      else
-
-        write(fd, 201) (trim(speciesNames(species(ii))), coords(:, ii) * Bohr__AA, ii = 1, nAtom)
-
-      end if
-
-    end if
+    end do
 
   end subroutine writeXYZFormat_fid
 

--- a/src/dftbp/io/formatout.F90
+++ b/src/dftbp/io/formatout.F90
@@ -103,7 +103,7 @@ contains
     integer, intent(in) :: fd
 
     !> Coordinates in atomic units
-    real(dp),          intent(in) :: coord(:,:)
+    real(dp), intent(in) :: coord(:,:)
 
     !> Species of the atoms
     integer, intent(in) :: species(:)
@@ -120,9 +120,8 @@ contains
     !> Print out fractional coordinates?
     logical, intent(in), optional :: tFracCoord
 
-    integer :: nAtom, nSpecies
+    integer :: ii, nAtom, nSpecies
     character(mc) :: formatCoordinates
-    integer :: ii
     logical :: tFractional, tHelical, tPeriodic
     real(dp) :: invLatVec(3,3)
 
@@ -307,13 +306,10 @@ contains
     !> Optional comment for line 2 of the file
     character(len=*), intent(in), optional :: comment
 
-    integer :: nAtom, nSpecies, iAt
+    integer :: nAtom, nSpecies, iAt, nFields
     real(dp), parameter :: forceConv = Hartree__eV / Bohr__AA
     real(dp), parameter :: velocityConv = Bohr__AA * 1000.0_dp / au__fs
-
-    character(len=*), parameter :: formatElement = "(A5)"
-    character(len=*), parameter :: formatScalar = "(F16.8)"
-    character(len=*), parameter :: formatVector = "(3F16.8)"
+    real(dp), allocatable :: values(:)
 
     nAtom = size(coords, dim=2)
     nSpecies = maxval(species)
@@ -346,16 +342,35 @@ contains
       write(fd%unit, *) ""
     end if
 
+    nFields = 3
+    if (present(charges)) nFields = nFields + 1
+    if (present(velocities)) nFields = nFields + 3
+    if (present(forces)) nFields = nFields + 3
+    if (present(vectors)) nFields = nFields + 3
+    allocate(values(nFields))
+
     do iAt = 1, nAtom
 
-      write(fd%unit, formatElement, advance="NO") trim(speciesNames(species(iAt)))
-      write(fd%unit, formatVector, advance="NO") coords(:, iAt) * Bohr__AA
-      if (present(charges)) write(fd%unit, formatScalar, advance="NO") charges(iAt)
-      if (present(velocities)) write(fd%unit, formatVector, advance="NO")&
-          & velocities(:,iAt) * velocityConv
-      if (present(forces)) write(fd%unit, formatVector, advance="NO") forces(:,iAt) * forceConv
-      if (present(vectors))  write(fd%unit, formatVector, advance="NO") vectors(:,iAt)
-      write(fd%unit, *)
+      values(1:3) = coords(:, iAt) * Bohr__AA
+      nFields = 4
+      if (present(charges)) then
+        values(nFields) = charges(iAt)
+        nFields = nFields + 1
+      end if
+      if (present(velocities)) then
+        values(nFields:nFields+2) = velocities(:,iAt) * velocityConv
+        nFields = nFields + 3
+      end if
+      if (present(forces)) then
+        values(nFields:nFields+2) = forces(:,iAt) * forceConv
+        nFields = nFields + 3
+      end if
+      if (present(vectors)) then
+        values(nFields:nFields+2) = vectors(:,iAt)
+        nFields = nFields + 3
+      end if
+
+      write(fd%unit, "(A5, *(F16.8))")trim(speciesNames(species(iAt))), values
 
     end do
 

--- a/src/dftbp/transport/negfint.F90
+++ b/src/dftbp/transport/negfint.F90
@@ -2153,7 +2153,8 @@ contains
 
     if (tIoProc) then
       write(stdOut,*)
-      call writeXYZFormat("supercell.xyz", lc_coord, lc_species, speciesName)
+      call writeXYZFormat("supercell.xyz", lc_coord, lc_species,&
+          & speciesName)
       write(stdOut,*) " <<< supercell.xyz written on file"
     end if
 


### PR DESCRIPTION
Slightly slower code (if tests for what is being printed now inside loop), but clearer and simpler writing code. Single routine for writing xyz files with or without force vectors.

Fixes a conversion factor bug in the vector print, in the case of atomic populations present.