### PR TITLE
Use symmetric rank-k update for distributed density matrix

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -47,6 +47,8 @@ contributed to DFTB+ :
 
 * Jan Hermann (Free University of Berlin, Germany)
 
+* Yuze Hou (Peking University, China)
+
 * Jacek Jakowski (Oak Ridge National Laboratory, USA)
 
 * Eisuke Kawashima (RIKEN, Japan)

--- a/src/dftbp/dftb/densitymatrix.F90
+++ b/src/dftbp/dftb/densitymatrix.F90
@@ -20,8 +20,8 @@ module dftbp_dftb_densitymatrix
   use dftbp_math_blasroutines, only : herk
   use dftbp_type_commontypes, only : TParallelKS
 #:if WITH_SCALAPACK
-  use dftbp_extlibs_scalapackfx, only : blacsgrid, blocklist, M_, pblasfx_pgemm, pblasfx_psyrk,&
-      & pblasfx_ptran, pblasfx_ptranc, scalafx_islocal, size
+  use dftbp_extlibs_scalapackfx, only : blacsgrid, blocklist, CSRC_, NB_, pblasfx_pgemm,&
+      & pblasfx_psyrk, pblasfx_ptran, pblasfx_ptranc, scalafx_indxl2g, scalafx_islocal, size
 #:endif
 #:if WITH_MAGMA
   use iso_fortran_env, only : int64
@@ -913,15 +913,18 @@ contains
     !> Scratch array with the same shape and descriptor as matrix
     real(dp), intent(inout) :: work(:,:)
 
-    integer :: ii, iLocRow, iLocCol
+    integer :: ii, iGlob, iLocRow, iLocCol
     logical :: isLocal
 
     ! Mirror the lower triangle into the upper triangle by adding the transpose;
     ! this doubles the diagonal, which is halved afterwards.
     work(:,:) = matrix
     call pblasfx_ptran(work, desc, matrix, desc, alpha=1.0_dp, beta=1.0_dp)
-    do ii = 1, desc(M_)
-      call scalafx_islocal(myBlacs, desc, ii, ii, isLocal, iLocRow, iLocCol)
+    ! Halve the diagonal. Loop over this rank's local columns only (rather than the
+    ! full matrix order on every rank, which would scale serially).
+    do ii = 1, size(matrix, dim=2)
+      iGlob = scalafx_indxl2g(ii, desc(NB_), myBlacs%mycol, desc(CSRC_), myBlacs%ncol)
+      call scalafx_islocal(myBlacs, desc, iGlob, iGlob, isLocal, iLocRow, iLocCol)
       if (isLocal) then
         matrix(iLocRow, iLocCol) = 0.5_dp * matrix(iLocRow, iLocCol)
       end if

--- a/src/dftbp/dftb/densitymatrix.F90
+++ b/src/dftbp/dftb/densitymatrix.F90
@@ -20,7 +20,8 @@ module dftbp_dftb_densitymatrix
   use dftbp_math_blasroutines, only : herk
   use dftbp_type_commontypes, only : TParallelKS
 #:if WITH_SCALAPACK
-  use dftbp_extlibs_scalapackfx, only : blacsgrid, blocklist, pblasfx_pgemm, pblasfx_ptranc, size
+  use dftbp_extlibs_scalapackfx, only : blacsgrid, blocklist, M_, pblasfx_pgemm, pblasfx_psyrk,&
+      & pblasfx_ptran, pblasfx_ptranc, scalafx_islocal, size
 #:endif
 #:if WITH_MAGMA
   use iso_fortran_env, only : int64
@@ -832,7 +833,8 @@ contains
     !> Eigenvalues, if energy weighted density matrix required
     real(dp), intent(in), optional :: eigenVals(:)
 
-    integer  :: ii, jj, iGlob, iLoc, blockSize
+    integer  :: ii, jj, iGlob, iLoc, blockSize, iLocRow, iLocCol
+    logical :: isLocal
     type(blocklist) :: blocks
     real(dp), allocatable :: work(:,:)
 
@@ -842,23 +844,48 @@ contains
     ! Scale a copy of the eigenvectors
     call blocks%init(myBlacs, desc, "c")
     if (present(eigenVals)) then
+      ! Energy-weighted matrix: eigenvalues of occupied states may be negative,
+      ! so the rank-k update below is not applicable. Use a matrix product.
       do ii = 1, size(blocks)
         call blocks%getblock(ii, iGlob, iLoc, blockSize)
         do jj = 0, blockSize - 1
           work(:, iLoc + jj) = eigenVecs(:, iLoc + jj) * eigenVals(iGlob + jj) * filling(iGlob + jj)
         end do
       end do
-    else
+      call pblasfx_pgemm(eigenVecs, desc, work, desc, densityMtx, desc, transb="T")
+    else if (minval(filling) < 0.0_dp) then
+      ! Some occupations are negative (e.g. Methfessel-Paxton filling), so
+      ! sqrt(filling) is not real. Use a matrix product, as above.
       do ii = 1, size(blocks)
         call blocks%getblock(ii, iGlob, iLoc, blockSize)
         do jj = 0, blockSize - 1
           work(:, iLoc + jj) = eigenVecs(:, iLoc + jj) * filling(iGlob + jj)
         end do
       end do
