### PR TITLE
Fix bugs in helpsetupgeom

### DIFF
--- a/app/transporttools/helpsetupgeom.F90
+++ b/app/transporttools/helpsetupgeom.F90
@@ -86,11 +86,15 @@ contains
     ! 4. re-sort the second contact PL to be a shifted copy of the first
     call arrangeContactPLs(geom, iAtInRegion, contacts, contVec, contDir, nPLs, plcutoff)
 
-    ! 5. Define device PLs
+    ! 5. Define device PLs and reorder them along contact direction
     call defineDevicePLs(geom, iAtInRegion, plcutoff, contVec, PLlist)
+    call reorder_PLs(geom, contDir, PLlist, iAtInRegion)
 
     ! 6. write ordered geometry
     call print_gen(geom, contacts, iAtInRegion, PLlist, plcutoff)
+
+    ! 7. Print the sorting vector
+    call print_sort_indices(iAtInRegion)
 
     write(stdOut,*)
     write(stdOut,*) "Written processed geometry file 'processed.gen'"
@@ -112,6 +116,7 @@ contains
     allocate(mask(geom%nAtom))
     mask = .true.
 
+    ! Mask away atoms belonging to contacts (and check for duplications)
     do icont = 1, ncont
       do ii = 1, size(iAtInRegion(icont)%data)
         jj = iAtInRegion(icont)%data(ii)
@@ -124,11 +129,10 @@ contains
       end do
     end do
 
-    jj = count(mask)
     if (allocated(iAtInRegion(ncont+1)%data)) then
       deallocate(iAtInRegion(ncont+1)%data)
     end if
-    allocate(iAtInRegion(ncont+1)%data(jj))
+    allocate(iAtInRegion(ncont+1)%data(count(mask)))
 
     jj = 0
     do ii = 1, geom%nAtom
@@ -158,38 +162,44 @@ contains
       ! check position of contact w.r.t. device atoms
       ! and decide sign of contact direction
       associate(data=>iAtInRegion(icont)%data, dir=>contDir(icont))
+      ! identify contact direction wrt device
       mean = sum(geom%coords(dir, data))/real(size(data),dp)
       if (mean < minval(geom%coords(dir,iAtInRegion(ncont+1)%data ))) then
         dir = -dir
       end if
-      end associate
+      !print*,'signed contact dir:',dir
 
-      allocate(subarray(size(iAtInRegion(icont)%data)))
+      ! Sorting contact atoms along contact direction
+      allocate(subarray(size(data)))
       allocate(indxs(size(subarray)))
-      ! identify contact direction wrt device
-      if (contDir(icont)>0) then
-        subarray(:)=geom%coords(abs(contDir(icont)), iAtInRegion(icont)%data(:))
+      if (dir > 0) then
+        subarray(:)=geom%coords(abs(dir), data(:))
       else
-        subarray(:)=-geom%coords(abs(contDir(icont)), iAtInRegion(icont)%data(:))
+        subarray(:)=-geom%coords(abs(dir), data(:))
       end if
-      ! sort contact directions perpendicular to device by largest coord range in that direction
-      contRange(:) = abs(maxval(geom%coords(:,iAtInRegion(icont)%data(:)),dim=2)&
-          & - minval(geom%coords(:,iAtInRegion(icont)%data(:)),dim=2))
-      contRange(abs(contDir(icont))) = huge(1.0)
-      call index_heap_sort(visitOrder, contRange)
-      do ii = 3, 1, -1
-        jj = visitOrder(ii)
-        if (jj == abs(contDir(icont))) then
-          cycle
-        end if
-        subarray(:) = subarray * (abs(maxval(geom%coords(jj,iAtInRegion(icont)%data(:))) -&
-            & minval(geom%coords(jj,iAtInRegion(icont)%data(:)))) + epsilon(1.0))
-        subarray(:) = subarray + geom%coords(jj, iAtInRegion(icont)%data(:))
-      end do
+      ! Commented out because totally buggy
+      ! sort contact atoms in directions others than contact dir
+      ! by the largest coord range in that direction
+      !contRange(:) = abs(maxval(geom%coords(:,data(:)),dim=2)&
+      !    & - minval(geom%coords(:,data(:)),dim=2))
+      !contRange(abs(dir)) = huge(1.0)
+      !print*,'contRange:',contRange
+      !call index_heap_sort(visitOrder, contRange)
+      !print*,'visitOrder:',visitOrder
+      !do ii = 3, 1, -1
+      !  jj = visitOrder(ii)
+      !  if (jj == abs(dir)) then
+      !    cycle
+      !  end if
+      !  ! subarray is the slice of coordinates to sort
+      !  subarray(:) = subarray(:) * (contRange(jj) + epsilon(1.0))
+      !  subarray(:) = subarray(:) + geom%coords(jj, data(:))
+      !end do
       call index_heap_sort(indxs, subarray)
