### PR TITLE
Speed up RPA charge calls a bit

### DIFF
--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -5014,6 +5014,11 @@ contains
       ctrl%lrespini%tOscillatorWindow = ctrl%lrespini%oscillatorWindow /= 0.0_dp
       call convertUnitHsd(char(modifier), dipoleUnits, child2, ctrl%lrespini%oscillatorWindow)
       call getChildValue(child, "CacheCharges", ctrl%lrespini%tCacheCharges, default=.true.)
+    #:if WITH_MPI
+      if (.not.ctrl%lrespini%tCacheCharges) then
+        call detailedError(child, "Uncached charges currently not supported for MPI enabled builds")
+      end if
+    #:endif
       call getChildValue(child, "WriteMulliken", ctrl%lrespini%tMulliken, default=.false.)
       call getChildValue(child, "WriteCoefficients", ctrl%lrespini%tCoeffs, default=.false.)
       ctrl%lrespini%tGrndState = .false.

--- a/src/dftbp/timedep/linresp.F90
+++ b/src/dftbp/timedep/linresp.F90
@@ -173,8 +173,16 @@ contains
     end if
 
     if (this%iLinRespSolver == linrespSolverTypes%Arpack .and. .not. withArpack) then
-      call error('This binary is buit without ARPACK support, but it is requested.')
+      call error('This binary is built without ARPACK support, but it is requested.')
     end if
+
+  #:if WITH_MPI
+    if (this%iLinRespSolver == linrespSolverTypes%Arpack) then
+      if (.not. ini%tCacheCharges) then
+        call error("Uncached charges currently not supported for MPI enabled builds")
+      end if
+    end if
+  #:endif
 
     this%nExc = ini%nExc
     this%tEnergyWindow = ini%tEnergyWindow

--- a/src/dftbp/timedep/linrespgrad.F90
+++ b/src/dftbp/timedep/linrespgrad.F90
@@ -40,7 +40,7 @@ module dftbp_timedep_linrespgrad
       & transitionDipole, twothird, writeExcMulliken, writeSPExcitations
   use dftbp_timedep_linresptypes, only : linrespSolverTypes, TCasidaParameter,&
       & TCasidaParameter_init, TLinResp
-  use dftbp_timedep_transcharges, only : transq, TTransCharges, TTransCharges_init
+  use dftbp_timedep_transcharges, only : TTransCharges, TTransCharges_init
   use dftbp_type_commontypes, only : TOrbitals
   use dftbp_type_densedescr, only : TDenseDescr
 

--- a/src/dftbp/timedep/pprpa.F90
+++ b/src/dftbp/timedep/pprpa.F90
@@ -310,7 +310,8 @@ contains
     integer :: ab_r, cd_r, ij_r, kl_r
     integer :: at1, at2, natom
     real(dp):: factor1, factor2
-    logical :: updwn
+    ! Spin-up channel only for closed-shell systems
+    real(dp), parameter :: updwn = +1.0_dp
     real(dp):: q_1(size(gamma_eri, dim=1))
     real(dp):: q_2(size(gamma_eri, dim=1))
     real(dp):: q_3(size(gamma_eri, dim=1))
@@ -334,9 +335,6 @@ contains
     allocate(work(5*nRPA))
     allocate(wi(nRPA))
     allocate(PP(nRPA, nRPA))
-
-    ! Spin-up channel only for closed-shell systems
-    updwn = .true.
 
     if (sym == "S") then !------ singlets -------
 

--- a/src/dftbp/timedep/transcharges.F90
+++ b/src/dftbp/timedep/transcharges.F90
@@ -11,15 +11,13 @@
 module dftbp_timedep_transcharges
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : TEnvironment
-  use dftbp_io_message, only : error
-  use dftbp_type_densedescr, only : TDenseDescr
-
 #:if WITH_SCALAPACK
   use dftbp_extlibs_mpifx, only : MPI_SUM, mpifx_allreduceip
   use dftbp_extlibs_scalapackfx, only : CSRC_, DLEN_, MB_, NB_, pblasfx_pgemm, RSRC_,&
       & scalafx_indxl2g
