### PR TITLE
Relax periodic boundary condition error into warning

### DIFF
--- a/src/dftbp/type/typegeometryhsd.F90
+++ b/src/dftbp/type/typegeometryhsd.F90
@@ -817,7 +817,7 @@ contains
           call getNextToken(commandInput, text, iStart, iErr)
           call checkError(node, iErr, "Error reading boundary in command file")
           if (char(text) /= "p") then
-            call detailedError(node, "Only periodic boundary conditions supported")
+            call detailedWarning(node, "No periodic boundary condition in dimension " // i2c(i))
           end if
         end do
         call jumpToEndOfLine(commandInput, iStart)


### PR DESCRIPTION
Raise a warning instead of an error if the boundary condition in the Lammps input file is not 'periodic'. In some physical setups run by the FHI colleagues, the Lammps boundary condition is actually non-periodic, while effectively, it can be considered periodic in DFTB+.