-      buffer = iAtInRegion(icont)%data(indxs)
-      iAtInRegion(icont)%data = buffer
+      buffer = data(indxs)
+      data = buffer
       deallocate(subarray,indxs,buffer)
+      end associate
     end do
   end subroutine sortContacts
 
@@ -221,6 +231,7 @@ contains
         write(stdOut, *) "PL size:",PLsize
         write(stdOut, *) "Number of PLs:",nPLs(icont)
         write(stdOut, *) "contact vector:",contvec(1:3,icont)*Bohr__AA,'(A)'
+        write(stdOut, *) "contact direction:",contdir(icont)
         write(stdOut, *) "tolerance:",tol
         ! check PL size
         mindist=minDist2ndPL(geom%coords,data,PLsize,contvec(1:3,icont))
@@ -510,12 +521,59 @@ contains
 
   end subroutine translateAndFold
 
+  ! -----------------------------------------------------------------------------------------------
+  subroutine reorder_PLs(geom, contDir, PLlist, iAtInRegion)
+    type(TGeometry), intent(in) :: geom
+    integer, intent(in) :: contDir(:)
+    type(TListIntR1), intent(inout) :: PLlist
+    type(TWrappedInt1), intent(inout) :: iAtInRegion(:)
+
+    integer :: ks, kk, jj, ncont, dir
+    integer, allocatable :: atomsInPL(:), indxs(:)
+    real(dp), allocatable :: subarray(:)
+    real(dp) :: mean
+
+    print*,'Reorder the PLs'
+    ncont = size(iAtInRegion)-1
+    associate(data=>iAtInRegion(1)%data)
+      dir = contDir(1)
+      ! identify contact direction wrt device
+      mean = sum(geom%coords(dir, data))/real(size(data),dp)
+      if (mean < minval(geom%coords(dir,iAtInRegion(ncont+1)%data ))) then
+        dir = -dir
+      end if
+    end associate
+
+    print*,'Reference Direction:',dir
+
+    kk = 0
+    do jj = 1, len(PLlist)
+      print*,'Process PL:',jj
+      ks = kk+1
+      call get(PLlist, atomsInPL, jj)
+      kk = kk + size(atomsInPL)
+      ! Notice that signs here are opposite wrt sortContacts, because
+      ! if contact dir<0, the device is for increasing coords on dir
+      allocate(subarray(size(atomsInPL)))
+      allocate(indxs(size(subarray)))
+      if (dir > 0) then
+        subarray(:) = -geom%coords(abs(dir), atomsInPL(:))
+      else
+        subarray(:) = geom%coords(abs(dir), atomsInPL(:))
+      end if
+      call index_heap_sort(indxs, subarray)
+      iAtInRegion(ncont+1)%data(ks:kk) = atomsInPL(indxs(:))
+      deallocate(subarray, indxs)
+      deallocate(atomsInPL)
+    end do
+
+  end subroutine reorder_PLs
 
   ! -----------------------------------------------------------------------------------------------
   subroutine print_gen(geom, contacts, iAtInRegion, PLlist, plCutoff)
     type(TGeometry), intent(in) :: geom
     type(contactInfo), intent(in) :: contacts(:)
-    type(TWrappedInt1), intent(in) :: iAtInRegion(:)
+    type(TWrappedInt1), intent(inout) :: iAtInRegion(:)
     type(TListIntR1), intent(inout) :: PLlist
     real(dp), intent(in) :: plCutoff
 
@@ -523,7 +581,7 @@ contains
     type(TFileDescr) :: fd1, fd2
     integer, allocatable :: atomsInPL(:)
     character(10) :: sindx
