### PR TITLE
Handle tiny occupation weights in distributed rank-k density matrix

### DIFF
--- a/src/dftbp/dftb/densitymatrix.F90
+++ b/src/dftbp/dftb/densitymatrix.F90
@@ -13,15 +13,16 @@
 !! Caveat: The routines create the transposed and complex conjugated of the density matrices
 !! (cc* instead of the conventional c*c).
 module dftbp_dftb_densitymatrix
-  use dftbp_common_accuracy, only : dp, lc
+  use dftbp_common_accuracy, only : dp, lc, rdp
   use dftbp_common_constants, only : imag, pi
   use dftbp_common_status, only : TStatus
   use dftbp_elecsolvers_dmsolvertypes, only : densityMatrixTypes
   use dftbp_math_blasroutines, only : herk
   use dftbp_type_commontypes, only : TParallelKS
 #:if WITH_SCALAPACK
-  use dftbp_extlibs_scalapackfx, only : blacsgrid, blocklist, CSRC_, NB_, pblasfx_pgemm,&
-      & pblasfx_psyrk, pblasfx_ptran, pblasfx_ptranc, scalafx_indxl2g, scalafx_islocal, size
+  use dftbp_extlibs_scalapackfx, only : blacsgrid, blocklist, pblasfx_pgemm, pblasfx_psyr,&
+      & pblasfx_psyrk, pblasfx_ptranc, size
+  use dftbp_math_matrixops, only : adjointLowerTriangle_BLACS
 #:endif
 #:if WITH_MAGMA
   use iso_fortran_env, only : int64
@@ -833,33 +834,67 @@ contains
     !> Eigenvalues, if energy weighted density matrix required
     real(dp), intent(in), optional :: eigenVals(:)
 
-    integer  :: ii, jj, iGlob, iLoc, blockSize
+    integer  :: ii, jj, iGlob, iLoc, blockSize, iLev, nTiny
     type(blocklist) :: blocks
     real(dp), allocatable :: work(:,:)
+    real(dp) :: weight
+
+    ! Square-rooting occupation weights close to underflow in the rank-k updates below has
+    ! been observed to destabilise subsequent ScaLAPACK eigensolver (MRRR) calls for some
+    ! compiler/library combinations. Levels with weight magnitude in [dropTol, sqrt(eps))
+    ! are therefore applied through exact rank-1 updates instead, while weights below
+    ! dropTol are dropped: a few times eps is still negligible in any matrix element, and
+    ! truncating at 1 * eps has been observed to be insufficient for some compilers.
+    ! Should more than maxRank1 levels fall into the rank-1 window (each update is a
+    ! memory-bound level-2 pass over the distributed matrix), the plain matrix product is
+    ! used instead. The thresholds are anchored to double precision, matching the
+    ! ScaLAPACK solver behaviour they guard against, rather than the working kind.
+    real(dp), parameter :: sqrtEps = sqrt(epsilon(1.0_rdp))
+    real(dp), parameter :: dropTol = 16.0_dp * epsilon(1.0_rdp)
+    integer, parameter :: maxRank1 = 32
 
     densityMtx(:, :) = 0.0_dp
     work = densityMtx
 
-    ! Scale a copy of the eigenvectors
+    ! Scale a copy of the eigenvectors. Note: filling and eigenVals are replicated, so all
+    ! ranks take identical branches below and the collective calls stay matched.
     call blocks%init(myBlacs, desc, "c")
     if (present(eigenVals)) then
-      if (all(filling * eigenVals <= 0.0_dp)) then
+      nTiny = count(abs(filling * eigenVals) >= dropTol&
+          & .and. abs(filling * eigenVals) < sqrtEps)
+      if (all(filling * eigenVals <= 0.0_dp .or. abs(filling * eigenVals) < dropTol)&
+          & .and. nTiny <= maxRank1) then
         ! Energy-weighted matrix W = V diag(f e) V^T. When every occupied product
         ! f*e is non-positive (the common case, occupied levels below the reference
         ! energy), W = -(Y Y^T) with Y = V sqrt(-f e), so a symmetric rank-k update
