### PR TITLE
More accurate kWeight normalisation

### DIFF
--- a/src/dftbp/dftb/periodic.F90
+++ b/src/dftbp/dftb/periodic.F90
@@ -1233,8 +1233,8 @@ contains
     allocate(allKWeights(nAllKPoint))
     call asArray(lr1, allKPoints)
     call destruct(lr1)
-    allKPoints = modulo(allKPoints, 1.0_dp)
-    allKWeights = 1.0_dp / real(nAllKPoint, dp)
+    allKPoints(:,:) = modulo(allKPoints, 1.0_dp)
+    allKWeights(:) = 1.0_dp / real(nAllKPoint, dp)
 
     ! Reduce by inversion if needed
     if (tReduce) then

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -105,6 +105,7 @@ module dftbp_dftbplus_initprogram
   use dftbp_math_randomgenpool, only : init, TRandomGenPool
   use dftbp_math_ranlux, only : getRandom, TRanlux
   use dftbp_math_simplealgebra, only : determinant33, diagonal, invert33
+  use dftbp_math_summation, only : kahanSum
   use dftbp_md_thermostats, only : createThermostat, thermostatTypes, TThermostat
   use dftbp_md_mdcommon, only : init, TMDCommon, TMDOutput
   use dftbp_md_mdintegrator, only : init, TMDIntegrator
@@ -1539,7 +1540,8 @@ contains
       if (sum(input%ctrl%kWeight) < epsilon(1.0_dp)) then
         call error("Sum of k-point weights should be greater than zero!")
       end if
-      this%kWeight(:) = input%ctrl%kWeight / sum(input%ctrl%kWeight)
+
+      this%kWeight(:) = input%ctrl%kWeight / kahanSum(input%ctrl%kWeight)
       if (this%tHelical) then
         if (any(abs(this%kPoint(2,:) * nint(this%latVec(3,1)) - nint(this%kPoint(2,:) *&
             & nint(this%latVec(3,1)))) > input%ctrl%helicalSymTol)) then

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -104,6 +104,7 @@ module dftbp_dftbplus_initprogram
   use dftbp_math_randomgenpool, only : init, TRandomGenPool
   use dftbp_math_ranlux, only : getRandom, TRanlux
   use dftbp_math_simplealgebra, only : determinant33, diagonal, invert33
+  use dftbp_math_summation, only : kahanSum
   use dftbp_md_thermostats, only : createThermostat, thermostatTypes, TThermostat
   use dftbp_md_mdcommon, only : init, TMDCommon, TMDOutput
   use dftbp_md_mdintegrator, only : init, TMDIntegrator
@@ -1538,7 +1539,8 @@ contains
       if (sum(input%ctrl%kWeight) < epsilon(1.0_dp)) then
         call error("Sum of k-point weights should be greater than zero!")
       end if
-      this%kWeight(:) = input%ctrl%kWeight / sum(input%ctrl%kWeight)
+
+      this%kWeight(:) = input%ctrl%kWeight / kahanSum(input%ctrl%kWeight)
       if (this%tHelical) then
         if (any(abs(this%kPoint(2,:) * nint(this%latVec(3,1)) - nint(this%kPoint(2,:) *&
             & nint(this%latVec(3,1)))) > input%ctrl%helicalSymTol)) then

--- a/src/dftbp/math/summation.F90
+++ b/src/dftbp/math/summation.F90
@@ -11,13 +11,13 @@ module dftbp_math_summation
   implicit none
 
   private
-  public :: kahan
+  public :: kahan, kahanSum
 
 contains
 
   !> Kahan–Babušk compensated summation with Neumaier improvement
   !! Note, compiler should not be allowed to optimise this out
-  pure subroutine kahan(summation, input, compensator)
+  subroutine kahan(summation, input, compensator)
 
     !> Value being accumulated over sum
     real(dp), intent(inout) :: summation
@@ -28,7 +28,7 @@ contains
     !> Compensator for underflow
     real(dp), intent(inout) :: compensator
 
-    real(dp) :: tmp
+    real(dp), volatile :: tmp
 
     tmp = summation + input
     ! Neumaier improvement
@@ -40,5 +40,27 @@ contains
     summation = tmp
 
   end subroutine kahan
+
+
+  !> Sum function for a 1D array
+  function kahanSum(input)
+
+    !> Array to total up
+    real(dp), intent(in) :: input(:)
+
+    !> Function result
+    real(dp) :: kahanSum
+
+    real(dp) :: compensator
+    integer :: ii
+
+    compensator = 0.0_dp
+    kahanSum = 0.0_dp
+    do ii = 1, size(input)
+      call kahan(kahanSum, input(ii), compensator)
+    end do
+    kahanSum = kahanSum + compensator
+
+  end function kahanSum
 
 end module dftbp_math_summation


### PR DESCRIPTION
For large k-grids, underflow affects the normalisation of sum(kWeights). Also block compiler optimisation of Kahan sum.