-    integer :: ii, jj, kk, icont, ncont
+    integer :: ii, jj, kk, ks, icont, ncont
 
     ncont = size(iAtInRegion)-1
 
@@ -535,7 +593,8 @@ contains
     write(fd2%unit,'(4x,A)', advance='no') 'FirstLayerAtoms={ '
     kk = 0
     do jj = 1, len(PLlist)
-      write(sindx,'(I10)') kk+1
+      ks = kk+1
+      write(sindx,'(I10)') ks
       write(fd2%unit,'(A)', advance='no') ' '//trim(adjustl(sindx))
       call get(PLlist, atomsInPL, jj)
       kk = kk + size(atomsInPL)
@@ -584,14 +643,9 @@ contains
 
     ! Write Device Atoms
     write(fd1%unit,"(4X,A)") '# device atoms'
-    do jj = 1, len(PLlist)
-      kk = 0
-      call get(PLlist, atomsInPL, jj)
-      do ii = 1, size(atomsInPL)
-        kk = kk + 1
-        write(fd1%unit,102) kk, geom%species(atomsInPL(ii)), geom%coords(:,atomsInPL(ii))*Bohr__AA
-      end do
-      deallocate(atomsInPL)
+    do jj = 1, size(iAtInRegion(ncont+1)%data)
+      write(fd1%unit,102) jj, geom%species(iAtInRegion(ncont+1)%data(jj)), &
+                            & geom%coords(:,iAtInRegion(ncont+1)%data(jj))*Bohr__AA
     end do
 
     ! Write Contact Atoms
@@ -613,6 +667,35 @@ contains
     call closeFile(fd1)
 
   end subroutine print_gen
+
+  !> Print the sorting indices for other uses
+  subroutine print_sort_indices(iAtInRegion)
+
+    !> array of indices
+    type(TWrappedInt1), intent(in) :: iAtInRegion(:)
+
+    type(TFileDescr) :: fd2
+    integer :: ncont, ii, jj, kk
+
+    ncont = size(iAtInRegion)-1
+
+    call openFile(fd2, 'sort_indices.dat', mode="w")
+
+    do jj = 1, size(iAtInRegion(ncont+1)%data)
+       write(fd2%unit,"(I,I)") jj, iAtInRegion(ncont+1)%data(jj)
+    end do
+
+    kk = size(iAtInRegion(ncont+1)%data)
+    do ii = 1, ncont
+      do jj = 1, size(iAtInRegion(ii)%data)
+         write(fd2%unit,"(I,I)") kk+jj, iAtInRegion(ii)%data(jj)
+      end do
+      kk = kk + size(iAtInRegion(ii)%data)
+    end do
+
+    call closeFile(fd2)
+
+  end subroutine print_sort_indices
 
   !> Fold coordinates back in the central cell.
   !>

--- a/app/transporttools/helpsetupgeom.F90
+++ b/app/transporttools/helpsetupgeom.F90
@@ -682,13 +682,13 @@ contains
     call openFile(fd2, 'sort_indices.dat', mode="w")
 
     do jj = 1, size(iAtInRegion(ncont+1)%data)
-       write(fd2%unit,"(I,I)") jj, iAtInRegion(ncont+1)%data(jj)
+       write(fd2%unit,"(I0,I0)") jj, iAtInRegion(ncont+1)%data(jj)
     end do
 
     kk = size(iAtInRegion(ncont+1)%data)
     do ii = 1, ncont
       do jj = 1, size(iAtInRegion(ii)%data)
-         write(fd2%unit,"(I,I)") kk+jj, iAtInRegion(ii)%data(jj)
+         write(fd2%unit,"(I0,I0)") kk+jj, iAtInRegion(ii)%data(jj)
       end do
       kk = kk + size(iAtInRegion(ii)%data)
     end do


### PR DESCRIPTION
I realized today creating a transport geometry that I had a pending fix in setupgeom that might be relevant for the tutorial and in general. 
- A bug was found in the processing of the second contact PL that was occasionally missing the correct atom and the minimal distance of the second neighbour PLs.
- A new subroutine reordering the PLs was introduced. 

Certainly the code is now working on a relatively complex Au/MoS2/Au system with random defects whereas the current version is failing with strange errors.