-        ! with a prefactor of -1 applies, as for the density matrix below.
+        ! with a prefactor of -1 applies, as for the density matrix below. Products
+        ! below dropTol in magnitude are negligible either way, so they cannot veto
+        ! this path. The .not. form of the weight test keeps non-finite weights on
+        ! the square-root path, so they stay visible in the result.
         do ii = 1, size(blocks)
           call blocks%getblock(ii, iGlob, iLoc, blockSize)
           do jj = 0, blockSize - 1
-            work(:, iLoc + jj) = eigenVecs(:, iLoc + jj)&
-                & * sqrt(-eigenVals(iGlob + jj) * filling(iGlob + jj))
+            if (.not. (-eigenVals(iGlob + jj) * filling(iGlob + jj) < sqrtEps)) then
+              work(:, iLoc + jj) = eigenVecs(:, iLoc + jj)&
+                  & * sqrt(-eigenVals(iGlob + jj) * filling(iGlob + jj))
+            else
+              work(:, iLoc + jj) = 0.0_dp
+            end if
           end do
         end do
         call pblasfx_psyrk(work, desc, densityMtx, desc, uplo="L", trans="N", alpha=-1.0_dp)
-        call addLowerTriangleTranspose(myBlacs, desc, densityMtx, work)
+        do iLev = 1, size(filling)
+          weight = eigenVals(iLev) * filling(iLev)
+          if (-weight >= dropTol .and. -weight < sqrtEps) then
+            call pblasfx_psyr(eigenVecs, desc, densityMtx, desc, uplo="L", alpha=weight,&
+                & jx=iLev)
+          end if
+        end do
+        call adjointLowerTriangle_BLACS(desc, myBlacs%mycol, myBlacs%myrow, myBlacs%ncol,&
+            & myBlacs%nrow, densityMtx)
       else
-        ! Occupied products f*e have mixed signs, so the rank-k update is not
-        ! applicable. Use a matrix product.
+        ! Occupied products f*e have mixed signs (or too many levels fall into the
+        ! rank-1 window), so the rank-k update is not applicable. Use a matrix product.
         do ii = 1, size(blocks)
           call blocks%getblock(ii, iGlob, iLoc, blockSize)
           do jj = 0, blockSize - 1
@@ -869,68 +904,49 @@ contains
         end do
         call pblasfx_pgemm(eigenVecs, desc, work, desc, densityMtx, desc, transb="T")
       end if
-    else if (any(filling < 0.0_dp)) then
-      ! Some occupations are negative (e.g. Methfessel-Paxton filling), so
-      ! sqrt(filling) is not real. Use a matrix product.
-      do ii = 1, size(blocks)
-        call blocks%getblock(ii, iGlob, iLoc, blockSize)
-        do jj = 0, blockSize - 1
-          work(:, iLoc + jj) = eigenVecs(:, iLoc + jj) * filling(iGlob + jj)
-        end do
-      end do
-      call pblasfx_pgemm(eigenVecs, desc, work, desc, densityMtx, desc, transb="T")
     else
-      ! For non-negative occupations the density matrix rho = V diag(f) V^T equals
-      ! W W^T with W = V sqrt(f). This symmetric rank-k update forms only one
-      ! triangle, roughly halving the work of the matrix product above. The
-      ! serial (herk) and GPU (syrk) density-matrix builds already do this.
-      do ii = 1, size(blocks)
-        call blocks%getblock(ii, iGlob, iLoc, blockSize)
-        do jj = 0, blockSize - 1
-          work(:, iLoc + jj) = eigenVecs(:, iLoc + jj) * sqrt(filling(iGlob + jj))
+      nTiny = count(filling >= dropTol .and. filling < sqrtEps)
+      if (any(filling < -dropTol) .or. nTiny > maxRank1) then
+        ! Some occupations are meaningfully negative (e.g. Methfessel-Paxton filling),
+        ! so sqrt(filling) is not real (or too many levels fall into the rank-1
+        ! window). Use a matrix product.
+        do ii = 1, size(blocks)
+          call blocks%getblock(ii, iGlob, iLoc, blockSize)
+          do jj = 0, blockSize - 1
+            work(:, iLoc + jj) = eigenVecs(:, iLoc + jj) * filling(iGlob + jj)
+          end do
         end do