+      call pblasfx_pgemm(eigenVecs, desc, work, desc, densityMtx, desc, transb="T")
+    else
+      ! For non-negative occupations the density matrix rho = V diag(f) V^T equals
+      ! W W^T with W = V sqrt(f). This symmetric rank-k update forms only one
+      ! triangle, roughly halving the work of the matrix product above. The
+      ! serial (herk) and GPU (syrk) density-matrix builds already do this.
+      do ii = 1, size(blocks)
+        call blocks%getblock(ii, iGlob, iLoc, blockSize)
+        do jj = 0, blockSize - 1
+          work(:, iLoc + jj) = eigenVecs(:, iLoc + jj) * sqrt(filling(iGlob + jj))
+        end do
+      end do
+      call pblasfx_psyrk(work, desc, densityMtx, desc, uplo="L", trans="N")
+      ! psyrk fills only the lower triangle. Mirror it into the upper triangle by
+      ! adding the transpose; this doubles the diagonal, which is halved below.
+      work(:,:) = densityMtx
+      call pblasfx_ptran(work, desc, densityMtx, desc, alpha=1.0_dp, beta=1.0_dp)
+      do ii = 1, desc(M_)
+        call scalafx_islocal(myBlacs, desc, ii, ii, isLocal, iLocRow, iLocCol)
+        if (isLocal) then
+          densityMtx(iLocRow, iLocCol) = 0.5_dp * densityMtx(iLocRow, iLocCol)
+        end if
+      end do
     end if
-
-    ! Create matrix
-    call pblasfx_pgemm(eigenVecs, desc, work, desc, densityMtx, desc, transb="T")
 
   end subroutine makeDensityMtxRealBlacs
 

--- a/src/dftbp/dftb/densitymatrix.F90
+++ b/src/dftbp/dftb/densitymatrix.F90
@@ -833,8 +833,7 @@ contains
     !> Eigenvalues, if energy weighted density matrix required
     real(dp), intent(in), optional :: eigenVals(:)
 
-    integer  :: ii, jj, iGlob, iLoc, blockSize, iLocRow, iLocCol
-    logical :: isLocal
+    integer  :: ii, jj, iGlob, iLoc, blockSize
     type(blocklist) :: blocks
     real(dp), allocatable :: work(:,:)
 
@@ -844,18 +843,35 @@ contains
     ! Scale a copy of the eigenvectors
     call blocks%init(myBlacs, desc, "c")
     if (present(eigenVals)) then
-      ! Energy-weighted matrix: eigenvalues of occupied states may be negative,
-      ! so the rank-k update below is not applicable. Use a matrix product.
-      do ii = 1, size(blocks)
-        call blocks%getblock(ii, iGlob, iLoc, blockSize)
-        do jj = 0, blockSize - 1
-          work(:, iLoc + jj) = eigenVecs(:, iLoc + jj) * eigenVals(iGlob + jj) * filling(iGlob + jj)
+      if (all(filling * eigenVals <= 0.0_dp)) then
+        ! Energy-weighted matrix W = V diag(f e) V^T. When every occupied product
+        ! f*e is non-positive (the common case, occupied levels below the reference
+        ! energy), W = -(Y Y^T) with Y = V sqrt(-f e), so a symmetric rank-k update
+        ! with a prefactor of -1 applies, as for the density matrix below.
+        do ii = 1, size(blocks)
+          call blocks%getblock(ii, iGlob, iLoc, blockSize)
+          do jj = 0, blockSize - 1
+            work(:, iLoc + jj) = eigenVecs(:, iLoc + jj)&
+                & * sqrt(-eigenVals(iGlob + jj) * filling(iGlob + jj))
+          end do
         end do
-      end do
-      call pblasfx_pgemm(eigenVecs, desc, work, desc, densityMtx, desc, transb="T")
-    else if (minval(filling) < 0.0_dp) then
+        call pblasfx_psyrk(work, desc, densityMtx, desc, uplo="L", trans="N", alpha=-1.0_dp)
+        call addLowerTriangleTranspose(myBlacs, desc, densityMtx, work)
+      else
+        ! Occupied products f*e have mixed signs, so the rank-k update is not
+        ! applicable. Use a matrix product.
+        do ii = 1, size(blocks)
+          call blocks%getblock(ii, iGlob, iLoc, blockSize)
+          do jj = 0, blockSize - 1
+            work(:, iLoc + jj) = eigenVecs(:, iLoc + jj) * eigenVals(iGlob + jj)&
+                & * filling(iGlob + jj)
+          end do
+        end do
+        call pblasfx_pgemm(eigenVecs, desc, work, desc, densityMtx, desc, transb="T")
+      end if
+    else if (any(filling < 0.0_dp)) then
       ! Some occupations are negative (e.g. Methfessel-Paxton filling), so
-      ! sqrt(filling) is not real. Use a matrix product, as above.
+      ! sqrt(filling) is not real. Use a matrix product.
       do ii = 1, size(blocks)
         call blocks%getblock(ii, iGlob, iLoc, blockSize)
         do jj = 0, blockSize - 1