-
 #:endif
+  use dftbp_io_message, only : error
+  use dftbp_type_densedescr, only : TDenseDescr
 
   implicit none
 
@@ -73,7 +71,6 @@ module dftbp_timedep_transcharges
 
   end type TTransCharges
 
-
 contains
 
   !> initialise the cache/on-the fly transition charge evaluator
@@ -111,11 +108,11 @@ contains
     integer, intent(in) :: nXvvUD(:)
 
     !> Should occ-vir transitions be stored?
-    !> this is sufficient for single-point TD-DFTB
+    !! this is sufficient for single-point TD-DFTB
     logical, intent(in) :: tStoreOccVir
 
     !> Should also occ-occ and vir-vir transitions be stored?
-    !> required for excited state forces and TD-LC-DFTB
+    !! required for excited state forces and TD-LC-DFTB
     logical, intent(in) :: tStoreSame
 
     !> If tFirstCall = .false. recompute only occ-vir charges for
@@ -284,14 +281,13 @@ contains
       end if
       allocate(this%qCacheOccVir(this%nAtom, nTrans))
 
-      !!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(ia,ii,aa,kk,updwn) SCHEDULE(RUNTIME)
+      !!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(ia,ii,aa,kk) SCHEDULE(RUNTIME)
       do ia = 1, nTrans
         kk = win(ia)
         ii = getia(kk, 1)
         aa = getia(kk, 2)
-        updwn = (kk <= this%nMatUp)
-        this%qCacheOccVir(:,ia) = transq(ii, aa, env, denseDesc, updwn,  sTimesGrndEigVecs,&
-            & grndEigVecs)
+        this%qCacheOccVir(:,ia) = transq(ii, aa, env, denseDesc, updwnSign(kk, this%nMatUp),&
+            & sTimesGrndEigVecs, grndEigVecs)
       end do
       !!$OMP END PARALLEL DO
 
@@ -310,23 +306,21 @@ contains
       @:ASSERT(.not.allocated(this%qCacheVirVir))
       allocate(this%qCacheVirVir(this%nAtom, sum(nXvvUD)))
 
-      !!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(ij,ii,jj,updwn) SCHEDULE(RUNTIME)
+      !!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(ij,ii,jj) SCHEDULE(RUNTIME)
       do ij = 1, sum(nXooUD)
         ii = getij(ij, 1)
         jj = getij(ij, 2)
-        updwn = (ij <= nXooUD(1))
-        this%qCacheOccOcc(:,ij) = transq(ii, jj, env, denseDesc, updwn,  sTimesGrndEigVecs,&
-             & grndEigVecs)
+        this%qCacheOccOcc(:,ij) = transq(ii, jj, env, denseDesc, updwnSign(ij, nXooUD(1)),&
+            & sTimesGrndEigVecs, grndEigVecs)
       enddo
       !!$OMP END PARALLEL DO
 
-      !!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(ab,aa,bb,updwn) SCHEDULE(RUNTIME)
+      !!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(ab,aa,bb) SCHEDULE(RUNTIME)
       do ab = 1, sum(nXvvUD)
         aa = getab(ab, 1)
         bb = getab(ab, 2)
-        updwn = (ab <= nXvvUD(1))
-        this%qCacheVirVir(:,ab) = transq(aa, bb, env, denseDesc, updwn,  sTimesGrndEigVecs,&
-            & grndEigVecs)
+        this%qCacheVirVir(:,ab) = transq(aa, bb, env, denseDesc, updwnSign(ab, nXvvUD(1)),&
+            & sTimesGrndEigVecs, grndEigVecs)
       end do
       !!$OMP END PARALLEL DO
 
@@ -343,7 +337,7 @@ contains
   end subroutine TTransCharges_init
 
 