-      end do
-      call pblasfx_psyrk(work, desc, densityMtx, desc, uplo="L", trans="N")
-      call addLowerTriangleTranspose(myBlacs, desc, densityMtx, work)
+        call pblasfx_pgemm(eigenVecs, desc, work, desc, densityMtx, desc, transb="T")
+      else
+        ! For non-negative occupations the density matrix rho = V diag(f) V^T equals
+        ! W W^T with W = V sqrt(f). This symmetric rank-k update forms only one
+        ! triangle, roughly halving the work of the matrix product above. The
+        ! serial (herk) and GPU (syrk) density-matrix builds already do this. The
+        ! .not. form of the weight test keeps non-finite occupations on the
+        ! square-root path, so they stay visible in the result.
+        do ii = 1, size(blocks)
+          call blocks%getblock(ii, iGlob, iLoc, blockSize)
+          do jj = 0, blockSize - 1
+            if (.not. (filling(iGlob + jj) < sqrtEps)) then
+              work(:, iLoc + jj) = eigenVecs(:, iLoc + jj) * sqrt(filling(iGlob + jj))
+            else
+              work(:, iLoc + jj) = 0.0_dp
+            end if
+          end do
+        end do
+        call pblasfx_psyrk(work, desc, densityMtx, desc, uplo="L", trans="N")
+        do iLev = 1, size(filling)
+          if (filling(iLev) >= dropTol .and. filling(iLev) < sqrtEps) then
+            call pblasfx_psyr(eigenVecs, desc, densityMtx, desc, uplo="L",&
+                & alpha=filling(iLev), jx=iLev)
+          end if
+        end do
+        call adjointLowerTriangle_BLACS(desc, myBlacs%mycol, myBlacs%myrow, myBlacs%ncol,&
+            & myBlacs%nrow, densityMtx)
+      end if
     end if
 
   end subroutine makeDensityMtxRealBlacs
-
-
-  !> Completes a symmetric matrix held as its lower triangle (as produced by a
-  !> rank-k update) by adding its transpose and correcting the doubled diagonal.
-  subroutine addLowerTriangleTranspose(myBlacs, desc, matrix, work)
-
-    !> BLACS grid information
-    type(blacsgrid), intent(in) :: myBlacs
-
-    !> Matrix descriptor
-    integer, intent(in) :: desc(:)
-
-    !> Lower triangle on entry, full symmetric matrix on exit
-    real(dp), intent(inout) :: matrix(:,:)
-
-    !> Scratch array with the same shape and descriptor as matrix
-    real(dp), intent(inout) :: work(:,:)
-
-    integer :: ii, iGlob, iLocRow, iLocCol
-    logical :: isLocal
-
-    ! Mirror the lower triangle into the upper triangle by adding the transpose;
-    ! this doubles the diagonal, which is halved afterwards.
-    work(:,:) = matrix
-    call pblasfx_ptran(work, desc, matrix, desc, alpha=1.0_dp, beta=1.0_dp)
-    ! Halve the diagonal. Loop over this rank's local columns only (rather than the
-    ! full matrix order on every rank, which would scale serially).
-    do ii = 1, size(matrix, dim=2)
-      iGlob = scalafx_indxl2g(ii, desc(NB_), myBlacs%mycol, desc(CSRC_), myBlacs%ncol)
-      call scalafx_islocal(myBlacs, desc, iGlob, iGlob, isLocal, iLocRow, iLocCol)
-      if (isLocal) then
-        matrix(iLocRow, iLocCol) = 0.5_dp * matrix(iLocRow, iLocCol)
-      end if
-    end do
-
-  end subroutine addLowerTriangleTranspose
 
 
   !> Create density or energy weighted density matrix (complex) for both triangles.

--- a/src/dftbp/extlibs/scalapackfx.F90
+++ b/src/dftbp/extlibs/scalapackfx.F90
@@ -12,11 +12,11 @@ module dftbp_extlibs_scalapackfx
 #:if WITH_SCALAPACK
   use libscalapackfx_module, only : blacsfx_gemr2d, blacsfx_gsum, blacsgrid, blocklist, CSRC_,&
       & CTXT_, DLEN_, linecomm, M_, MB_, N_, NB_, pblasfx_pgemm, pblasfx_phemm, pblasfx_psymm,&
