### PR TITLE
Add NrOfEmptyStates option to restrict the ELPA eigenspectrum (via ELSI)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,10 @@ Added
   with optional MPI redistribution to a lower number of ranks for all
   ELPA calls
 
+- NrOfEmptyStates option for the ELPA solver (via the ELSI library),
+  restricting the eigenspectrum to the occupied states plus a window
+  of empty states instead of computing all eigenvectors
+
 
 Changed
 -------

--- a/doc/dftb+/manual/dftbp.tex
+++ b/doc/dftb+/manual/dftbp.tex
@@ -2519,6 +2519,7 @@ It accepts following options
   \kw{AutotuneFile} & s& Autotune = Yes & "elpa\_autotune\_state.out" & \\
   \kw{Gpu}    & l& & No & \\
   \kw{Mode} & i& & 2 & \\
+  \kw{NrOfEmptyStates} & i& & -1 & \\
   \kw{PreferElsi} & l& & No & \\
   \kw{RedistributeFactor} & i& & 1 & \\
   \kw{RedistributeRanks} & p& RedistributeFactor = 1 & \cb & \\
@@ -2535,6 +2536,25 @@ It accepts following options
 \item[\is{Mode}] ELPA operation mode (possible values: \is{1}, \is{2},
   default: \is{2}). Mode 2 is supposed to be more efficient for large problems.
   Mode 1 is strongly recommended if \is{Gpu = Yes}.
+\item[\is{NrOfEmptyStates}] If set to zero or a positive value, the
+  eigenspectrum solved by ELPA is restricted to the (nominally) occupied
+  states plus this number of empty states above them, instead of computing
+  eigenvectors for all states. As only (partially) occupied states contribute
+  to the density matrix, a sufficiently large window yields the same self
+  consistent results at a reduced solver cost, which can be substantial for
+  large systems. The window must cover all states with non-negligible
+  occupations: for finite electron temperatures (see p.~\pref{sec:dftbp.Filling})
+  enough empty states must be included to also cover the smearing tail of the
+  distribution, and the code stops with an error if states above the window
+  would carry occupations larger than $10^{-7}$. Eigenvalues are still
+  obtained for the full spectrum, but eigenvectors of states above the window
+  are not available and those states are excluded from the density
+  matrix. This option should therefore not be combined with features that
+  require eigenvectors of unoccupied states (for example eigenvector output
+  or response calculations involving empty states). Negative values (default:
+  \is{-1}) compute the full spectrum. This feature is only available if ELPA
+  is included via the ELSI library, using the dense interface (\is{Sparse} =
+  \is{No}).
 \item[\is{PreferElsi}] Whether to call ELPA using the ELSI interface. This
   setting is only relevant if \dftbp{} was built and linked with the ELSI
   library.

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -3362,6 +3362,12 @@ contains
     call getFillingsAndBandEnergies(eigen, nEl, nSpin, tempElec, kWeight, tSpinSharedEf,&
         & tFillKSep, tFixEf, iDistribFn, Ef, filling, energy%Eband, energy%TS, energy%E0, deltaDftb)
 
+    if (electronicSolver%isElsiSolver) then
+      ! If only part of the eigenspectrum was computed, states above the solved window must not
+      ! contribute to the density matrix
+      call electronicSolver%elsi%truncateFillings(filling)
+    end if
+
     call env%globalTimer%startTimer(globalTimers%densityMatrix)
     if (nSpin /= 4) then
       if (tRealHS) then

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -2751,6 +2751,18 @@ contains
               & the GPU acceleration for the ELPA solver")
         end if
       #:endif
