### PR TITLE
Fix WITH_API=OFF build: guard isASICallbackEnabled in ensureSolverCompatibility call

### DIFF
--- a/src/dftbp/dftbplus/inputdata.F90
+++ b/src/dftbp/dftbplus/inputdata.F90
@@ -149,12 +149,9 @@ module dftbp_dftbplus_inputdata
     !> Choice of electronic hamiltonian
     integer :: hamiltonian = hamiltonianTypes%none
 
-  #:if WITH_API
     !> Is this ASI callback interface for H,S,P enabled (Stishenko et al.,
     !! https://doi.org/10.21105/joss.05186)
     logical :: isAsiCallbackEnabled = .false.
-
-  #:endif
 
     !> Random number generator seed
     integer :: iSeed = 0


### PR DESCRIPTION
When building with -DWITH_API=OFF, compilation fails in src/dftbp/dftbplus/initprogram.F90

This PR wraps the call so WITH_API=OFF builds pass .false. instead.