### PR TITLE
Add SinglePrecisionCycles option for the ELPA solver (via ELSI)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -93,3 +93,5 @@ contributed to DFTB+ :
 * Bo Thomsen (Japan Atomic Energy Agency, Japan)
 
 * Victor Yu (Duke University, USA)
+
+* Samuel Zheng (National Tsing Hua University, Taiwan)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,10 @@ Added
   with optional MPI redistribution to a lower number of ranks for all
   ELPA calls
 
+- SinglePrecisionCycles option for the ELPA solver (via the ELSI
+  library), solving the eigenvalue problem in the first few SCC cycles in
+  single precision
+
 
 Changed
 -------

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -2522,6 +2522,7 @@ It accepts following options
   \kw{PreferElsi} & l& & No & \\
   \kw{RedistributeFactor} & i& & 1 & \\
   \kw{RedistributeRanks} & p& RedistributeFactor = 1 & \cb & \\
+  \kw{SinglePrecisionCycles} & i& & 0 & \\
   \kw{Sparse} & l& & No & \\
 \end{ptable}
 \begin{description}
@@ -2547,6 +2548,17 @@ It accepts following options
   available if ELPA is included via the ELSI library.
 \item[\is{RedistributeRanks}] Explicit list of MPI ranks to be used to call
   ELPA, for example, \is{\{0, 2\}}. The matrix will be redistributed accordingly.
+\item[\is{SinglePrecisionCycles}] Number of initial SCC cycles for which the
+  eigenvalue problem is solved in single precision~\cite{kus2019optimizations}
+  (must be greater or equal to \is{0}, default: \is{0}, i.e., all cycles are
+  solved in double precision). All later SCC cycles, and therefore the final
+  results, are obtained in double precision, while the early cycles, where the
+  charges are far from self-consistency anyway, become considerably
+  cheaper. Depending on the requested \is{SCCTolerance}, a few additional SCC
+  cycles may be needed to reach self-consistency. This feature is only
+  available if ELPA is included via the ELSI library, and requires the
+  ELPA library within ELSI to have been built with single precision support
+  enabled.
 \item[\is{Sparse}] Whether the sparse matrix interface of ELPA should be used or
   the dense one (default: dense). The sparse interface does not reduce memory
   usage and is mainly for testing purposes.

--- a/doc/dftb+/manual/manual.bib
+++ b/doc/dftb+/manual/manual.bib
@@ -550,6 +550,20 @@ year = {2020}
   doi = {https://doi.org/10.1016/j.cpc.2020.107459}
 }
 