-      & pblasfx_psymv, pblasfx_psyrk, pblasfx_ptran, pblasfx_ptranc, pblasfx_ptranu, RSRC_,&
-      & scalafx_addg2l, scalafx_addl2g, scalafx_cpg2l, scalafx_cpl2g, scalafx_getdescriptor,&
-      & scalafx_getlocalshape, scalafx_indxl2g, scalafx_infog2l, scalafx_islocal, scalafx_pgetri,&
-      & scalafx_pgetrf, scalafx_phegv, scalafx_phegvd, scalafx_phegvr, scalafx_pposv,&
-      & scalafx_ppotrf, scalafx_numroc, scalafx_ppotri, scalafx_psygv, scalafx_psygvd,&
+      & pblasfx_psymv, pblasfx_psyr,pblasfx_psyrk, pblasfx_ptran, pblasfx_ptranc, pblasfx_ptranu,&
+      & RSRC_, scalafx_addg2l, scalafx_addl2g, scalafx_cpg2l, scalafx_cpl2g, scalafx_getdescriptor,&
+      & scalafx_getlocalshape, scalafx_indxl2g, scalafx_infog2l, scalafx_islocal, scalafx_numroc,&
+      & scalafx_pgetri, scalafx_pgetrf, scalafx_phegv, scalafx_phegvd, scalafx_phegvr,&
+      & scalafx_pposv, scalafx_ppotrf, scalafx_ppotri, scalafx_psygv, scalafx_psygvd,&
       & scalafx_psygvr, size
 #:endif
   implicit none


### PR DESCRIPTION
Fixes the regression-test failures @bhourahine reported against the rank-k density-matrix build from #1872: with some compiler/library combinations, `scc/C60_Fermi` ends with NaN outputs in the final SCC steps, set off by a Fermi occupation that is greater than zero but smaller than √ε, with a `dstegr2()` call inside the following diagonalisation failing with an impossible argument number.

### Diagnosis

Reproduced in part with Intel oneAPI 2025.3 + MKL ScaLAPACK. `scc/C60_Fermi` has six levels with occupations in [ε, √ε) (a triply degenerate level with f ≈ 5.5e-10 and one with 4.2e-14) plus ~114 Fermi-tail occupations below ε that never underflow to zero at the test's fixed Fermi level. With the rank-k build, MKL's PDSYEVR deterministically reports

```
DSTEGR2 parameter number -202 had an illegal value
```

on 1 MPI rank, in the diagonalisation right after these fillings settle (20/20 runs; 0/20 with the pre-#1872 PGEMM build of the same source). MKL recovers and still converges to the reference results (deviations ≤ 1e-12), while the NAG stack turns the same MRRR fragility into NaN. The DSTEGR2 defect itself appears to be library-side — under MKL it keeps triggering on the bit-level DM differences that remain after this fix — but square-rooting near-underflow occupations is the part the failing toolchains cannot tolerate (zeroing them was already shown to make the NAG failure disappear).

### Change

- Occupation weights with magnitude in [ε, √ε) are excluded from the square-rooted rank-k update and applied exactly through rank-1 updates (PDSYR, real α = f or f·e — no square root involved).
- Weights below ε are dropped: they contribute below double-precision resolution to any matrix element.
- Should more than a handful (32) of levels fall into the rank-1 window — each rank-1 update is a memory-bound level-2 pass over the distributed matrix, and a strongly smeared metallic system could put hundreds of levels there — the previous full matrix product is used instead.
- Products below ε in magnitude no longer veto the rank-k paths (previously a single virtual level with f·e = +1e-16 was enough to force the energy-weighted build onto PGEMM permanently).
- The weight tests use the `.not. (w < √ε)` form, so non-finite occupations still propagate through `sqrt` instead of being silently zeroed.
- `pblasfx_psyr` is re-exported from the scalapackfx wrapper module (as `pblasfx_psyrk` was in #1872).

### Validation (Intel oneAPI 2025.3 + MKL ScaLAPACK)

| check | result |
|---|---|
| `scc/C60_Fermi` vs reference, np = 1…16 | pass, worst deviation 1.2e-12 (forces now on the rank-k + rank-1 energy-weighted path) |
| same source built with the original PGEMM code, cross-compared at np = 1, 2, 4 | all fields agree to ≤ 1e-11 |
| vs the plain #1872 rank-k build at np = 2, 8 | ≤ 1.1e-12 |
| `scc/C60`, `scc/GaAs_2` | pass |

We have no NAG compiler available, so the confirmation for the originally failing combinations has to come from that side. The same treatment for the complex (PHERK) paths has been pushed to #1874.