@@ -875,19 +891,43 @@ contains
         end do
       end do
       call pblasfx_psyrk(work, desc, densityMtx, desc, uplo="L", trans="N")
-      ! psyrk fills only the lower triangle. Mirror it into the upper triangle by
-      ! adding the transpose; this doubles the diagonal, which is halved below.
-      work(:,:) = densityMtx
-      call pblasfx_ptran(work, desc, densityMtx, desc, alpha=1.0_dp, beta=1.0_dp)
-      do ii = 1, desc(M_)
-        call scalafx_islocal(myBlacs, desc, ii, ii, isLocal, iLocRow, iLocCol)
-        if (isLocal) then
-          densityMtx(iLocRow, iLocCol) = 0.5_dp * densityMtx(iLocRow, iLocCol)
-        end if
-      end do
+      call addLowerTriangleTranspose(myBlacs, desc, densityMtx, work)
     end if
 
   end subroutine makeDensityMtxRealBlacs
+
+
+  !> Completes a symmetric matrix held as its lower triangle (as produced by a
+  !> rank-k update) by adding its transpose and correcting the doubled diagonal.
+  subroutine addLowerTriangleTranspose(myBlacs, desc, matrix, work)
+
+    !> BLACS grid information
+    type(blacsgrid), intent(in) :: myBlacs
+
+    !> Matrix descriptor
+    integer, intent(in) :: desc(:)
+
+    !> Lower triangle on entry, full symmetric matrix on exit
+    real(dp), intent(inout) :: matrix(:,:)
+
+    !> Scratch array with the same shape and descriptor as matrix
+    real(dp), intent(inout) :: work(:,:)
+
+    integer :: ii, iLocRow, iLocCol
+    logical :: isLocal
+
+    ! Mirror the lower triangle into the upper triangle by adding the transpose;
+    ! this doubles the diagonal, which is halved afterwards.
+    work(:,:) = matrix
+    call pblasfx_ptran(work, desc, matrix, desc, alpha=1.0_dp, beta=1.0_dp)
+    do ii = 1, desc(M_)
+      call scalafx_islocal(myBlacs, desc, ii, ii, isLocal, iLocRow, iLocCol)
+      if (isLocal) then
+        matrix(iLocRow, iLocCol) = 0.5_dp * matrix(iLocRow, iLocCol)
+      end if
+    end do
+
+  end subroutine addLowerTriangleTranspose
 
 
   !> Create density or energy weighted density matrix (complex) for both triangles.

--- a/src/dftbp/extlibs/scalapackfx.F90
+++ b/src/dftbp/extlibs/scalapackfx.F90
@@ -12,7 +12,8 @@ module dftbp_extlibs_scalapackfx
 #:if WITH_SCALAPACK
   use libscalapackfx_module, only : blacsfx_gemr2d, blacsfx_gsum, blacsgrid, blocklist, CSRC_,&
       & DLEN_, linecomm, M_, MB_, N_, NB_, pblasfx_pgemm, pblasfx_phemm, pblasfx_psymm,&
-      & pblasfx_psymv, pblasfx_ptran, pblasfx_ptranc, pblasfx_ptranu, RSRC_, scalafx_addg2l, scalafx_addl2g,&
+      & pblasfx_psymv, pblasfx_psyrk, pblasfx_ptran, pblasfx_ptranc, pblasfx_ptranu, RSRC_,&
+      & scalafx_addg2l, scalafx_addl2g,&
       & scalafx_cpg2l, scalafx_cpl2g, scalafx_getdescriptor, scalafx_getlocalshape,&
       & scalafx_indxl2g, scalafx_infog2l, scalafx_islocal, scalafx_pgetri, scalafx_pgetrf, scalafx_phegv,&
       & scalafx_phegvd, scalafx_phegvr, scalafx_pposv, scalafx_ppotrf, scalafx_ppotri,&


### PR DESCRIPTION
## Summary

`makeDensityMtxRealBlacs` builds the (non energy-weighted) distributed density matrix with a full `PGEMM`. For non-negative occupations, `rho = V diag(f) V^T = W W^T` with `W = V sqrt(f)`, so a symmetric rank-k update (`PSYRK`) forms only one triangle and roughly halves the floating-point work. The lower triangle is then mirrored into the upper one and the doubled diagonal halved. The serial (`herk`) and GPU (`syrk`) density-matrix builds already use a rank-k update; this brings the ScaLAPACK path in line.

## Correctness / fallbacks

The rank-k form assumes non-negative weights, so the existing `PGEMM` is kept where that does not hold:

- the energy-weighted matrix — occupied eigenvalues may be negative;
- negative occupations, e.g. Methfessel-Paxton filling, where `sqrt(f)` is not real.

Both fallback paths are byte-for-byte unchanged.

## Notes

- First of several upstreaming contributions discussed by email with Ben Hourahine; this is the self-contained, internal-only one (no input or interface change).
- Re-exports `pblasfx_psyrk` from the `scalapackfx` wrapper module.
- `AUTHORS.rst` updated.