+@article{kus2019optimizations,
+  title = {Optimizations of the eigensolvers in the {ELPA} library},
+  author = {K\r{u}s, Pavel and Marek, Andreas and K{\"o}cher, Simone
+                  S. and Kowalski, Hermann-Herbert and Carbogno,
+                  Christian and Scheurer, Christoph and Reuter,
+                  Karsten and Scheffler, Matthias and Lederer,
+                  Hermann},
+  journal = {Parallel Computing},
+  volume = {85},
+  pages = {167-177},
+  year = {2019},
+  doi = {https://doi.org/10.1016/j.parco.2019.04.003}
+}
+
 @article{vuong2023accelerating,
   title={Accelerating the density-functional tight-binding method
                   using graphical processing units},

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -2751,6 +2751,17 @@ contains
               & the GPU acceleration for the ELPA solver")
         end if
       #:endif
+      call getChildValue(value1, "SinglePrecisionCycles", ctrl%solver%elpa%nSinglePrecCycles, 0,&
+          & child=child)
+      if (ctrl%solver%elpa%nSinglePrecCycles < 0) then
+        call detailedError(child, "SinglePrecisionCycles must not be negative")
+      end if
+      #:if not WITH_ELSI
+        if (ctrl%solver%elpa%nSinglePrecCycles /= 0) then
+          call detailedError(child, "Single precision cycles are only possible if ELPA is&
+              & included via the ELSI library")
+        end if
+      #:endif
       call getChildValue(value1, "RedistributeFactor", ctrl%solver%elpa%redistributeFactor, 1,&
           & child=child)
       #:if not WITH_ELPA

--- a/src/dftbp/elecsolvers/elpa.F90
+++ b/src/dftbp/elecsolvers/elpa.F90
@@ -52,6 +52,9 @@ module dftbp_elecsolvers_elpa
     !> Whether to use the ELSI library for calling ELPA
     logical :: preferElsi = .false.
 
+    !> Number of initial SCC cycles solved in single precision (requires the ELSI interface)
+    integer :: nSinglePrecCycles = 0
+
     !> On what fraction of the original number of ranks to redistribute the matrix
     integer :: redistributeFactor = 1
 
@@ -190,6 +193,11 @@ contains
 
     if (env%blacs%rowBlockSize /= env%blacs%columnBlockSize) then
       call error("Error during ELPA initialization: different block sizes for rows and columns")
+    end if
+
+    if (inp%nSinglePrecCycles /= 0) then
+      call error("SinglePrecisionCycles is only supported if ELPA is called via the ELSI library&
+          & (set PreferElsi = Yes)")
     end if
 
     status = elpa_init(20220510) ! minimum ELPA version is 2022.05.001

--- a/src/dftbp/elecsolvers/elsisolver.F90
+++ b/src/dftbp/elecsolvers/elsisolver.F90
@@ -38,9 +38,10 @@ module dftbp_elecsolvers_elsisolver
       & elsi_get_edm_complex_sparse, elsi_get_edm_real, elsi_get_edm_real_sparse, elsi_get_entropy,&
       & elsi_get_mu, elsi_get_pexsi_mu_max, elsi_get_pexsi_mu_min, elsi_get_version, elsi_init,&
       & elsi_init_rw, elsi_reinit, elsi_set_blacs, elsi_set_csc, elsi_set_csc_blk,&
-      & elsi_set_elpa_autotune, elsi_set_elpa_gpu, elsi_set_elpa_solver, elsi_set_kpoint,&
-      & elsi_set_mpi, elsi_set_mpi_global, elsi_set_mu_broaden_scheme, elsi_set_mu_broaden_width,&
-      & elsi_set_mu_mp_order, elsi_set_ntpoly_filter, elsi_set_ntpoly_method, elsi_set_ntpoly_tol,&
+      & elsi_set_elpa_autotune, elsi_set_elpa_gpu, elsi_set_elpa_n_single, elsi_set_elpa_solver,&
+      & elsi_set_kpoint, elsi_set_mpi, elsi_set_mpi_global, elsi_set_mu_broaden_scheme,&
+      & elsi_set_mu_broaden_width, elsi_set_mu_mp_order, elsi_set_ntpoly_filter,&
+      & elsi_set_ntpoly_method, elsi_set_ntpoly_tol,&
       & elsi_set_omm_flavor, elsi_set_omm_n_elpa, elsi_set_omm_tol, elsi_set_output,&
       & elsi_set_output_log, elsi_set_pexsi_delta_e, elsi_set_pexsi_method, elsi_set_pexsi_mu_max,&
       & elsi_set_pexsi_mu_min, elsi_set_pexsi_n_mu, elsi_set_pexsi_n_pole,&
@@ -236,6 +237,9 @@ module dftbp_elecsolvers_elsisolver
 
     !> Whether ELPA uses GPUs (1=true)
     integer :: elpaGpu
+
+    !> Number of initial SCC cycles solved by ELPA in single precision
+    integer :: elpaNSinglePrec
 
     !! OMM settings
 
@@ -485,6 +489,10 @@ contains
       else
         this%elpaGpu = 0
       end if
+      if (inpElpa%nSinglePrecCycles < 0) then
+        call error("Number of single precision cycles for the ELPA solver must not be negative")
+      end if
+      this%elpaNSinglePrec = inpElpa%nSinglePrecCycles
     end if
 
     ! OMM settings
@@ -679,6 +687,10 @@ contains
 
         call elsi_set_elpa_autotune(this%handle, this%elpaAutotune)
         call elsi_set_elpa_gpu(this%handle, this%elpaGpu)
+        if (this%elpaNSinglePrec > 0) then
+          ! solve the first SCC cycles in single precision, later ones in double precision
+          call elsi_set_elpa_n_single(this%handle, this%elpaNSinglePrec)
+        end if
 
       case(electronicSolverTypes%omm)
         ! libOMM

--- a/src/dftbp/extlibs/elsiiface.F90
+++ b/src/dftbp/extlibs/elsiiface.F90
@@ -19,8 +19,8 @@ module dftbp_extlibs_elsiiface
       & elsi_get_edm_real_sparse, elsi_get_entropy, elsi_get_mu, elsi_get_pexsi_mu_max,&
       & elsi_get_pexsi_mu_min, elsi_get_version, elsi_handle, elsi_init, elsi_init_rw, elsi_reinit,&
       & elsi_rw_handle, elsi_set_blacs, elsi_set_csc, elsi_set_csc_blk, elsi_set_elpa_autotune,&
-      & elsi_set_elpa_gpu, elsi_set_elpa_solver, elsi_set_kpoint, elsi_set_mpi,&
-      & elsi_set_mpi_global, elsi_set_mu_broaden_scheme, elsi_set_mu_broaden_width,&
+      & elsi_set_elpa_gpu, elsi_set_elpa_n_single, elsi_set_elpa_solver, elsi_set_kpoint,&
+      & elsi_set_mpi, elsi_set_mpi_global, elsi_set_mu_broaden_scheme, elsi_set_mu_broaden_width,&
       & elsi_set_mu_mp_order, elsi_set_ntpoly_filter, elsi_set_ntpoly_method, elsi_set_ntpoly_tol,&
       & elsi_set_omm_flavor, elsi_set_omm_n_elpa, elsi_set_omm_tol, elsi_set_output,&
       & elsi_set_output_log, elsi_set_pexsi_delta_e, elsi_set_pexsi_method, elsi_set_pexsi_mu_max,&
@@ -53,7 +53,8 @@ module dftbp_extlibs_elsiiface
   public :: elsi_set_pexsi_mu_min, elsi_set_pexsi_mu_max
   public :: elsi_get_mu, elsi_get_entropy
   public :: elsi_set_mu_mp_order, elsi_set_mu_broaden_width, elsi_set_mu_broaden_scheme
-  public :: elsi_set_elpa_solver, elsi_set_elpa_autotune, elsi_set_elpa_gpu
+  public :: elsi_set_elpa_solver, elsi_set_elpa_autotune, elsi_set_elpa_gpu,&
+      & elsi_set_elpa_n_single
   public :: elsi_set_omm_flavor, elsi_set_omm_n_elpa, elsi_set_omm_tol
   public :: elsi_set_pexsi_method
   public :: elsi_set_pexsi_np_per_pole, elsi_set_pexsi_temp, elsi_set_pexsi_n_pole
@@ -293,6 +294,13 @@ contains
     integer(i4), intent(in) :: gpu
     call stubError("elsi_set_elpa_gpu")
   end subroutine elsi_set_elpa_gpu
+
+
+  subroutine elsi_set_elpa_n_single(eh, n_single)
+    type(elsi_handle), intent(inout) :: eh
+    integer(i4), intent(in) :: n_single
+    call stubError("elsi_set_elpa_n_single")
+  end subroutine elsi_set_elpa_n_single
 
 
   subroutine elsi_set_kpoint(eh, n_kpt, i_kpt, i_wt)


### PR DESCRIPTION
### Motivation

ELSI has long provided a mixed-precision mode for its ELPA interface
(`elsi_set_elpa_n_single`, part of the ELPA-AEO work, Kus et al., Parallel
Computing 85 (2019) 167, arXiv:1806.01036): the first *n* solves after
(re)initialisation are carried out by ELPA in single precision, all later
solves in double precision. Since the early SCC iterations operate on charges
that are still far from self-consistency, solving them to ~7 significant
digits is enough — the SCC loop itself irons out the difference, and the
final iterations (and hence the converged result) are full double precision.
In the ELPA-AEO paper the effect of the mixed-precision startup on converged
total energies was below ~1e-6 eV.

DFTB+ currently never calls `elsi_set_elpa_n_single`, so this lever is
inaccessible to users. This PR exposes it as an option of the `ELPA{}` solver
block.

Why it is worth having: on large dense problems the eigensolve dominates the
SCC iteration cost, and a single-precision ELPA solve runs substantially
faster than the double-precision one (roughly 1.5–1.9x per solve in the
ELPA-AEO paper). We have not benchmarked `elsi_set_elpa_n_single` itself in
DFTB+ (that is exactly what this PR enables); the closest measurement we do
have is an analogous FP32-early/FP64-tail SCC schedule implemented on a GPU
eigensolver backend for the same system class (8000-atom 3C-SiC, n = 32,000
basis functions, DFTB+ 25.1): 382 s -> 269 s (~1.4x) for the precision change
alone, converged total energy within 1.4e-9 H of the all-double reference.
(The 382 s is itself down from a 420 s FP64 baseline, but that first step came
from moving the density-matrix build onto the GPU and is a separate lever, so
it is not counted here.) For a run with 10+ SCC iterations, solving the early
ones in single precision saves a significant fraction of the total wall clock
at no cost to the converged result.

(Caveat on that measurement: the 8000-atom cell is an antisite-defected
geometry that came with an input deck I cannot redistribute, so the figure is
not independently reproducible as it stands. I will rebuild the case on a
generated geometry with a CPU-eigensolver reference and re-measure.)

### What changed

- `ELPA{ SinglePrecisionCycles = <int> }` HSD option (default `0` =
  unchanged current behaviour). Parsed in `parser.F90` in the same way as the
  other ELPA-block options, stored in `TElpaInp`, copied into `TElsiSolver`,
  and applied via a new `elsi_set_elpa_n_single` wrapper in
  `dftbp_extlibs_elsiiface` (with the usual stub for non-ELSI builds).
- The ELSI call is made only when the value is positive, so default inputs
  produce a bit-identical call sequence to current `main`.
- Validation:
  - negative values are rejected (parser `detailedError` + a defensive check
    in `TElsiSolver_init` for API-driven inputs);
  - builds without ELSI reject a non-zero value at parse time;
  - if the standalone ELPA path is dispatched (built `WITH_ELPA` and
    `PreferElsi = No`), `TElpa_init` stops with an error pointing the user to
    `PreferElsi = Yes` — the option is deliberately not implemented for the
    standalone path in this PR (the standalone `TElpa` type is double
    precision only at the moment; can be done as a follow-up if there is
    interest).
- Manual: new entry in the ELPA solver block section (including the pointer
  that a few extra SCC iterations may be needed depending on `SCCTolerance`),
  with the ELPA-AEO reference added to `manual.bib`.
- `CHANGELOG.rst`: entry under Unreleased/Added.

Files touched: `src/dftbp/dftbplus/parser.F90`,
`src/dftbp/elecsolvers/elpa.F90`, `src/dftbp/elecsolvers/elsisolver.F90`,
`src/dftbp/extlibs/elsiiface.F90`, `doc/dftb+/manual/dftbp.tex`,
`doc/dftb+/manual/manual.bib`, `CHANGELOG.rst`.

### Accuracy discussion

- Only the first `SinglePrecisionCycles` diagonalisations are affected. As
  long as the SCC loop still converges (it does in all our tests of the
  GPU-eigensolver analogue, sometimes with 1–2 extra iterations), the
  converged energies/forces are produced by double-precision solves and match
  the reference to the usual SCC tolerance; ELPA-AEO reports total-energy
  deviations below ~1e-6 eV.
- Results within the *first* iterations (e.g. non-SCC runs printing the first
  diagonalisation) would be single precision — hence the conservative default
  of 0, and the manual wording that later cycles/final results stay double
  precision.
- One thing reviewers may want to weigh in on: ELSI applies `elpa_n_single`
  to the first *n* solves after `elsi_init`/`elsi_reinit`. Since DFTB+ calls
  `elsi_reinit` on geometry changes, the single-precision startup applies to
  the first iterations of each geometry step of an MD/relaxation run. That
  falls out of ELSI resetting its call counter on reinit rather than from a
  deliberate choice on our part, so whether it is the desired semantics is a
  decision for the maintainers rather than something we should assert.
- Requirement on the ELSI side: the linked ELPA must provide single-precision
  routines (ELSI's internal ELPA does; an external ELPA needs
  `--enable-single-precision`). If it does not, ELSI fails the solve at run
  time; we did not add a configure-time check — input welcome on whether one
  is wanted.

### Test plan

- Serial (no MPI/ELSI/ELPA) Debug build with GNU 13.2 compiles cleanly with
  this branch; fypp expansion checked for the WITH_ELSI / WITH_ELPA-only /
  serial variants. [Done locally.]
- Not yet validated in an ELSI build. The serial build above does not compile
  the ELSI code path, so this change has not yet been exercised. Before taking
  this out of draft I intend to do a `WITH_ELSI=1` MPI build and run `ctest`
  over the existing `solvers/*_ELPA*` cases to confirm the defaults are
  regression-free, plus a manual run of `Si384_ELPA2` with the new option set.
  I will report those results here rather than ask for review before they
  exist.
- Offer to maintainers: add an autotest case (clone of an existing ELPA test
  with `SinglePrecisionCycles = 2`); its references should agree with the
  double-precision ones within autotest tolerances since the final iterations
  are double precision. Depends on the CI ELSI build having single-precision
  ELPA support.