-  !> returns transition charges between occ-vir single particle levels
+  !> Returns transition charges between occ-vir single particle levels
   function TTransCharges_qTransIA(this, ij, env, denseDesc, sTimesGrndEigVecs, grndEigVecs, getia,&
       & win) result(q)
 
@@ -373,7 +367,6 @@ contains
     !> Transition charge on exit. (nAtom)
     real(dp), dimension(size(denseDesc%iAtomStart)-1) :: q
 
-    logical :: updwn
     integer :: ii, jj, kk
 
     if (allocated(this%qCacheOccVir)) then
@@ -382,13 +375,14 @@ contains
       kk = win(ij)
       ii = getia(kk,1)
       jj = getia(kk,2)
-      updwn = (kk <= this%nMatUp)
-      q(:) = transq(ii, jj, env, denseDesc, updwn, sTimesgrndEigVecs, grndEigVecs)
+      q(:) = transq(ii, jj, env, denseDesc, updwnSign(kk, this%nMatUp), sTimesgrndEigVecs,&
+          & grndEigVecs)
     end if
 
   end function TTransCharges_qTransIA
 
-  !> returns transition charges between occ-occ single particle levels
+
+  !> Returns transition charges between occ-occ single particle levels
   function TTransCharges_qTransIJ(this, ij, env, denseDesc, sTimesGrndEigVecs, grndEigVecs, getij)&
       & result(q)
 
@@ -416,7 +410,6 @@ contains
     !> Transition charge on exit. (nAtom)
     real(dp), dimension(size(denseDesc%iAtomStart)-1) :: q
 
-    logical :: updwn
     integer :: ii, jj
 
     if (allocated(this%qCacheOccOcc)) then
@@ -424,14 +417,15 @@ contains
     else
       ii = getij(ij, 1)
       jj = getij(ij, 2)
-      updwn = (ij <= this%nMatUpOccOcc)
-      q(:) = transq(ii, jj, env, denseDesc, updwn, sTimesgrndEigVecs, grndEigVecs)
+      q(:) = transq(ii, jj, env, denseDesc, updwnSign(ij, this%nMatUpOccOcc), sTimesgrndEigVecs,&
+          & grndEigVecs)
 
     end if
 
   end function TTransCharges_qTransIJ
 
-  !> returns transition charges between vir-vir single particle levels
+
+  !> Returns transition charges between vir-vir single particle levels
   function TTransCharges_qTransAB(this, ab, env, denseDesc, sTimesGrndEigVecs, grndEigVecs, getab)&
       & result(q)
 
@@ -459,7 +453,6 @@ contains
     !> Transition charge on exit. (nAtom)
     real(dp), dimension(size(denseDesc%iAtomStart)-1) :: q
 
-    logical :: updwn
     integer :: aa, bb
 
     if (allocated(this%qCacheVirVir)) then
@@ -467,15 +460,15 @@ contains
     else
       aa = getab(ab, 1)
       bb = getab(ab, 2)
-      updwn = (ab <= this%nMatUpVirVir)
-      q(:) = transq(aa, bb, env, denseDesc, updwn, sTimesgrndEigVecs, grndEigVecs)
+      q(:) = transq(aa, bb, env, denseDesc, updwnSign(ab, this%nMatUpVirVir), sTimesgrndEigVecs,&
+          & grndEigVecs)
     end if
 
   end function TTransCharges_qTransAB
 
 
-  !> Transition charges left produced with a vector Q * v
-  !> qProduct has dimension nAtom
+  !> Transition charges left product with a vector Q * v
+  !! qProduct has dimension nAtom
   subroutine TTransCharges_qMatVec(this, env, denseDesc, sTimesGrndEigVecs, grndEigVecs, getia,&
       & win, vector, qProduct, indexOffSet)
 
@@ -511,7 +504,6 @@ contains
 
     real(dp), allocatable :: qij(:)
     integer :: ii, jj, ij, kk, iOff, iGlb, fGlb
-    logical :: updwn
 
     ! RPA vectors are distributed for MPI: size(vector) < nOcc*nVir
     if (present(indexOffSet)) then