+      call getChildValue(value1, "NrOfEmptyStates", ctrl%solver%elpa%nEmptyStates, -1,&
+          & child=child)
+      if (ctrl%solver%elpa%nEmptyStates >= 0) then
+        if (ctrl%solver%elsi%elsiCsr) then
+          call detailedError(child, "NrOfEmptyStates is not available for the sparse (density&
+              & matrix) interface of ELPA")
+        end if
+        #:if not WITH_ELSI
+          call detailedError(child, "Restricting the eigenspectrum is only possible if ELPA is&
+              & included via the ELSI library")
+        #:endif
+      end if
       call getChildValue(value1, "RedistributeFactor", ctrl%solver%elpa%redistributeFactor, 1,&
           & child=child)
       #:if not WITH_ELPA

--- a/src/dftbp/elecsolvers/elpa.F90
+++ b/src/dftbp/elecsolvers/elpa.F90
@@ -52,6 +52,10 @@ module dftbp_elecsolvers_elpa
     !> Whether to use the ELSI library for calling ELPA
     logical :: preferElsi = .false.
 
+    !> Number of empty states to solve above the occupied ones, if the eigenspectrum should be
+    !> restricted (negative: solve for all states, requires the ELSI interface otherwise)
+    integer :: nEmptyStates = -1
+
     !> On what fraction of the original number of ranks to redistribute the matrix
     integer :: redistributeFactor = 1
 
@@ -190,6 +194,11 @@ contains
 
     if (env%blacs%rowBlockSize /= env%blacs%columnBlockSize) then
       call error("Error during ELPA initialization: different block sizes for rows and columns")
+    end if
+
+    if (inp%nEmptyStates >= 0) then
+      call error("NrOfEmptyStates is only supported if ELPA is called via the ELSI library&
+          & (set PreferElsi = Yes)")
     end if
 
     status = elpa_init(20220510) ! minimum ELPA version is 2022.05.001

--- a/src/dftbp/elecsolvers/elsisolver.F90
+++ b/src/dftbp/elecsolvers/elsisolver.F90
@@ -9,7 +9,7 @@
 
 !> Contains the interface to the ELSI solvers
 module dftbp_elecsolvers_elsisolver
-  use dftbp_common_accuracy, only : dp, lc
+  use dftbp_common_accuracy, only : dp, elecTolMax, lc
   use dftbp_common_environment, only : globalTimers, TEnvironment
   use dftbp_common_globalenv, only : stdOut
   use dftbp_common_version, only : TVersion
@@ -299,6 +299,7 @@ module dftbp_elecsolvers_elsisolver
     procedure :: reset => TElsiSolver_reset
     procedure :: updateGeometry => TElsiSolver_updateGeometry
     procedure :: updateElectronicTemp => TElsiSolver_updateElectronicTemp
+    procedure :: truncateFillings => TElsiSolver_truncateFillings
     procedure :: getDensity => TElsiSolver_getDensity
     procedure :: getEDensity => TElsiSolver_getEDensity
     procedure :: initPexsiDeltaVRanges => TElsiSolver_initPexsiDeltaVRanges
@@ -361,6 +362,7 @@ contains
 
     character(lc) :: buffer
     integer :: version(3)
+    integer :: nOccupied
 
     call elsi_get_version(version(1), version(2), version(3))
     call supportedVersionNumber(TVersion(version(1), version(2), version(3)))
@@ -371,8 +373,21 @@ contains
 
     case (electronicSolverTypes%elpa)
       this%solver = elsiEnum%ELPA_SOLVER
-      ! ELPA is asked for all states
+      ! By default ELPA is asked for all states
       this%nState = nBasisFn
+      if (allocated(inpElpa)) then
+        if (inpElpa%nEmptyStates >= 0) then
+          ! Restrict the eigenspectrum to the occupied states and a window of empty states
+          ! above them. The same window is used for all spin channels and k-points, so for
+          ! spin polarised cases the occupied states of both channels are counted.
+          if (nSpin == 1) then
+            nOccupied = ceiling(sum(nEl) * 0.5_dp)
+          else
+            nOccupied = ceiling(sum(nEl))
+          end if
+          this%nState = min(nBasisFn, max(1, nOccupied + inpElpa%nEmptyStates))
+        end if
+      end if
 
     case (electronicSolverTypes%omm)
       this%solver = elsiEnum%OMM_SOLVER
@@ -835,6 +850,48 @@ contains
   #:endif
 
   end subroutine TElsiSolver_updateElectronicTemp
+
+
+  !> Removes any occupation from states above the eigenspectrum window solved by ELPA.
+  !>
+  !> If the solver was asked for a part of the eigenspectrum only, the states above the solved
+  !> window have no eigenvectors available and must not contribute to the density matrix. The
+  !> routine stops with an error, if those states would carry a non-negligible occupation, as
+  !> the requested window is too small in that case.
+  subroutine TElsiSolver_truncateFillings(this, fillings)
+
+    !> Instance
+    class(TElsiSolver), intent(in) :: this
+
+    !> Occupations of the states (state, k-point, spin), as obtained for the full spectrum
+    real(dp), intent(inout) :: fillings(:,:,:)
+
+  #:if WITH_ELSI
+
+    character(lc) :: buffer
+    real(dp) :: maxTailFilling
+
+    if (this%iSolver /= electronicSolverTypes%elpa .or. this%nState >= this%nBasis) then
+      return
+    end if
+
+    maxTailFilling = maxval(abs(fillings(this%nState + 1 :, :, :)))
+    if (maxTailFilling > elecTolMax) then
+      write(buffer, "(A,ES10.2,A)") "States above the eigenspectrum window solved by ELPA would&
+          & carry occupations up to ", maxTailFilling, ". Increase NrOfEmptyStates, so that all&
+          & (partially) occupied states are covered by the window."
+      call error(trim(buffer))
+    end if
+    fillings(this%nState + 1 :, :, :) = 0.0_dp
+
+  #:else
+
+    call error("Internal error: TElsiSolver_truncateFillings() called despite missing ELSI&
+        & support")
+
+  #:endif
+
+  end subroutine TElsiSolver_truncateFillings
 
 
   !> Returns the density matrix using ELSI non-diagonalisation routines.


### PR DESCRIPTION
### Motivation

For the dense ELPA path, DFTB+ always asks the solver for the complete
eigenspectrum: `TElsiSolver_init` sets `nState = nBasisFn`, which ELSI passes
to ELPA as `nev`. However, only the (partially) occupied states contribute to
the density matrix, and ELPA supports computing a partial spectrum: the
tridiagonal stage still yields *all* eigenvalues, but eigenvector
back-transformation — a large share of the solve time — is only done for the
requested `nev` states. In typical DFTB systems the occupied manifold is only a
fraction of the basis — for this SiC case it is half (16,000 occupied states in
a 32,000-function basis; the basis is sp on both species, with no d shell) — so
about half of the eigenvector work is spent on states that are never used.

Measurements (DFTB+ 25.1 + ELSI 2.9.1, ELPA 2-stage, CPU, single node,
16 MPI ranks; 8000-atom 3C-SiC supercell, n = 32,000 basis functions, Fermi
filling T = 40 K, static SCC run):

- all states (current behaviour): 2792 s wall clock;
- occupied + 64 empty states: 2267 s wall clock — **1.23x** end-to-end;
- buffer sweep: 64 and 1600 empty states both ran to convergence (2267 s and
  2326 s), with the converged total energy identical to the all-states
  reference in all printed digits (-12200.7869138229 H) in both. A 256-state
  buffer was checked only for the first two SCC iterations, where it agreed;
  no convergence run was recorded for it.

At low electronic temperature the states above the occupied manifold carry
occupations far below the density-matrix drop tolerance, so the
self-consistent solution is unchanged while the eigensolver does
substantially less work; the insensitivity of the result to the buffer size
(64 vs 1600) shows the window is not aggressive.

(Caveat on the benchmark: the 8000-atom cell is an antisite-defected geometry
that came with an input deck I cannot redistribute, so these numbers are not
independently reproducible as they stand. I will rebuild the case on a
generated geometry with a reference from an all-states run and re-measure on
it; happy to add other sizes at the same time.)

### What changed

- `ELPA{ NrOfEmptyStates = <int> }` HSD option. If >= 0, the ELSI/ELPA solver
  is asked for `min(nBasis, nOccupied + NrOfEmptyStates)` states instead of
  all of them (`nOccupied` counted like the existing OMM branch, summed over
  spin channels so that every parallel group uses the same window; `ceiling`
  rather than `nint` so fractional occupation never undercounts). Negative
  values (default `-1`) keep the current all-states behaviour — default
  inputs are bit-identical to current `main`.
- Safety net for the occupation tail: a new `TElsiSolver%truncateFillings`,
  called in `main.F90` directly after `getFillingsAndBandEnergies`:
  - it stops with a clear error if any state above the solved window would
    carry an occupation above `elecTolMax` (1e-7, the existing electron-count
    tolerance) — i.e. if the window is too small for the chosen filling
    temperature (or for non-Aufbau/Delta-DFTB promotions into states above
    the window);
  - otherwise it zeroes the (negligible) occupations above the window, so the
    corresponding eigenvector columns — which ELSI leaves as workspace
    content, not results — can never leak into the density / energy-weighted
    density matrix, on any of the density-matrix build paths.
  - No-op whenever the full spectrum was computed, i.e. for every existing
    input.
- Fermi level, fillings, band energy, entropy and the printed band structure
  are computed from the eigenvalues, which ELPA still returns for the full
  spectrum — these are unaffected by construction.
- Guards: option rejected for the sparse (`Sparse = Yes`, density-matrix)
  interface and for non-ELSI builds at parse time; the standalone ELPA path
  (`WITH_ELPA`, `PreferElsi = No`) stops in `TElpa_init` with a pointer to
  `PreferElsi = Yes`. Extending the standalone path via ELPA's `nev` would be
  a natural follow-up (contained in `TElpa_initConfig`), but is left out here
  to keep the change reviewable.
- Manual: new entry in the ELPA block documenting the semantics, the
  interaction with the filling temperature (window must cover the smearing
  tail; the run aborts if occupations above the window exceed 1e-7), and that
  the option must not be combined with features needing unoccupied
  eigenvectors (eigenvector output, response-type calculations).
- `CHANGELOG.rst`: entry under Unreleased/Added.

Files touched: `src/dftbp/dftbplus/parser.F90`, `src/dftbp/dftbplus/main.F90`,
`src/dftbp/elecsolvers/elpa.F90`, `src/dftbp/elecsolvers/elsisolver.F90`,
`doc/dftb+/manual/dftbp.tex`, `CHANGELOG.rst`.

### Accuracy discussion (honest limitations)

- Correctness requires the window to cover *all* states with non-negligible
  occupation. This is not silently assumed: every SCC iteration the actual
  fillings above the window are checked against `elecTolMax` and the run
  aborts with an actionable message if they are exceeded. For metals or high
  electronic temperatures the user therefore needs a correspondingly larger
  `NrOfEmptyStates` (the error message says so); for gapped systems at
  ordinary temperatures a buffer of O(100) states is already generous, as the
  buffer sweep above shows.
- States above the window have no eigenvectors. Downstream features that use
  unoccupied eigenvectors (WriteEigenvectors output of empty states,
  perturbation/response modules, Casida via ground-state vectors) must not be
  combined with a reduced window — currently documented in the manual; if
  maintainers prefer, we can add hard incompatibility checks in
  `initprogram` for the relevant options (suggestions welcome on which list
  to guard).
- The density matrix misses the (enforced < 1e-7) occupation tail, so the
  Mulliken charge sum can deviate from the electron count by up to roughly
  that order; the band energy/entropy still include the exact tail since
  they come from the eigenvalues. In practice (see table) the converged
  results were bit-identical.
- ELSI detail that shaped the implementation: with `nev < nBasis` ELSI's
  back-transformation writes only the first `nState` eigenvector columns, and
  the remaining columns of the caller's array contain leftover *workspace*
  data (checked against `elsi_elpa.f90` of ELSI 2.9.1). Zeroing the tail
  *fillings* (rather than trying to blank distributed matrix columns) makes
  every density-matrix path ignore those columns exactly, including the
  rank-1 update paths of `makeDensityMtxRealBlacs` that would otherwise pick
  up tiny-but-nonzero tail occupations.

### Test plan

- Serial (no MPI/ELSI/ELPA) Debug build with GNU 13.2 compiles cleanly with
  this branch (includes the always-compiled `truncateFillings` interface and
  the `main.F90` call site); fypp expansion checked for WITH_ELSI /
  WITH_ELPA-only / serial variants. [Done locally.]
- Not yet validated in an ELSI build. The serial build above does not compile
  the ELSI code path, so this change has not yet been exercised. Before taking
  this out of draft I intend to do a `WITH_ELSI=1` MPI build and run `ctest`
  over the existing `solvers/*_ELPA*` cases to confirm the defaults are
  regression-free (`nState` only changes when the new option is set), plus
  manual runs of `Si384_ELPA2` with `NrOfEmptyStates = 16 / 64` checking
  (a) unchanged tagged results and (b) that the error triggers when the window
  is made deliberately too small (e.g. `NrOfEmptyStates = 0` with a high
  filling temperature). I will report those results here rather than ask for
  review before they exist.
- Offer to maintainers: add autotest cases (clone of an existing dense ELPA
  test with `NrOfEmptyStates` set); references should match the existing ones
  within tolerances.