@@ -527,6 +519,7 @@ contains
       qProduct(:) = qProduct + matmul(this%qCacheOccVir(:,iGlb:fGlb), vector)
 
     else
+
       allocate(qij(this%nAtom))
 
       do ij = 1, size(vector)
@@ -534,8 +527,8 @@ contains
         ii = getia(kk,1)
         jj = getia(kk,2)
 
-        updwn = (kk <= this%nMatUp)
-        qij(:) = transq(ii, jj, env, denseDesc, updwn, sTimesGrndEigVecs, grndEigVecs)
+        qij(:) = transq(ii, jj, env, denseDesc, updwnSign(kk, this%nMatUp), sTimesGrndEigVecs,&
+            & grndEigVecs)
         qProduct(:) = qProduct + qij * vector(ij)
       end do
 
@@ -546,8 +539,8 @@ contains
   end subroutine TTransCharges_qMatVec
 
 
-  !> Transition charges right produced with a vector v * Q
-  !> qProduct has dimension nOcc*nVir
+  !> Transition charges right product with a vector v * Q
+  !! qProduct has dimension nOcc*nVir
   subroutine TTransCharges_qVecMat(this, env, denseDesc, sTimesGrndEigVecs, grndEigVecs, getia,&
       & win, vector, qProduct, indexOffSet)
 
@@ -583,7 +576,6 @@ contains
 
     real(dp), allocatable :: qij(:)
     integer :: ii, jj, ij, kk, iOff, iGlb, fGlb
-    logical :: updwn
 
     ! RPA vectors are distributed for MPI: size(vector) < nOcc*nVir
     if (present(indexOffSet)) then
@@ -606,8 +598,8 @@ contains
         kk = win(iOff+ij)
         ii = getia(kk,1)
         jj = getia(kk,2)
-        updwn = (kk <= this%nMatUp)
-        qij(:) = transq(ii, jj, env, denseDesc, updwn, sTimesGrndEigVecs, grndEigVecs)
+        qij(:) = transq(ii, jj, env, denseDesc, updwnSign(kk, this%nMatUp), sTimesGrndEigVecs,&
+            & grndEigVecs)
         qProduct(ij) = qProduct(ij) + dot_product(qij, vector)
       end do
       !!$OMP END PARALLEL DO
@@ -619,9 +611,9 @@ contains
   end subroutine TTransCharges_qVecMat
 
 
-  !> Transition charges left produced with a vector Q * v for spin up
-  !> minus Transition charges left produced with a vector Q * v for spin down
-  !> sum_ias q_ias V_ias delta_s,  where delta_s = 1 for spin up and delta_s = -1 for spin down
+  !> Transition charges, Q, left product with a vector (Q * v) for spin up, minus transition
+  !! charges left produced with a vector (Q * v) for spin down, sum_ias q_ias V_ias delta_s, where
+  !! delta_s = 1 for spin up and delta_s = -1 for spin down
   subroutine TTransCharges_qMatVecDs(this, env, denseDesc, sTimesGrndEigVecs, grndEigVecs, getia,&
       & win, vector, qProduct, indexOffSet)
 
@@ -657,7 +649,7 @@ contains
 
     real(dp), allocatable :: qij(:)
     integer :: ii, jj, ij, kk, iOff, iGlb, fGlb
-    logical :: updwn
+    real(dp) :: prefac
 
     ! RPA vectors are distributed for MPI: size(vector) < nOcc*nVir
     if (present(indexOffSet)) then
@@ -669,18 +661,14 @@ contains
     fGlb = iOff + size(vector)
 
     if (this%tCacheChargesOccVir) then
+
       do ij = 1, size(vector)
         kk = win(iOff+ij)
-        updwn = (kk <= this%nMatUp)
-
-        if (updwn) then
-          qProduct(:) = qProduct + this%qCacheOccVir(:,ij) * vector(ij)
-        else
-          qProduct(:) = qProduct - this%qCacheOccVir(:,ij) * vector(ij)
-        end if
+        qProduct(:) = qProduct + updwnSign(kk, this%nMatUp) * this%qCacheOccVir(:,ij) * vector(ij)
       end do
 
     else
+
       allocate(qij(this%nAtom))
 
       !!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(ij,ii,jj,kk,updwn,qij)&
@@ -689,24 +677,21 @@ contains
         kk = win(iOff+ij)
         ii = getia(kk, 1)
         jj = getia(kk, 2)
-        updwn = (kk <= this%nMatUp)
-        qij(:) = transq(ii, jj, env, denseDesc, updwn, sTimesGrndEigVecs, grndEigVecs)
-        if (updwn) then
-          qProduct(:) = qProduct + qij * vector(ij)
-        else
-          qProduct(:) = qProduct - qij * vector(ij)
-        end if
+        prefac = updwnSign(kk, this%nMatUp)
+        qij(:) = transq(ii, jj, env, denseDesc, prefac, sTimesGrndEigVecs, grndEigVecs)
+        qProduct(:) = qProduct + prefac * qij * vector(ij)
       end do
       !!$OMP END PARALLEL DO
 
       deallocate(qij)
+
     endif
 
   end subroutine TTransCharges_qMatVecDs
 
 
-  !> Transition charges right produced with a vector v * Q for spin up
-  !! and negative transition charges right produced with a vector v * Q for spin down
+  !> Transition charges right product with a vector v * Q for spin up
+  !! and negative transition charges right product with a vector v * Q for spin down
   !! R_ias = delta_s sum_A q_A^(ias) V_A,  where delta_s = 1 for spin up and delta_s = -1 for spin
   !! down
   subroutine TTransCharges_qVecMatDs(this, env, denseDesc, sTimesGrndEigVecs, grndEigVecs, getia,&
@@ -744,7 +729,7 @@ contains
 
     real(dp), allocatable :: qij(:)
     integer :: ii, jj, ij, kk, iOff, iGlb, fGlb
-    logical :: updwn
+    real(dp) :: prefac
 
     ! RPA vectors are distributed for MPI: size(vector) < nOcc*nVir
     if (present(indexOffSet)) then
@@ -759,13 +744,8 @@ contains
 
       do ij = 1, this%nTransitions
         kk = win(iOff+ij)
-        updwn = (kk <= this%nMatUp)
-
-        if (updwn) then
-          qProduct(ij) = qProduct(ij) + dot_product(this%qCacheOccVir(:,ij), vector)
-        else
-          qProduct(ij) = qProduct(ij) - dot_product(this%qCacheOccVir(:,ij), vector)
-        end if
+        qProduct(ij) = qProduct(ij) + updwnSign(kk, this%nMatUp) *&
+            & dot_product(this%qCacheOccVir(:,ij), vector)
       end do
 
     else
@@ -778,13 +758,9 @@ contains
         kk = win(iOff+ij)
         ii = getia(kk, 1)
         jj = getia(kk, 2)
-        updwn = (kk <= this%nMatUp)
-        qij(:) = transq(ii, jj, env, denseDesc, updwn, sTimesGrndEigVecs, grndEigVecs)
-        if (updwn) then
-          qProduct(ij) = qProduct(ij) + dot_product(qij, vector)
-        else
-          qProduct(ij) = qProduct(ij) - dot_product(qij, vector)
-        end if
+        prefac = updwnSign(kk, this%nMatUp)
+        qij(:) = transq(ii, jj, env, denseDesc, prefac, sTimesGrndEigVecs, grndEigVecs)
+        qProduct(ij) = qProduct(ij) + prefac * dot_product(qij, vector)
       end do
       !!$OMP END PARALLEL DO
 
@@ -796,10 +772,10 @@ contains
 
 
   !> Calculates atomic transition charges for a specified excitation.
-  !> Calculates qij = 0.5 * (c_i S c_j + c_j S c_i) where c_i and c_j are selected eigenvectors, and
-  !> S the overlap matrix.
-  !> Since qij is an atomic quantity (so far) the corresponding values for the atom are summed up.
-  !> Note: the parameters 'updwn' were added for spin alpha and beta channels.
+  !! Calculates qij = 0.5 * (c_i S c_j + c_j S c_i) where c_i and c_j are selected eigenvectors, and
+  !! S the overlap matrix.
+  !! Since qij is an atomic quantity (so far) the corresponding values for the atom are summed up.
+  !! Note: the parameters 'updwn' were added for spin alpha and beta channels.
   function transq(ii, jj, env, denseDesc, updwn, sTimesGrndEigVecs, grndEigVecs) result(qij)
 
     !> Index of initial state
@@ -814,8 +790,8 @@ contains
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc
 
-    !> Up spin channel (T) or down spin channel (F)
-    logical, intent(in) :: updwn
+    !> Up spin channel (+1) or down spin channel (-1)
+    real(dp), intent(in) :: updwn
 
     !> Overlap times eigenvector: sum_m Smn cmi (nOrb, nOrb)
     real(dp), intent(in) :: sTimesGrndEigVecs(:,:,:)
@@ -828,17 +804,15 @@ contains
 
     integer :: kk, aa, bb, ss
     real(dp), allocatable :: qTmp(:)
+    integer, parameter :: indx(-1:1) = [2,0,1] ! corresponds to ordering in updwnSign()
 
-  #:if WITH_SCALAPACK
+  #:if WITH_MPI
 
     call error('Direct call to transq not allowed under MPI.')
 
   #:endif
 
-    ss = 1
-    if (.not. updwn) then
-      ss = 2
-    end if
+    ss = indx(int(updwn))
 
     allocate(qTmp(size(grndEigVecs,dim=1)))
     qTmp(:) =  grndEigVecs(:,ii,ss) * sTimesGrndEigVecs(:,jj,ss)&
@@ -851,5 +825,23 @@ contains
     end do
 
   end function transq
+
+
+  !> Returns +1 if ii <= jj, -1 otherwise, i.e., +1 if jj > ii.
+  pure function updwnSign(ii, jj)
+
+    !> First index
+    integer, intent(in) :: ii
+
+    !> Second index
+    integer, intent(in) :: jj
+
+    !> Resulting signed value
+    real(dp) :: updwnSign
+
+    ! Fortran defn. sign(a,b) : if b>=0 then abs(a), else -abs(a).
+    updwnSign = real(sign(1, jj - ii), dp)
+
+  end function updwnSign
 
 end module dftbp_timedep_transcharges

--- a/test/app/dftb+/tests
+++ b/test/app/dftb+/tests
@@ -442,7 +442,7 @@ timedep/C4H6-S1-Force_uncache          #? WITH_ARPACK and not WITH_MPI
 timedep/NH-Force-spinpol               #? WITH_ARPACK and not WITH_MPI
 
 timedep/C4H6-S1-Force_uncache-Stratmann #? not WITH_MPI
-timedep/NH-Force-spinpol-Stratmann     #? not WITH_MPI
+timedep/NH-Force-spinpol-Stratmann     #? MPI_PROCS <= 4
 
 timedep/cyclopentadienyl               #? WITH_ARPACK and MPI_PROCS <= 4
 timedep/C6H6-Sym                       #? WITH_ARPACK and MPI_PROCS <= 8

--- a/test/app/dftb+/timedep/NH-Force-spinpol-Stratmann/dftb_in.hsd
+++ b/test/app/dftb+/timedep/NH-Force-spinpol-Stratmann/dftb_in.hsd
@@ -63,4 +63,5 @@ Parallel {
   # Allow OMP threads explicitely to test for hybrid parallelisation with
   # MPI-binary. (Check the manual before using this in production runs!)
   UseOmpThreads = Yes
+  Blacs = BlockSize { 1 } # Very small for testing only
 }


### PR DESCRIPTION
Remove if branches inside loops and some comment clean-up.

Gives about a 10% speed-up over the timedep test set.