### PR TITLE
Eliminate global stdout

### DIFF
--- a/app/dftb+/dftbplus.F90
+++ b/app/dftb+/dftbplus.F90
@@ -21,12 +21,13 @@ program dftbplus
   type(TEnvironment) :: env
   type(TInputData), allocatable :: input
   type(TDftbPlusMain), allocatable, target :: main
+  integer :: stdOut, stdErr
 
-  call initGlobalEnv()
-  call printDftbHeader(releaseName, releaseYear)
+  call initGlobalEnv(stdOut=stdOut, stdErr=stdErr)
+  call TEnvironment_init(env, stdOut=stdOut, stdErr=stdErr)
+  call printDftbHeader(env%stdOut, releaseName, releaseYear)
   allocate(input)
-  call parseHsdInput(input)
-  call TEnvironment_init(env)
+  call parseHsdInput(env, input)
   allocate(main)
   call main%initProgramVariables(input, env)
   deallocate(input)

--- a/app/dftb+/dftbplus.F90
+++ b/app/dftb+/dftbplus.F90
@@ -21,10 +21,10 @@ program dftbplus
   type(TEnvironment) :: env
   type(TInputData), allocatable :: input
   type(TDftbPlusMain), allocatable, target :: main
-  integer :: stdOut, stdErr
+  integer :: stdOut
 
-  call initGlobalEnv(stdOut=stdOut, stdErr=stdErr)
-  call TEnvironment_init(env, stdOut=stdOut, stdErr=stdErr)
+  call initGlobalEnv(stdOut=stdOut)
+  call TEnvironment_init(env, stdOut=stdOut)
   call printDftbHeader(env%stdOut, releaseName, releaseYear)
   allocate(input)
   call parseHsdInput(env, input)

--- a/app/misc/skderivs/skderivs.F90
+++ b/app/misc/skderivs/skderivs.F90
@@ -11,8 +11,9 @@
 program skderivs
   use dftbp_common_accuracy, only : dp, lc
   use dftbp_common_constants, only : maxL, shellNames
+  use dftbp_common_environment, only : TEnvironment, TEnvironment_init
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut
+  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv
   use dftbp_dftb_slakoeqgrid, only : getNIntegrals, getSKIntegrals, init, skEqGridNew, skEqGridOld,&
       & TSlakoEqGrid
   use dftbp_io_charmanip, only : i2c, unquote
@@ -28,6 +29,7 @@ program skderivs
       & string
 implicit none
 
+  type(TEnvironment) :: env
 
   !> Contains the data necessary for the main program
   type TInputData
@@ -43,24 +45,32 @@ implicit none
   !> input data for the calculation of the derivatives
   type(TInputData) :: inp
 
-#:if WITH_MPI
-  !> MPI environment, if compiled with mpifort
-  type(TMpiEnv) :: mpi
+  call initGlobalEnv()
+  call TEnvironment_init(env)
 
+#:if WITH_MPI
   ! As this is serial code, trap for run time execution on more than 1 processor with an mpi enabled
   ! build
-  call TMpiEnv_init(mpi)
-  call mpi%mpiSerialEnv()
+  call TMpiEnv_init(env%mpi)
+  if (.not. env%mpi%isSerialEnv()) then
+    call error('This is serial code, but invoked on multiple processors')
+  end if
 #:endif
 
-  call parseHSDInput(inp, "skderivs_in.hsd", "skderivs_in")
-  call main(inp)
+  call parseHSDInput(env, inp, "skderivs_in.hsd", "skderivs_in")
+  call main(env, inp)
+
+  call env%destruct()
+  call destructGlobalEnv()
 
 contains
 
 
   !> Does the main job of calculating derivatives and writing them to disc
-  subroutine main(inp)
+  subroutine main(env, inp)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> instance
     type(TInputData), intent(inout) :: inp
@@ -79,18 +89,18 @@ contains
     allocate(fdHam(size(inp%iHam)))
     allocate(fdOver(size(inp%iOver)))
 
-    write(stdout, "(A)") ""
-    write(stdout, "(A)") "Following files will be created:"
+    write(env%stdout, "(A)") ""
+    write(env%stdout, "(A)") "Following files will be created:"
     call resize_string(buffer, 1024)
     do ii = 1, size(inp%iHam)
       strTmp = trim(inp%output) // ".ham." // i2c(ii)
       call openFile(fdHam(ii), strTmp, mode="w")
-      write(stdout, "(2X,A)") trim(strTmp)
+      write(env%stdout, "(2X,A)") trim(strTmp)
     end do
     do ii = 1, size(inp%iOver)
       strTmp = trim(inp%output) // ".ovr." // i2c(ii)
       call openFile(fdOver(ii), strTmp, mode="w")
-      write(stdout, "(2X,A)") trim(strTmp)
+      write(env%stdout, "(2X,A)") trim(strTmp)
     end do
 
     do ii = 1, nGrid
@@ -154,7 +164,10 @@ contains
 
 
   !> Parses the HSD input
-  subroutine parseHSDInput(inp, hsdInputName, rootTag)
+  subroutine parseHSDInput(env, inp, hsdInputName, rootTag)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> parsed data
     type(TInputData), intent(out) :: inp
@@ -183,8 +196,8 @@ contains
 
     call parseHSD(rootTag, hsdInputName, root)
 
-    write(stdout, "(A)") repeat("-", 80)
-    write(stdout, "(A)") "Interpreting input file '" // hsdInputName // "'"
+    write(env%stdout, "(A)") repeat("-", 80)
+    write(env%stdout, "(A)") "Interpreting input file '" // hsdInputName // "'"
 
     call getChild(hsdTree, rootTag, root)
 
@@ -283,9 +296,9 @@ contains
     end if
 
     !! Issue warning about unprocessed nodes
-    call warnUnprocessedNodes(root)
-    write(stdout, "(A)") "Done."
-    write(stdout, "(A)") repeat("-", 80)
+    call warnUnprocessedNodes(env%stdOut, root)
+    write(env%stdout, "(A)") "Done."
+    write(env%stdout, "(A)") repeat("-", 80)
 
   end subroutine parseHSDInput
 

--- a/app/misc/slakovalue/integvalue.F90
+++ b/app/misc/slakovalue/integvalue.F90
@@ -9,12 +9,14 @@
 !! and second derivatives.
 program integvalue
   use dftbp_common_accuracy, only : dp, lc
-  use dftbp_common_globalenv, only : stdOut
+  use dftbp_common_environment, only : TEnvironment, TEnvironment_init
+  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv
   use dftbp_dftb_slakoeqgrid, only : getCutoff, getSKIntegrals, init, skEqGridNew, TSlakoEqGrid
   use dftbp_io_message, only : error
   use dftbp_type_oldskdata, only : readFromFile, TOldSKData
   implicit none
 
+  type(TEnvironment) :: env
   integer, parameter :: nSKInter = 20
   integer, parameter :: nSKInterOld = 10
   integer, parameter :: iSKInterOld(nSKInterOld) &
@@ -29,20 +31,29 @@ program integvalue
   real(dp), parameter :: rStart = 0.01_dp, dr = 0.001_dp
   real(dp), pointer :: data(:,:)
 
-  call processArguments(fname, homo, extended, col)
+  call initGlobalEnv()
+  call TEnvironment_init(env)
+
+  call processArguments(env, fname, homo, extended, col)
   call readFromFile(skdata, fname, homo)
   call getSkColumnData(extended, skData, col, data)
   call init(skgrid, skdata%dist, data, skEqGridNew)
   nPoint = floor((getCutoff(skgrid) - rStart) / dr) + 1
-  call writeValues(skgrid, rStart, dr, nPoint)
+  call writeValues(env%stdOut, skgrid, rStart, dr, nPoint)
+
+  call env%destruct()
+  call destructGlobalEnv()
 
 contains
 
 
   !> Prints help and stops.
-  subroutine printHelp()
+  subroutine printHelp(output)
 
-    write(stdout, "(A)") &
+    !> output for write processes
+    integer, intent(in) :: output
+
+    write(output, "(A)") &
         & "Usage: integvalue  {homo|hetero}  skfile {orig|ext} col",&
         & "",&
         "Reads an SK-file, extracts the given column in the integral table and&
@@ -63,7 +74,10 @@ contains
 
   !> Process program arguments.
   !!
-  subroutine processArguments(fname, homo, extended, col)
+  subroutine processArguments(env, fname, homo, extended, col)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> File name
     character(*), intent(out) :: fname
@@ -86,7 +100,7 @@ contains
     end if
     call get_command_argument(1, arg)
     if (arg == "-h" .or. arg == "--help") then
-      call printHelp()
+      call printHelp(env%stdOut)
     end if
     if (command_argument_count() /= 4) then
       call error("Invalid number of arguments. Use 'integvalue -h' to obtain&
@@ -159,7 +173,10 @@ contains
 
   !> Writes values on a given grid.
   !!
-  subroutine writeValues(skgrid, rStart, dr, nPoint)
+  subroutine writeValues(output, skgrid, rStart, dr, nPoint)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> SK data grid
     type(TSlakoEqGrid), intent(in) :: skgrid
@@ -181,7 +198,7 @@ contains
       call getSKIntegrals(skgrid, sk0, dist)
       call getSKIntegrals(skgrid, skp1, dist + deltaXDiff)
       call getSKIntegrals(skgrid, skm1, dist - deltaXDiff)
-      write(stdout, "(4E23.15)") dist, sk0, (skp1 - skm1) / deltaXDiff, &
+      write(output, "(4E23.15)") dist, sk0, (skp1 - skm1) / deltaXDiff, &
           & (skp1 + skm1 - 2.0_dp * sk0) / (deltaXDiff * deltaXDiff)
     end do
 

--- a/app/misc/slakovalue/integvalue.F90
+++ b/app/misc/slakovalue/integvalue.F90
@@ -50,7 +50,7 @@ contains
   !> Prints help and stops.
   subroutine printHelp(output)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     write(output, "(A)") &
@@ -175,7 +175,7 @@ contains
   !!
   subroutine writeValues(output, skgrid, rStart, dr, nPoint)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> SK data grid

--- a/app/misc/slakovalue/polyvalue.F90
+++ b/app/misc/slakovalue/polyvalue.F90
@@ -8,13 +8,15 @@
 !> Reads a spline repulsive from an SK-table and returns its value and its first
 !! and second derivatives.
 program polyvalue
+  use dftbp_common_environment, only : TEnvironment, TEnvironment_init
   use dftbp_common_accuracy, only : dp, lc
+  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut
-  use dftbp_dftb_repulsive_polyrep, only : TPolyRep, TPolyRep_init, TPolyRepInp
+  use dftbp_dftb_repulsive_polyrep, only : TPolyRepInp, TPolyRep, TPolyRep_init
   use dftbp_io_message, only : error
   implicit none
 
+  type(TEnvironment) :: env
   character(lc) :: arg, fname
   logical :: homo
   type(TPolyRepInp) :: polyRepInp
@@ -24,12 +26,15 @@ program polyvalue
   real(dp), parameter :: rstart = 0.01_dp, dr = 0.01_dp
   real(dp) :: rr, energy, dEnergy, d2Energy, rTemporary
 
+  call initGlobalEnv()
+  call TEnvironment_init(env)
+
   if (command_argument_count() == 0) then
     call error("Wrong number of arguments. Use 'polyvalue -h' to obtain help.")
   end if
   call get_command_argument(1, arg)
   if (arg == "-h" .or. arg == "--help") then
-    write(stdout, "(A)") &
+    write(env%stdOut, "(A)") &
         & "Usage: polyvalue  homo | hetero  skfile",&
         & "",&
         & "Reads an SK-file, extracts the polynomial repulsive from it and &
@@ -65,7 +70,10 @@ program polyvalue
   do ii = 0, nPoint
     rr = rStart + real(ii, dp) * dr
     call polyRep%getValue(rr, energy=energy, dEnergy=dEnergy, d2Energy=d2Energy)
-    write(stdout, "(4E23.15)") rr, energy, dEnergy, d2Energy
+    write(env%stdOut, "(4E23.15)") rr, energy, dEnergy, d2Energy
   end do
+
+  call env%destruct()
+  call destructGlobalEnv()
 
 end program polyvalue

--- a/app/misc/slakovalue/splvalue.F90
+++ b/app/misc/slakovalue/splvalue.F90
@@ -10,9 +10,10 @@
 !> Reads a spline repulsive from an SK-table and returns its value and its first
 !! and second derivatives.
 program splvalue
+  use dftbp_common_environment, only : TEnvironment, TEnvironment_init
   use dftbp_common_accuracy, only : dp, lc
+  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_dftb_repulsive_splinerep, only : TSplineRep, TSplineRep_init, TSplineRepInp
   use dftbp_io_message, only : error
   use dftbp_type_oldskdata, only : readsplinerep
@@ -21,6 +22,7 @@ program splvalue
 #:endif
   implicit none
 
+  type(TEnvironment) :: env
   character(*), parameter :: fname = "test.skf"
   character(lc) :: arg
   type(TSplineRepInp) :: splineRepInp
@@ -30,14 +32,16 @@ program splvalue
   real(dp), parameter :: rstart = 0.01_dp, dr = 0.01_dp
   real(dp) :: rr, energy, dEnergy, d2Energy
 
-#:if WITH_MPI
-  !> MPI environment, if compiled with mpifort
-  type(TMpiEnv) :: mpi
+  call initGlobalEnv()
+  call TEnvironment_init(env)
 
+#:if WITH_MPI
   ! As this is serial code, trap for run time execution on more than 1 processor with an mpi enabled
   ! build
-  call TMpiEnv_init(mpi)
-  call mpi%mpiSerialEnv()
+  call TMpiEnv_init(env%mpi)
+  if (.not. env%mpi%isSerialEnv()) then
+    call error('This is serial code, but invoked on multiple processors')
+  end if
 #:endif
 
   if (command_argument_count() /= 1) then
@@ -45,7 +49,7 @@ program splvalue
   end if
   call get_command_argument(1, arg)
   if (arg == "-h" .or. arg == "--help") then
-    write(stdout, "(A)") &
+    write(env%stdOut, "(A)") &
         & "Usage: splvalue [ options ] skfile",&
         & "",&
         & "Reads an SK-file, extracts the spline repulsive from it and prints &
@@ -68,7 +72,10 @@ program splvalue
   do ii = 0, npoint
     rr = rstart + real(ii, dp) * dr
     call splineRep%getValue(rr, energy=energy, dEnergy=dEnergy, d2Energy=d2Energy)
-    write(stdout, "(4E23.15)") rr, energy, dEnergy, d2Energy
+    write(env%stdOut, "(4E23.15)") rr, energy, dEnergy, d2Energy
   end do
+
+  call env%destruct()
+  call destructGlobalEnv()
 
 end program splvalue

--- a/app/modes/initmodes.F90
+++ b/app/modes/initmodes.F90
@@ -9,11 +9,11 @@
 
 !> Contains the routines for initialising modes.
 module modes_initmodes
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp, lc
   use dftbp_common_atomicmass, only : getAtomicMass
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_filesystem, only : findFile, getParamSearchPaths, joinPathsPrettyErr
-  use dftbp_common_globalenv, only : stdOut
+  use dftbp_common_filesystem, only : findFile, joinPathsPrettyErr, getParamSearchPaths
 #:if WITH_MAGMA
   use dftbp_common_gpuenv, only : TGpuEnv, TGpuEnv_init
 #:endif
@@ -144,8 +144,11 @@ module modes_initmodes
 contains
 
 
-  !> Initialise program variables.
-  subroutine initProgramVariables()
+  !> Initialise program variables
+  subroutine initProgramVariables(env)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     type(TOldSKData) :: skData
     type(fnode), pointer :: root, node, tmp, hsdTree
@@ -167,14 +170,14 @@ contains
     integer :: iErr
 
     !! Write header
-    call printDftbHeader('(MODES '// version //')', releaseYear)
+    call printDftbHeader(env%stdOut, '(MODES '// version //')', releaseYear)
 
     !! Read in input file as HSD
     call parseHSD(rootTag, hsdInput, hsdTree)
     call getChild(hsdTree, rootTag, root)
 
-    write(stdout, "(A)") "Interpreting input file '" // hsdInput // "'"
-    write(stdout, "(A)") repeat("-", 80)
+    write(env%stdOut, "(A)") "Interpreting input file '" // hsdInput // "'"
+    write(env%stdOut, "(A)") repeat("-", 80)
 
     !! Check if input version is the one, which we can handle
     call getChildValue(root, "InputVersion", inputVersion, parserVersion)
@@ -184,13 +187,13 @@ contains
     end if
 
     call getChild(root, "Geometry", tmp)
-    call readGeometry(tmp, geo)
+    call readGeometry(env, tmp, geo)
 
     call getChildValue(root, "RemoveTranslation", tRemoveTranslate, .false.)
     call getChildValue(root, "RemoveRotation", tRemoveRotate, .false.)
 
     call getChildValue(root, "Atoms", buffer2, "1:-1", child=child, multiple=.true.)
-    call getSelectedAtomIndices(child, char(buffer2), geo%speciesNames, geo%species, iMovedAtoms)
+    call getSelectedAtomIndices(env%stdOut, child, char(buffer2), geo%speciesNames, geo%species, iMovedAtoms)
     nMovedAtom = size(iMovedAtoms)
     nDerivs = 3 * nMovedAtom
 
@@ -201,7 +204,7 @@ contains
     if (associated(node)) then
       tPlotModes = .true.
       call getChildValue(node, "PlotModes", buffer2, "1:-1", child=child, multiple=.true.)
-      call getSelectedIndices(child, char(buffer2), [1, 3 * nMovedAtom], modesToPlot)
+      call getSelectedIndices(env%stdOut, child, char(buffer2), [1, 3 * nMovedAtom], modesToPlot)
       nModesToPlot = size(modesToPlot)
       call getChildValue(node, "Animate", tAnimateModes, .true.)
     end if
@@ -305,7 +308,7 @@ contains
       end do
     end if
 
-    call getInputMasses(root, geo, replacementMasses)
+    call getInputMasses(env, root, geo, replacementMasses)
     allocate(atomicMasses(nMovedAtom))
     do iAt = 1, nMovedAtom
       atomicMasses(iAt) = speciesMass(geo%species(iMovedAtoms(iAt)))
@@ -388,22 +391,25 @@ contains
     tEigenVectors = tPlotModes .or. allocated(bornMatrix) .or. allocated(bornDerivsMatrix)
 
     !! Issue warning about unprocessed nodes
-    call warnUnprocessedNodes(root, .true.)
+    call warnUnprocessedNodes(env%stdOut, root, .true.)
 
     !! Finish parsing, dump parsed and processed input
     if (tWriteHSD) then
       call dumpHSD(hsdTree, hsdParsedInput)
-      write(stdout, "(A)") "Processed input written as HSD to '" // hsdParsedInput // "'"
+      write(env%stdOut, "(A)") "Processed input written as HSD to '" // hsdParsedInput // "'"
     end if
-    write(stdout, "(A)") repeat("-", 80)
-    write(stdout, *)
+    write(env%stdOut, "(A)") repeat("-", 80)
+    write(env%stdOut, *)
     call destroyNode(hsdTree)
 
   end subroutine initProgramVariables
 
 
   !> Read in the geometry stored as gen format.
-  subroutine readGeometry(geonode, geo)
+  subroutine readGeometry(env, geonode, geo)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node containing the geometry
     type(fnode), pointer :: geonode
@@ -418,7 +424,7 @@ contains
     call getNodeName(child, buffer)
     select case (char(buffer))
     case ("genformat")
-      call readTGeometryGen(child, geo)
+      call readTGeometryGen(env, child, geo)
       call removeChildNodes(geonode)
       call writeTGeometryHSD(geonode, geo)
     case ("xyzformat")
@@ -426,7 +432,7 @@ contains
       call removeChildNodes(geonode)
       call writeTGeometryHSD(geonode, geo)
     case ("vaspformat")
-      call readTGeometryVasp(child, geo)
+      call readTGeometryVasp(env, child, geo)
       call removeChildNodes(geonode)
       call writeTGeometryHSD(geonode, geo)
     case default
@@ -436,8 +442,11 @@ contains
   end subroutine readGeometry
 
 
-  !> Reads atomic masses from input file.
-  subroutine getInputMasses(node, geo, masses)
+  !> Reads atomic masses from input file
+  subroutine getInputMasses(env, node, geo, masses)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Relevant node of input data
     type(fnode), pointer :: node
@@ -469,13 +478,13 @@ contains
     do ii = 1, getLength(children)
       call getItem1(children, ii, child2)
       call getChildValue(child2, "Atoms", buffer, child=child3, multiple=.true.)
-      call getSelectedAtomIndices(child3, char(buffer), geo%speciesNames, geo%species, pTmpI1)
+      call getSelectedAtomIndices(env%stdOut, child3, char(buffer), geo%speciesNames, geo%species, pTmpI1)
       call getChildValue(child2, "MassPerAtom", rTmp, modifier=modifier, child=child)
       call convertUnitHsd(char(modifier), massUnits, child, rTmp)
       do jj = 1, size(pTmpI1)
         iAt = pTmpI1(jj)
         if (masses(iAt) >= 0.0_dp) then
-          call detailedWarning(child3, "Previous setting for the mass  of atom" // i2c(iAt)&
+          call detailedWarning(env%stdOut, child3, "Previous setting for the mass  of atom" // i2c(iAt)&
               & // " overwritten")
         end if
         masses(iAt) = rTmp

--- a/app/modes/initmodes.F90
+++ b/app/modes/initmodes.F90
@@ -223,7 +223,7 @@ contains
       iSolver = solverTypes%relativelyRobust
     case ("magma")
     #:if WITH_MAGMA
-      call TGpuEnv_init(gpu)
+      call TGpuEnv_init(gpu, env%stdOut)
     #:else
       call error("Magma-solver selected, but program was compiled without MAGMA")
     #:endif

--- a/app/modes/modeprojection.F90
+++ b/app/modes/modeprojection.F90
@@ -24,9 +24,13 @@ module modes_modeprojection
 
 contains
 
-  !> Projection out of the space of the dynamical matrix.
-  subroutine project(dynMatrix, tRemoveTranslate, tRemoveRotate, nDerivs, nMovedAtom, geo,&
+
+  !> Projection out of the space of the dynamical matrix
+  subroutine project(output, dynMatrix, tRemoveTranslate, tRemoveRotate, nDerivs, nMovedAtom, geo,&
       & atomicMasses)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Dynamical matrix
     real(dp), intent(inout) :: dynMatrix(:,:)
@@ -80,7 +84,7 @@ contains
 
     if (tRemoveRotate) then
       if (geo%tPeriodic) then
-        call warning("Rotational modes were requested to be removed for a periodic geometry -&
+        call warning(output, "Rotational modes were requested to be removed for a periodic geometry -&
             & results probably unphysical!")
       end if
 

--- a/app/modes/modeprojection.F90
+++ b/app/modes/modeprojection.F90
@@ -29,7 +29,7 @@ contains
   subroutine project(output, dynMatrix, tRemoveTranslate, tRemoveRotate, nDerivs, nMovedAtom, geo,&
       & atomicMasses)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Dynamical matrix

--- a/app/modes/modes.F90
+++ b/app/modes/modes.F90
@@ -9,10 +9,11 @@
 
 !> Program for calculating system normal modes from a Hessian.
 program modes
+  use dftbp_common_environment, only : TEnvironment, TEnvironment_init
   use dftbp_common_accuracy, only : dp, lc
   use dftbp_common_constants, only : Hartree__cm, pi
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut
+  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv
   use dftbp_io_formatout, only : writeXYZFormat
   use dftbp_io_message, only : error
   use dftbp_io_taggedoutput, only : TTaggedWriter, TTaggedWriter_init
@@ -29,12 +30,13 @@ program modes
 #:endif
   use modes_modeprojection, only : project
 #:if WITH_MPI
-  use mpi, only : MPI_THREAD_FUNNELED
+  use dftbp_io_message, only : error
   use dftbp_common_mpienv, only : TMpiEnv, TMpiEnv_init
-  use dftbp_extlibs_mpifx, only : mpifx_finalize, mpifx_init_thread
+  use dftbp_extlibs_mpifx, only : mpifx_finalize
 #:endif
   implicit none
 
+  type(TEnvironment) :: env
   type(TTaggedWriter) :: taggedWriter
 
   integer :: ii, jj, kk, ll, iMode, iAt, iAtMoved, nAtom, nTrans
@@ -48,20 +50,21 @@ program modes
   type(TFileDescr) :: fd
   logical :: isAppend
 
-#:if WITH_MPI
-  !> MPI environment, if compiled with mpifort
-  type(TMpiEnv) :: mpiEnv
+  call initGlobalEnv()
+  call TEnvironment_init(env)
 
+#:if WITH_MPI
   ! As this is serial code, trap for run time execution on more than 1 processor with an mpi enabled
   ! build
-  call mpifx_init_thread(requiredThreading=MPI_THREAD_FUNNELED)
-  call TMpiEnv_init(mpiEnv)
-  call mpiEnv%mpiSerialEnv()
+  call TMpiEnv_init(env%mpi)
+  if (.not. env%mpi%isSerialEnv()) then
+    call error('This is serial code, but invoked on multiple processors')
+  end if
 #:endif
 
   ! Allocate resources
-  call initProgramVariables()
-  write(stdout, "(/,A,/)") "Starting main program"
+  call initProgramVariables(env)
+  write(env%stdOut, "(/,A,/)") "Starting main program"
 
   allocate(eigenValues(3 * nMovedAtom))
   if (tPlotModes) allocate(eigenModesScaled(3 * nMovedAtom, 3 * nMovedAtom))
@@ -87,7 +90,7 @@ program modes
   end do
 
   ! remove translations or rotations if necessary
-  call project(dynMatrix, tRemoveTranslate, tRemoveRotate, nDerivs, nMovedAtom, geo, atomicMasses)
+  call project(env%stdOut, dynMatrix, tRemoveTranslate, tRemoveRotate, nDerivs, nMovedAtom, geo, atomicMasses)
 
   ! solve the eigenproblem
   if (tEigenVectors) then
@@ -202,10 +205,10 @@ program modes
 
   if (tPlotModes) then
     call taggedWriter%write(fd%unit, "saved_modes", modesToPlot)
-    write(stdout, *) "Writing eigenmodes to vibrations.tag"
+    write(env%stdOut, *) "Writing eigenmodes to vibrations.tag"
     call taggedWriter%write(fd%unit, "eigenmodes", dynMatrix(:, modesToPlot))
-    write(stdout, *) "Plotting eigenmodes:"
-    write(stdout, "(16I5)") modesToPlot(:)
+    write(env%stdOut, *) "Plotting eigenmodes:"
+    write(env%stdOut, "(16I5)") modesToPlot(:)
     call taggedWriter%write(fd%unit, "eigenmodes_scaled", eigenModesScaled(:, modesToPlot))
     if (tAnimateModes) then
       do ii = 1, nModesToPlot
@@ -233,39 +236,39 @@ program modes
     end if
   end if
 
-  write(stdout, *) "Vibrational modes"
+  write(env%stdOut, *) "Vibrational modes"
   if (allocated(bornMatrix) .and. allocated(bornDerivsMatrix)) then
-    write(stdout, "(T7,A,T16,A,T28,A)") "freq.", "IR", "Polarisability"
-    write(stdout, "(A,T7,A,T16,A,T28,A)") "Mode", "/ cm-1", "/ a.u.", "change / a.u."
+    write(env%stdOut, "(T7,A,T16,A,T28,A)") "freq.", "IR", "Polarisability"
+    write(env%stdOut, "(A,T7,A,T16,A,T28,A)") "Mode", "/ cm-1", "/ a.u.", "change / a.u."
   else if (allocated(bornMatrix)) then
-    write(stdout, "(T7,A,T16,A)") "freq.", "IR"
-    write(stdout, "(A,T7,A,T16,A)") "Mode", "/ cm-1", "/ a.u."
+    write(env%stdOut, "(T7,A,T16,A)") "freq.", "IR"
+    write(env%stdOut, "(A,T7,A,T16,A)") "Mode", "/ cm-1", "/ a.u."
   else if (allocated(bornDerivsMatrix)) then
-    write(stdout, "(T7,A,T16,A)") "freq.", "Polarisability"
-    write(stdout, "(A,T7,A,T16,A)") "Mode", "/ cm-1", "change / a.u."
+    write(env%stdOut, "(T7,A,T16,A)") "freq.", "Polarisability"
+    write(env%stdOut, "(A,T7,A,T16,A)") "Mode", "/ cm-1", "change / a.u."
   else
-    write(stdout, "(T7,A)") "freq."
-    write(stdout, "(A,T7,A)") "Mode", "cm-1"
+    write(env%stdOut, "(T7,A)") "freq."
+    write(env%stdOut, "(A,T7,A)") "Mode", "cm-1"
   end if
   if (allocated(bornMatrix) .and. allocated(bornDerivsMatrix)) then
     do ii = 1, 3 * nMovedAtom
-      write(stdout, "(i5,f8.2,2E12.4)") ii, eigenValues(ii) * Hartree__cm, transDip(ii),&
+      write(env%stdOut, "(i5,f8.2,2E12.4)") ii, eigenValues(ii) * Hartree__cm, transDip(ii),&
           & transPol(ii)
     end do
   else if (allocated(bornMatrix)) then
     do ii = 1, 3 * nMovedAtom
-      write(stdout, "(i5,f8.2,E12.4)") ii, eigenValues(ii) * Hartree__cm, transDip(ii)
+      write(env%stdOut, "(i5,f8.2,E12.4)") ii, eigenValues(ii) * Hartree__cm, transDip(ii)
     end do
   else if (allocated(bornDerivsMatrix)) then
     do ii = 1, 3 * nMovedAtom
-      write(stdout, "(i5,f8.2,E12.4)") ii, eigenValues(ii) * Hartree__cm, transPol(ii)
+      write(env%stdOut, "(i5,f8.2,E12.4)") ii, eigenValues(ii) * Hartree__cm, transPol(ii)
     end do
   else
     do ii = 1, 3 * nMovedAtom
-      write(stdout, "(i5,f8.2)") ii,eigenValues(ii) * Hartree__cm
+      write(env%stdOut, "(i5,f8.2)") ii,eigenValues(ii) * Hartree__cm
     end do
   end if
-  write(stdout, *)
+  write(env%stdOut, *)
 
   call taggedWriter%write(fd%unit, "frequencies", eigenValues)
 
@@ -286,5 +289,8 @@ program modes
 #:if WITH_MPI
   call mpifx_finalize()
 #:endif
+
+  call env%destruct()
+  call destructGlobalEnv()
 
 end program modes

--- a/app/phonons/initphonons.F90
+++ b/app/phonons/initphonons.F90
@@ -13,7 +13,7 @@ module phonons_initphonons
   use dftbp_common_constants, only : amu__au
   use dftbp_common_environment, only : TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut, tIoProc
+  use dftbp_common_globalenv, only : tIoProc
   use dftbp_common_status, only : TStatus
   use dftbp_common_unitconversion, only : energyUnits, lengthUnits
   use dftbp_dftb_periodic, only : getCellTranslations, getNrOfNeighboursForAll, getSuperSampling,&
@@ -206,8 +206,8 @@ contains
 
     integer :: cubicType
 
-    write(stdOut, "(/, A)") "Starting initialization..."
-    write(stdOut, "(A80)") repeat("-", 80)
+    write(env%stdOut, "(/, A)") "Starting initialization..."
+    write(env%stdOut, "(A80)") repeat("-", 80)
 
     nGroups = 1
 #:if WITH_MPI
@@ -215,8 +215,8 @@ contains
 #:endif
 
     !! Read in input file as HSD or XML.
-    write(stdOut, "(A)") "Interpreting input file '" // hsdInput // "'"
-    write(stdOut, "(A)") repeat("-", 80)
+    write(env%stdOut, "(A)") "Interpreting input file '" // hsdInput // "'"
+    write(env%stdOut, "(A)") repeat("-", 80)
     call parseHSD(rootTag, hsdInput, hsdTree)
     call getChild(hsdTree, rootTag, root)
 
@@ -227,7 +227,7 @@ contains
     call readOptions(child, parserFlags)
 
     call getChild(root, "Geometry", tmp)
-    call readGeometry(tmp, geo)
+    call readGeometry(env, tmp, geo)
 
     ! Read Transport block
     ! This defines system partitioning
@@ -235,11 +235,11 @@ contains
     call getChild(root, "Transport", child, requested=.false.)
     if (associated(child)) then
       tTransport = .true.
-      call readTransportGeometry(child, geo, transpar)
+      call readTransportGeometry(env, child, geo, transpar)
     end if
 
     call getChildValue(root, "Atoms", buffer2, "1:-1", child=child)
-    call getSelectedAtomIndices(child, char(buffer2), geo%speciesNames, geo%species, iMovedAtoms)
+    call getSelectedAtomIndices(env%stdOut, child, char(buffer2), geo%speciesNames, geo%species, iMovedAtoms)
     nMovedAtom = size(iMovedAtoms)
 
     tCompModes = .false.
@@ -254,7 +254,7 @@ contains
       if (associated(node)) then
         tPlotModes = .true.
         call getChildValue(node, "PlotModes", buffer2, "1:-1", child=child, multiple=.true.)
-        call getSelectedIndices(child, char(buffer2), [1, 3 * nMovedAtom], modesToPlot)
+        call getSelectedIndices(env%stdOut, child, char(buffer2), [1, 3 * nMovedAtom], modesToPlot)
         nModesToPlot = size(modesToPlot)
         call getChildValue(node, "Animate", tAnimateModes, .true.)
         call getChildValue(node, "XMakeMol", tXmakeMol, .true.)
@@ -293,9 +293,9 @@ contains
     if ( associated(node) ) then
       call getChild(node, "SlaterKosterFiles", child=value,requested=.false.)
       if ( associated(value) ) then
-        call readSKfiles(value, geo, speciesMass)
+        call readSKfiles(env%stdOut, value, geo, speciesMass)
       else
-        call readMasses(node, geo, speciesMass)
+        call readMasses(env%stdOut, node, geo, speciesMass)
       endif
     endif
     allocate(atomicMasses(nMovedAtom))
@@ -317,11 +317,11 @@ contains
     call getNodeName(value, buffer)
     select case(trim(char(buffer)))
     case ("dftb")
-      call readDftbHessian(value)
+      call readDftbHessian(env%stdOut, value)
     case ("dynmatrix")
-      call readDynMatrix(value)
+      call readDynMatrix(env%stdOut, value)
     case ("cp2k")
-      call readCp2kHessian(value)
+      call readCp2kHessian(env%stdOut, value)
     case default
       call detailedError(node,"Unknown Hessian type "//char(buffer))
     end select
@@ -344,7 +344,7 @@ contains
       end select
     end if
 
-    call buildNeighbourList()
+    call buildNeighbourList(env)
 
     call getChildValue(root, "Analysis", tmp, "", child=child, list=.true., &
         &allowEmptyValue=.true., dontMarkProcessed=.true.)
@@ -353,17 +353,17 @@ contains
       if (tPhonDispersion) then
          call detailedError(root, "Analysis and PhononDispersion cannot coexist")
       end if
-      call readAnalysis(child, geo, tundos, transpar)
+      call readAnalysis(env, child, geo, tundos, transpar)
     endif
 
     !! Issue warning about unprocessed nodes
-    write(stdOut, "(/, A)") "check unprocessed nodes..."
-    call warnUnprocessedNodes(root, parserFlags%tIgnoreUnprocessed )
+    write(env%stdOut, "(/, A)") "check unprocessed nodes..."
+    call warnUnprocessedNodes(env%stdOut, root, parserFlags%tIgnoreUnprocessed )
 
     !! Dump processed tree in HSD and XML format
     if (tIoProc .and. parserFlags%tWriteHSD) then
       call dumpHSD(hsdTree, hsdParsedInput)
-      write(stdOut, '(/,/,A)') "Processed input in HSD format written to '" &
+      write(env%stdOut, '(/,/,A)') "Processed input in HSD format written to '" &
           &// hsdParsedInput // "'"
     end if
 
@@ -372,12 +372,16 @@ contains
       call error("Keyword 'StopAfterParsing' is set to Yes. Stopping.")
     end if
 
-    write(stdOut, "(/, A)") "Initialization done..."
+    write(env%stdOut, "(/, A)") "Initialization done..."
 
   end subroutine initProgramVariables
 
   !!* destruct the program variables created in initProgramVariables
-  subroutine destructProgramVariables()
+  subroutine destructProgramVariables(output)
+
+    !> output for write processes
+    integer, intent(in) :: output
+
     deallocate(atomicMasses)
     deallocate(dynMatrix)
     if (allocated(iMovedAtoms)) then
@@ -386,7 +390,7 @@ contains
     if (allocated(modesToPlot)) then
       deallocate(modesToPlot)
     end if
-    write(stdOut, "(/,A)") repeat("=", 80)
+    write(output, "(/,A)") repeat("=", 80)
   end subroutine destructProgramVariables
 
 
@@ -422,7 +426,10 @@ contains
 
 
   !> Read in the geometry stored as xml in internal or gen format.
-  subroutine readGeometry(geonode, geo)
+  subroutine readGeometry(env, geonode, geo)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node containing the geometry
     type(fnode), pointer :: geonode
@@ -437,24 +444,28 @@ contains
     call getNodeName(value, buffer)
     select case (char(buffer))
     case ("genformat")
-      call readTGeometryGen(value, geo)
+      call readTGeometryGen(env, value, geo)
     case default
       call setUnprocessed(value)
       call readTGeometryHSD(child, geo)
     end select
 
     if (geo%tPeriodic) then
-      write(stdOut,*) 'supercell lattice vectors:'
-      write(stdOut,*) 'a1:',geo%latVecs(1,:)
-      write(stdOut,*) 'a2:',geo%latVecs(2,:)
-      write(stdOut,*) 'a3:',geo%latVecs(3,:)
+      write(env%stdOut,*) 'supercell lattice vectors:'
+      write(env%stdOut,*) 'a1:',geo%latVecs(1,:)
+      write(env%stdOut,*) 'a2:',geo%latVecs(2,:)
+      write(env%stdOut,*) 'a3:',geo%latVecs(3,:)
     end if
 
   end subroutine readGeometry
 
 
   !> Read geometry information for transport calculation
-  subroutine readTransportGeometry(root, geom, tp)
+  subroutine readTransportGeometry(env, root, geom, tp)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
+
     type(fnode), pointer :: root
     type(TGeometry), intent(inout) :: geom
     type(TTransPar), intent(inout) :: tp
@@ -479,7 +490,7 @@ contains
     end if
     allocate(tp%contacts(tp%ncont))
     !! Parse contact geometry
-    call readContacts(pNodeList, tp%contacts, geom, .true.)
+    call readContacts(env, pNodeList, tp%contacts, geom, .true.)
 
   end subroutine readTransportGeometry
 
@@ -532,7 +543,11 @@ contains
 
 
   !> Read bias information, used in Analysis and Green's function solver
-  subroutine readContacts(pNodeList, contacts, geom, upload)
+  subroutine readContacts(env, pNodeList, contacts, geom, upload)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
+
     type(fnodeList), pointer :: pNodeList
     type(ContactInfo), allocatable, dimension(:), intent(inout) :: contacts
     type(TGeometry), intent(in) :: geom
@@ -566,7 +581,7 @@ contains
       call convertUnitHsd(char(modif), lengthUnits, field, contactLayerTol)
 
       call getChildValue(pNode, "AtomRange", contacts(ii)%idxrange, child=pTmp)
-      call getContactVectorII(contacts(ii)%idxrange, geom, ii, pTmp, contactLayerTol, &
+      call getContactVectorII(env%stdOut, contacts(ii)%idxrange, geom, ii, pTmp, contactLayerTol, &
                               & contacts(ii)%lattice, contacts(ii)%dir)
       contacts(ii)%length = sqrt(sum(contacts(ii)%lattice**2))
 
@@ -600,7 +615,11 @@ contains
 
 
   !> Verification checking of atom ranges and returning contact vector and direction.
-  subroutine getContactVectorII(atomrange, geom, id, pContact, plShiftTol, contactVec, contactDir)
+  subroutine getContactVectorII(output, atomrange, geom, id, pContact, plShiftTol, contactVec, contactDir)
+
+    !> Output for write processes
+    integer, intent(in) :: output
+
     integer, intent(in) :: atomrange(2)
     type(TGeometry), intent(in) :: geom
     integer, intent(in) :: id
@@ -629,18 +648,18 @@ contains
     contactVec = geom%coords(:,iStart) - geom%coords(:,iStart2)
     if (any(sqrt(sum((geom%coords(:,iStart:iStart2-1) - geom%coords(:,iStart2:iEnd) &
         &- spread(contactVec, dim=2, ncopies=iStart2-iStart))**2, dim=1)) > plShiftTol)) then
-      write(stdOut,*) 'coords:', geom%coords(:,iStart)
-      write(stdOut,*) 'coords:', geom%coords(:,iStart2)
-      write(stdOut,*) 'Contact Vector:', contactVec(1:3)
-      write(stdOut,*) iStart,iStart2,iEnd
-      write(stdOut,*) 'X:'
-      write(stdOut,*) ((geom%coords(1,iStart:iStart2-1) - geom%coords(1,iStart2:iEnd)&
+      write(output,*) 'coords:', geom%coords(:,iStart)
+      write(output,*) 'coords:', geom%coords(:,iStart2)
+      write(output,*) 'Contact Vector:', contactVec(1:3)
+      write(output,*) iStart,iStart2,iEnd
+      write(output,*) 'X:'
+      write(output,*) ((geom%coords(1,iStart:iStart2-1) - geom%coords(1,iStart2:iEnd)&
           & - spread(contactVec(1), dim=1, ncopies=iStart2-iStart)))
-      write(stdOut,*) 'Y:'
-      write(stdOut,*) ((geom%coords(2,iStart:iStart2-1) - geom%coords(2,iStart2:iEnd) &
+      write(output,*) 'Y:'
+      write(output,*) ((geom%coords(2,iStart:iStart2-1) - geom%coords(2,iStart2:iEnd) &
           & - spread(contactVec(2), dim=1, ncopies=iStart2-iStart)))
-      write(stdOut,*) 'Z:'
-      write(stdOut,*) ((geom%coords(3,iStart:iStart2-1) - geom%coords(3,iStart2:iEnd) &
+      write(output,*) 'Z:'
+      write(output,*) ((geom%coords(3,iStart:iStart2-1) - geom%coords(3,iStart2:iEnd) &
           &- spread(contactVec(3), dim=1, ncopies=iStart2-iStart)))
       call error("Contact " // i2c(id) &
           &// " does not consist of two rigidly shifted layers."//new_line('a') &
@@ -653,7 +672,11 @@ contains
 
 
   !> Used to read atomic masses from SK files
-  subroutine readSKfiles(child, geo, speciesMass)
+  subroutine readSKfiles(output, child, geo, speciesMass)
+
+    !> output for write processes
+    integer, intent(in) :: output
+
     type(fnode), pointer :: child
     type(TGeometry), intent(in) :: geo
     real(dp), dimension(:) :: speciesMass
@@ -667,7 +690,7 @@ contains
     integer :: ii, iSp1
     logical :: tLower, tExist
 
-    write(stdOut, "(/, A)") "read atomic masses from sk files..."
+    write(output, "(/, A)") "read atomic masses from sk files..."
     !! Slater-Koster files
     allocate(skFiles(geo%nSpecies))
     do iSp1 = 1, geo%nSpecies
@@ -742,7 +765,11 @@ contains
   end subroutine readSKfiles
 
 
-  subroutine readMasses(value, geo, speciesMass)
+  subroutine readMasses(output, value, geo, speciesMass)
+
+    !> Output for write processes
+    integer, intent(in) :: output
+
     type(fnode), pointer :: value
     type(TGeometry), intent(in) :: geo
     real(dp), dimension(:) :: speciesMass
@@ -752,14 +779,14 @@ contains
     integer :: iSp
     real(dp) :: mass, defmass
 
-    write(stdOut, "(/, A)") "set atomic masses as IUPAC defaults ..."
+    write(output, "(/, A)") "set atomic masses as IUPAC defaults ..."
 
     do iSp = 1, geo%nSpecies
       defmass = getAtomicMass(trim(geo%speciesNames(iSp)))
       call getChildValue(value, geo%speciesNames(iSp), mass, defmass,&
                &modifier=modif, child= child2)
       speciesMass(iSp) = mass
-      write(stdOut,*) trim(geo%speciesNames(iSp)),": ", mass/amu__au, "amu", &
+      write(output,*) trim(geo%speciesNames(iSp)),": ", mass/amu__au, "amu", &
             &SpeciesMass(iSp),"a.u."
     end do
 
@@ -922,7 +949,11 @@ contains
   !!  ---------- + --------- + --------- + ---------- + ---------- +...
   !!  dx_1 dx_1    dy_1 dx_1   dz_1 dx_1   dx_2 dx_1    dy_2 dx_1
   !!
-  subroutine readDftbHessian(child)
+  subroutine readDftbHessian(output, child)
+
+    !> Output for write processes
+    integer, intent(in) :: output
+
     type(fnode), pointer :: child
 
     integer :: iCount, jCount, ii, kk, jj, ll
@@ -939,7 +970,7 @@ contains
     strTmp = char(filename)
     inquire(file=strTmp, exist=texist )
     if (texist) then
-      write(stdOut, "(/, A)") "read dftb hessian '"//trim(char(filename))//"'..."
+      write(output, "(/, A)") "read dftb hessian '"//trim(char(filename))//"'..."
     else
       call detailedError(child,"Hessian file "//trim(char(filename))//" does not exist")
     end if
@@ -975,7 +1006,11 @@ contains
   end subroutine readDftbHessian
 
 
-  subroutine readDynMatrix(child)
+  subroutine readDynMatrix(output, child)
+
+    !> Output for write processes
+    integer, intent(in) :: output
+
     type(fnode), pointer :: child
 
     type(TListRealR1) :: realBuffer
@@ -991,7 +1026,7 @@ contains
     !! ---------- + --------- + --------- + ---------- + ---------- +...
     !! dx_1 dx_1    dy_1 dx_1   dz_1 dx_1   dx_2 dx_1    dy_2 dx_1
 
-    write(stdOut, "(/, A)") "read dynamical matrix..."
+    write(output, "(/, A)") "read dynamical matrix..."
 
     call init(realBuffer)
     call getChildValue(child, "", nDerivs, realBuffer)
@@ -1006,7 +1041,11 @@ contains
   end subroutine readDynMatrix
 
 
-  subroutine readCp2kHessian(child)
+  subroutine readCp2kHessian(output, child)
+
+    !> Output for write processes
+    integer, intent(in) :: output
+
     type(fnode), pointer :: child
 
     integer :: iCount, jCount, ii, kk, jj, ll
@@ -1027,7 +1066,7 @@ contains
     strTmp = char(filename)
     inquire(file=strTmp, exist=texist )
     if (texist) then
-      write(stdOut, "(/, A)") "read cp2k hessian '"//trim(char(filename))//"'..."
+      write(output, "(/, A)") "read cp2k hessian '"//trim(char(filename))//"'..."
     else
       call detailedError(child,"Hessian file "//trim(char(filename))//" does not exist")
     end if
@@ -1077,8 +1116,17 @@ contains
 
 
   !> Reads the Analysis block.
+<<<<<<< HEAD
   subroutine readAnalysis(node, geo, tundos, transpar)
     type(fnode), pointer :: node
+=======
+  subroutine readAnalysis(env, node, geo, pdos, tundos, transpar, atTemperature)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
+
+    type(fnode), pointer :: node, pnode
+>>>>>>> 9104a69c9 (Eliminate global stdout (first step))
     type(TGeometry), intent(in) :: geo
     type(TNEGFTunDos), intent(inout) :: tundos
     type(TTransPar), intent(inout) :: transpar
@@ -1092,7 +1140,7 @@ contains
       if (.not.tTransport) then
         call detailedError(node, "Tunneling requires Transport block")
       end if
-      call readTunAndDos(child, geo, tundos, transpar, maxval(transpar%contacts(:)%kbT) )
+      call readTunAndDos(env, child, geo, tundos, transpar, maxval(transpar%contacts(:)%kbT) )
     endif
 
     !call readKPoints(node, geo, tBadKpoints)
@@ -1120,7 +1168,11 @@ contains
   end subroutine readAnalysis
 
 
-  subroutine readPDOSRegions(children, geo, iAtInregion, regionLabels)
+  subroutine readPDOSRegions(env, children, geo, iAtInregion, regionLabels)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
+
     type(fnodeList), pointer :: children
     type(TGeometry), intent(in) :: geo
     type(TWrappedInt1), allocatable, intent(out) :: iAtInRegion(:)
@@ -1139,7 +1191,7 @@ contains
       call getItem1(children, iReg, child)
       call getChildValue(child, "Atoms", buffer, child=child2, &
           & multiple=.true.)
-      call getSelectedAtomIndices(child2, char(buffer), geo%speciesNames, geo%species, tmpI1)
+      call getSelectedAtomIndices(env%stdOut, child2, char(buffer), geo%speciesNames, geo%species, tmpI1)
       iAtInRegion(iReg)%data = tmpI1
       write(strTmp, "('region',I0)") iReg
       call getChildValue(child, "Label", buffer, trim(strTmp))
@@ -1150,7 +1202,11 @@ contains
 
 
   !> Read Tunneling and Dos options from analysis block
-  subroutine readTunAndDos(root, geo, tundos, transpar, temperature)
+  subroutine readTunAndDos(env, root, geo, tundos, transpar, temperature)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
+
     type(fnode), pointer :: root
     type(TGeometry), intent(in) :: geo
 
@@ -1238,7 +1294,7 @@ contains
         &tundos%broadeningDelta)
 
     call getChildren(root, "Region", pNodeList)
-    call readPDOSRegions(pNodeList, geo, iAtInRegion, regionLabelPrefixes)
+    call readPDOSRegions(env, pNodeList, geo, iAtInRegion, regionLabelPrefixes)
     call destroyNodeList(pNodeList)
 
     call addAtomResolvedRegion(tundos%dosOrbitals, tundos%dosLabels)
@@ -1372,7 +1428,10 @@ contains
 
   !> Build a simple neighbor list. Currently does not work for periodic systems.
   !! Have to fix this important point
-  subroutine buildNeighbourList()
+  subroutine buildNeighbourList(env)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     integer ::  iAtom, jAtom, jj, PL1, PL2
     !* First guess for nr. of neighbors.
@@ -1415,7 +1474,7 @@ contains
     allocate(nNeighbour(geo%nAtom))
     nNeighbour(:) = 0
 
-    call getNrOfNeighboursForAll(nNeighbour, neighbourList, mCutoff)
+    call getNrOfNeighboursForAll(env%stdOut, nNeighbour, neighbourList, mCutoff)
 
     ! Check PL size with neighbor list
     do iAtom = 1, transpar%idxdevice(2)
@@ -1425,7 +1484,7 @@ contains
         if (jAtom > transpar%idxdevice(2)) cycle
         PL2 = getPL(jAtom)
         if (.not.(PL1.eq.PL2 .or. PL1.eq.PL2+1 .or. PL1.eq.PL2-1)) then
-          write(stdOut,*) 'ERROR: PL size inconsistent with cutoff'
+          write(env%stdOut,*) 'ERROR: PL size inconsistent with cutoff'
           stop
         end if
       end do

--- a/app/phonons/initphonons.F90
+++ b/app/phonons/initphonons.F90
@@ -379,7 +379,7 @@ contains
   !!* destruct the program variables created in initProgramVariables
   subroutine destructProgramVariables(output)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     deallocate(atomicMasses)
@@ -617,7 +617,7 @@ contains
   !> Verification checking of atom ranges and returning contact vector and direction.
   subroutine getContactVectorII(output, atomrange, geom, id, pContact, plShiftTol, contactVec, contactDir)
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     integer, intent(in) :: atomrange(2)
@@ -674,7 +674,7 @@ contains
   !> Used to read atomic masses from SK files
   subroutine readSKfiles(output, child, geo, speciesMass)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     type(fnode), pointer :: child
@@ -767,7 +767,7 @@ contains
 
   subroutine readMasses(output, value, geo, speciesMass)
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     type(fnode), pointer :: value
@@ -951,7 +951,7 @@ contains
   !!
   subroutine readDftbHessian(output, child)
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     type(fnode), pointer :: child
@@ -1008,7 +1008,7 @@ contains
 
   subroutine readDynMatrix(output, child)
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     type(fnode), pointer :: child
@@ -1043,7 +1043,7 @@ contains
 
   subroutine readCp2kHessian(output, child)
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     type(fnode), pointer :: child
@@ -1116,17 +1116,12 @@ contains
 
 
   !> Reads the Analysis block.
-<<<<<<< HEAD
-  subroutine readAnalysis(node, geo, tundos, transpar)
-    type(fnode), pointer :: node
-=======
-  subroutine readAnalysis(env, node, geo, pdos, tundos, transpar, atTemperature)
+  subroutine readAnalysis(env, node, geo, tundos, transpar)
 
     !> Environment
     type(TEnvironment), intent(in) :: env
 
-    type(fnode), pointer :: node, pnode
->>>>>>> 9104a69c9 (Eliminate global stdout (first step))
+    type(fnode), pointer :: node
     type(TGeometry), intent(in) :: geo
     type(TNEGFTunDos), intent(inout) :: tundos
     type(TTransPar), intent(inout) :: transpar

--- a/app/phonons/libnegfint.F90
+++ b/app/phonons/libnegfint.F90
@@ -260,7 +260,7 @@ contains
 
   subroutine negf_destroy(output)
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     write(output, *)
@@ -275,7 +275,7 @@ contains
 
   subroutine negf_init_str(output, nAtoms, transpar, iNeigh, nNeigh, img2CentCell)
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Number of atoms

--- a/app/phonons/libnegfint.F90
+++ b/app/phonons/libnegfint.F90
@@ -29,7 +29,7 @@ module phonons_libnegfint
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut, tIoProc
+  use dftbp_common_globalenv, only : tIoProc
   use dftbp_extlibs_negf, only : associate_ldos, associate_lead_currents, associate_transmission,&
       & COMP_SGF, compute_phonon_current, convertHeatConductance, convertHeatCurrent, create,&
       & csr2dns, DELTA_MINGO, DELTA_SQ, DELTA_W, destroy, destroy_negf, dns2csr, get_params,&
@@ -258,19 +258,25 @@ contains
   end subroutine init_tun_proj
 
 
-  subroutine negf_destroy()
+  subroutine negf_destroy(output)
 
-    write(stdOut, *)
-    write(stdOut, *) 'Release NEGF memory:'
+    !> Output for write processes
+    integer, intent(in) :: output
+
+    write(output, *)
+    write(output, *) 'Release NEGF memory:'
     call destruct(csrHam)
     call destroy_negf(negf)
-    call writePeakInfo(stdOut)
-    call writeMemInfo(stdOut)
+    call writePeakInfo(output)
+    call writeMemInfo(output)
 
   end subroutine negf_destroy
 
 
-  subroutine negf_init_str(nAtoms, transpar, iNeigh, nNeigh, img2CentCell)
+  subroutine negf_init_str(output, nAtoms, transpar, iNeigh, nNeigh, img2CentCell)
+
+    !> Output for write processes
+    integer, intent(in) :: output
 
     !> Number of atoms
     integer, intent(in) :: nAtoms
@@ -361,8 +367,8 @@ contains
 
        do j1 = 1, ncont
           if (count(minv(:,j1).eq.j1).gt.1) then
-             write(stdOut,*) 'Contact',j1,'interacts with more than one PL:'
-             write(stdOut,*) 'PLs:',minv(:,j1)
+             write(output,*) 'Contact',j1,'interacts with more than one PL:'
+             write(output,*) 'PLs:',minv(:,j1)
              call error('check cutoff value or PL size')
           end if
           do m = 1, transpar%nPLs
@@ -371,11 +377,11 @@ contains
        end do
 
 
-       write(stdOut,*)
-       write(stdOut,*) ' Structure info:'
-       write(stdOut,*) ' Number of PLs:',nbl
-       write(stdOut,*) ' PLs coupled to contacts:',cblk(1:ncont)
-       write(stdOut,*)
+       write(output,*)
+       write(output,*) ' Structure info:'
+       write(output,*) ' Number of PLs:',nbl
+       write(output,*) ' PLs coupled to contacts:',cblk(1:ncont)
+       write(output,*)
 
     end if
 
@@ -833,6 +839,5 @@ contains
     end if
 
   end subroutine write_file
-
 
 end module phonons_libnegfint

--- a/app/phonons/phonons.F90
+++ b/app/phonons/phonons.F90
@@ -95,7 +95,7 @@ contains
 
   subroutine printHeader(output)
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     write (output, "(A)") repeat("=", 80)
@@ -117,7 +117,7 @@ contains
 
   subroutine ComputeModes(output)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     type(TFileDescr) :: fd
@@ -235,7 +235,7 @@ contains
 
   subroutine PhononDispersion(output, tWriter)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     type(TTaggedWriter) :: tWriter

--- a/app/phonons/phonons.F90
+++ b/app/phonons/phonons.F90
@@ -18,7 +18,7 @@ program phonons
   use dftbp_common_constants, only : Bohr__AA, Hartree__cm, Hartree__eV, Hartree__J, hbar, pi
   use dftbp_common_environment, only : TEnvironment, TEnvironment_init
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv, stdOut, tIOProc
+  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv, tIOProc
   use dftbp_io_message, only : error
   use dftbp_io_taggedoutput, only : TTaggedWriter, TTaggedWriter_init
   use dftbp_math_eigensolver, only : heev
@@ -35,34 +35,34 @@ program phonons
   integer :: nProcs
 
   call initGlobalEnv()
-  call printHeader()
   call TEnvironment_init(env)
+  call printHeader(env%stdOut)
   call initProgramVariables(env)
   call TTaggedWriter_init(taggedWriter)
 
   nProcs = 1
-  write(stdOut,*)'Computing environment'
+  write(env%stdOut,*)'Computing environment'
 #:if WITH_MPI
   write(*,*)env%mpi%globalComm%rank, env%mpi%globalComm%size, tIOProc, env%mpi%globalComm%lead
   nProcs = env%mpi%globalComm%size
 #:else
-  write(stdOut,*)'Not compiled with MPI enabled'
+  write(env%stdOut,*)'Not compiled with MPI enabled'
 #:endif
 
   if (tCompModes) then
     if (nProcs > 1) then
       call error("Mode calculation is not parallel yet. Run just on 1 node")
-      call destructProgramVariables()
+      call destructProgramVariables(env%stdOut)
     end if
-    call ComputeModes()
+    call ComputeModes(env%stdOut)
   end if
 
   if (tPhonDispersion) then
     if (nProcs > 1) then
       call error("Phonon dispersion is not parallel yet. Run just on 1 node")
-      call destructProgramVariables()
+      call destructProgramVariables(env%stdOut)
     end if
-    call PhononDispersion(taggedWriter)
+    call PhononDispersion(env%stdOut, taggedWriter)
   end if
 
   if (tTransport) then
@@ -75,7 +75,7 @@ program phonons
       call error("libnegf not initialized")
     end if
 
-    call negf_init_str(geo%nAtom, transpar, neighbourList%iNeighbour, nNeighbour, img2CentCell)
+    call negf_init_str(env%stdOut, geo%nAtom, transpar, neighbourList%iNeighbour, nNeighbour, img2CentCell)
 
     call calc_phonon_current(env, dynMatrix, tunnTot, ldosTot, currLead, conductance, &
                         & twriteTunn, twriteLDOS)
@@ -86,32 +86,39 @@ program phonons
 
   end if
 
-  call destructProgramVariables()
+  call destructProgramVariables(env%stdOut)
   call destructGlobalEnv()
 
-  write(stdOut, "(A)") "Program completed successfully"
+  write(env%stdOut, "(A)") "Program completed successfully"
 
 contains
 
-  subroutine printHeader()
-    write (stdOut, "(A)") repeat("=", 80)
-    write (stdOut, "(30X,A)") "PHONONS"
-    write (stdOut, "(A,/)") repeat("=", 80)
-    write (stdOut, "(A)") ""
-    write (stdOut, "(A)") "Version 0.1"
-    write (stdOut, "(A)") "A tool to compute phonon transmission in nanostructures based on&
+  subroutine printHeader(output)
+
+    !> Output for write processes
+    integer, intent(in) :: output
+
+    write (output, "(A)") repeat("=", 80)
+    write (output, "(30X,A)") "PHONONS"
+    write (output, "(A,/)") repeat("=", 80)
+    write (output, "(A)") ""
+    write (output, "(A)") "Version 0.1"
+    write (output, "(A)") "A tool to compute phonon transmission in nanostructures based on&
         & Hessians"
-    write (stdOut, "(A)") "Authors: Alessandro Pecchia, Leonardo Medrano Sandonas"
-    write (stdOut, "(A)") "When using this code, please cite this work:"
-    write (stdOut, "(A)") "Leonardo Medrano Sandonas, Rafaei Gutierrez, Alessandro Pecchia,"
-    write (stdOut, "(A)") "Alexander Croy, Gianaurelio Cuniberti, Quantum phonon transport in"
-    write (stdOut, "(A)") "nanomaterials: combining atomistic with non-equilibrium Green's&
+    write (output, "(A)") "Authors: Alessandro Pecchia, Leonardo Medrano Sandonas"
+    write (output, "(A)") "When using this code, please cite this work:"
+    write (output, "(A)") "Leonardo Medrano Sandonas, Rafaei Gutierrez, Alessandro Pecchia,"
+    write (output, "(A)") "Alexander Croy, Gianaurelio Cuniberti, Quantum phonon transport in"
+    write (output, "(A)") "nanomaterials: combining atomistic with non-equilibrium Green's&
         & functions"
-    write (stdOut, "(A)") "techniques, Entropy 21, 735 (2019)"
-    write (stdOut, "(A)") ""
+    write (output, "(A)") "techniques, Entropy 21, 735 (2019)"
+    write (output, "(A)") ""
   end subroutine printHeader
 
-  subroutine ComputeModes()
+  subroutine ComputeModes(output)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     type(TFileDescr) :: fd
     integer  :: ii, jj, kk, ll, nAtom, iMode, jCount, iAt, iAtMoved
@@ -125,24 +132,24 @@ contains
 
     ! solve the eigenproblem
     if (tPlotModes) then
-      write(stdOut,*) 'Computing vibrational frequencies and modes'
+      write(output,*) 'Computing vibrational frequencies and modes'
       call heev(dynMatrix,eigenValues,'U','V')
     else
-      write(stdOut,*) 'Computing vibrational frequencies'
+      write(output,*) 'Computing vibrational frequencies'
       call heev(dynMatrix,eigenValues,'U','N')
     end if
 
     ! take square root of modes (allowing for imaginary modes) and print
     eigenValues =  sign(sqrt(abs(eigenValues)),eigenValues)
-    write(stdOut,*)'Vibrational modes (cm-1):'
+    write(output,*)'Vibrational modes (cm-1):'
     do ii = 1, 3 * nMovedAtom
-      write(stdOut,'(f8.2)')eigenValues(ii)*Hartree__cm
+      write(output,'(f8.2)')eigenValues(ii)*Hartree__cm
     end do
-    write(stdOut,*)
+    write(output,*)
 
     if (tPlotModes) then
-      write(stdOut,*)'Plotting eigenmodes:'
-      write(stdOut,*)ModesToPlot(:)
+      write(output,*)'Plotting eigenmodes:'
+      write(output,*)ModesToPlot(:)
       ! scale mode compoents on each atom by mass and then normalise total mode
       do ii = 1, nModesToPlot
         iMode = ModesToPlot(ii)
@@ -226,7 +233,11 @@ contains
 
   end subroutine ComputeModes
 
-  subroutine PhononDispersion(tWriter)
+  subroutine PhononDispersion(output, tWriter)
+
+    !> output for write processes
+    integer, intent(in) :: output
+
     type(TTaggedWriter) :: tWriter
 
     type(TFileDescr) :: fu, ftag
@@ -242,24 +253,24 @@ contains
 
     call setConversionUnits(unitsConv)
 
-    write(stdOut,*) 'Supercell repetitions:'
-    write(stdOut,*) nCells(1),'x',nCells(2),'x',nCells(3)
+    write(output,*) 'Supercell repetitions:'
+    write(output,*) nCells(1),'x',nCells(2),'x',nCells(3)
 
     latVecs(1,:) = geo%latVecs(1,:)/real(nCells(1),dp)
     latVecs(2,:) = geo%latVecs(2,:)/real(nCells(2),dp)
     latVecs(3,:) = geo%latVecs(3,:)/real(nCells(3),dp)
 
     call invert33(invLatt, latVecs)
-    write(stdOut,*) 'reciprocal lattice vectors:'
-    write(stdOut,*) 'b1:',invLatt(:,1)
-    write(stdOut,*) 'b2:',invLatt(:,2)
-    write(stdOut,*) 'b3:',invLatt(:,3)
+    write(output,*) 'reciprocal lattice vectors:'
+    write(output,*) 'b1:',invLatt(:,1)
+    write(output,*) 'b2:',invLatt(:,2)
+    write(output,*) 'b3:',invLatt(:,3)
     invLatt = transpose(invLatt) * 2.0_dp * pi
 
     allocate(KdynMatrix(3*nAtomUnitCell,3*nAtomUnitCell))
     allocate(eigenValues(3*nAtomUnitCell))
 
-    write(stdOut,*) 'Computing Phonon Dispersion (units '//trim(outputUnits)//')'
+    write(output,*) 'Computing Phonon Dispersion (units '//trim(outputUnits)//')'
     if (tIOProc) then
       call openFile(fu, 'phononDispersion.dat', mode="w")
       if (tWriteTagged) then
@@ -278,7 +289,7 @@ contains
       q(2) = dot_product(invLatt(:,2), kPoint(:,iK))
       q(3) = dot_product(invLatt(:,3), kPoint(:,iK))
 
-      write(stdOut,*) ' q:',q(:)
+      write(output,*) ' q:',q(:)
       do  iAtom = 1,  nAtomUnitCell
         do  jAtom = 1, nAtomUnitCell
           ! This loops over all periodic copies

--- a/app/transporttools/helpsetupgeom.F90
+++ b/app/transporttools/helpsetupgeom.F90
@@ -8,8 +8,8 @@
 module transporttools_helpsetupgeom
   use dftbp_common_accuracy, only : dp, lc
   use dftbp_common_constants, only : Bohr__AA
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_io_message, only : error, warning
   use dftbp_math_simplealgebra, only : cross3
   use dftbp_math_sorting, only : index_heap_sort
@@ -25,7 +25,10 @@ module transporttools_helpsetupgeom
 contains
 
   !> Set up transport structure with contacts
-  subroutine setupGeometry(geom, iAtInRegion, contacts, plCutoff, nPLs, printDebug)
+  subroutine setupGeometry(env, geom, iAtInRegion, contacts, plCutoff, nPLs, printDebug)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Container of the system geometry
     type(TGeometry), intent(inout) :: geom
@@ -80,14 +83,14 @@ contains
 
     ! Print atom lists
     if (printDebug) then
-      call print_debug(iAtInRegion)
+      call print_debug(env%stdOut, iAtInRegion)
     end if
 
     ! 4. re-sort the second contact PL to be a shifted copy of the first
-    call arrangeContactPLs(geom, iAtInRegion, contacts, contVec, contDir, nPLs, plcutoff)
+    call arrangeContactPLs(env, geom, iAtInRegion, contacts, contVec, contDir, nPLs, plcutoff)
 
     ! 5. Define device PLs and reorder them along contact direction
-    call defineDevicePLs(geom, iAtInRegion, plcutoff, contVec, PLlist)
+    call defineDevicePLs(env, geom, iAtInRegion, plcutoff, contVec, PLlist)
     call reorder_PLs(geom, contDir, PLlist, iAtInRegion)
 
     ! 6. write ordered geometry
@@ -96,9 +99,9 @@ contains
     ! 7. Print the sorting vector
     call print_sort_indices(iAtInRegion)
 
-    write(stdOut,*)
-    write(stdOut,*) "Written processed geometry file 'processed.gen'"
-    write(stdOut,*) "Written input lines in 'transport.hsd'"
+    write(env%stdOut,*)
+    write(env%stdOut,*) "Written processed geometry file 'processed.gen'"
+    write(env%stdOut,*) "Written input lines in 'transport.hsd'"
 
   end subroutine setupGeometry
 
@@ -204,7 +207,11 @@ contains
   end subroutine sortContacts
 
   ! -----------------------------------------------------------------------------------------------!
-  subroutine arrangeContactPLs(geom, iAtInRegion, contacts, contVec, contDir, nPLs, plcutoff)
+  subroutine arrangeContactPLs(env, geom, iAtInRegion, contacts, contVec, contDir, nPLs, plcutoff)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
+
     type(TGeometry), intent(inout) :: geom
     type(TWrappedInt1), intent(inout) :: iAtInRegion(:)
     type(contactInfo), intent(in) :: contacts(:)
@@ -220,7 +227,7 @@ contains
     ncont = size(iAtInRegion)-1
 
     do icont = 1, ncont
-      write(stdOut, *) "Contact",icont, '"'//trim(contacts(icont)%name)//'"'
+      write(env%stdOut, *) "Contact",icont, '"'//trim(contacts(icont)%name)//'"'
       if (nPLs(icont)==2) then
         associate(data=>iAtInRegion(icont)%data)
         uu = 0.0_dp
@@ -228,14 +235,21 @@ contains
         vv = contvec(1:3,icont)
         tol = norm2(vv)*contvec(4,icont)
         PLsize = size(data)/2
+<<<<<<< HEAD
         write(stdOut, *) "PL size:",PLsize
         write(stdOut, *) "Number of PLs:",nPLs(icont)
         write(stdOut, *) "contact vector:",contvec(1:3,icont)*Bohr__AA,'(A)'
         write(stdOut, *) "contact direction:",contdir(icont)
         write(stdOut, *) "tolerance:",tol
+=======
+        write(env%stdOut, *) "PL size:",PLsize
+        write(env%stdOut, *) "Number of PLs:",nPLs(icont)
+        write(env%stdOut, *) "contact vector:",contvec(1:3,icont)*Bohr__AA,'(A)'
+        write(env%stdOut, *) "tolerance:",tol
+>>>>>>> 9104a69c9 (Eliminate global stdout (first step))
         ! check PL size
         mindist=minDist2ndPL(geom%coords,data,PLsize,contvec(1:3,icont))
-        write(stdOut, *) "minimum distance 2nd neighbour PL:", mindist*Bohr__AA,'(A)'
+        write(env%stdOut, *) "minimum distance 2nd neighbour PL:", mindist*Bohr__AA,'(A)'
         if (mindist<plcutoff) then
           errmess(1) = "The size of the contact PL is shorter than SK cutoff"
           errmess(2) = "Check your input geometry or force SKTruncation"
@@ -244,7 +258,7 @@ contains
           call error(errmess)
         end if
         !
-        write(stdOut, *) "check and reorder contact PLs"
+        write(env%stdOut, *) "check and reorder contact PLs"
         do ii = 1, PLsize
           bestcross = huge(bestcross)
           bestdiff = huge(bestdiff)
@@ -259,30 +273,30 @@ contains
             end if
           end do
           if (bestcross>tol .or. bestdiff>tol) then
-             write(stdOut, *) "Atom ",data(ii)
-             write(stdOut, *) "Best cross vector:", bestcross*Bohr__AA, '(A)'
-             write(stdOut, *) "Best difference:", bestdiff*Bohr__AA, '(A)'
+             write(env%stdOut, *) "Atom ",data(ii)
+             write(env%stdOut, *) "Best cross vector:", bestcross*Bohr__AA, '(A)'
+             write(env%stdOut, *) "Best difference:", bestdiff*Bohr__AA, '(A)'
              call error("Atom not found")
           end if
           call swap(data(PLsize+ii),data(jj))
         end do
         end associate
-        write(stdOut, *) "contact done"
+        write(env%stdOut, *) "contact done"
       else if (nPLs(icont)==1) then
         PLsize = size(iAtInRegion(icont)%data)
-        write(stdOut, *) "PL size:",PLsize
+        write(env%stdOut, *) "PL size:",PLsize
         contVec(1:3,icont) = contVec(1:3,icont)*real(sign(1,contDir(icont)),dp)
-        write(stdOut, *) "contact vector:",contvec(1:3,icont)*Bohr__AA, '(A)'
+        write(env%stdOut, *) "contact vector:",contvec(1:3,icont)*Bohr__AA, '(A)'
         ! counting number of added PLs. Factor of 2 is needed to get
         ! always an even total number
         mindist=minDist2ndPL(geom%coords,iAtInRegion(icont)%data,PLsize,contvec(1:3,icont))
         nAddPLs = floor(plcutoff/mindist)*2 + 1
         if (nAddPLs==1) then
-          write(stdOut, *) "Adding",nAddPLs,"PL"
+          write(env%stdOut, *) "Adding",nAddPLs,"PL"
         else
-          write(stdOut, *) "Adding",nAddPLs,"PLs"
+          write(env%stdOut, *) "Adding",nAddPLs,"PLs"
           if (nAddPLs>=3) then
-            call warning("More than 1 copy of the supplied PL will be added to this contact")
+            call warning(env%stdOut, "More than 1 copy of the supplied PL will be added to this contact")
           end if
         end if
         call reallocateInt(iAtInRegion(icont)%data, nAddPLs*PLsize)
@@ -342,7 +356,11 @@ contains
   end subroutine arrangeContactPLs
 
   ! -----------------------------------------------------------------------------------------------
-  subroutine defineDevicePLs(geom, iAtInRegion, plcutoff, contVec, PLlist)
+  subroutine defineDevicePLs(env, geom, iAtInRegion, plcutoff, contVec, PLlist)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
+
     type(TGeometry), intent(in) :: geom
     type(TWrappedInt1), intent(inout) :: iAtInRegion(:)
     real(dp), intent(in) :: plCutoff
@@ -378,7 +396,7 @@ contains
     end if
 
 
-    write(stdOut,*) "Partitioning device into PLs"
+    write(env%stdOut,*) "Partitioning device into PLs"
     ! put array of contact atoms in the first node of PLlist
     associate(dataD=>iAtInRegion(ncont+1)%data, dataR=>iAtInRegion(2)%data)
 
@@ -433,10 +451,10 @@ contains
       if (sizeL==0) then
         call error("Found layer of 0 size")
       end if
-      write(stdOut,*) "* Layer size:",sizeL
+      write(env%stdOut,*) "* Layer size:",sizeL
     end do
     end associate
-    write(stdOut,*) "Done."
+    write(env%stdOut,*) "Done."
 
   end subroutine defineDevicePLs
   ! -----------------------------------------------------------------------------------------------
@@ -482,7 +500,11 @@ contains
 
   ! -----------------------------------------------------------------------------------------------
   ! debug subroutine
-  subroutine print_debug(iAtInRegion)
+  subroutine print_debug(output, iAtInRegion)
+
+    !> output for write processes
+    integer, intent(in) :: output
+
     type(TWrappedInt1), intent(in) :: iAtInRegion(:)
 
     integer :: icont, ncont, PLsize
@@ -492,17 +514,17 @@ contains
     do icont = 1, ncont
       if (allocated(iAtInRegion(icont)%data)) then
         PLsize = size(iAtInRegion(icont)%data)/2
-        write(stdOut,*) 'Atoms in contact',icont,':'
-        write(stdOut,*) iAtInRegion(icont)%data(1:PLsize)
-        write(stdOut,*) iAtInRegion(icont)%data(PLsize+1:2*PLsize)
-        write(stdOut,*)
+        write(output,*) 'Atoms in contact',icont,':'
+        write(output,*) iAtInRegion(icont)%data(1:PLsize)
+        write(output,*) iAtInRegion(icont)%data(PLsize+1:2*PLsize)
+        write(output,*)
       else
         call error("Atom list not allocated")
       end if
     end do
-    write(stdOut,*) 'Atoms in device:'
-    write(stdOut,*) iAtInRegion(ncont+1)%data
-    write(stdOut,*)
+    write(output,*) 'Atoms in device:'
+    write(output,*) iAtInRegion(ncont+1)%data
+    write(output,*)
 
   end subroutine print_debug
 

--- a/app/transporttools/helpsetupgeom.F90
+++ b/app/transporttools/helpsetupgeom.F90
@@ -235,18 +235,11 @@ contains
         vv = contvec(1:3,icont)
         tol = norm2(vv)*contvec(4,icont)
         PLsize = size(data)/2
-<<<<<<< HEAD
-        write(stdOut, *) "PL size:",PLsize
-        write(stdOut, *) "Number of PLs:",nPLs(icont)
-        write(stdOut, *) "contact vector:",contvec(1:3,icont)*Bohr__AA,'(A)'
-        write(stdOut, *) "contact direction:",contdir(icont)
-        write(stdOut, *) "tolerance:",tol
-=======
         write(env%stdOut, *) "PL size:",PLsize
         write(env%stdOut, *) "Number of PLs:",nPLs(icont)
         write(env%stdOut, *) "contact vector:",contvec(1:3,icont)*Bohr__AA,'(A)'
+        write(env%stdOut, *) "contact direction:",contdir(icont)
         write(env%stdOut, *) "tolerance:",tol
->>>>>>> 9104a69c9 (Eliminate global stdout (first step))
         ! check PL size
         mindist=minDist2ndPL(geom%coords,data,PLsize,contvec(1:3,icont))
         write(env%stdOut, *) "minimum distance 2nd neighbour PL:", mindist*Bohr__AA,'(A)'
@@ -502,7 +495,7 @@ contains
   ! debug subroutine
   subroutine print_debug(output, iAtInRegion)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     type(TWrappedInt1), intent(in) :: iAtInRegion(:)

--- a/app/transporttools/parser.F90
+++ b/app/transporttools/parser.F90
@@ -9,11 +9,12 @@
 
 !> Fills the derived type with the input parameters from an HSD or an XML file.
 module transporttools_parser
+  use dftbp_common_environment, only : TEnvironment
   use transporttools_helpsetupgeom, only : setupGeometry
   use transporttools_inputdata, only : TInputData
   use dftbp_common_accuracy, only : distFudge, distFudgeOld, dp, lc, mc
   use dftbp_common_constants, only : Bohr__AA
-  use dftbp_common_globalenv, only : stdOut, tIoProc
+  use dftbp_common_globalenv, only : tIoProc
   use dftbp_common_unitconversion, only : lengthUnits
   use dftbp_dftb_slakoeqgrid, only : skEqGridNew, skEqGridOld
   use dftbp_dftbplus_oldcompat, only : convertOldHsd
@@ -84,7 +85,10 @@ contains
 
 
   !> Parse input from an HSD/XML file
-  subroutine parseHsdInput(input)
+  subroutine parseHsdInput(env, input)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Returns initialised input variables on exit
     type(TInputData), intent(out) :: input
@@ -93,32 +97,32 @@ contains
     type(fnode), pointer :: root, tmp, child, placeholder
     type(TParserflags) :: parserFlags
 
-    write(stdOut, "(/, A, /)") "***  Parsing and initializing"
+    write(env%stdOut, "(/, A, /)") "***  Parsing and initializing"
 
     ! Read in the input
     call parseHSD(rootTag, hsdInputName, hsdTree)
     call getChild(hsdTree, rootTag, root)
 
-    write(stdout, '(A,1X,I0,/)') 'Parser version:', parserVersion
-    write(stdout, "(A)") "Interpreting input file '" // hsdInputName // "'"
-    write(stdout, "(A)") repeat("-", 80)
+    write(env%stdOut, '(A,1X,I0,/)') 'Parser version:', parserVersion
+    write(env%stdOut, "(A)") "Interpreting input file '" // hsdInputName // "'"
+    write(env%stdOut, "(A)") repeat("-", 80)
 
     ! Handle parser options
     call getChildValue(root, "ParserOptions", placeholder, "", child=child, list=.true.,&
         & allowEmptyValue=.true., dontMarkProcessed=.true.)
-    call readParserOptions(child, root, parserFlags)
+    call readParserOptions(env, child, root, parserFlags)
 
     ! Read in the different blocks
 
     ! Atomic geometry and boundary conditions
     call getChild(root, "Geometry", tmp)
-    call readGeometry(tmp, input)
+    call readGeometry(env, tmp, input)
 
     call getChild(root, "Transport", child, requested=.false.)
 
     ! Read in transport and modify geometry if it is only a contact calculation
     if (associated(child)) then
-      call readTransportGeometry(child, input%geom, input%transpar)
+      call readTransportGeometry(env, child, input%geom, input%transpar)
     else
       input%transpar%ncont=0
       allocate(input%transpar%contacts(0))
@@ -130,12 +134,12 @@ contains
     input%tInitialized = .true.
 
     ! Issue warning about unprocessed nodes
-    call warnUnprocessedNodes(root, parserFlags%tIgnoreUnprocessed)
+    call warnUnprocessedNodes(env%stdOut, root, parserFlags%tIgnoreUnprocessed)
 
     ! Dump processed tree in HSD and XML format
     if (tIoProc .and. parserFlags%tWriteHSD) then
       call dumpHSD(hsdTree, hsdProcInputName)
-      write(stdout, '(/,/,A)') "Processed input in HSD format written to '" &
+      write(env%stdOut, '(/,/,A)') "Processed input in HSD format written to '" &
           &// hsdProcInputName // "'"
     end if
 
@@ -146,13 +150,16 @@ contains
 
     call destroyNode(hsdTree)
 
-    write(stdout,*) 'Geometry processed. Job finished'
+    write(env%stdOut,*) 'Geometry processed. Job finished'
 
   end subroutine parseHsdInput
 
 
   !> Read in parser options (options not passed to the main code)
-  subroutine readParserOptions(node, root, flags)
+  subroutine readParserOptions(env, node, root, flags)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to get the information from
     type(fnode), pointer :: node
@@ -178,16 +185,16 @@ contains
           &"Sorry, no compatibility mode for parser version " &
           &// i2c(inputVersion) // " (too old)")
     elseif (inputVersion /= parserVersion) then
-      write(stdout, "(A,I2,A,I2,A)") "***  Converting input from version ", &
+      write(env%stdOut, "(A,I2,A,I2,A)") "***  Converting input from version ", &
           &inputVersion, " to version ", parserVersion, " ..."
-      call convertOldHSD(root, inputVersion, parserVersion)
-      write(stdout, "(A,/)") "***  Done."
+      call convertOldHSD(env%stdOut, root, inputVersion, parserVersion)
+      write(env%stdOut, "(A,/)") "***  Done."
     end if
 
     call getChildValue(node, "WriteHSDInput", flags%tWriteHSD, .true.)
     call getChildValue(node, "WriteXMLInput", flags%tWriteXML, .false.)
     if (.not. (flags%tWriteHSD .or. flags%tWriteXML)) then
-      call detailedWarning(node, &
+      call detailedWarning(env%stdOut, node, &
           &"WriteHSDInput and WriteXMLInput both turned off. You are not&
           & guaranteed" &
           &// newline // &
@@ -203,7 +210,10 @@ contains
 
 
   !> Read in Geometry
-  subroutine readGeometry(node, input)
+  subroutine readGeometry(env, node, input)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to get the information from
     type(fnode), pointer :: node
@@ -218,7 +228,7 @@ contains
     call getNodeName(value1, buffer)
     select case (char(buffer))
     case ("genformat")
-      call readTGeometryGen(value1, input%geom)
+      call readTGeometryGen(env, value1, input%geom)
     case default
       call setUnprocessed(value1)
       call readTGeometryHSD(child, input%geom)
@@ -228,7 +238,10 @@ contains
 
 
   !> Read geometry information for transport calculation
-  subroutine readTransportGeometry(root, geom, transpar)
+  subroutine readTransportGeometry(env, root, geom, transpar)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Root node containing the current block
     type(fnode), pointer :: root
@@ -272,11 +285,11 @@ contains
     select case (char(buffer))
     case ("setupgeometry")
 
-      call readContacts(pNodeList, transpar%contacts, geom, char(buffer), iAtInRegion, nPLs)
-      call getSKcutoff(pTask, geom, skCutoff)
-      write(stdOut,*) 'Maximum SK cutoff:', SKcutoff*Bohr__AA,'(A)'
+      call readContacts(env, pNodeList, transpar%contacts, geom, char(buffer), iAtInRegion, nPLs)
+      call getSKcutoff(env, pTask, geom, skCutoff)
+      write(env%stdOut,*) 'Maximum SK cutoff:', SKcutoff*Bohr__AA,'(A)'
       call getChildValue(pTask, "printInfo", printDebug, .false.)
-      call setupGeometry(geom, iAtInRegion, transpar%contacts, skCutoff, nPLs, printDebug)
+      call setupGeometry(env, geom, iAtInRegion, transpar%contacts, skCutoff, nPLs, printDebug)
 
     case default
 
@@ -291,7 +304,11 @@ contains
 
 
   !> Read bias information, used in Analysis and Green's function eigensolver
-  subroutine readContacts(pNodeList, contacts, geom, task, iAtInRegion, nPLs)
+  subroutine readContacts(env, pNodeList, contacts, geom, task, iAtInRegion, nPLs)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
+
     type(fnodeList), pointer :: pNodeList
     type(ContactInfo), allocatable, dimension(:), intent(inout) :: contacts
     type(TGeometry), intent(in) :: geom
@@ -340,7 +357,7 @@ contains
           selectionRange(:) = [1, size(geom%species)]
           ishift = 0
         end if
-        call getSelectedAtomIndices(pTmp, char(buffer), geom%speciesNames, geom%species, &
+        call getSelectedAtomIndices(env%stdOut, pTmp, char(buffer), geom%speciesNames, geom%species, &
             & iAtInRegion(ii)%data, selectionRange=selectionRange)
         iAtInRegion(ii)%data = iAtInRegion(ii)%data + ishift
         call init(vecBuffer)
@@ -383,7 +400,11 @@ contains
   end subroutine readContacts
 
 
-  subroutine getSKcutoff(node, geo, mSKCutoff)
+  subroutine getSKcutoff(env, node, geo, mSKCutoff)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
+
     !> Node to get the information from
     type(fnode), pointer :: node
 
@@ -407,10 +428,10 @@ contains
 
     call getChild(node, "TruncateSKRange", child, requested=.false.)
     if (associated(child)) then
-      call warning("Artificially truncating the SK table, this is normally a bad idea!")
+      call warning(env%stdOut, "Artificially truncating the SK table, this is normally a bad idea!")
       call SKTruncations(child, mSKCutOff, skInterMeth)
     else
-      call readSKFiles(node, geo%nSpecies, geo%speciesNames, mSKCutOff)
+      call readSKFiles(env, node, geo%nSpecies, geo%speciesNames, mSKCutOff)
     end if
     ! The fudge distance is added to get complete cutoff
     select case(skInterMeth)
@@ -425,7 +446,11 @@ contains
   !> Reads Slater-Koster files
   !> Should be replaced with a more sophisticated routine, once the new SK-format has been
   !> established
-  subroutine readSKFiles(node, nSpecies, speciesNames, maxSKcutoff)
+  subroutine readSKFiles(env, node, nSpecies, speciesNames, maxSKcutoff)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
+
     !> Node to get the information from
     type(fnode), pointer :: node
 
@@ -514,17 +539,17 @@ contains
       end do
     end select
 
-    write(stdout, "(A)") "Reading SK-files:"
+    write(env%stdOut, "(A)") "Reading SK-files:"
     do iSp1 = 1, nSpecies
       do iSp2 = iSp1, nSpecies
         call get(skFiles(iSp2, iSp1), fileName, 1)
-        write(stdout,*) trim(fileName)
+        write(env%stdOut,*) trim(fileName)
         call readFromFile(skData, fileName, (iSp1 == iSp2))
         maxSKcutoff = max(maxSKcutoff, skData%dist * size(skData%skHam,1))
       end do
     end do
-    write(stdout, "(A)") "Done."
-    write(stdout, *)
+    write(env%stdOut, "(A)") "Done."
+    write(env%stdOut, *)
 
     do iSp1 = 1, nSpecies
       do iSp2 = 1, nSpecies

--- a/app/transporttools/setupgeom.F90
+++ b/app/transporttools/setupgeom.F90
@@ -8,6 +8,7 @@
 #:include 'common.fypp'
 
 program setupgeom
+  use dftbp_common_environment, only : TEnvironment, TEnvironment_init
   use transporttools_inputdata, only : TInputData
   use transporttools_parser, only : parseHsdInput
   use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv
@@ -15,30 +16,36 @@ program setupgeom
   use dftbp_io_formatout, only : printDftbHeader
 #:if WITH_MPI
   use mpi, only : MPI_COMM_WORLD, MPI_THREAD_FUNNELED
+  use dftbp_io_message, only : error
   use dftbp_common_mpienv, only : TMpiEnv, TMpiEnv_init
   use dftbp_extlibs_mpifx, only : mpifx_finalize, mpifx_init_thread
 #:endif
   implicit none
 
+  type(TEnvironment) :: env
   type(TInputData), allocatable :: input
 
-#:if WITH_MPI
-  !> MPI environment, if compiled with mpifort
-  type(TMpiEnv) :: mpiEnv
 
+
+#:if WITH_MPI
+  call initGlobalEnv(mpiComm=MPI_COMM_WORLD)
+  call TEnvironment_init(env)
   ! As this is serial code, trap for run time execution on more than 1 processor with an mpi enabled
   ! build
   call mpifx_init_thread(requiredThreading=MPI_THREAD_FUNNELED)
-  call TMpiEnv_init(mpiEnv)
-  call mpiEnv%mpiSerialEnv()
-  call initGlobalEnv(mpiComm=MPI_COMM_WORLD)
+  call TMpiEnv_init(env%mpi)
+  if (.not. env%mpi%isSerialEnv()) then
+    call error('This is serial code, but invoked on multiple processors')
+  end if
 #:else
   call initGlobalEnv()
+  call TEnvironment_init(env)
 #:endif
-  call printDftbHeader('(setupgeom)', releaseYear)
+  call printDftbHeader(env%stdOut, '(setupgeom)', releaseYear)
   allocate(input)
-  call parseHsdInput(input)
+  call parseHsdInput(env, input)
   deallocate(input)
+  call env%destruct()
   call destructGlobalEnv()
 
 #:if WITH_MPI

--- a/app/waveplot/gridcache.F90
+++ b/app/waveplot/gridcache.F90
@@ -11,11 +11,11 @@
 !! This object is responsible for reading in the eigenvectors from a specified file and passing the
 !! appropriate eigenvectors to the molecule orbital calculator.
 module waveplot_gridcache
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : pi
   use dftbp_common_environment, only : TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut
 #:if WITH_MPI
   use dftbp_common_schedule, only : getStartAndEndIndex
 #:endif
@@ -254,7 +254,10 @@ contains
 
 
   !> Returns the next entry from the cache (real version).
-  subroutine TGridCache_next_real(sf, gridValReal, levelIndex, tFinished)
+  subroutine TGridCache_next_real(env, sf, gridValReal, levelIndex, tFinished)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Gridcache instance
     type(TgridCache), intent(inout) :: sf
@@ -270,13 +273,16 @@ contains
 
     complex(dp), pointer, save :: gridValCmpl(:,:,:) => null()
 
-    call localNext(sf, gridValReal, gridValCmpl, levelIndex, tFinished)
+    call localNext(env, sf, gridValReal, gridValCmpl, levelIndex, tFinished)
 
   end subroutine TGridCache_next_real
 
 
   !> Returns the next entry from the cache (complex version).
-  subroutine TGridCache_next_cmpl(sf, gridValCmpl, levelIndex, tFinished)
+  subroutine TGridCache_next_cmpl(env, sf, gridValCmpl, levelIndex, tFinished)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Gridcache instance
     type(TgridCache), intent(inout) :: sf
@@ -292,13 +298,16 @@ contains
 
     real(dp), pointer, save :: gridValReal(:,:,:) => null()
 
-    call localNext(sf, gridValReal, gridValCmpl, levelIndex, tFinished)
+    call localNext(env, sf, gridValReal, gridValCmpl, levelIndex, tFinished)
 
   end subroutine TGridCache_next_cmpl
 
 
   !> Working subroutine for the TGridCache_next_* subroutines.
-  subroutine localNext(sf, gridValReal, gridValCmpl, levelIndex, tFinished)
+  subroutine localNext(env, sf, gridValReal, gridValCmpl, levelIndex, tFinished)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Gridcache instance
     type(TgridCache), intent(inout), target :: sf
@@ -347,14 +356,14 @@ contains
         if (all([iLevel, iKPoint, iSpin] == sf%levelIndex(:,iStartAbs+ind-1))) then
           ind = ind + 1
           if (sf%tVerbose) then
-            write(stdout, "(I5,I7,I7,A8)") iSpin, iKPoint, iLevel, "read"
+            write(env%stdout, "(I5,I7,I7,A8)") iSpin, iKPoint, iLevel, "read"
           end if
         end if
       end do
 
       ! Get molecular orbital for that eigenvector
       if (sf%tVerbose) then
-        write(stdout, "(/,A,/)") "Calculating grid"
+        write(env%stdout, "(/,A,/)") "Calculating grid"
       end if
       if (sf%tReal) then
         eigReal => sf%eigenvecReal(:, :iEnd)

--- a/app/waveplot/initwaveplot.F90
+++ b/app/waveplot/initwaveplot.F90
@@ -15,7 +15,7 @@ module waveplot_initwaveplot
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : TEnvironment
   use dftbp_common_file, only : closeFile, openFile, setDefaultBinaryAccess, TFileDescr
-  use dftbp_common_globalenv, only : stdOut, tIoProc
+  use dftbp_common_globalenv, only : tIoProc
   use dftbp_common_release, only : releaseYear
   use dftbp_common_status, only : TStatus
   use dftbp_common_unitconversion, only : lengthUnits
@@ -289,13 +289,13 @@ contains
     type(TStatus) :: errStatus
 
     ! Write header
-    call printDftbHeader('(WAVEPLOT '// version //')', releaseYear)
+    call printDftbHeader(env%stdOut, '(WAVEPLOT '// version //')', releaseYear)
 
     ! Read in input file as HSD
     call parseHSD(rootTag, hsdInput, hsdTree)
     call getChild(hsdTree, rootTag, root)
 
-    write(stdout, "(A)") "Interpreting input file '" // hsdInput // "'"
+    write(env%stdOut, "(A)") "Interpreting input file '" // hsdInput // "'"
 
     ! Check if input version is the one, which we can handle
     call getChildValue(root, "InputVersion", inputVersion, parserVersion)
@@ -310,7 +310,7 @@ contains
     call getChildValue(root, "DetailedXML", strBuffer)
     call readHSDAsXML(unquote(char(strBuffer)), tmp)
     call getChild(tmp, "detailedout", detailed)
-    call readDetailed(this, detailed, tGroundState, kPointsWeights)
+    call readDetailed(this, env, detailed, tGroundState, kPointsWeights)
     call destroyNode(tmp)
 
     nKPoint = size(kPointsWeights, dim=2)
@@ -325,18 +325,18 @@ contains
 
     ! Read options
     call getChild(root, "Options", tmp)
-    call readOptions(this, tmp, this%eig%nState, nKPoint, nSpin, nCached, tShiftGrid)
+    call readOptions(this, env, tmp, this%eig%nState, nKPoint, nSpin, nCached, tShiftGrid)
 
     ! Issue warning about unprocessed nodes
-    call warnUnprocessedNodes(root, .true.)
+    call warnUnprocessedNodes(env%stdOut, root, .true.)
 
     ! Finish parsing, dump parsed and processed input
     if (tIoProc) then
       call dumpHSD(hsdTree, hsdParsedInput)
     end if
-    write(stdout, "(A)") "Processed input written as HSD to '" // hsdParsedInput &
+    write(env%stdout, "(A)") "Processed input written as HSD to '" // hsdParsedInput &
         &//"'"
-    write(stdout, "(A,/)") repeat("-", 80)
+    write(env%stdOut, "(A,/)") repeat("-", 80)
     call destroyNode(hsdTree)
 
   #:if WITH_MPI
@@ -363,7 +363,7 @@ contains
     end if
     this%loc%gridVol = abs(determinant33(this%loc%gridVec))
 
-    write(stdout, "(A)") "Doing initialisation"
+    write(env%stdOut, "(A)") "Doing initialisation"
 
     ! Set the same access for readwrite as for write (we do not open any files in readwrite mode)
     call setDefaultBinaryAccess(this%opt%binaryAccessTypes(1), this%opt%binaryAccessTypes(2),&
@@ -387,10 +387,13 @@ contains
 
 
   !> Interpret the information stored in detailed.xml.
-  subroutine readDetailed(this, detailed, tGroundState, kPointsWeights)
+  subroutine readDetailed(this, env, detailed, tGroundState, kPointsWeights)
 
     !> Container of program variables
     type(TProgramVariables), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Pointer to the node, containing the information
     type(fnode), pointer :: detailed
@@ -418,7 +421,7 @@ contains
 
     call getChildValue(detailed, "Identity", this%input%identity)
     call getChild(detailed, "Geometry", tmp)
-    call readGeometry(this%input%geo, tmp)
+    call readGeometry(env, this%input%geo, tmp)
 
     call getChildValue(detailed, "Real", this%input%tRealHam)
     call getChildValue(detailed, "NrOfKPoints", nKPoint)
@@ -461,7 +464,10 @@ contains
 
 
   !> Read in the geometry stored as .xml in internal or .gen format.
-  subroutine readGeometry(geo, geonode)
+  subroutine readGeometry(env, geo, geonode)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Geometry instance
     type(TGeometry), intent(out) :: geo
@@ -480,7 +486,7 @@ contains
 
     select case (char(buffer))
     case ("genformat")
-      call readTGeometryGen(child, geo)
+      call readTGeometryGen(env, child, geo)
       call removeChildNodes(geonode)
       call writeTGeometryHSD(geonode, geo)
     case ("xyzformat")
@@ -488,7 +494,7 @@ contains
       call removeChildNodes(geonode)
       call writeTGeometryHSD(geonode, geo)
     case ("vaspformat")
-      call readTGeometryVasp(child, geo)
+      call readTGeometryVasp(env, child, geo)
       call removeChildNodes(geonode)
       call writeTGeometryHSD(geonode, geo)
     case default
@@ -499,10 +505,13 @@ contains
 
 
   !> Interpret the options.
-  subroutine readOptions(this, node, nLevel, nKPoint, nSpin, nCached, tShiftGrid)
+  subroutine readOptions(this, env, node, nLevel, nKPoint, nSpin, nCached, tShiftGrid)
 
     !> Container of program variables
     type(TProgramVariables), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node containing the information
     type(fnode), pointer :: node
@@ -552,7 +561,7 @@ contains
     ! Warning, if processed input is read in, but eigenvectors are different
     call getChildValue(node, "Identity", curId, this%input%identity)
     if (curId /= this%input%identity) then
-      call warning(warnId)
+      call warning(env%stdOut, warnId)
     end if
 
     call getChildValue(node, "TotalChargeDensity", this%opt%tPlotTotChrg, .false.)
@@ -578,23 +587,23 @@ contains
     call getChildValue(node, "ImagComponent", this%opt%tPlotImag, .false., child=field)
 
     if (this%opt%tPlotImag .and. this%input%tRealHam) then
-      call detailedWarning(field, "Wave functions are real, no imaginary part will be plotted")
+      call detailedWarning(env%stdOut, field, "Wave functions are real, no imaginary part will be plotted")
       this%opt%tPlotImag = .false.
     end if
 
     call getChildValue(node, "PlottedLevels", buffer, child=field, multiple=.true.)
-    call getSelectedIndices(node, char(buffer), [1, nLevel], this%opt%plottedLevels)
+    call getSelectedIndices(env%stdOut, node, char(buffer), [1, nLevel], this%opt%plottedLevels)
 
     if (this%input%geo%tPeriodic) then
       call getChildValue(node, "PlottedKPoints", buffer, child=field, multiple=.true.)
-      call getSelectedIndices(node, char(buffer), [1, nKPoint], this%opt%plottedKPoints)
+      call getSelectedIndices(env%stdOut, node, char(buffer), [1, nKPoint], this%opt%plottedKPoints)
     else
       allocate(this%opt%plottedKPoints(1))
       this%opt%plottedKPoints(1) = 1
     end if
 
     call getChildValue(node, "PlottedSpins", buffer, child=field, multiple=.true.)
-    call getSelectedIndices(node, char(buffer), [1, nSpin], this%opt%plottedSpins)
+    call getSelectedIndices(env%stdOut, node, char(buffer), [1, nSpin], this%opt%plottedSpins)
 
     ! Create the list of the levels, which must be calculated explicitely
     call init(indexBuffer)

--- a/app/waveplot/waveplot.F90
+++ b/app/waveplot/waveplot.F90
@@ -429,7 +429,7 @@ contains
     !> Name of the file to create
     character(len=*), intent(in) :: fileName
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> First two comment lines of the file

--- a/app/waveplot/waveplot.F90
+++ b/app/waveplot/waveplot.F90
@@ -15,7 +15,7 @@ program waveplot
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : TEnvironment, TEnvironment_init
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv, stdOut
+  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv
   use dftbp_dftb_periodic, only : getCellTranslations
   use dftbp_io_charmanip, only : i2c
   use dftbp_io_message, only : error, warning
@@ -79,7 +79,8 @@ program waveplot
 
   ! Allocate resources
   call TProgramVariables_init(wp, env)
-  write(stdOut, "(/,A,/)") "Starting main program"
+
+  write(env%stdOut, "(/,A,/)") "Starting main program"
 
   ! Allocating buffer for general grid, total charge and spin up
   allocate(buffer(wp%opt%nPoints(1), wp%opt%nPoints(2), wp%opt%nPoints(3)))
@@ -126,15 +127,15 @@ program waveplot
     end do
   end if
 
-  write(stdOut, "(A)") "Origin"
-  write(stdOut, "(2X,3(F0.5,1X))") wp%opt%origin
-  write(stdOut, "(A)") "Box"
+  write(env%stdOut, "(A)") "Origin"
+  write(env%stdOut, "(2X,3(F0.5,1X))") wp%opt%origin
+  write(env%stdOut, "(A)") "Box"
   do i1 = 1, 3
-    write(stdOut, "(2X,3(F0.5,1X))") wp%opt%boxVecs(:, i1)
+    write(env%stdOut, "(2X,3(F0.5,1X))") wp%opt%boxVecs(:, i1)
   end do
-  write(stdOut, "(A)") "Spatial resolution [1/Bohr]:"
-  write(stdOut, "(2X,3(F0.5,1X))") 1.0_dp / norm2(wp%loc%gridVec, dim=1)
-  write(stdOut, *)
+  write(env%stdOut, "(A)") "Spatial resolution [1/Bohr]:"
+  write(env%stdOut, "(2X,3(F0.5,1X))") 1.0_dp / norm2(wp%loc%gridVec, dim=1)
+  write(env%stdOut, *)
 
   ! Create density superposition of the atomic orbitals. Occupation is distributed equally on
   ! orbitals with the same angular momentum.
@@ -158,18 +159,18 @@ program waveplot
       buffer(:,:,:) = atomicChrg(:,:,:, 1)
 
       if (wp%opt%tVerbose) then
-        write(stdOut, "('Total charge of atomic densities:',F12.6,/)") sumAtomicChrg
+        write(env%stdOut, "('Total charge of atomic densities:',F12.6,/)") sumAtomicChrg
       end if
       if (wp%opt%tPlotAtomDens) then
         write(comments(2), 9989) wp%input%identity
 9989    format('Calc-Id:',I11,', atomdens')
         fileName = "wp-atomdens.cube"
         call writeCubeFile(wp%input%geo, wp%aNr%atomicNumbers, wp%loc%gridVec, wp%opt%gridOrigin,&
-            & buffer, fileName, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
+            & buffer, fileName, env%stdOut, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
         if (ioStat /= 0) then
           call error("Error while writing file '" // trim(fileName) // "'.")
         else
-          write(stdOut, "(A)") "File '" // trim(fileName) // "' written"
+          write(env%stdOut, "(A)") "File '" // trim(fileName) // "' written"
         end if
       end if
     end if
@@ -180,7 +181,7 @@ program waveplot
   end if
 
   if (wp%opt%tVerbose) then
-    write(stdOut, "(/,A5,' ',A6,' ',A6,' ',A7,' ',A11,' ',A11)") "Spin", "KPoint", "State",&
+    write(env%stdOut, "(/,A5,' ',A6,' ',A6,' ',A7,' ',A11,' ',A11)") "Spin", "KPoint", "State",&
         & "Action", "Norm", "W. Occup."
   end if
 
@@ -246,9 +247,9 @@ program waveplot
   lpStates: do while (.not. tFinished)
     ! Get the next grid and its parameters
     if (wp%input%tRealHam) then
-      call next(wp%loc%grid, gridValReal, levelIndex, tFinished)
+      call next(env, wp%loc%grid, gridValReal, levelIndex, tFinished)
     else
-      call next(wp%loc%grid, gridValCmpl, levelIndex, tFinished)
+      call next(env, wp%loc%grid, gridValCmpl, levelIndex, tFinished)
     end if
     iLevel = levelIndex(1)
     iKPoint = levelIndex(2)
@@ -269,7 +270,7 @@ program waveplot
       end if
       sumChrg = sum(buffer) * wp%loc%gridVol
       if (wp%opt%tVerbose) then
-        write(*, "(I5,I7,I7,A8,F12.6,F12.6)") iSpin, iKPoint, iLevel, "calc", sumChrg,&
+        write(env%stdOut, "(I5,I7,I7,A8,F12.6,F12.6)") iSpin, iKPoint, iLevel, "calc", sumChrg,&
             & wp%input%occupations(iLevel, iKPoint, iSpin)
       end if
     end if
@@ -286,9 +287,9 @@ program waveplot
 9990    format('Calc-Id:',I11,', Spin:',I2,', K-Point:',I6,', State:',I6, ', abs2')
         fileName = "wp-" // i2c(iSpin) // "-" // i2c(iKPoint) // "-" // i2c(iLevel) // "-abs2.cube"
         call writeCubeFile(wp%input%geo, wp%aNr%atomicNumbers, wp%loc%gridVec, wp%opt%gridOrigin,&
-            & buffer, fileName, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
+            & buffer, fileName, env%stdOut, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
         hasIoError = hasIoError .or. ioStat /= 0
-        if (ioStat == 0) write(*, "(A)") "File '" // trim(fileName) // "' written"
+        if (ioStat == 0) write(env%stdOut, "(A)") "File '" // trim(fileName) // "' written"
       end if
 
       if (wp%opt%tPlotChrgDiff) then
@@ -298,9 +299,9 @@ program waveplot
         fileName = "wp-" // i2c(iSpin) // "-" // i2c(iKPoint) // "-" // i2c(iLevel) //&
             & "-abs2diff.cube"
         call writeCubeFile(wp%input%geo, wp%aNr%atomicNumbers, wp%loc%gridVec, wp%opt%gridOrigin,&
-            & buffer, fileName, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
+            & buffer, fileName, env%stdOut, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
         hasIoError = hasIoError .or. ioStat /= 0
-        if (ioStat == 0) write(*, "(A)") "File '" // trim(fileName) // "' written"
+        if (ioStat == 0) write(env%stdOut, "(A)") "File '" // trim(fileName) // "' written"
       end if
 
       if (wp%opt%tPlotReal) then
@@ -313,9 +314,9 @@ program waveplot
 9991    format('Calc-Id:',I11,', Spin:',I2,', K-Point:',I6,', State:',I6, ', real')
         fileName = "wp-" // i2c(iSpin) // "-" // i2c(iKPoint) // "-" // i2c(iLevel) // "-real.cube"
         call writeCubeFile(wp%input%geo, wp%aNr%atomicNumbers, wp%loc%gridVec, wp%opt%gridOrigin,&
-            & buffer, fileName, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
+            & buffer, fileName, env%stdOut, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
         hasIoError = hasIoError .or. ioStat /= 0
-        if (ioStat == 0) write(*, "(A)") "File '" // trim(fileName) // "' written"
+        if (ioStat == 0) write(env%stdOut, "(A)") "File '" // trim(fileName) // "' written"
       end if
 
       if (wp%opt%tPlotImag) then
@@ -324,9 +325,9 @@ program waveplot
 9992    format('Calc-Id:',I11,', Spin:',I2,', K-Point:',I6,', State:',I6, ', imag')
         fileName = "wp-" // i2c(iSpin) // "-" // i2c(iKPoint) // "-" // i2c(iLevel) // "-imag.cube"
         call writeCubeFile(wp%input%geo, wp%aNr%atomicNumbers, wp%loc%gridVec, wp%opt%gridOrigin,&
-            & buffer, fileName, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
+            & buffer, fileName, env%stdOut, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
         hasIoError = hasIoError .or. ioStat /= 0
-        if (ioStat == 0) write(*, "(A)") "File '" // trim(fileName) // "' written"
+        if (ioStat == 0) write(env%stdOut, "(A)") "File '" // trim(fileName) // "' written"
       end if
     end if
   end do lpStates
@@ -351,14 +352,14 @@ program waveplot
 9993 format('Calc-Id:',I11,', abs2')
     fileName = "wp-abs2.cube"
     call writeCubeFile(wp%input%geo, wp%aNr%atomicNumbers, wp%loc%gridVec, wp%opt%gridOrigin,&
-        & totChrg, fileName, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
+        & totChrg, fileName, env%stdOut, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
     if (ioStat /= 0) then
       call error("Error while writing file '" // trim(fileName) // "'.")
     else
-      write(stdOut, "(A)") "File '" // trim(fileName) // "' written"
+      write(env%stdOut, "(A)") "File '" // trim(fileName) // "' written"
     end if
     if (wp%opt%tVerbose) then
-      write(stdOut, "(/,'Total charge:',F12.6,/)") sumTotChrg
+      write(env%stdOut, "(/,'Total charge:',F12.6,/)") sumTotChrg
     end if
   end if
 
@@ -369,11 +370,11 @@ program waveplot
 9994 format('Calc-Id:',I11,', abs2diff')
     fileName = 'wp-abs2diff.cube'
     call writeCubeFile(wp%input%geo, wp%aNr%atomicNumbers, wp%loc%gridVec, wp%opt%gridOrigin,&
-        & buffer, fileName, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
+        & buffer, fileName, env%stdOut, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
     if (ioStat /= 0) then
       call error("Error while writing file '" // trim(fileName) // "'.")
     else
-      write(stdOut, "(A)") "File '" // trim(fileName) // "' written"
+      write(env%stdOut, "(A)") "File '" // trim(fileName) // "' written"
     end if
   end if
 
@@ -390,22 +391,24 @@ program waveplot
 9996 format('Calc-Id:',I11,', spinpol')
     fileName = 'wp-spinpol.cube'
     call writeCubeFile(wp%input%geo, wp%aNr%atomicNumbers, wp%loc%gridVec, wp%opt%gridOrigin,&
-        & buffer, fileName, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
+        & buffer, fileName, env%stdOut, comments=comments, repeatBox=wp%opt%repeatBox, ioStat=ioStat)
     if (ioStat /= 0) then
       call error("Error while writing file '" // trim(fileName) // "'.")
     else
-      write(stdOut, "(A)") "File '" // trim(fileName) // "' written"
+      write(env%stdOut, "(A)") "File '" // trim(fileName) // "' written"
     end if
   end if
 
   call env%destruct()
   call destructGlobalEnv()
 
+  call env%destruct()
+  call destructGlobalEnv()
 
 contains
 
   !> Writes a 3D function as cube file.
-  subroutine writeCubeFile(geo, atomicNumbers, gridVecs, origin, gridVal, fileName, comments,&
+  subroutine writeCubeFile(geo, atomicNumbers, gridVecs, origin, gridVal, fileName, output, comments,&
       & repeatBox, ioStat)
 
     !> Geometry information about the structure
@@ -425,6 +428,9 @@ contains
 
     !> Name of the file to create
     character(len=*), intent(in) :: fileName
+
+    !> Output for write processes
+    integer, intent(in) :: output
 
     !> First two comment lines of the file
     character(len=*), intent(in), optional :: comments(:)
@@ -470,7 +476,7 @@ contains
     if (present(ioStat)) ioStat = ioStat_
 
     if (ioStat_ /= 0) then
-      call warning("Error while opening file '" // trim(fileName) // "'.")
+      call warning(output, "Error while opening file '" // trim(fileName) // "'.")
       return
     end if
     if (present(comments)) then

--- a/src/dftbp/api/api.F90
+++ b/src/dftbp/api/api.F90
@@ -9,12 +9,10 @@
 
 !> Provides DFTB+ API
 module dftbp_api
-  use, intrinsic :: iso_fortran_env, only : output_unit
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : TEnvironment, TEnvironment_init
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv, instanceSafeBuild, withMpi,&
-      & stdOut
+  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv, instanceSafeBuild, withMpi
   use dftbp_dftbplus_hsdhelpers, only : doPostParseJobs
   use dftbp_dftbplus_initprogram, only : TDftbPlusMain
   use dftbp_dftbplus_inputdata, only : TInputData
@@ -363,6 +361,8 @@ contains
     !! multiple TDftbPlus instances within an MPI-process)
     integer, intent(in), optional :: devNull
 
+    integer :: stdOut, stdErr
+
   #:if not INSTANCE_SAFE_BUILD
     if (nInstance_ /= 0) then
       call error("This build does not support multiple DFTB+ instances")
@@ -374,10 +374,11 @@ contains
       call error("MPI Communicator supplied to initialise a serial DFTB+ instance")
     end if
 
-    call initGlobalEnv(outputUnit=outputUnit, mpiComm=mpiComm, devNull=devNull)
+    call initGlobalEnv(outputUnit=outputUnit, mpiComm=mpiComm, devNull=devNull, stdOut=stdOut,&
+        & stdErr=stdErr)
     allocate(this%env)
     allocate(this%main)
-    call TEnvironment_init(this%env)
+    call TEnvironment_init(this%env, stdOut=stdOut, stdErr=stdErr)
     this%env%tAPICalculation = .true.
     this%isInitialised = .true.
 
@@ -470,8 +471,8 @@ contains
 
     call this%checkInit()
 
-    call parseHsdTree(input%hsdTree, inpData, parserFlags)
-    call doPostParseJobs(input%hsdTree, parserFlags)
+    call parseHsdTree(this%env, input%hsdTree, inpData, parserFlags)
+    call doPostParseJobs(this%env%stdOut, input%hsdTree, parserFlags)
     call this%main%initProgramVariables(inpData, this%env)
 
   end subroutine TDftbPlus_setupCalculator
@@ -1296,7 +1297,8 @@ contains
       call error("Perturbation wrt to external charges requested, but no external charges present")
     end if
     if (.not. allocated(this%main%response)) then
-      write(stdOut, *)"Making a generic initialization of settings for coupled-perturbed response"
+      write(this%env%stdOut, *)"Making a generic initialization of settings for coupled-perturbed&
+          & response"
       allocate(this%main%response)
       ! eigenvalue-based, non-fixed Fermi level, degeneracy tolerances of 1E-9 and static:
       call TResponse_init(this%main%response, responseSolverTypes%spectralSum, .false., 1.0E-9_dp,&

--- a/src/dftbp/api/api.F90
+++ b/src/dftbp/api/api.F90
@@ -361,7 +361,7 @@ contains
     !! multiple TDftbPlus instances within an MPI-process)
     integer, intent(in), optional :: devNull
 
-    integer :: stdOut, stdErr
+    integer :: stdOut
 
   #:if not INSTANCE_SAFE_BUILD
     if (nInstance_ /= 0) then
@@ -374,11 +374,10 @@ contains
       call error("MPI Communicator supplied to initialise a serial DFTB+ instance")
     end if
 
-    call initGlobalEnv(outputUnit=outputUnit, mpiComm=mpiComm, devNull=devNull, stdOut=stdOut,&
-        & stdErr=stdErr)
+    call initGlobalEnv(outputUnit=outputUnit, mpiComm=mpiComm, devNull=devNull, stdOut=stdOut)
     allocate(this%env)
     allocate(this%main)
-    call TEnvironment_init(this%env, stdOut=stdOut, stdErr=stdErr)
+    call TEnvironment_init(this%env, stdOut=stdOut)
     this%env%tAPICalculation = .true.
     this%isInitialised = .true.
 

--- a/src/dftbp/common/assert.F90
+++ b/src/dftbp/common/assert.F90
@@ -9,7 +9,8 @@
 
 !> Auxiliary subroutines for the ASSERT command
 module dftbp_common_assert
-  use dftbp_common_globalenv, only : abortProgram, stdOut
+  use dftbp_common_globalenv, only : stdOut0
+  use dftbp_common_globalenv, only : abortProgram
   implicit none
 
   private
@@ -34,11 +35,11 @@ contains
     !> Additional message for error
     character(*), intent(in), optional :: message
 
-    write(stdout, '(A)') "!!! UNFULLFILLED ASSERTION"
-    write(stdout, '(A,A)') "!!! FILE:      ", fileName
-    write(stdout, '(A,I0)') "!!! LINE NR.:  ", lineNr
+    write(stdOut0, '(A)') "!!! UNFULLFILLED ASSERTION"
+    write(stdOut0, '(A,A)') "!!! FILE:      ", fileName
+    write(stdOut0, '(A,I0)') "!!! LINE NR.:  ", lineNr
     if (present(message)) then
-      write(stdout, '(A,A,A)') '!!! MESSAGE:  "', trim(message), '"'
+      write(stdOut0, '(A,A,A)') '!!! MESSAGE:  "', trim(message), '"'
     end if
     call abortProgram()
 

--- a/src/dftbp/common/coherence.F90
+++ b/src/dftbp/common/coherence.F90
@@ -163,7 +163,7 @@ contains
 
     if (env%tAPICalculation) then
        if (.not. coherence${NAME}$${DIM}$(env, data)) then
-         @:ERROR_HANDLING(err, -1, "Coherence failure in " //trim(adjustl(message))//&
+         @:ERROR_HANDLING(env%stdOut, err, -1, "Coherence failure in " //trim(adjustl(message))//&
              & " across nodes")
        end if
     end if
@@ -272,7 +272,7 @@ contains
     if (env%tAPICalculation) then
       if (.not. approxCoherence${NAME}$${DIM}$(env, data, tol_)) then
         Write(tol_str, '(E12.5)') tol_
-        @:ERROR_HANDLING(err, -1, "Coherence failure in "//trim(adjustl(message))//" across nodes&
+        @:ERROR_HANDLING(env%stdOut, err, -1, "Coherence failure in "//trim(adjustl(message))//" across nodes&
             & for a tolerance of: "//trim(adjustl(tol_str)))
       end if
     end if

--- a/src/dftbp/common/envcheck.F90
+++ b/src/dftbp/common/envcheck.F90
@@ -42,7 +42,7 @@ contains
   !> Checks stacksize settings for optimal user experience/performance.
   subroutine checkStackSize(output)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !! Current stacksize

--- a/src/dftbp/common/envcheck.F90
+++ b/src/dftbp/common/envcheck.F90
@@ -13,7 +13,6 @@ module dftbp_common_envcheck
   use, intrinsic :: iso_c_binding, only : c_char, c_int
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : TEnvironment
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_io_message, only : warning
   implicit none
 
@@ -41,10 +40,10 @@ module dftbp_common_envcheck
 contains
 
   !> Checks stacksize settings for optimal user experience/performance.
-  subroutine checkStackSize(env)
+  subroutine checkStackSize(output)
 
-    !> Environment settings
-    type(TEnvironment), intent(in) :: env
+    !> output for write processes
+    integer, intent(in) :: output
 
     !! Current stacksize
     integer :: cStack
@@ -55,14 +54,14 @@ contains
     call get_stacksize(cStack, iErr)
 
     if (iErr /= 0) then
-      write(stdOut, "(A,':',T30,A,I0,A)") "Current stacksize", "N/A (error code: ", iErr, ")"
+      write(output, "(A,':',T30,A,I0,A)") "Current stacksize", "N/A (error code: ", iErr, ")"
     else
       if (cStack == -1 .or. cStack == 0) then
-        write(stdOut, "(A,':',T30,A)") "Current stacksize", "unlimited"
+        write(output, "(A,':',T30,A)") "Current stacksize", "unlimited"
       else
-        write(stdOut, "(A,':',T30,I0,A)") "Current stacksize",&
+        write(output, "(A,':',T30,I0,A)") "Current stacksize",&
             & nint(real(cStack, dp) / 1024.0_dp**2), " [Mb] (recommended: unlimited)"
-        call warning("Current stacksize not set to unlimited or hard limit, which might cause"&
+        call warning(output, "Current stacksize not set to unlimited or hard limit, which might cause"&
             & // new_line("A") // "   random crashes (e.g. segmentation faults). It is advised to&
             & unlimit the" // new_line("A") // "   stacksize by issuing 'ulimit -s unlimited'&
             & (Linux) or setting it to the " // new_line("A") // "   hard limit by 'ulimit -s hard'&

--- a/src/dftbp/common/environment.F90
+++ b/src/dftbp/common/environment.F90
@@ -77,9 +77,6 @@ module dftbp_common_environment
     !> Standard output unit
     integer, public :: stdOut = -1
 
-    !> Standard error unit
-    integer, public :: stdErr = -1
-
   contains
     procedure :: destruct => TEnvironment_destruct
     procedure :: shutdown => TEnvironment_shutdown
@@ -190,7 +187,7 @@ module dftbp_common_environment
 contains
 
   !> Returns an initialized instance.
-  subroutine TEnvironment_init(this, stdOut, stdErr)
+  subroutine TEnvironment_init(this, stdOut)
 
     !> Instance
     type(TEnvironment), intent(out) :: this
@@ -198,18 +195,10 @@ contains
     !> Standard output unit
     integer, intent(in), optional :: stdOut
 
-    !> Standard error unit
-    integer, intent(in), optional :: stdErr
-
     if (present(stdOut)) then
       this%stdOut = stdOut
     else
       this%stdOut = globalStdOut
-    end if
-    if (present(stdErr)) then
-      this%stdErr = stdErr
-    else
-      this%stdErr = globalStdErr
     end if
 
   end subroutine TEnvironment_init

--- a/src/dftbp/common/environment.F90
+++ b/src/dftbp/common/environment.F90
@@ -346,7 +346,7 @@ contains
     !> Instance
     class(TEnvironment), intent(inout) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     call TGpuEnv_init(this%gpu, output)

--- a/src/dftbp/common/environment.F90
+++ b/src/dftbp/common/environment.F90
@@ -10,7 +10,8 @@
 
 !> Contains computer environment settings
 module dftbp_common_environment
-  use dftbp_common_globalenv, only : shutdown, stdOut
+  use iso_fortran_env, only : globalStdErr => error_unit, globalStdOut => output_unit
+  use dftbp_common_globalenv, only : shutdown
   use dftbp_common_status, only : TStatus
   use dftbp_common_timerarray, only : TTimerArray, TTimerArray_init, TTimerItem
 #:if WITH_MAGMA
@@ -72,6 +73,12 @@ module dftbp_common_environment
 
     !> Is this calculation called by the API?
     logical, public :: tAPICalculation = .false.
+
+    !> Standard output unit
+    integer, public :: stdOut = -1
+
+    !> Standard error unit
+    integer, public :: stdErr = -1
 
   contains
     procedure :: destruct => TEnvironment_destruct
@@ -183,12 +190,27 @@ module dftbp_common_environment
 contains
 
   !> Returns an initialized instance.
-  subroutine TEnvironment_init(this)
+  subroutine TEnvironment_init(this, stdOut, stdErr)
 
     !> Instance
     type(TEnvironment), intent(out) :: this
 
-    continue
+    !> Standard output unit
+    integer, intent(in), optional :: stdOut
+
+    !> Standard error unit
+    integer, intent(in), optional :: stdErr
+
+    if (present(stdOut)) then
+      this%stdOut = stdOut
+    else
+      this%stdOut = globalStdOut
+    end if
+    if (present(stdErr)) then
+      this%stdErr = stdErr
+    else
+      this%stdErr = globalStdErr
+    end if
 
   end subroutine TEnvironment_init
 
@@ -217,7 +239,9 @@ contains
       end if
     #:endif
 
-    flush(stdOut)
+    if (this%stdOut > 0) then
+      flush(this%stdOut)
+    end if
 
   end subroutine TEnvironment_destruct
 
@@ -253,8 +277,7 @@ contains
     integer, intent(in) :: unit
 
     allocate(this%globalTimer)
-    call TTimerArray_init(this%globalTimer, globalTimerItems, maxLevel=timingLevel, header=header,&
-        & unit=unit)
+    call TTimerArray_init(this%globalTimer, globalTimerItems, unit, maxLevel=timingLevel, header=header)
 
   end subroutine TEnvironment_initGlobalTimer
 
@@ -318,12 +341,15 @@ contains
 #:if WITH_MAGMA
 
   !> Initialize GPU environment
-  subroutine TEnvironment_initGpu(this)
+  subroutine TEnvironment_initGpu(this, output)
 
     !> Instance
     class(TEnvironment), intent(inout) :: this
 
-    call TGpuEnv_init(this%gpu)
+    !> output for write processes
+    integer, intent(in) :: output
+
+    call TGpuEnv_init(this%gpu, output)
 
   end subroutine TEnvironment_initGpu
 

--- a/src/dftbp/common/globalenv.F90
+++ b/src/dftbp/common/globalenv.F90
@@ -26,7 +26,8 @@ module dftbp_common_globalenv
   private
   public :: initGlobalEnv, destructGlobalEnv
   public :: abortProgram, shutdown, synchronizeAll
-  public :: stdOut, stdOut0, stdErr, stdErr0, tIoProc
+  public :: stdOut0, stdErr0
+  public :: tIoProc
   public :: withScalapack, withMpi
   public :: instanceSafeBuild
   #:if WITH_MPI
@@ -39,12 +40,6 @@ module dftbp_common_globalenv
 
   !> Unredirected standard error
   integer, parameter :: stdErr0 = error_unit
-
-  !> Standard out file handler
-  integer, protected :: stdOut = stdOut0
-
-  !> Standard error file handler
-  integer, protected :: stdErr = stdErr0
 
   !> Whether current process is the global lead process
   logical, protected :: tIoProc = .true.
@@ -62,7 +57,7 @@ module dftbp_common_globalenv
 
 #:if WITH_MPI
   !> Whether MPI finalization should be performed at the end
-  logical :: doMpiFinalization = .true.
+  logical, protected :: doMpiFinalization = .true.
 #:endif
 
   !> Whether code was compiled with many-body dispersion support
@@ -76,7 +71,7 @@ module dftbp_common_globalenv
 contains
 
   !> Initializes global environment (must be the first statement of a program)
-  subroutine initGlobalEnv(outputUnit, mpiComm, errorUnit, devNull)
+  subroutine initGlobalEnv(outputUnit, mpiComm, errorUnit, devNull, stdOut, stdErr)
 
     !> Customised global standard output
     integer, intent(in), optional :: outputUnit
@@ -90,52 +85,60 @@ contains
     !> Unit of the null device (needed for follow processes to suppress their output)
     integer, intent(in), optional :: devNull
 
+    !> Effective standard output for the calling process (on an MPI run, this is redirected to
+    !> the null device on every process but the lead one)
+    integer, intent(out), optional :: stdOut
 
-    integer :: outputUnit0, errorUnit0, devNull0
+    !> Effective standard error for the calling process (on an MPI run, this is redirected to
+    !> the null device on every process but the lead one)
+    integer, intent(out), optional :: stdErr
 
-  #:if WITH_MPI
-    integer :: mpiComm0
-  #:endif
+    integer :: outputUnit_, errorUnit_
 
     if (present(outputUnit)) then
-      outputUnit0 = outputUnit
+      outputUnit_ = outputUnit
     else
-      outputUnit0 = stdOut0
+      outputUnit_ = stdOut0
     end if
 
     if (present(errorUnit)) then
-      errorUnit0 = errorUnit
+      errorUnit_ = errorUnit
     else
-      errorUnit0 = stdErr0
+      errorUnit_ = stdErr0
     end if
 
   #:if WITH_MPI
-    if (present(mpiComm)) then
-      mpiComm0 = mpiComm
-      doMpiFinalization = .false.
-    else
-      mpiComm0 = MPI_COMM_WORLD
-      call mpifx_init_thread(requiredThreading=MPI_THREAD_FUNNELED)
-    end if
+    block
+      integer :: mpiComm_, devNull_
 
-    call globalMpiComm%init(commid=mpiComm0)
-    if (globalMpiComm%lead) then
-      stdOut = outputUnit0
-      stdErr = errorUnit0
-    else
-      if (present(devNull)) then
-        devNull0 = devNull
+      if (present(mpiComm)) then
+        mpiComm_ = mpiComm
+        doMpiFinalization = .false.
       else
-        open(newunit=devNull0, file="/dev/null", action="write")
+        mpiComm_ = MPI_COMM_WORLD
+        call mpifx_init_thread(requiredThreading=MPI_THREAD_FUNNELED)
       end if
-      stdOut = devNull0
-      stdErr = devNull0
-    end if
-    tIoProc = globalMpiComm%lead
-  #:else
-    stdOut = outputUnit0
-    stdErr = errorUnit0
+
+      call globalMpiComm%init(commid=mpiComm_)
+      if (.not. globalMpiComm%lead) then
+        if (present(devNull)) then
+          devNull_ = devNull
+        else
+          open(newunit=devNull_, file="/dev/null", action="write")
+        end if
+        outputUnit_ = devNull_
+        errorUnit_ = devNull_
+      end if
+      tIoProc = globalMpiComm%lead
+    end block
   #:endif
+
+    if (present(stdOut)) then
+      stdOut = outputUnit_
+    end if
+    if (present(stdErr)) then
+      stdErr = errorUnit_
+    end if
 
   end subroutine initGlobalEnv
 

--- a/src/dftbp/common/globalenv.F90
+++ b/src/dftbp/common/globalenv.F90
@@ -71,7 +71,7 @@ module dftbp_common_globalenv
 contains
 
   !> Initializes global environment (must be the first statement of a program)
-  subroutine initGlobalEnv(outputUnit, mpiComm, errorUnit, devNull, stdOut, stdErr)
+  subroutine initGlobalEnv(outputUnit, mpiComm, errorUnit, devNull, stdOut)
 
     !> Customised global standard output
     integer, intent(in), optional :: outputUnit
@@ -89,22 +89,12 @@ contains
     !> the null device on every process but the lead one)
     integer, intent(out), optional :: stdOut
 
-    !> Effective standard error for the calling process (on an MPI run, this is redirected to
-    !> the null device on every process but the lead one)
-    integer, intent(out), optional :: stdErr
-
-    integer :: outputUnit_, errorUnit_
+    integer :: outputUnit_
 
     if (present(outputUnit)) then
       outputUnit_ = outputUnit
     else
       outputUnit_ = stdOut0
-    end if
-
-    if (present(errorUnit)) then
-      errorUnit_ = errorUnit
-    else
-      errorUnit_ = stdErr0
     end if
 
   #:if WITH_MPI
@@ -127,7 +117,6 @@ contains
           open(newunit=devNull_, file="/dev/null", action="write")
         end if
         outputUnit_ = devNull_
-        errorUnit_ = devNull_
       end if
       tIoProc = globalMpiComm%lead
     end block
@@ -135,9 +124,6 @@ contains
 
     if (present(stdOut)) then
       stdOut = outputUnit_
-    end if
-    if (present(stdErr)) then
-      stdErr = errorUnit_
     end if
 
   end subroutine initGlobalEnv

--- a/src/dftbp/common/gpuenv.F90
+++ b/src/dftbp/common/gpuenv.F90
@@ -11,7 +11,6 @@
 !> Information on any GPUs on the system
 module dftbp_common_gpuenv
   use, intrinsic :: iso_c_binding, only : c_int
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_extlibs_magma, only : getGpusAvailable, getGpusRequested, gpusInit
   implicit none
 
@@ -32,18 +31,21 @@ contains
 
 
   !> Initilises a TGpuEnv instance
-  subroutine TGpuEnv_init(this)
+  subroutine TGpuEnv_init(this, output)
 
     !> Instance
     type(TGpuEnv), intent(out) :: this
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     integer(c_int) :: nGpuReq
 
     call gpusInit()
     call getGpusAvailable(this%nGpu)
     call getGpusRequested(nGpuReq)
-    write(stdOut, *) "Number of GPUs requested:", nGpuReq
-    write(stdOut, *) "Number of GPUs found    :", this%nGpu
+    write(output, *) "Number of GPUs requested:", nGpuReq
+    write(output, *) "Number of GPUs found    :", this%nGpu
     if ((nGpuReq <= this%nGpu) .and. (nGpuReq >= 1)) then
       this%nGpu = nGpuReq
     end if

--- a/src/dftbp/common/gpuenv.F90
+++ b/src/dftbp/common/gpuenv.F90
@@ -36,7 +36,7 @@ contains
     !> Instance
     type(TGpuEnv), intent(out) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     integer(c_int) :: nGpuReq

--- a/src/dftbp/common/mpienv.F90
+++ b/src/dftbp/common/mpienv.F90
@@ -61,7 +61,7 @@ module dftbp_common_mpienv
 
   contains
 
-    procedure :: mpiSerialEnv
+    procedure :: isSerialEnv
 
   end type TMpiEnv
 
@@ -148,22 +148,14 @@ contains
 
 
   !> Routine to check this is a single processor instance, stopping otherwise (useful to call in
-  !! purely serial codes to avid multiple copies being invoked with mpirun)
-  subroutine mpiSerialEnv(this, iErr)
-
-    !> Instance
+  !> purely serial codes to avid multiple copies being invoked with mpirun)
+  pure function isSerialEnv(this) result(isSerial)
     class(TMpiEnv), intent(in) :: this
+    logical :: isSerial
 
-    !> Optional error flag
-    integer, intent(out), optional :: iErr
+    isSerial = this%globalComm%size == 1
 
-    if (this%globalComm%size > 1) then
-
-      @:ERROR_HANDLING(iErr, -1, 'This is serial code, but invoked on multiple processors')
-
-    end if
-
-  end subroutine mpiSerialEnv
+  end function isSerialEnv
 
 
   !> Sets up subgrids and group communicators used with common (non-NEGF) solvers.

--- a/src/dftbp/common/timer.F90
+++ b/src/dftbp/common/timer.F90
@@ -7,7 +7,6 @@
 
 !> Time stages in the code
 module dftbp_common_timer
-  use dftbp_common_globalenv, only : stdOut
   implicit none
 
   private
@@ -102,7 +101,7 @@ contains
 
 
   !> Writes the current measured times.
-  subroutine writeTimes(this, msg, node, fp)
+  subroutine writeTimes(this, msg, unit, node)
 
     !> Instance.
     class(TTimer), intent(in) :: this
@@ -110,25 +109,17 @@ contains
     !> Message to print along the timings
     character(*), intent(in) :: msg
 
+    !> File in which to write the times
+    integer, intent(in) :: unit
+
     !> Node information (default: no node information is printed)
     integer, intent(in), optional :: node
 
-    !> File in which to write the times (default: actual standard out)
-    integer, intent(in), optional :: fp
-
-    integer :: fp0
-
-    if (present(fp)) then
-      fp0 = fp
-    else
-      fp0 = stdOut
-    end if
-
     if (present(node)) then
-      write(fp0, "(A,1X,I5.5,A,1X,A,T48,A,1X,F8.2,5X,A,1X,F8.2)") 'NODE', node, '|TIME',&
+      write(unit, "(A,1X,I5.5,A,1X,A,T48,A,1X,F8.2,5X,A,1X,F8.2)") 'NODE', node, '|TIME',&
           & trim(msg), 'CPU:', this%getCpuTime(), 'WALL:', this%getWallClockTime()
     else
-      write(fp0, "(A,1X,A,T48,A,1X,F8.2,5X,A,1X,F8.2)") 'TIME', trim(msg), 'CPU:',&
+      write(unit, "(A,1X,A,T48,A,1X,F8.2,5X,A,1X,F8.2)") 'TIME', trim(msg), 'CPU:',&
           & this%getCpuTime(), 'WALL:', this%getWallClockTime()
     end if
 

--- a/src/dftbp/common/timer.F90
+++ b/src/dftbp/common/timer.F90
@@ -101,7 +101,7 @@ contains
 
 
   !> Writes the current measured times.
-  subroutine writeTimes(this, msg, unit, node)
+  subroutine writeTimes(this, msg, output, node)
 
     !> Instance.
     class(TTimer), intent(in) :: this
@@ -109,17 +109,17 @@ contains
     !> Message to print along the timings
     character(*), intent(in) :: msg
 
-    !> File in which to write the times
-    integer, intent(in) :: unit
+    !> Output unit to write the times into
+    integer, intent(in) :: output
 
     !> Node information (default: no node information is printed)
     integer, intent(in), optional :: node
 
     if (present(node)) then
-      write(unit, "(A,1X,I5.5,A,1X,A,T48,A,1X,F8.2,5X,A,1X,F8.2)") 'NODE', node, '|TIME',&
+      write(output, "(A,1X,I5.5,A,1X,A,T48,A,1X,F8.2,5X,A,1X,F8.2)") 'NODE', node, '|TIME',&
           & trim(msg), 'CPU:', this%getCpuTime(), 'WALL:', this%getWallClockTime()
     else
-      write(unit, "(A,1X,A,T48,A,1X,F8.2,5X,A,1X,F8.2)") 'TIME', trim(msg), 'CPU:',&
+      write(output, "(A,1X,A,T48,A,1X,F8.2,5X,A,1X,F8.2)") 'TIME', trim(msg), 'CPU:',&
           & this%getCpuTime(), 'WALL:', this%getWallClockTime()
     end if
 

--- a/src/dftbp/common/timerarray.F90
+++ b/src/dftbp/common/timerarray.F90
@@ -10,7 +10,6 @@
 !> Machinery for timers for code
 module dftbp_common_timerarray
   use dftbp_common_accuracy, only : dp
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_common_timer, only : TTimer
   implicit none
 
@@ -46,7 +45,7 @@ module dftbp_common_timerarray
 contains
 
   !> Initializes a global timer
-  subroutine TTimerArray_init(this, timerItems, maxLevel, header, unit)
+  subroutine TTimerArray_init(this, timerItems, unit, maxLevel, header)
 
     !> Instance
     type(TTimerArray), intent(out) :: this
@@ -54,14 +53,14 @@ contains
     !> Names of the sub-timers to use
     type(TTimerItem), intent(in) :: timerItems(:)
 
+    !> File unit to write the statistics to
+    integer, intent(in) :: unit
+
     !> Last timer level to be included in printing (default: all)
     integer, intent(in), optional :: maxLevel
 
     !> Optional header message for the timings
     character(*), intent(in), optional :: header
-
-    !> File unit to write the statistics to (default: standard output)
-    integer, intent(in), optional :: unit
 
     integer :: nTimer
 
@@ -77,11 +76,7 @@ contains
       this%header = "Timing"
     end if
 
-    if (present(unit)) then
-      this%unit = unit
-    else
-      this%unit = stdOut
-    end if
+    this%unit = unit
 
     this%timerNames = timerItems(:)%name
     this%timerLevels = timerItems(:)%level

--- a/src/dftbp/common/timerarray.F90
+++ b/src/dftbp/common/timerarray.F90
@@ -34,7 +34,7 @@ module dftbp_common_timerarray
     real(dp), allocatable :: wallClockTimes(:)
     integer :: maxLevel
     character(:), allocatable :: header
-    integer :: unit
+    integer :: output
   contains
     procedure :: startTimer
     procedure :: stopTimer
@@ -45,7 +45,7 @@ module dftbp_common_timerarray
 contains
 
   !> Initializes a global timer
-  subroutine TTimerArray_init(this, timerItems, unit, maxLevel, header)
+  subroutine TTimerArray_init(this, timerItems, output, maxLevel, header)
 
     !> Instance
     type(TTimerArray), intent(out) :: this
@@ -53,8 +53,8 @@ contains
     !> Names of the sub-timers to use
     type(TTimerItem), intent(in) :: timerItems(:)
 
-    !> File unit to write the statistics to
-    integer, intent(in) :: unit
+    !> Output unit to write the statistics to
+    integer, intent(in) :: output
 
     !> Last timer level to be included in printing (default: all)
     integer, intent(in), optional :: maxLevel
@@ -76,7 +76,7 @@ contains
       this%header = "Timing"
     end if
 
-    this%unit = unit
+    this%output = output
 
     this%timerNames = timerItems(:)%name
     this%timerLevels = timerItems(:)%level
@@ -161,7 +161,7 @@ contains
     totalCpu = this%myTimer%getCpuTime()
     totalWall = this%myTimer%getWallClockTime()
 
-    fp = this%unit
+    fp = this%output
     write(fp, *)
     write(fp, "(A)") repeat("-", 80)
     write(fp, "(A,T46,A,T66,A)") this%header, 'cpu [s]', 'wall clock [s]'

--- a/src/dftbp/derivs/perturb.F90
+++ b/src/dftbp/derivs/perturb.F90
@@ -15,7 +15,6 @@ module dftbp_derivs_perturb
   use dftbp_common_constants, only : AA__Bohr, Bohr__AA, Hartree__eV, quaternionName
   use dftbp_common_environment, only : TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_common_status, only : TStatus
   use dftbp_derivs_fermihelper, only : deltamn
   use dftbp_derivs_linearresponse, only : dRhoCmplx, dRhoFermiChangeCmplx, dRhoFermiChangePauli,&
@@ -386,11 +385,11 @@ contains
 
     beta = 1.0_dp / tempElec
 
-    write(stdOut,*)
-    write(stdOut,*)'Perturbation calculation with respect to applied electric field'
-    write(stdOut,*)
+    write(env%stdOut,*)
+    write(env%stdOut,*)'Perturbation calculation with respect to applied electric field'
+    write(env%stdOut,*)
 
-    call init_perturbation(parallelKS, this%tolDegen, nOrbs, nKpts, nSpin, nIndepHam, maxFill,&
+    call init_perturbation(env, parallelKS, this%tolDegen, nOrbs, nKpts, nSpin, nIndepHam, maxFill,&
         & filling, ham, nFilled, nEmpty, dHam, dRho, idHam, idRho, degenTransform, hybridXc,&
         & sSqrReal, over, neighbourList, nNeighbourSK, denseDesc, iSparseStart, img2CentCell,&
         & dRhoOut, dRhoIn, dRhoInSqr, dRhoOutSqr, dPotential, orb, nAtom, tMetallic, neFermi,&
@@ -431,7 +430,7 @@ contains
     lpCart: do iCart = 1, 3
 
       if (boundaryCond%iBoundaryCondition == boundaryCondsEnum%cluster) then
-        write(stdOut,*)"Polarisabilty for field along ", trim(quaternionName(iCart+1))
+        write(env%stdOut,*)"Polarisabilty for field along ", trim(quaternionName(iCart+1))
       end if
 
       ! set outside loop: in the time dependent case, if adjacent frequencies are similar, this
@@ -493,10 +492,10 @@ contains
         end if
 
         if (any(tMetallic)) then
-          write(stdOut,*)
-          write(stdOut,"(A,2E20.12)")'d E_f / d E_'//trim(quaternionName(iCart+1))//':',&
+          write(env%stdOut,*)
+          write(env%stdOut,"(A,2E20.12)")'d E_f / d E_'//trim(quaternionName(iCart+1))//':',&
               & dEfdE(:,iCart)
-          write(stdOut,*)
+          write(env%stdOut,*)
         end if
 
       end do
@@ -510,7 +509,7 @@ contains
   #:endif
 
     if (boundaryCond%iBoundaryCondition == boundaryCondsEnum%cluster) then
-      call permitivityPrint(stdOut, polarisability, omega)
+      call permitivityPrint(env%stdOut, polarisability, omega)
     end if
 
   end subroutine wrtEField
@@ -740,15 +739,15 @@ contains
       isSccRequired = isSccConvRequired
     end if
 
-    call init_perturbation(parallelKS, this%tolDegen, nOrbs, nKpts, nSpin, nIndepHam, maxFill,&
+    call init_perturbation(env, parallelKS, this%tolDegen, nOrbs, nKpts, nSpin, nIndepHam, maxFill,&
         & filling, ham, nFilled, nEmpty, dHam, dRho, idHam, idRho, degenTransform, hybridXc,&
         & sSqrReal, over, neighbourList, nNeighbourSK, denseDesc, iSparseStart, img2CentCell,&
         & dRhoOut, dRhoIn, dRhoInSqr, dRhoOutSqr, dPotential, orb, nAtom, tMetallic, neFermi,&
         & eigvals, beta, Ef, kWeight)
 
-    write(stdOut,*)
-    write(stdOut,*)'Perturbation calculation of atomic polarisability kernel'
-    write(stdOut,*)
+    write(env%stdOut,*)
+    write(env%stdOut,*)'Perturbation calculation of atomic polarisability kernel'
+    write(env%stdOut,*)
 
     allocate(dqOut(orb%mOrb, nAtom, nSpin))
     allocate(dqNetAtom(nAtom))
@@ -788,7 +787,7 @@ contains
 
     lpAtom: do iAt = 1, nAtom
 
-      write(stdOut,*)'Derivative with respect to potential at atom ', iAt
+      write(env%stdOut,*)'Derivative with respect to potential at atom ', iAt
 
       dqOut(:,:,:) = 0.0_dp
       dqIn(:,:,:) = 0.0_dp
@@ -827,17 +826,17 @@ contains
           dEiTmp(:,:,:,iAt,iOmega) = dEi
         end if
 
-        write(stdOut,*)'Frontier orbital derivatives'
+        write(env%stdOut,*)'Frontier orbital derivatives'
         do iS = 1, nIndepHam
           do iK = 1, nKpts
-            write(stdOut,*)dEi(nFilled(iS, iK), iK, iS), dEi(nEmpty(iS, iK), iK, iS)
+            write(env%stdOut,*)dEi(nFilled(iS, iK), iK, iS), dEi(nEmpty(iS, iK), iK, iS)
           end do
         end do
 
         call getOnsitePopulation(dRho(:,1), orb, iSparseStart, dqNetAtom)
-        write(stdOut,*)'Derivatives of Mulliken and on-site (net) populations'
+        write(env%stdOut,*)'Derivatives of Mulliken and on-site (net) populations'
         do jAt = 1, nAtom
-          write(stdOut,*)jAt, sum(dqOut(:,jAt,1)), dqNetAtom(jAt)
+          write(env%stdOut,*)jAt, sum(dqOut(:,jAt,1)), dqNetAtom(jAt)
         end do
 
         if (isAutotestWritten.or.isTagResultsWritten) then
@@ -1145,14 +1144,14 @@ contains
     ! obtain the external charge coordinates and their values
     call sccCalc%getExternalCharges(nExtCharge, extCoord, extCharge, blurWidths=blurWidths)
     if (nExtCharge < 1) then
-      write (stdOut,*) "No external charges, nothing to do in dxExtCharges."
+      write(env%stdOut,*) "No external charges, nothing to do in dxExtCharges."
       return
     end if
 
     nDerivs = countDerivs(wrtWhichCharges, nCombinedCharges, wrtCombinedCharges, nExtCharge)
 
     if (nDerivs < 1) then
-      write (stdOut,*) "No requested derivatives wrt to external charges, nothing to do in&
+      write(env%stdOut,*) "No requested derivatives wrt to external charges, nothing to do in&
           & dxExtCharges."
       return
     end if
@@ -1176,14 +1175,14 @@ contains
       @:RAISE_ERROR(errStatus, -1, "SCC currently required for external charge derivatives")
     end if
 
-    write(stdOut,*)
-    write(stdOut,*)'Perturbation calculation of derivative with respect to external charges'
-    write(stdOut,*)
+    write(env%stdOut,*)
+    write(env%stdOut,*)'Perturbation calculation of derivative with respect to external charges'
+    write(env%stdOut,*)
 
     nIter = maxSccIter
     isSccRequired = .true.
 
-    call init_perturbation(parallelKS, this%tolDegen, nOrbs, nKpts, nSpin, nIndepHam, maxFill,&
+    call init_perturbation(env, parallelKS, this%tolDegen, nOrbs, nKpts, nSpin, nIndepHam, maxFill,&
         & filling, ham, nFilled, nEmpty, dHam, dRho, idHam, idRho, degenTransform, hybridXc,&
         & sSqrReal, over, neighbourList, nNeighbourSK, denseDesc, iSparseStart, img2CentCell,&
         & dRhoOut, dRhoIn, dRhoInSqr, dRhoOutSqr, dPotential, orb, nAtom, tMetallic, neFermi,&
@@ -1212,13 +1211,13 @@ contains
 
       if (allocated(wrtWhichCharges)) then
         iExtChrgWrt = wrtWhichCharges(iDeriv)
-        write(stdOut,"(A,I0)")'Derivative with respect to external charge ', iExtChrgWrt
+        write(env%stdOut,"(A,I0)")'Derivative with respect to external charge ', iExtChrgWrt
       else if (allocated(wrtCombinedCharges)) then
-        write(stdOut,"(A,I0,A)")'Derivative with respect to external charge group ',iDeriv, ':'
-        write(stdOut,*)wrtCombinedCharges(:nCombinedCharges(iDeriv), iDeriv)
+        write(env%stdOut,"(A,I0,A)")'Derivative with respect to external charge group ',iDeriv, ':'
+        write(env%stdOut,*)wrtCombinedCharges(:nCombinedCharges(iDeriv), iDeriv)
       else
         iExtChrgWRT = iDeriv
-        write(stdOut,"(A,I0)")'Derivative with respect to external charge ', iExtChrgWRT
+        write(env%stdOut,"(A,I0)")'Derivative with respect to external charge ', iExtChrgWRT
       end if
 
       if (allocated(wrtCombinedCharges)) then
@@ -1261,7 +1260,7 @@ contains
       ! perturbation direction
       lpCart: do iCart = 1, 3
 
-        write(stdOut,"(A,A,A,I0)")'Calculating derivative for displacement along ', &
+        write(env%stdOut,"(A,A,A,I0)")'Calculating derivative for displacement along ', &
             & trim(direction(iCart)),' for charge ', iExtChrgWRT
 
         dPotential%extAtom(:,:) = 0.0_dp
@@ -1291,9 +1290,9 @@ contains
       #:endif
 
           call getOnsitePopulation(dRho(:,1), orb, iSparseStart, dqNetAtom)
-          write(stdOut,*)'Derivatives of Mulliken and on-site (net) populations'
+          write(env%stdOut,*)'Derivatives of Mulliken and on-site (net) populations'
           do jAt = 1, nAtom
-            write(stdOut,*)jAt, -sum(dqOut(:,jAt,1)), -dqNetAtom(jAt)
+            write(env%stdOut,*)jAt, -sum(dqOut(:,jAt,1)), -dqNetAtom(jAt)
           end do
 
           if (associated(pdqdxExt)) then
@@ -1654,7 +1653,7 @@ contains
     nDerivs =  countDerivs(wrtWhichCharges, nCombinedCharges, wrtCombinedCharges, nAtom)
 
     if (nDerivs < 1) then
-      write (stdOut,*) "No requested derivatives wrt to external charges, nothing to do in&
+      write(env%stdOut,*) "No requested derivatives wrt to external charges, nothing to do in&
           & dxAtom."
       return
     end if
@@ -1664,7 +1663,7 @@ contains
       @:ASSERT(all(shape(dqdx) >= [nAtom, 3, nDerivs]))
     end if
 
-    call init_perturbation(parallelKS, this%tolDegen, nOrbs, nKpts, nSpin, nIndepHam, maxFill,&
+    call init_perturbation(env, parallelKS, this%tolDegen, nOrbs, nKpts, nSpin, nIndepHam, maxFill,&
         & filling, ham, nFilled, nEmpty, dHam, dRho, idHam, idRho, degenTransform, hybridXc,&
         & sSqrReal, over, neighbourList, nNeighbourSK, denseDesc, iSparseStart, img2CentCell,&
         & dRhoOut, dRhoIn, dRhoInSqr, dRhoOutSqr, dPotential, orb, nAtom, tMetallic, neFermi,&
@@ -1812,13 +1811,13 @@ contains
 
       if (allocated(wrtWhichCharges)) then
         iAt = wrtWhichCharges(iDeriv)
-        write(stdOut,"(A,I0)")'Derivative with respect to atom ', iAt
+        write(env%stdOut,"(A,I0)")'Derivative with respect to atom ', iAt
       else if (allocated(wrtCombinedCharges)) then
-        write(stdOut,"(A,I0,A)")'Derivative with respect to atom group ',iDeriv, ':'
-        write(stdOut,*)wrtCombinedCharges(:nCombinedCharges(iDeriv), iDeriv)
+        write(env%stdOut,"(A,I0,A)")'Derivative with respect to atom group ',iDeriv, ':'
+        write(env%stdOut,*)wrtCombinedCharges(:nCombinedCharges(iDeriv), iDeriv)
       else
         iAt = iDeriv
-        write(stdOut,"(A,I0)")'Derivative with respect to atom ', iAt
+        write(env%stdOut,"(A,I0)")'Derivative with respect to atom ', iAt
       end if
 
       if (allocated(wrtCombinedCharges)) then
@@ -1851,7 +1850,7 @@ contains
       ! perturbation direction
       lpCart: do iCart = 1, 3
 
-        write(stdOut,"(A,A,A,I0)")'Calculating derivative for displacement along ', &
+        write(env%stdOut,"(A,A,A,I0)")'Calculating derivative for displacement along ', &
             & trim(direction(iCart)),' for atom ', iAt
 
         if (tSccCalc) then
@@ -1921,7 +1920,7 @@ contains
             dRhoOut(:) = 0.0_dp
           end if
 
-          write(stdOut,"(1X,A,T12,A)")'SCC Iter','Error'
+          write(env%stdOut,"(1X,A,T12,A)")'SCC Iter','Error'
         end if
 
         iSccIter = 1
@@ -2111,7 +2110,7 @@ contains
             sccErrorQ = maxval(abs(dqDiffRed))
 
             if (maxSccIter > 1) then
-              write(stdOut,"(1X,I0,T10,E20.12)")iSccIter, sccErrorQ
+              write(env%stdOut,"(1X,I0,T10,E20.12)")iSccIter, sccErrorQ
             end if
             tConverged = (sccErrorQ < sccTol)
 
@@ -2203,22 +2202,22 @@ contains
     call mpifx_allreduceip(env%mpi%globalComm, dEi, MPI_SUM)
   #:endif
 
-!    write(stdOut, "(A)")'dEi/d (eV / AA)'
-!    write(stdOut,"(T16,A,T32,A,T48,A)")direction
+!    write(env%stdOut, "(A)")'dEi/d (eV / AA)'
+!    write(env%stdOut,"(T16,A,T32,A,T48,A)")direction
 !    do iS = 1, nSpin
 !      if (allocated(wrtWhichCharges)) then
 !        do iDeriv = 1, size(wrtWhichCharges)
 !          iAt = wrtWhichCharges(iDeriv)
-!          write(stdOut, "(1X,A,I0)")'dEi/d At.', iAt
+!          write(env%stdOut, "(1X,A,I0)")'dEi/d At.', iAt
 !          do iOrb = 1, size(dEi,dim=1)
-!            write(stdOut, "(3F16.8)") dEi(iOrb, 1, iS, :, iDeriv) * AA__Bohr
+!            write(env%stdOut, "(3F16.8)") dEi(iOrb, 1, iS, :, iDeriv) * AA__Bohr
 !          end do
 !        end do
 !      else
 !        do iAt = 1, nAtom
-!          write(stdOut, "(1X,A,I0)")'dEi/d At.', iAt
+!          write(env%stdOut, "(1X,A,I0)")'dEi/d At.', iAt
 !          do iOrb = 1, size(dEi,dim=1)
-!            write(stdOut, "(3F16.8)") dEi(iOrb, 1, iS, :, iAt) * AA__Bohr
+!            write(env%stdOut, "(3F16.8)") dEi(iOrb, 1, iS, :, iAt) * AA__Bohr
 !          end do
 !        end do
 !      end if
@@ -2258,29 +2257,29 @@ contains
 
     if (tPrintMulliken) then
 
-      write(stdOut, *)
-      write(stdOut, "(A)")'Derivatives of atomic Mulliken charges with atom positions'
+      write(env%stdOut, *)
+      write(env%stdOut, "(A)")'Derivatives of atomic Mulliken charges with atom positions'
       if (allocated(wrtWhichCharges)) then
         do iDeriv = 1, size(wrtWhichCharges)
           iAt = wrtWhichCharges(iDeriv)
-          write(stdOut,"(1X,A,I0,T10,A,T26,A,T42,A)")"At",iAt,"x","y","z"
+          write(env%stdOut,"(1X,A,I0,T10,A,T26,A,T42,A)")"At",iAt,"x","y","z"
           do iS = 1, nSpin
             do jAt = 1, nAtom
-              write(stdOut, "(1X,I0,T4,3F16.8)")jAt, -sum(dqOut(:,jAt,iS,:,iDeriv),dim=1)&
+              write(env%stdOut, "(1X,I0,T4,3F16.8)")jAt, -sum(dqOut(:,jAt,iS,:,iDeriv),dim=1)&
                   & * AA__Bohr
             end do
-            write(stdOut, *)
+            write(env%stdOut, *)
           end do
         end do
       else
         do iAt = 1, nAtom
-          write(stdOut,"(A,I0,T10,A,T26,A,T42,A)")"At",iAt,"x","y","z"
+          write(env%stdOut,"(A,I0,T10,A,T26,A,T42,A)")"At",iAt,"x","y","z"
           do iS = 1, nSpin
             do jAt = 1, nAtom
-              write(stdOut, "(1X,I0,T4,3F16.8)")jAt, -sum(dqOut(:,jAt,iS,:,iAt),dim=1)&
+              write(env%stdOut, "(1X,I0,T4,3F16.8)")jAt, -sum(dqOut(:,jAt,iS,:,iAt),dim=1)&
                   & * AA__Bohr
             end do
-            write(stdOut, *)
+            write(env%stdOut, *)
           end do
         end do
       end if
@@ -2369,7 +2368,7 @@ contains
       end if
 
       if (tWriteDetailedOut) call writeBorn(fdDetailedOut, bornCharges, wrtWhichCharges)
-      call writeBorn(stdOut, bornCharges, wrtWhichCharges)
+      call writeBorn(env%stdOut, bornCharges, wrtWhichCharges)
 
       if (isAutotestWritten) then
         open(newunit=fdResults, file=autoTestTagFile, position="append")
@@ -2673,15 +2672,15 @@ contains
     end if
 
     if (abs(omega) > epsilon(0.0_dp)) then
-      write(stdOut, "(1X,A)")"Frequency dependant response calculation"
-      write(stdOut, format2U)"  omega driving frequency", omega, ' H ', omega * Hartree__eV, ' eV'
+      write(env%stdOut, "(1X,A)")"Frequency dependant response calculation"
+      write(env%stdOut, format2U)"  omega driving frequency", omega, ' H ', omega * Hartree__eV, ' eV'
     else
-      write(stdOut, "(1X,A)")"Static response calculation"
+      write(env%stdOut, "(1X,A)")"Static response calculation"
     end if
 
 
     if (tSccCalc .and. maxSccIter > 1) then
-      write(stdOut,"(1X,A,T12,A)")'SCC Iter','Error'
+      write(env%stdOut,"(1X,A,T12,A)")'SCC Iter','Error'
     end if
 
     lpSCC: do iSccIter = 1, maxSccIter
@@ -2942,7 +2941,7 @@ contains
         sccErrorQ = maxval(abs(dqDiffRed))
 
         if (maxSccIter > 1) then
-          write(stdOut,"(1X,I0,T10,E20.12)")iSCCIter, sccErrorQ
+          write(env%stdOut,"(1X,I0,T10,E20.12)")iSCCIter, sccErrorQ
         end if
         tConverged = (sccErrorQ < sccTol)
 
@@ -3044,7 +3043,7 @@ contains
         if (allocated(dRhoIn)) then
           dRhoInBackup(:) = dRhoIn
         end if
-        call warning("SCC in perturbation is NOT converged, maximal SCC iterations exceeded")
+        call warning(env%stdOut, "SCC in perturbation is NOT converged, maximal SCC iterations exceeded")
       end if
     end if
 
@@ -3057,11 +3056,14 @@ contains
 
 
   !> Initialise variables for perturbation
-  subroutine init_perturbation(parallelKS, tolDegen, nOrbs, nKpts, nSpin, nIndepHam, maxFill,&
+  subroutine init_perturbation(env, parallelKS, tolDegen, nOrbs, nKpts, nSpin, nIndepHam, maxFill,&
       & filling, ham, nFilled, nEmpty, dHam, dRho, idHam, idRho, degenTransform, hybridXc,&
       & sSqrReal, over, neighbourList, nNeighbourSK, denseDesc, iSparseStart, img2CentCell,&
       & dRhoOut, dRhoIn, dRhoInSqr, dRhoOutSqr, dPotential, orb, nAtom, tMetallic, neFermi,&
       & eigvals, beta, Ef, kWeight)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> The k-points and spins to process
     type(TParallelKS), intent(in) :: parallelKS
@@ -3230,7 +3232,7 @@ contains
     allocate(tMetallic(nIndepHam, nKpts))
     tMetallic(:,:) = .not.(nFilled == nEmpty -1)
     if (any(tMetallic)) then
-      write(stdOut,*)'Metallic system'
+      write(env%stdOut,*)'Metallic system'
       ! Density of electrons at the Fermi energy, required to correct later for shift in Fermi level
       ! at q=0 in metals
       if (allocated(neFermi)) then
@@ -3246,9 +3248,9 @@ contains
         end do
       end do
       neFermi(:) = maxFill * neFermi
-      write(stdOut,*)'Density of states at the Fermi energy Nf (a.u.):', neFermi
+      write(env%stdOut,*)'Density of states at the Fermi energy Nf (a.u.):', neFermi
     else
-      write(stdOut,*)'Non-metallic system'
+      write(env%stdOut,*)'Non-metallic system'
     end if
 
   end subroutine init_perturbation

--- a/src/dftbp/dftb/coordnumber.F90
+++ b/src/dftbp/dftb/coordnumber.F90
@@ -9,6 +9,7 @@
 
 !> Coordination number implementation
 module dftbp_dftb_coordnumber
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : AA__Bohr, pi, symbolToNumber
   use dftbp_dftb_periodic, only : getNrOfNeighboursForAll, TNeighbourList
@@ -317,10 +318,13 @@ contains
 
 
   !> Update internal stored coordinates
-  subroutine updateCoords(this, neighList, img2CentCell, coords, species0)
+  subroutine updateCoords(this, env, neighList, img2CentCell, coords, species0)
 
     !> Data structure
     class(TCNCont), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> List of neighbours to atoms
     type(TNeighbourList), intent(in) :: neighList
@@ -337,7 +341,7 @@ contains
     integer, allocatable :: nNeigh(:)
 
     allocate(nNeigh(this%nAtom))
-    call getNrOfNeighboursForAll(nNeigh, neighList, this%rCutoff)
+    call getNrOfNeighboursForAll(env%stdOut, nNeigh, neighList, this%rCutoff)
     call getCoordinationNumber(this%nAtom, coords, species0, nNeigh, &
         & neighList%iNeighbour, neighList%neighDist2, img2CentCell, &
         & this%covRad, this%en, this%tENScale, this%kcn, this%countFunc, &

--- a/src/dftbp/dftb/dispdftd4.F90
+++ b/src/dftbp/dftb/dispdftd4.F90
@@ -277,7 +277,7 @@ contains
 
     if (allocated(this%sc)) then
       allocate(nNeighbour(this%nAtom))
-      call getNrOfNeighboursForAll(nNeighbour, neigh, this%calc%cutoffInter)
+      call getNrOfNeighboursForAll(env%stdOut, nNeighbour, neigh, this%calc%cutoffInter)
       call weightDispMat(this%calc, this%ref, env, this%nAtom, nNeighbour, neigh, &
           & img2CentCell, species0, this%cnCont%cn, this%sc%scratch, this%sc%dispMat)
     end if
@@ -1054,11 +1054,11 @@ contains
     sigma(:, :) = 0.0_dp
 
     if (present(eeqCont)) then
-      call eeqCont%updateCoords(neigh, img2CentCell, coords, species, stat)
+      call eeqCont%updateCoords(env, neigh, img2CentCell, coords, species, stat)
       @:PROPAGATE_ERROR(stat)
     end if
 
-    call cnCont%updateCoords(neigh, img2CentCell, coords, species)
+    call cnCont%updateCoords(env, neigh, img2CentCell, coords, species)
 
     nRef = maxval(ref%nRef)
     allocate(nNeighbour(nAtom))
@@ -1077,7 +1077,7 @@ contains
     localSigma(:,:) = 0.0_dp
 
     if (present(eeqCont)) then
-      call getNrOfNeighboursForAll(nNeighbour, neigh, calc%cutoffInter)
+      call getNrOfNeighboursForAll(env%stdOut, nNeighbour, neigh, calc%cutoffInter)
 
       call weightReferences(calc, ref, env, nAtom, species, cnCont%cn, &
           & eeqCont%charges, zetaVec, zetadq, zetadcn)
@@ -1091,7 +1091,7 @@ contains
     end if
 
     if (calc%s9 > 0.0_dp) then
-      call getNrOfNeighboursForAll(nNeighbour, neigh, calc%cutoffThree)
+      call getNrOfNeighboursForAll(env%stdOut, nNeighbour, neigh, calc%cutoffThree)
 
       call weightReferences(calc, ref, env, nAtom, species, cnCont%cn, zero, &
           & zetaVec, zetadq, zetadcn)
@@ -1543,7 +1543,7 @@ contains
     localDeriv(:,:) = 0.0_dp
     localSigma(:,:) = 0.0_dp
 
-    call getNrOfNeighboursForAll(nNeighbour, neigh, calc%cutoffInter)
+    call getNrOfNeighboursForAll(env%stdOut, nNeighbour, neigh, calc%cutoffInter)
 
     call weightReferences(calc, ref, env, nAtom, species, cnCont%cn, &
         & charges, zetaVec, zetadq, zetadcn)

--- a/src/dftbp/dftb/dispmbd.F90
+++ b/src/dftbp/dftb/dispmbd.F90
@@ -10,10 +10,11 @@
 
 !> MBD/TS dispersion model.
 module dftbp_dftb_dispmbd
+  ! TODO: Customizable output for mbdPrinter
+  use iso_fortran_env, only : stdOut => output_unit
   use dftbp_common_accuracy, only : dp, lc, mc
   use dftbp_common_constants, only : symbolToNumber
   use dftbp_common_environment, only : TEnvironment
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_common_status, only : TStatus
   use dftbp_dftb_dispiface, only : TDispersionIface
   use dftbp_dftb_periodic, only : TNeighbourList
@@ -389,16 +390,19 @@ contains
 
 
   !> Raises error if it was previously caught
-  subroutine checkError(this, err)
+  subroutine checkError(this, env, err)
 
     !> Data structure
     class(TDispMbd), intent(in) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Error code return, 0 if no problems
     integer, intent(out), optional :: err
 
     if (this%errCode /= 0) then
-      @:ERROR_HANDLING(err, this%errCode, this%errMessage)
+      @:ERROR_HANDLING(env%stdOut, err, this%errCode, this%errMessage)
     end if
   end subroutine checkError
 

--- a/src/dftbp/dftb/dispmbd.F90
+++ b/src/dftbp/dftb/dispmbd.F90
@@ -11,10 +11,10 @@
 !> MBD/TS dispersion model.
 module dftbp_dftb_dispmbd
   ! TODO: Customizable output for mbdPrinter
-  use iso_fortran_env, only : stdOut => output_unit
   use dftbp_common_accuracy, only : dp, lc, mc
   use dftbp_common_constants, only : symbolToNumber
   use dftbp_common_environment, only : TEnvironment
+  use dftbp_common_globalenv, only : stdOut0
   use dftbp_common_status, only : TStatus
   use dftbp_dftb_dispiface, only : TDispersionIface
   use dftbp_dftb_periodic, only : TNeighbourList
@@ -413,7 +413,7 @@ contains
     !> Message
     character(len=*), intent(in) :: str
 
-    write(stdOut, "(A,A)") '* Libmbd: ', str
+    write(stdOut0, "(A,A)") '* Libmbd: ', str
 
   end subroutine mbdPrinter
 

--- a/src/dftbp/dftb/dispslaterkirkw.F90
+++ b/src/dftbp/dftb/dispslaterkirkw.F90
@@ -251,7 +251,7 @@ contains
     integer, allocatable :: nNeighDamp(:)
 
     allocate(nNeighReal(this%nAtom))
-    call getNrOfNeighboursForAll(nNeighReal, neigh, this%rCutoff)
+    call getNrOfNeighboursForAll(env%stdOut, nNeighReal, neigh, this%rCutoff)
     this%energies(:) = 0.0_dp
     this%gradients(:,:) = 0.0_dp
     this%stress(:,:) = 0.0_dp
@@ -262,7 +262,7 @@ contains
           & this%energies, this%gradients, this%stress)
       ! Correct those terms, where damping is important
       allocate(nNeighDamp(this%nAtom))
-      call getNrOfNeighboursForAll(nNeighDamp, neigh, this%dampCutoff)
+      call getNrOfNeighboursForAll(env%stdOut, nNeighDamp, neigh, this%dampCutoff)
       call addDispEnergyAndGrad_cluster(env, this%nAtom, coords, nNeighDamp, neigh%iNeighbour,&
         & neigh%neighDist2, img2CentCell, this%c6, this%rVdW2, this%energies, this%gradients,&
         & dampCorrection=-1.0_dp, stress=this%stress, vol=this%vol)

--- a/src/dftbp/dftb/dispuff.F90
+++ b/src/dftbp/dftb/dispuff.F90
@@ -234,13 +234,13 @@ contains
     integer, allocatable :: nNeigh(:)
 
     allocate(nNeigh(this%nAtom))
-    call getNrOfNeighboursForAll(nNeigh, neigh, this%rCutoff)
+    call getNrOfNeighboursForAll(env%stdOut, nNeigh, neigh, this%rCutoff)
     if (this%tPeriodic) then
       call getDispEnergyAndGrad_cluster(env, this%nAtom, coords, species0, nNeigh,&
           & neigh%iNeighbour, neigh%neighDist2, img2CentCell, this%c6, this%c12, this%cPoly,&
           & this%r0, this%energies, this%gradients, removeR6=.true., stress=this%stress,&
           & vol=this%vol)
-      call getNrOfNeighboursForAll(nNeigh, neigh, this%ewaldRCut)
+      call getNrOfNeighboursForAll(env%stdOut, nNeigh, neigh, this%ewaldRCut)
       call addDispEGr_per_species(env, this%nAtom, coords, species0, nNeigh, neigh%iNeighbour,&
           & neigh%neighDist2, img2CentCell, this%c6, this%eta, this%vol, this%gLatPoints,&
           & this%energies, this%gradients, this%stress)

--- a/src/dftbp/dftb/elecconstraints.F90
+++ b/src/dftbp/dftb/elecconstraints.F90
@@ -10,6 +10,7 @@
 !> Module to impose constraints on the electronic ground state.
 module dftbp_dftb_elecconstraints
   use dftbp_common_accuracy, only : dp, hugeIterations
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_dftbplus_input_geoopt, only : readOptimizerInput
   use dftbp_extlibs_xmlf90, only : char, destroyNodeList, fnode, fnodeList, getItem1, getLength,&
       & string
@@ -160,7 +161,10 @@ contains
 
 
   !> Reads electronic constraint input from HSD.
-  subroutine readElecConstraintInput(node, geo, isSpinPol, is2Component, input)
+  subroutine readElecConstraintInput(env, node, geo, isSpinPol, is2Component, input)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Input structure to be filled
     type(TElecConstraintInp), intent(out) :: input
@@ -189,14 +193,18 @@ contains
 
     call getChildValue(node, "Constraints", placeholderNode, "", child=constrContainer,&
         & allowEmptyValue=.true., dontMarkProcessed=.true., list=.true.)
-    call readMullikenConstraintInputs(constrContainer, geo, isSpinPol, is2Component,&
+    call readMullikenConstraintInputs(env%stdOut, constrContainer, geo, isSpinPol, is2Component,&
         & input%mullikenConstrs)
 
   end subroutine readElecConstraintInput
 
 
   !> Reads Mulliken constraint inputs from HSD.
-  subroutine readMullikenConstraintInputs(constrContainer, geo, isSpinPol, is2Component, inputs)
+  subroutine readMullikenConstraintInputs(output, constrContainer, geo, isSpinPol, is2Component,&
+      & inputs)
+
+    !> Output unit
+    integer, intent(in) :: output
 
     !> Node containing all constraints
     type(fnode), pointer, intent(in) :: constrContainer
@@ -230,7 +238,7 @@ contains
       associate(input => inputs(iConstrInp))
         call getItem1(constrNodes, iConstrInp, constrNode)
         call getChildValue(constrNode, "Atoms", buffer, child=child1, multiple=.true.)
-        call getSelectedAtomIndices(child1, char(buffer), geo%speciesNames, geo%species,&
+        call getSelectedAtomIndices(output, child1, char(buffer), geo%speciesNames, geo%species,&
             & input%atoms)
 
         call getChild(constrNode, "Populations", populationsNode, requested=.false.)

--- a/src/dftbp/dftb/encharges.F90
+++ b/src/dftbp/dftb/encharges.F90
@@ -13,6 +13,7 @@
 !>
 !> This implementation is general enough to be used outside of DFT-D4.
 module dftbp_dftb_encharges
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : pi
   use dftbp_common_status, only : TStatus
@@ -241,10 +242,13 @@ contains
 
 
   !> Notifies the objects about changed coordinates.
-  subroutine updateCoords(this, neigh, img2CentCell, coords, species, stat)
+  subroutine updateCoords(this, env, neigh, img2CentCell, coords, species, stat)
 
     !> Instance of EEQ container
     class(TEeqCont), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Updated neighbour list.
     type(TNeighbourList), intent(in) :: neigh
@@ -263,10 +267,10 @@ contains
 
     integer, allocatable :: nNeigh(:)
 
-    call this%cnCont%updateCoords(neigh, img2CentCell, coords, species)
+    call this%cnCont%updateCoords(env, neigh, img2CentCell, coords, species)
 
     allocate(nNeigh(this%nAtom))
-    call getNrOfNeighboursForAll(nNeigh, neigh, this%cutoff)
+    call getNrOfNeighboursForAll(env%stdOut, nNeigh, neigh, this%cutoff)
 
     call getEEQCharges(this%nAtom, coords, species, this%nrChrg, nNeigh, &
         & neigh%iNeighbour, neigh%neighDist2, img2CentCell, this%recPoint, this%parEwald, &

--- a/src/dftbp/dftb/extfields.F90
+++ b/src/dftbp/dftb/extfields.F90
@@ -81,8 +81,11 @@ module dftbp_dftb_extfields
 contains
 
   !> Sets up external electric or other fields
-  subroutine addUpExternalField(eField, tPeriodic, neighbourList, nNeighbourSK, iCellVec,&
+  subroutine addUpExternalField(output, eField, tPeriodic, neighbourList, nNeighbourSK, iCellVec,&
       & cellVec, deltaT, iGeoStep, coord0Fold, coord, potential)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Whether an external field is present
     type(TEfield), intent(inout), allocatable :: eField
@@ -147,7 +150,7 @@ contains
             end do
           end do lpAtom
           if (isBoundaryCrossed) then
-            call warning("Interactions between atoms cross the saw-tooth discontinuity in the&
+            call warning(output, "Interactions between atoms cross the saw-tooth discontinuity in the&
                 & electric field")
           end if
           do iAt1 = 1, nAtom

--- a/src/dftbp/dftb/extfields.F90
+++ b/src/dftbp/dftb/extfields.F90
@@ -84,7 +84,7 @@ contains
   subroutine addUpExternalField(output, eField, tPeriodic, neighbourList, nNeighbourSK, iCellVec,&
       & cellVec, deltaT, iGeoStep, coord0Fold, coord, potential)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Whether an external field is present

--- a/src/dftbp/dftb/getenergies.F90
+++ b/src/dftbp/dftb/getenergies.F90
@@ -332,7 +332,10 @@ contains
 
 
   !> Calculates dispersion energy for current geometry.
-  subroutine calcDispersionEnergy(dispersion, Eatom, Etotal, iAtInCentralRegion)
+  subroutine calcDispersionEnergy(env, dispersion, Eatom, Etotal, iAtInCentralRegion)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Dispersion interactions
     class(TDispersionIface), intent(inout) :: dispersion
@@ -350,7 +353,7 @@ contains
   #:if WITH_MBD
     select type (dispersion)
     type is (TDispMbd)
-      call dispersion%checkError()
+      call dispersion%checkError(env)
     end select
   #:endif
     Etotal = sum(Eatom(iAtInCentralRegion))

--- a/src/dftbp/dftb/h5correction.F90
+++ b/src/dftbp/dftb/h5correction.F90
@@ -171,7 +171,7 @@ contains
   ! Get H5 parameters for all species pairs.
   subroutine getParams_(output, speciesNames, elementParams, h5Scaling_, sumVdw_)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     character(*), intent(in) :: speciesNames(:)

--- a/src/dftbp/dftb/h5correction.F90
+++ b/src/dftbp/dftb/h5correction.F90
@@ -10,6 +10,7 @@
 !> H5 H-bond correction. Scales the gamma function at short-range for H-bond acceptor element pairs.
 !> See http://dx.doi.org/10.1021/acs.jctc.7b00629 for details.
 module dftbp_dftb_h5correction
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp, mc
   use dftbp_dftb_vdwdata, only : getVdwData
   use dftbp_io_message, only : warning
@@ -68,10 +69,13 @@ module dftbp_dftb_h5correction
 contains
 
   !> Initialization of a H5Corr instance.
-  subroutine TH5Correction_init(this, input)
+  subroutine TH5Correction_init(this, env, input)
 
     !> Initialised instance at return.
     type(TH5Correction), intent(out) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Input parameters
     type(TH5CorrectionInput), intent(inout) :: input
@@ -84,7 +88,7 @@ contains
     nSpecies = size(input%speciesNames)
     allocate(this%sumVdw_(nSpecies, nSpecies))
     allocate(this%h5Scaling_(nSpecies, nSpecies))
-    call getParams_(input%speciesNames, input%elementParams, this%h5Scaling_, this%sumVdw_)
+    call getParams_(env%stdOut, input%speciesNames, input%elementParams, this%h5Scaling_, this%sumVdw_)
 
   end subroutine TH5Correction_init
 
@@ -165,7 +169,11 @@ contains
 
 
   ! Get H5 parameters for all species pairs.
-  subroutine getParams_(speciesNames, elementParams, h5Scaling_, sumVdw_)
+  subroutine getParams_(output, speciesNames, elementParams, h5Scaling_, sumVdw_)
+
+    !> output for write processes
+    integer, intent(in) :: output
+
     character(*), intent(in) :: speciesNames(:)
     real(dp), intent(in) :: elementParams(:)
     real(dp), intent(out) :: h5Scaling_(:,:)
@@ -201,7 +209,7 @@ contains
 
         call getVdwData(speciesNames(iSpHeavy), vdwHeavy, found=tFoundRadius)
         if (.not. tFoundRadius .and. h5Scaling_(iSp2, iSp1) > 0.0_dp) then
-          call warning("The van de  Waals radius for " // trim(speciesNames(iSpHeavy)) //&
+          call warning(output, "The van de  Waals radius for " // trim(speciesNames(iSpHeavy)) //&
               & " is required for the H5 correction but is not available. H-" //&
               & trim(speciesNames(iSpHeavy)) // " contributions therefore neglected.")
           h5Scaling_(iSp2, iSp1) = -1.0_dp

--- a/src/dftbp/dftb/halogenx.F90
+++ b/src/dftbp/dftb/halogenx.F90
@@ -10,6 +10,7 @@
 !> Contains subroutines to add addition to repulsive pair contributions involving halogens
 !> from doi: 10.1021/ct5009137
 module dftbp_dftb_halogenx
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp, mc
   use dftbp_common_constants, only : AA__Bohr, Bohr__AA, kcal_mol__Hartree
   use dftbp_dftb_periodic, only : getNrOfNeighboursForAll, TNeighbourList
@@ -154,10 +155,13 @@ contains
 
 
   !> Get energy contributions from halogen-X correction
-  subroutine getEnergies(this, atomE, coords, species, neigh, img2CentCell)
+  subroutine getEnergies(this, env, atomE, coords, species, neigh, img2CentCell)
 
     !> Instance of the correction
     class(THalogenX), intent(in) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Resulting  energy contributions
     real(dp), intent(out) :: atomE(:)
@@ -180,7 +184,7 @@ contains
     real(dp) :: r, rvdw, eTmp
 
     allocate(nNeigh(this%nAtom))
-    call getNrOfNeighboursForAll(nNeigh, neigh, this%cutoff)
+    call getNrOfNeighboursForAll(env%stdOut, nNeigh, neigh, this%cutoff)
 
     atomE(:) = 0.0_dp
 
@@ -214,10 +218,13 @@ contains
 
 
   !> Gradient contribution from the halogen-X term
-  subroutine addGradients(this, derivs, coords, species, neigh, img2CentCell)
+  subroutine addGradients(this, env, derivs, coords, species, neigh, img2CentCell)
 
     !> Instance of the correction
     class(THalogenX), intent(in) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Derivatives to add contribution to to
     real(dp), intent(inout) :: derivs(:,:)
@@ -240,7 +247,7 @@ contains
     real(dp) :: rvdw, fTmp(3)
 
     allocate(nNeigh(this%nAtom))
-    call getNrOfNeighboursForAll(nNeigh, neigh, this%cutoff)
+    call getNrOfNeighboursForAll(env%stdOut, nNeigh, neigh, this%cutoff)
 
     do iAt1 = 1, this%nAtom
       iSp1 = species(iAt1)
@@ -298,10 +305,13 @@ contains
 
 
   !> The stress tensor contribution from the halogen-X term
-  subroutine getStress(this, st, coords, neigh, species, img2CentCell, cellVol)
+  subroutine getStress(this, env, st, coords, neigh, species, img2CentCell, cellVol)
 
     !> Instance of the correction
     class(THalogenX), intent(in) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Stress tensor
     real(dp), intent(out) :: st(:,:)
@@ -328,7 +338,7 @@ contains
     st(:,:) = 0.0_dp
 
     allocate(nNeigh(this%nAtom))
-    call getNrOfNeighboursForAll(nNeigh, neigh, this%cutoff)
+    call getNrOfNeighboursForAll(env%stdOut, nNeigh, neigh, this%cutoff)
 
     do iAt1 = 1, this%nAtom
       iSp1 = species(iAt1)

--- a/src/dftbp/dftb/mdftb.F90
+++ b/src/dftbp/dftb/mdftb.F90
@@ -12,7 +12,6 @@
 module dftbp_dftb_mdftb
   use dftbp_common_accuracy, only : dp, lc
   use dftbp_common_environment, only : TEnvironment
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_common_status, only : TStatus
   use dftbp_dftb_nonscc, only : TNonSccDiff
   use dftbp_dftb_periodic, only : TNeighbourList, getNrOfNeighbours

--- a/src/dftbp/dftb/periodic.F90
+++ b/src/dftbp/dftb/periodic.F90
@@ -995,7 +995,7 @@ contains
   !> Returns the nr. of neighbours for a given cutoff for all atoms.
   subroutine getNrOfNeighboursForAll(output, nNeighbourSK, neigh, cutoff)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Contains the nr. of neighbours for each atom on exit.
@@ -1028,7 +1028,7 @@ contains
   !> Returns the nr. of neighbours for a given atom.
   function getNrOfNeighbours(output, neigh, cutoff, iAtom) result(nNeighbour)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Intialised neihgborlist.
@@ -1322,7 +1322,7 @@ contains
   !> Computes a domain decomposition of n atoms
   subroutine distributeAtoms(output, mpiRank, mpiSize, nAtom, startAtom, endAtom, error)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Current MPI rank

--- a/src/dftbp/dftb/periodic.F90
+++ b/src/dftbp/dftb/periodic.F90
@@ -536,7 +536,7 @@ contains
     isParallel = .false.
   #:if WITH_MPI
     if (present(env)) then
-      call distributeAtoms(env%mpi%nodeComm%rank, env%mpi%nodeComm%size, nAtom, startAtom, endAtom,&
+      call distributeAtoms(env%stdOut, env%mpi%nodeComm%rank, env%mpi%nodeComm%size, nAtom, startAtom, endAtom,&
           & isParallelSetupError)
       isParallel = .not. isParallelSetupError
     end if
@@ -993,7 +993,10 @@ contains
 
 
   !> Returns the nr. of neighbours for a given cutoff for all atoms.
-  subroutine getNrOfNeighboursForAll(nNeighbourSK, neigh, cutoff)
+  subroutine getNrOfNeighboursForAll(output, nNeighbourSK, neigh, cutoff)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Contains the nr. of neighbours for each atom on exit.
     integer, intent(out) :: nNeighbourSK(:)
@@ -1016,14 +1019,17 @@ contains
 
     ! Get last interacting neighbour for given cutoff
     do iAtom = 1, nAtom
-      nNeighbourSK(iAtom) = getNrOfNeighbours(neigh, cutoff, iAtom)
+      nNeighbourSK(iAtom) = getNrOfNeighbours(output, neigh, cutoff, iAtom)
     end do
 
   end subroutine getNrOfNeighboursForAll
 
 
   !> Returns the nr. of neighbours for a given atom.
-  function getNrOfNeighbours(neigh, cutoff, iAtom) result(nNeighbour)
+  function getNrOfNeighbours(output, neigh, cutoff, iAtom) result(nNeighbour)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Intialised neihgborlist.
     type(TNeighbourList), intent(in) :: neigh
@@ -1047,7 +1053,7 @@ contains
 99010 format ('Cutoff (', E16.6, ') greater than last cutoff ', '(', E13.6,&
           & ') passed to updateNeighbourList!')
       write(strError, 99010) cutoff, neigh%cutoff
-      call warning(strError)
+      call warning(output, strError)
     end if
 
     ! Get last interacting neighbour for given cutoff
@@ -1314,7 +1320,10 @@ contains
 
 
   !> Computes a domain decomposition of n atoms
-  subroutine distributeAtoms(mpiRank, mpiSize, nAtom, startAtom, endAtom, error)
+  subroutine distributeAtoms(output, mpiRank, mpiSize, nAtom, startAtom, endAtom, error)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Current MPI rank
     integer, intent(in) :: mpiRank
@@ -1332,7 +1341,7 @@ contains
     logical, intent(out) :: error
 
     if (nAtom < mpiSize) then
-      call warning("Cannot parallelize atomic distance computation: &
+      call warning(output, "Cannot parallelize atomic distance computation: &
           &The number of MPI ranks must not be greater than the number of atoms.")
       error = .true.
       return

--- a/src/dftbp/dftb/pmlocalisation.F90
+++ b/src/dftbp/dftb/pmlocalisation.F90
@@ -113,7 +113,7 @@ contains
     !> Instance
     class(TPipekMezey), intent(in) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
 
@@ -147,7 +147,7 @@ contains
     !> Instance.
     class(TPipekMezey), intent(in) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Wavefunction coefficients
@@ -266,7 +266,7 @@ contains
   !> using iterative sweeps over each pair of orbitals
   subroutine PipekMezeyOld_real(output, ci, S, iAtomStart, pipekTol, mIter)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Wavefunction coefficients
@@ -392,7 +392,7 @@ contains
   !> Performs Pipek-Mezey localisation for a molecule given the square overlap matrix, using a
   subroutine PipekMezeySuprtRegion_real(output, ci, S, iAtomStart, convergence, mIter, RegionTol)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Support region for each molecular orbital
@@ -831,7 +831,7 @@ contains
   subroutine PipekMezeyOld_kpoint(output, ci, S, over, kpoint, iNeighbour, nNeighbourSK, iCellVec, cellVec,&
       & iAtomStart, iPair, img2CentCell, convergence, mIter)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Wavefunction coefficients

--- a/src/dftbp/dftb/pmlocalisation.F90
+++ b/src/dftbp/dftb/pmlocalisation.F90
@@ -13,7 +13,6 @@
 module dftbp_dftb_pmlocalisation
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : imag
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_dftb_periodic, only : TNeighbourList
   use dftbp_dftb_sparse2dense, only : unpackHS
   use dftbp_io_message, only : error, warning
@@ -109,10 +108,14 @@ contains
 
 
   !> Performs Pipek-Mezey localisation for a molecule.
-  subroutine calcCoeffsReal(this, ci, SSqrReal, iAtomStart)
+  subroutine calcCoeffsReal(this, output, ci, SSqrReal, iAtomStart)
 
     !> Instance
     class(TPipekMezey), intent(in) :: this
+
+    !> output for write processes
+    integer, intent(in) :: output
+
 
     !> Wavefunction coefficients
     real(dp), intent(inout) :: ci(:,:)
@@ -127,22 +130,25 @@ contains
 
     if (allocated(this%sparseTols)) then
       do ii = 1, size(this%sparseTols)
-        call PipekMezeySuprtRegion_real(ci, SSqrReal, iAtomStart, this%tolerance, this%maxIter,&
+        call PipekMezeySuprtRegion_real(output, ci, SSqrReal, iAtomStart, this%tolerance, this%maxIter,&
             & this%sparseTols(ii))
       end do
     else
-      call pipekMezeyOld_real(ci, SSqrReal, iAtomStart, this%tolerance, this%maxIter)
+      call pipekMezeyOld_real(output, ci, SSqrReal, iAtomStart, this%tolerance, this%maxIter)
     end if
 
   end subroutine calcCoeffsReal
 
 
   !> Performs Pipek-Mezey localisation for a periodic system at a specified k-point.
-  subroutine calcCoeffsKPoint(this, ci, SSqrCplx, over, kPoint, neighbourList, nNeighbourSK,&
+  subroutine calcCoeffsKPoint(this, output, ci, SSqrCplx, over, kPoint, neighbourList, nNeighbourSK,&
       & iCellVec, cellVec, iAtomStart, iPair, img2CentCell)
 
     !> Instance.
     class(TPipekMezey), intent(in) :: this
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Wavefunction coefficients
     complex(dp), intent(inout) :: ci(:,:)
@@ -177,7 +183,7 @@ contains
     !> Index array back to central cell
     integer, intent(in) :: img2CentCell(:)
 
-    call PipekMezeyOld_kpoint(ci, SSqrCplx, over, kPoint, neighbourList%iNeighbour, nNeighbourSK,&
+    call PipekMezeyOld_kpoint(output, ci, SSqrCplx, over, kPoint, neighbourList%iNeighbour, nNeighbourSK,&
         & iCellVec, cellVec, iAtomStart, iPair, img2CentCell, this%tolerance, this%maxIter)
 
   end subroutine calcCoeffsKPoint
@@ -258,7 +264,10 @@ contains
 
   !> Performs conventional Pipek-Mezey localisation for a molecule given the square overlap matrix
   !> using iterative sweeps over each pair of orbitals
-  subroutine PipekMezeyOld_real(ci, S, iAtomStart, pipekTol, mIter)
+  subroutine PipekMezeyOld_real(output, ci, S, iAtomStart, pipekTol, mIter)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Wavefunction coefficients
     real(dp), intent(inout) :: ci(:,:)
@@ -312,7 +321,7 @@ contains
     lpLocalise: do iIter = 1, nIter
       alphamax = 0.0_dp
       ! Sweep over all pairs of levels
-      write(stdout, *)'Iter', iIter
+      write(output, *)'Iter', iIter
       do iLev1 = 1, nLev
 
         if (iLev1 < nLev) then
@@ -374,14 +383,17 @@ contains
     end do lpLocalise
 
     if (.not.tConverged) then
-      call warning("Exceeded iterations in Pipek-Mezey localisation!")
+      call warning(output, "Exceeded iterations in Pipek-Mezey localisation!")
     end if
 
   end subroutine PipekMezeyOld_real
 
 
   !> Performs Pipek-Mezey localisation for a molecule given the square overlap matrix, using a
-  subroutine PipekMezeySuprtRegion_real(ci, S, iAtomStart, convergence, mIter, RegionTol)
+  subroutine PipekMezeySuprtRegion_real(output, ci, S, iAtomStart, convergence, mIter, RegionTol)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Support region for each molecular orbital
     real(dp), intent(inout) :: ci(:,:)
@@ -426,10 +438,10 @@ contains
     real(dp) :: Localisation, oldLocalisation
     integer, allocatable :: union(:)
 
-    write(stdout, *)'Pipek Mezey localisation'
+    write(output, *)'Pipek Mezey localisation'
 
     Localisation = PipekMezyLocality_real(ci,S,iAtomStart)
-    write(stdout, *)'Initial', Localisation
+    write(output, *)'Initial', Localisation
 
     @:ASSERT(size(ci,dim=1)>=size(ci,dim=2))
     @:ASSERT(size(ci,dim=1)==size(S,dim=1))
@@ -497,13 +509,13 @@ contains
     lpLocalise: do iIter = 1, nIter
       alphamax = 0.0_dp
 
-      write(stdout, "(' Iter:',I0,', tol:',E10.2)")iIter,RegionTol
+      write(output, "(' Iter:',I0,', tol:',E10.2)")iIter,RegionTol
       rCount = 0.0
 
       do iLev1 = 1, nLev
 
         if (real(iLev1)/real(nLev) > rCount) then
-          write(stdout, "(1X,I0,'%')")int(100*real(iLev1)/real(nLev))
+          write(output, "(1X,I0,'%')")int(100*real(iLev1)/real(nLev))
           rCount = rCount + 0.1 ! every 10%
         end if
 
@@ -665,34 +677,34 @@ contains
 
       oldLocalisation = Localisation
       Localisation = PipekMezyLocality_real(ci,S,iAtomStart)
-      write(stdout, "(A,F12.6,1X,A,E20.12)")'Current localisation ',Localisation,&
+      write(output, "(A,F12.6,1X,A,E20.12)")'Current localisation ',Localisation,&
           & 'change ',Localisation-oldLocalisation
 
       conv = abs(alphamax) - abs(alphalast)
       if (iIter > 2 .and. ((abs(conv)<convergence) .or. alphamax == 0.0)) then
-        write(stdout, *)'Converged on rotation angle'
+        write(output, *)'Converged on rotation angle'
         tConverged = .true.
         exit
       end if
 
       conv = abs(Localisation-oldLocalisation)
       if (abs(conv)<convergence) then
-        write(stdout, *)'Converged on localization value.'
+        write(output, *)'Converged on localization value.'
         tConverged = .true.
         exit
       end if
 
       alphalast = alphamax
-      write(stdout, "(' max(alpha)',E10.2)")alphamax
+      write(output, "(' max(alpha)',E10.2)")alphamax
 
     end do lpLocalise
 
     Localisation = PipekMezyLocality_real(ci,S,iAtomStart)
-    write(stdout, *)'Final',Localisation
+    write(output, *)'Final',Localisation
 
     if (.not.tConverged) then
-      write(stdout, *)alphamax
-      call warning("Exceeded iterations in Pipek-Mezey localisation!")
+      write(output, *)alphamax
+      call warning(output, "Exceeded iterations in Pipek-Mezey localisation!")
     end if
 
   end subroutine PipekMezeySuprtRegion_real
@@ -816,8 +828,11 @@ contains
 
   !> Performs conventional Pipek-Mezey localisation for a supercell using iterative sweeps over each
   !> pair of orbitals for a particular k and spin sub-matrix
-  subroutine PipekMezeyOld_kpoint(ci, S, over, kpoint, iNeighbour, nNeighbourSK, iCellVec, cellVec,&
+  subroutine PipekMezeyOld_kpoint(output, ci, S, over, kpoint, iNeighbour, nNeighbourSK, iCellVec, cellVec,&
       & iAtomStart, iPair, img2CentCell, convergence, mIter)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Wavefunction coefficients
     complex(dp), intent(inout) :: ci(:,:)
@@ -903,7 +918,7 @@ contains
 
     lpLocalise: do iIter = 1, nIter
 
-      write(stdout, *)'Iter', iIter
+      write(output, *)'Iter', iIter
 
       alphamax = 0.0_dp
 
@@ -979,7 +994,7 @@ contains
     !    & img2CentCell))
 
     if (.not.tConverged) then
-      call warning("Exceeded iterations in Pipek-Mezey localisation!")
+      call warning(output, "Exceeded iterations in Pipek-Mezey localisation!")
     end if
 
     ! Choose phase to make largest Bloch state element real for this k-point - dumb approch, as

--- a/src/dftbp/dftb/repulsive/chimesrep.F90
+++ b/src/dftbp/dftb/repulsive/chimesrep.F90
@@ -9,6 +9,7 @@
 
 !> Implements a repulsive correction using the ChIMES force field
 module dftbp_dftb_repulsive_chimesrep
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : AA__Bohr, Bohr__AA, kcal_mol__Hartree
   use dftbp_dftb_periodic, only : TNeighbourList
@@ -149,10 +150,13 @@ contains
 
 
   !> Transmits the updated coordinates to enable for pre-calculations.
-  subroutine TChimesRep_updateCoords(this, coords, species, img2CentCell, neighbourList)
+  subroutine TChimesRep_updateCoords(this, env, coords, species, img2CentCell, neighbourList)
 
     !> Instance
     class(TChimesRep), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> New coordinates (including those in repeated cells). Shape: [3, nAllAtom]
     real(dp), intent(in) :: coords(:,:)

--- a/src/dftbp/dftb/repulsive/repulsive.F90
+++ b/src/dftbp/dftb/repulsive/repulsive.F90
@@ -9,6 +9,7 @@
 
 !> Implements interface for the repulsive (force-field like) potential
 module dftbp_dftb_repulsive_repulsive
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp
   use dftbp_dftb_periodic, only : TNeighbourList
   implicit none
@@ -62,12 +63,15 @@ module dftbp_dftb_repulsive_repulsive
 
 
     !> Transmits the updated coordinates to enable for pre-calculations.
-    subroutine updateCoords(this, coords, species, img2CentCell, neighbourList)
-      import :: TRepulsive, TNeighbourList, dp
+    subroutine updateCoords(this, env, coords, species, img2CentCell, neighbourList)
+      import :: TRepulsive, TNeighbourList, dp, TEnvironment
       implicit none
 
       !> Instance
       class(TRepulsive), intent(inout) :: this
+
+      !> Environment
+      type(TEnvironment), intent(in) :: env
 
       !> New coordinates (including those in repeated cells). Shape: [3, nAllAtom]
       real(dp), intent(in) :: coords(:,:)

--- a/src/dftbp/dftb/repulsive/repulsivecont.F90
+++ b/src/dftbp/dftb/repulsive/repulsivecont.F90
@@ -10,6 +10,7 @@
 
 !> Implements interface for the repulsive (force-field like) potential
 module dftbp_dftb_repulsive_repulsivecont
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp
   use dftbp_dftb_periodic, only : TNeighbourList
   use dftbp_dftb_repulsive_repulsive, only : TRepulsive
@@ -92,10 +93,13 @@ contains
 
 
   !> Transmits the updated coordinates to enable for pre-calculations.
-  subroutine updateCoords(this, coords, species, img2CentCell, neighbourList)
+  subroutine updateCoords(this, env, coords, species, img2CentCell, neighbourList)
 
     !> Instance
     class(TRepulsiveCont), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> New coordinates (including those in repeated cells). Shape: [3, nAllAtom]
     real(dp), intent(in) :: coords(:,:)
@@ -114,7 +118,7 @@ contains
 
     do iRep = 1, this%repulsives%size()
       call this%repulsives%view(iRep, repulsive)
-      call repulsive%updateCoords(coords, species, img2CentCell, neighbourList)
+      call repulsive%updateCoords(env, coords, species, img2CentCell, neighbourList)
     end do
 
   end subroutine updateCoords

--- a/src/dftbp/dftb/repulsive/twobodyrep.F90
+++ b/src/dftbp/dftb/repulsive/twobodyrep.F90
@@ -9,6 +9,7 @@
 
 !> Implements a repulsive potential between two atoms represented by a polynomial of 9th degree
 module dftbp_dftb_repulsive_twobodyrep
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : pi
   use dftbp_geometry_boundarycond, only : zAxis
@@ -116,10 +117,13 @@ contains
 
 
   !> Transmits the updated coordinates to enable for pre-calculations.
-  subroutine updateCoords(this, coords, species, img2CentCell, neighbourList)
+  subroutine updateCoords(this, env, coords, species, img2CentCell, neighbourList)
 
     !> Instance
     class(TTwoBodyRep), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> New coordinates (including those in repeated cells). Shape: [3, nAllAtom]
     real(dp), intent(in) :: coords(:,:)
@@ -133,7 +137,7 @@ contains
     !> Neighbour list.
     type(TNeighbourList), intent(in) :: neighbourList
 
-    call getNrOfNeighboursForAll(this%nNeighbours, neighbourList, this%getRCutoff())
+    call getNrOfNeighboursForAll(env%stdOut, this%nNeighbours, neighbourList, this%getRCutoff())
 
   end subroutine updateCoords
 

--- a/src/dftbp/dftb/scc.F90
+++ b/src/dftbp/dftb/scc.F90
@@ -272,7 +272,7 @@ contains
 
     select case (this%elstatType)
     case (elstatTypes%gammaFunc)
-      call initShortGamma_(input%shortGammaInput, orb, this%shortGamma)
+      call initShortGamma_(env, input%shortGammaInput, orb, this%shortGamma)
       call initCoulomb_(input%coulombInput, env, this%nAtom, this%coulomb)
     case (elstatTypes%poisson)
       #:block REQUIRES_COMPONENT('Poisson-solver', WITH_POISSON)
@@ -369,7 +369,7 @@ contains
     select case (this%elstatType)
     case (elstatTypes%gammaFunc)
       call this%coulomb%updateCoords(env, neighList, coord, species)
-      call this%shortGamma%updateCoords(coord, species, neighList)
+      call this%shortGamma%updateCoords(env, coord, species, neighList)
     case (elstatTypes%poisson)
       #:block REQUIRES_COMPONENT('Poisson-solver', WITH_POISSON)
         ! Poisson solver needs currently the unfolded central cell coordinates (coord0), because the
@@ -1312,13 +1312,17 @@ contains
 
 
   ! Initializes the short gamma calculator
-  subroutine initShortGamma_(shortGammaInput, orb, shortGamma)
+  subroutine initShortGamma_(env, shortGammaInput, orb, shortGamma)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
+
     type(TShortGammaInput), intent(inout) :: shortGammaInput
     type(TOrbitals), intent(in) :: orb
     type(TShortGamma), allocatable, intent(out) :: shortGamma
 
     allocate(shortGamma)
-    call TShortGamma_init(shortGamma, shortGammaInput, orb)
+    call TShortGamma_init(shortGamma, env, shortGammaInput, orb)
 
   end subroutine initShortGamma_
 

--- a/src/dftbp/dftb/sccinit.F90
+++ b/src/dftbp/dftb/sccinit.F90
@@ -12,7 +12,6 @@
 module dftbp_dftb_sccinit
   use dftbp_common_accuracy, only : dp, elecTolMax
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_common_status, only : TStatus
   use dftbp_dftb_densitymatrix, only : TDensityMatrix
   use dftbp_dftb_hybridxc, only : checkSupercellFoldingMatrix, hybridXcAlgo
@@ -182,8 +181,11 @@ contains
   !! Checks that the total charge matches the expected value for the calculation.
   !! Should test the input, if the number of orbital charges per atom matches the number from the
   !! angular momentum.
-  subroutine initQFromFile(qq, fileName, tReadAscii, orb, qBlock, qiBlock, densityMatrix, tRealHS,&
+  subroutine initQFromFile(output, qq, fileName, tReadAscii, orb, qBlock, qiBlock, densityMatrix, tRealHS,&
       & errStatus, magnetisation, nEl, hybridXcAlg, coeffsAndShifts, multipoles)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> The charges per lm,atom,spin
     real(dp), intent(out) :: qq(:,:,:)
@@ -368,7 +370,7 @@ contains
     end if
 
     if (iSpin /= nSpin) then
-      write(stdout, *) iSpin
+      write(output, *) iSpin
       call error("Incorrect number of spins in restart file")
     end if
 

--- a/src/dftbp/dftb/sccinit.F90
+++ b/src/dftbp/dftb/sccinit.F90
@@ -184,7 +184,7 @@ contains
   subroutine initQFromFile(output, qq, fileName, tReadAscii, orb, qBlock, qiBlock, densityMatrix, tRealHS,&
       & errStatus, magnetisation, nEl, hybridXcAlg, coeffsAndShifts, multipoles)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> The charges per lm,atom,spin

--- a/src/dftbp/dftb/shortgamma.F90
+++ b/src/dftbp/dftb/shortgamma.F90
@@ -784,7 +784,7 @@ contains
   !> Updates the number of neighbours.
   subroutine updateNrOfNeighbours_(output, shortCutoffs, species, hubb, neighList, nNeigh)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     real(dp), intent(in) :: shortCutoffs(:,:,:,:)

--- a/src/dftbp/dftb/shortgamma.F90
+++ b/src/dftbp/dftb/shortgamma.F90
@@ -115,10 +115,13 @@ module dftbp_dftb_shortgamma
 contains
 
   !> Initializes a TShortGamma instance.
-  subroutine TShortGamma_init(this, input, orb)
+  subroutine TShortGamma_init(this, env, input, orb)
 
     !> Initialized instance
     type(TShortGamma), intent(out) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Input parameters
     type(TShortGammaInput), intent(inout) :: input
@@ -141,7 +144,7 @@ contains
 
     if (allocated(input%h5CorrectionInp)) then
       allocate(this%h5Correction_)
-      call TH5Correction_init(this%h5Correction_, input%h5CorrectionInp)
+      call TH5Correction_init(this%h5Correction_, env, input%h5CorrectionInp)
     end if
 
     if (allocated(input%damping)) then
@@ -174,10 +177,13 @@ contains
 
 
   !> Updates the coordinates.
-  subroutine updateCoords(this, coords, species, neighList)
+  subroutine updateCoords(this, env, coords, species, neighList)
 
     !> Instance
     class(TShortGamma), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Coordinates
     real(dp), intent(in) :: coords(:,:)
@@ -188,7 +194,7 @@ contains
     !> Neighbour list
     type(TNeighbourList), intent(in) :: neighList
 
-    call updateNrOfNeighbours_(this%shortCutoffs_, species, this%hubbU_, neighList, this%nNeigh_)
+    call updateNrOfNeighbours_(env%stdOut, this%shortCutoffs_, species, this%hubbU_, neighList, this%nNeigh_)
     call updateShortGammaValues_(coords, species, neighList, this%nNeigh_, this%hubbU_,&
         & this%damping_, this%h5Correction_, this%shortGamma_)
 
@@ -776,7 +782,11 @@ contains
 
 
   !> Updates the number of neighbours.
-  subroutine updateNrOfNeighbours_(shortCutoffs, species, hubb, neighList, nNeigh)
+  subroutine updateNrOfNeighbours_(output, shortCutoffs, species, hubb, neighList, nNeigh)
+
+    !> output for write processes
+    integer, intent(in) :: output
+
     real(dp), intent(in) :: shortCutoffs(:,:,:,:)
     integer, intent(in) :: species(:)
     type(TUniqueHubbard), intent(in) :: hubb
@@ -791,7 +801,7 @@ contains
         do iU1 = 1, hubb%nHubbU(species(iAt))
           do iU2 = 1, hubb%nHubbU(iSp)
             nNeigh(iU2, iU1, iSp, iAt) =&
-                & getNrOfNeighbours(neighList, shortCutoffs(iU2, iU1, iSp, species(iAt)), iAt)
+                & getNrOfNeighbours(output, neighList, shortCutoffs(iU2, iU1, iSp, species(iAt)), iAt)
           end do
         end do
       end do

--- a/src/dftbp/dftb/simpledftd3.F90
+++ b/src/dftbp/dftb/simpledftd3.F90
@@ -224,9 +224,9 @@ contains
     this%gradients(:, :) = 0.0_dp
     this%sigma(:, :) = 0.0_dp
 
-    call this%cnCont%updateCoords(neigh, img2CentCell, coords, species0)
+    call this%cnCont%updateCoords(env, neigh, img2CentCell, coords, species0)
 
-    call getNrOfNeighboursForAll(nNeighbour, neigh, this%cutoffInter)
+    call getNrOfNeighboursForAll(env%stdOut, nNeighbour, neigh, this%cutoffInter)
     call dispersionGradient(env, this%ref, this%param, nNeighbour, coords, &
         & species0, neigh, img2CentCell, this%cnCont%cn, this%cnCont%dcndr, &
         & this%cnCont%dcndL, this%energies, this%gradients, this%sigma)

--- a/src/dftbp/dftb/thirdorder.F90
+++ b/src/dftbp/dftb/thirdorder.F90
@@ -9,6 +9,7 @@
 
 !> Routines implementing the full 3rd order DFTB.
 module dftbp_dftb_thirdorder
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp, minHubDiff, tolSameDist
   use dftbp_dftb_charges, only : getSummedCharges
   use dftbp_dftb_periodic, only : getNrOfNeighbours, TNeighbourList
@@ -145,10 +146,13 @@ contains
 
 
   !> Updates data structures if there are changed coordinates for the instance.
-  subroutine updateCoords(this, neighList, species)
+  subroutine updateCoords(this, env, neighList, species)
 
     !> Instance
     class(TThirdOrder), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Neighbour list
     type(TNeighbourList), intent(in) :: neighList
@@ -164,7 +168,7 @@ contains
     do iAt1 = 1, this%nAtoms
       iSp1 = species(iAt1)
       do iSp2 = 1, this%nSpecies
-        this%nNeigh(iSp2, iAt1) = getNrOfNeighbours(neighList, this%cutoffs(iSp2, iSp1), iAt1)
+        this%nNeigh(iSp2, iAt1) = getNrOfNeighbours(env%stdOut, neighList, this%cutoffs(iSp2, iSp1), iAt1)
       end do
     end do
     this%nNeighMax = maxval(this%nNeigh, dim=1)

--- a/src/dftbp/dftbplus/eigenvects.F90
+++ b/src/dftbp/dftbplus/eigenvects.F90
@@ -194,8 +194,11 @@ contains
   !> Diagonalizes a sparse represented Hamiltonian and overlap to give the eigenValsvectors and
   !> values, as well as often the Cholesky factorized overlap matrix (due to a side effect of
   !> lapack)
-  subroutine diagDenseRealMtxBlacs(electronicSolver, iCholesky, jobz, desc, HSqr, SSqr, eigenVals,&
+  subroutine diagDenseRealMtxBlacs(env, electronicSolver, iCholesky, jobz, desc, HSqr, SSqr, eigenVals,&
       & eigenVecs, errStatus)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Electronic solver information
     type(TElectronicSolver), intent(inout) :: electronicSolver
@@ -250,7 +253,7 @@ contains
           call elsi_write_mat_real(electronicSolver%elsi%rwHandle, "ELSI_Hreal.bin", HSqr)
           call elsi_write_mat_real(electronicSolver%elsi%rwHandle, "ELSI_Sreal.bin", SSqr)
           call elsi_finalize_rw(electronicSolver%elsi%rwHandle)
-          call cleanShutdown("Finished dense matrix write")
+          call cleanShutdown(env%stdOut, "Finished dense matrix write")
         end if
         ! ELPA solver, returns eigenstates
         ! note, this only factorises overlap on first call - no skipchol equivalent
@@ -341,7 +344,7 @@ contains
           call elsi_write_mat_complex(electronicSolver%elsi%rwHandle, "ELSI_Hcmplx.bin", HSqr)
           call elsi_write_mat_complex(electronicSolver%elsi%rwHandle, "ELSI_Scmplx.bin", SSqr)
           call elsi_finalize_rw(electronicSolver%elsi%rwHandle)
-          call cleanShutdown("Finished dense matrix write")
+          call cleanShutdown(env%stdOut, "Finished dense matrix write")
         end if
         ! ELPA solver, returns eigenstates
         ! note, this only factorises overlap on first call - no skipchol equivalent

--- a/src/dftbp/dftbplus/hsdhelpers.F90
+++ b/src/dftbp/dftbplus/hsdhelpers.F90
@@ -9,7 +9,8 @@
 
 !> HSD-parsing related helper routines.
 module dftbp_dftbplus_hsdhelpers
-  use dftbp_common_globalenv, only : stdOut, tIoProc
+  use dftbp_common_environment, only : TEnvironment
+  use dftbp_common_globalenv, only : tIoProc
   use dftbp_dftbplus_inputdata, only : TInputData
   use dftbp_dftbplus_parser, only : parseHsdTree, readHsdFile, rootTag, TParserFlags
   use dftbp_extlibs_xmlf90, only : destroyNode, fnode
@@ -32,7 +33,10 @@ module dftbp_dftbplus_hsdhelpers
 contains
 
   !> Parses input file and returns initialised input structure
-  subroutine parseHsdInput(input)
+  subroutine parseHsdInput(env, input)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Input data parsed from the input file
     type(TInputData), intent(out) :: input
@@ -41,10 +45,10 @@ contains
     type(TParserFlags) :: parserFlags
 
     call ensureInputFilePresence()
-    write(stdout, "(A)") "Reading input file '" // hsdFileName // "'"
+    write(env%stdout, "(A)") "Reading input file '" // hsdFileName // "'"
     call readHsdFile(hsdFileName, hsdTree)
-    call parseHsdTree(hsdTree, input, parserFlags)
-    call doPostParseJobs(hsdTree, parserFlags)
+    call parseHsdTree(env, hsdTree, input, parserFlags)
+    call doPostParseJobs(env%stdOut, hsdTree, parserFlags)
     call destroyNode(hsdTree)
 
   end subroutine parseHsdInput
@@ -64,7 +68,10 @@ contains
 
 
   !> Execute parser related tasks (warning, processed input dumping) needed after parsing
-  subroutine doPostParseJobs(hsdTree, parserFlags)
+  subroutine doPostParseJobs(output, hsdTree, parserFlags)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Tree representation of the HSD input
     type(fnode), pointer, intent(in) :: hsdTree
@@ -77,12 +84,12 @@ contains
     call getChild(hsdTree, rootTag, root)
 
     ! Issue warning about unprocessed nodes
-    call warnUnprocessedNodes(root, parserFlags%tIgnoreUnprocessed)
+    call warnUnprocessedNodes(output, root, parserFlags%tIgnoreUnprocessed)
 
     ! Dump processed tree in HSD and XML format
     if (tIoProc .and. parserFlags%tWriteHSD) then
       call dumpHSD(hsdTree, hsdProcFileName)
-      write(stdout, '(/,/,A)') "Processed input in HSD format written to '" // hsdProcFileName&
+      write(output, '(/,/,A)') "Processed input in HSD format written to '" // hsdProcFileName&
           & // "'"
     end if
 

--- a/src/dftbp/dftbplus/hsdhelpers.F90
+++ b/src/dftbp/dftbplus/hsdhelpers.F90
@@ -70,7 +70,7 @@ contains
   !> Execute parser related tasks (warning, processed input dumping) needed after parsing
   subroutine doPostParseJobs(output, hsdTree, parserFlags)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Tree representation of the HSD input

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -5876,7 +5876,7 @@ contains
   !> Writes MBD-related info
   subroutine writeMbdInfo(output, input)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> MBD input parameters
@@ -6035,7 +6035,7 @@ contains
   !> Print out the reference occupations for atoms
   subroutine printCustomReferenceOccupations(output, orb, species, customOccAtoms, customOccFillings)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Atomic orbital information
@@ -6254,7 +6254,7 @@ contains
   subroutine ensureLinRespConditions(output, tSccCalc, t3rd, tRealHS, tPeriodic, tCasidaForces, solvation,&
       & isHybLinResp, nSpin, tHelical, tSpinOrbit, isDftbU, tempElec, isOnsiteCorrected, input)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Is the calculation SCC?
@@ -6946,7 +6946,7 @@ contains
   !> Print information about a REKS calculation
   subroutine printReksInitInfo(output, reks, orb, speciesName, nType)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Data type for REKS

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -19,7 +19,7 @@ module dftbp_dftbplus_initprogram
   use dftbp_common_envcheck, only : checkStackSize
   use dftbp_common_environment, only : globalTimers, TEnvironment
   use dftbp_common_file, only : clearFile, setDefaultBinaryAccess, TFileDescr
-  use dftbp_common_globalenv, only : stdOut, withMpi
+  use dftbp_common_globalenv, only : withMpi
   use dftbp_common_hamiltoniantypes, only : hamiltonianTypes
   use dftbp_common_status, only : TStatus
   use dftbp_derivs_numderivs2, only : create, TNumDerivs
@@ -1369,10 +1369,10 @@ contains
   #:endif
 
     @:ASSERT(input%tInitialized)
-    write(stdOut, "(/, A)") "Starting initialization..."
-    write(stdOut, "(A80)") repeat("-", 80)
+    write(env%stdOut, "(/, A)") "Starting initialization..."
+    write(env%stdOut, "(A80)") repeat("-", 80)
 
-    call env%initGlobalTimer(input%ctrl%timingLevel, "DFTB+ running times", stdOut)
+    call env%initGlobalTimer(input%ctrl%timingLevel, "DFTB+ running times", env%stdOut)
     call env%globalTimer%startTimer(globalTimers%globalInit)
 
     ! Set the same access for readwrite as for write (we do not open any files in readwrite mode)
@@ -1487,7 +1487,7 @@ contains
           allocate(eiTmp, mold=input%slako%skOcc)
           eiTmp(:,:) = 0.0_dp
           call this%tblite%getReferenceEi(this%species0, eiTmp)
-          write(stdOut, *) "Non-shell-resolved spin coupling constants from parameters for"
+          write(env%stdOut, *) "Non-shell-resolved spin coupling constants from parameters for"
         end if
         do iSp = 1, this%nType
           iElem = symbolToNumber(this%speciesName(iSp))
@@ -1508,7 +1508,7 @@ contains
             ! Use HOAO value
             ish = maxloc(eiTmp(:,iSp), dim=1, mask=input%slako%skOcc(:,iSp) > 0.0_dp)
             il = this%orb%angShell(iSh,iSp)
-            write(stdOut,"(1X,A,T6,A,A)")trim(this%speciesName(iSp)), ' : ', shellnames(il+1)
+            write(env%stdOut,"(1X,A,T6,A,A)")trim(this%speciesName(iSp)), ' : ', shellnames(il+1)
             input%ctrl%spinW(:this%orb%nShell(iSp), :this%orb%nShell(iSp), iSp) =&
                 & tmpSpinW(spindx(il, il))
           end if
@@ -1530,7 +1530,7 @@ contains
     ! Brillouin zone sampling
     if (this%tPeriodic .or. this%tHelical) then
       if (input%ctrl%poorKSampling) then
-        call warning("The suplied k-points are probably not accurate for properties requiring&
+        call warning(env%stdOut, "The suplied k-points are probably not accurate for properties requiring&
             & integration over the Brillouin zone")
       end if
       this%nKPoint = input%ctrl%nKPoint
@@ -1545,7 +1545,7 @@ contains
       if (this%tHelical) then
         if (any(abs(this%kPoint(2,:) * nint(this%latVec(3,1)) - nint(this%kPoint(2,:) *&
             & nint(this%latVec(3,1)))) > input%ctrl%helicalSymTol)) then
-          call warning("Specified k-value(s) incommensurate with C_n symmetry operation.")
+          call warning(env%stdOut, "Specified k-value(s) incommensurate with C_n symmetry operation.")
         end if
       end if
     else
@@ -1568,7 +1568,7 @@ contains
   #:if WITH_MPI
     if (input%ctrl%parallelOpts%nGroup > this%nIndepSpin * this%nKPoint&
         & .and. (.not. (this%isHybridXc .and. (.not. this%tRealHS)))) then
-      write(stdOut, *) "Parallel groups only relevant for tasks split over sufficient spins and/or&
+      write(env%stdOut, *) "Parallel groups only relevant for tasks split over sufficient spins and/or&
           & k-points"
       write(tmpStr,"('Nr. groups:',I4,', Nr. indepdendent spins times k-points:',I4)")&
           & input%ctrl%parallelOpts%nGroup, this%nIndepSpin * this%nKPoint
@@ -1622,7 +1622,7 @@ contains
         & errStatus)
     if (errStatus%hasError()) then
       if (errStatus%code == -1) then
-        call warning("Insufficient atoms for this number of MPI processors")
+        call warning(env%stdOut, "Insufficient atoms for this number of MPI processors")
       end if
       call error(errStatus%message)
     end if
@@ -1762,8 +1762,8 @@ contains
     call initElectronFilling_(input, this%nSpin, this%Ef, this%iDistribFn, this%tempElec,&
         & this%tFixEf, this%tSetFillingTemp, this%tFillKSep)
 
-    call ensureSolverCompatibility(input%ctrl%solver%iSolver, this%kPoint, input%ctrl%parallelOpts,&
-        & this%nIndepSpin, this%tempElec, input%ctrl%isASICallbackEnabled)
+    call ensureSolverCompatibility(env, input%ctrl%solver%iSolver, this%kPoint,&
+        & input%ctrl%parallelOpts, this%nIndepSpin, this%tempElec, input%ctrl%isASICallbackEnabled)
     nBufferedCholesky = countBufferedCholesky_(this%tRealHS, this%parallelKS%nLocalKS)
     call TElectronicSolver_init(this%electronicSolver, input%ctrl%solver, nBufferedCholesky)
 
@@ -1781,7 +1781,7 @@ contains
         & .and. .not. (this%electronicSolver%iSolver == electronicSolverTypes%OnlyTransport&
         & .and. .not. this%tSccCalc)
     if (this%tUpload) then
-      call initUploadArrays_(input%transpar, this%orb, this%nSpin, this%tMixBlockCharges,&
+      call initUploadArrays_(env, input%transpar, this%orb, this%nSpin, this%tMixBlockCharges,&
           & this%shiftPerLUp, this%chargeUp, this%blockUp)
       if (input%transpar%ncont < 1) then
         call error("At least one contact is required for an UploadContacts task")
@@ -1894,7 +1894,8 @@ contains
         call error("Halogen correction only fitted for 3rd order models")
       end if
       if (this%tPeriodic) then
-        call warning("Halogen correction was not fitted for periodic systems in original paper")
+        call warning(env%stdOut, "Halogen correction was not fitted for periodic systems in&
+            & original paper")
       end if
       allocate(this%halogenXCorrection)
       call THalogenX_init(this%halogenXCorrection, this%species0, this%speciesName)
@@ -2186,7 +2187,7 @@ contains
       end if
 
       allocate(this%filter)
-      call TFilter_init(this%filter, input%ctrl%geoOpt%filter, this%coord0, this%latVec)
+      call TFilter_init(this%filter, env%stdOut, input%ctrl%geoOpt%filter, this%coord0, this%latVec)
       call createOptimizer(input%ctrl%geoOpt%optimiser, this%filter%getDimension(), this%geoOpt)
       this%optTol = input%ctrl%geoOpt%tolerance
       allocate(this%gcurr(this%filter%getDimension()))
@@ -2389,10 +2390,10 @@ contains
           end if
           call TDispMbd_init(mbd, inp, input%geom, isPostHoc=.true.)
         end associate
-        call mbd%checkError()
+        call mbd%checkError(env)
         call move_alloc(mbd, this%dispersion)
         if (input%ctrl%dispInp%mbd%method == 'ts' .and. this%tForces) then
-          call warning("Forces for the TS-dispersion model are calculated by finite differences&
+          call warning(env%stdOut, "Forces for the TS-dispersion model are calculated by finite differences&
               & which may result in long gradient calculation times for large systems")
         end if
     #:endif
@@ -2451,7 +2452,7 @@ contains
       areNeighboursSymmetric = areNeighboursSymmetric .or. this%areSolventNeighboursSym
       this%cutOff%mCutOff = max(this%cutOff%mCutOff, this%solvation%getRCutOff())
 
-      call init_TScaleExtEField(this%eFieldScaling, this%solvation,&
+      call init_TScaleExtEField(this%eFieldScaling, env%stdOut, this%solvation,&
           & input%ctrl%isSolvatedFieldRescaled)
 
       if (allocated(this%eField)) then
@@ -2479,11 +2480,11 @@ contains
         logical :: isDipoleDefined
         isDipoleDefined = .true.
         if (abs(input%ctrl%nrChrg) > epsilon(0.0_dp)) then
-          call warning("Dipole printed for a charged system : origin dependent quantity")
+          call warning(env%stdOut, "Dipole printed for a charged system : origin dependent quantity")
           isDipoleDefined = .false.
         end if
         if (this%tPeriodic .or. this%tHelical) then
-          call warning("Dipole printed for extended system : value printed is not well defined")
+          call warning(env%stdOut, "Dipole printed for extended system : value printed is not well defined")
           isDipoleDefined = .false.
         end if
         if (.not. isDipoleDefined) then
@@ -2589,8 +2590,8 @@ contains
           call error("Coordinate derivative perturbations do not yet work with hybrid functionals")
         end if
         if (this%tempElec > minTemp) then
-          call warning("Fractional occupation is not yet supported for coordinate derivative&
-              & perturbations, so may halt with finite temperatures")
+          call warning(env%stdOut, "Fractional occupation is not yet supported for coordinate&
+              & derivative perturbations, so may halt with finite temperatures")
         end if
         if (this%nSpin > 1) then
           call error("Spin polarised calculations are not yet supported for coordinate derivative&
@@ -2655,8 +2656,8 @@ contains
         if (this%boundaryCond%iBoundaryCondition == boundaryCondsEnum%cluster) then
           allocate(this%polarisability(3, 3, size(this%dynRespEFreq)), source=0.0_dp)
         else
-          call warning("Electric field polarisability not currently available for this boundary&
-              & condition")
+          call warning(env%stdOut, "Electric field polarisability not currently available for this&
+              & boundary condition")
         end if
         if (input%ctrl%tWriteBandDat) then
           ! only one frequency at the moment if dynamic!
@@ -2687,7 +2688,7 @@ contains
       end if
       isOnsiteCorrected = allocated(this%onSiteElements)
 
-      call ensureLinRespConditions(this%tSccCalc, this%t3rd .or. this%t3rdFull, this%tRealHS,&
+      call ensureLinRespConditions(env%stdOut, this%tSccCalc, this%t3rd .or. this%t3rdFull, this%tRealHS,&
           & this%tPeriodic, this%tCasidaForces, this%solvation, this%isHybLinResp, this%nSpin,&
           & this%tHelical, this%tSpinOrbit, allocated(this%dftbU), this%tempElec,&
           & isOnsiteCorrected, input)
@@ -2732,7 +2733,7 @@ contains
             & corrections")
       end if
 
-      call LinResp_init(this%linearResponse, input%ctrl%lrespini, this%nAtom, this%nEl(1),&
+      call LinResp_init(this%linearResponse, env, input%ctrl%lrespini, this%nAtom, this%nEl(1),&
           & this%nSpin, this%onSiteElements, isIoProc)
 
     end if
@@ -2741,7 +2742,7 @@ contains
     if (allocated(input%ctrl%ppRPA)) then
 
       if (abs(input%ctrl%nrChrg - 2.0_dp) > elecTolMax) then
-        call warning("Particle-particle RPA should be for a reference system with a charge of +2.")
+        call warning(env%stdOut, "Particle-particle RPA should be for a reference system with a charge of +2.")
       end if
 
     #:for VAR, ERR in [("this%tSpinOrbit","spin orbit coupling"), &
@@ -2774,9 +2775,9 @@ contains
     #:endif
 
       if (this%geometryChanges%isGeoOpt .or. this%geometryChanges%tMd .or. this%tSocket) then
-        call warning ("Geometry optimisation with ppRPA is probably not what you want - forces in&
-            & the (N-2) electron ground state system do not match the targeted system for the&
-            & excited states")
+        call warning (env%stdOut, "Geometry optimisation with ppRPA is probably not what you want -&
+            & forces in the (N-2) electron ground state system do not match the targeted system for&
+            & the excited states")
       end if
 
       call move_alloc(input%ctrl%ppRPA, this%ppRPA)
@@ -2857,7 +2858,7 @@ contains
         call error("XLBOMD does not work with solvation models yet!")
       end if
       allocate(this%xlbomdIntegrator)
-      call Xlbomd_init(this%xlbomdIntegrator, input%ctrl%xlbomd, this%nIneqOrb)
+      call Xlbomd_init(this%xlbomdIntegrator, env, input%ctrl%xlbomd, this%nIneqOrb)
     end if
 
     this%minSccIter = getMinSccIters(this%tSccCalc, allocated(this%dftbU), this%nSpin)
@@ -2956,7 +2957,7 @@ contains
 
     end if
 
-    call this%initializeCharges(errStatus, initialSpins=input%ctrl%initialSpins,&
+    call this%initializeCharges(env, errStatus, initialSpins=input%ctrl%initialSpins,&
         & initialCharges=input%ctrl%initialCharges, hybridXcAlg=this%hybridXcAlg)
     if (errStatus%hasError()) call error(errStatus%message)
 
@@ -3158,9 +3159,10 @@ contains
       if (allocated(input%ctrl%atomicExtPotential)) then
         if (allocated(input%ctrl%atomicExtPotential%iAtOnSite)) then
           if (any(input%ctrl%atomicExtPotential%iAtOnSite > size(this%iAtInCentralRegion))) then
-            call warning("Some net potential atoms outside the range of atoms in device region.")
-            call warning("Chopping net potential atoms to fit within the range of atoms in central&
+            call warning(env%stdOut, "Some net potential atoms outside the range of atoms in device&
                 & region.")
+            call warning(env%stdOut, "Chopping net potential atoms to fit within the range of atoms&
+                & in central region.")
 
             allocate(iAtTmp(size(this%iAtInCentralRegion)))
             allocate(VextTmp(size(this%iAtInCentralRegion)))
@@ -3185,9 +3187,10 @@ contains
         end if
         if (allocated(input%ctrl%atomicExtPotential%iAt)) then
           if (any(input%ctrl%atomicExtPotential%iAt > size(this%iAtInCentralRegion))) then
-            call warning("Some gross potential atoms outside the range of atoms in device regoin.")
-            call warning("Chopping gross potential atoms to fit within the range of atoms in&
-                & central region.")
+            call warning(env%stdOut, "Some gross potential atoms outside the range of atoms in&
+                & device region.")
+            call warning(env%stdOut, "Chopping gross potential atoms to fit within the range of&
+                & atoms in central region.")
             allocate(iAtTmp(size(this%iAtInCentralRegion)))
             allocate(VextTmp(size(this%iAtInCentralRegion)))
             iCount = 0
@@ -3378,71 +3381,71 @@ contains
 
   #:if WITH_MPI
     if (env%mpi%nGroup > 1) then
-      write(stdOut, "('MPI processes: ',T30,I0,' (split into ',I0,' groups)')")&
+      write(env%stdOut, "('MPI processes: ',T30,I0,' (split into ',I0,' groups)')")&
           & env%mpi%globalComm%size, env%mpi%nGroup
     else
-      write(stdOut, "('MPI processes:',T30,I0)") env%mpi%globalComm%size
+      write(env%stdOut, "('MPI processes:',T30,I0)") env%mpi%globalComm%size
     end if
   #:endif
 
   #:if WITH_OMP
-    write(stdOut, "('OpenMP threads: ', T30, I0)") omp_get_max_threads()
+    write(env%stdOut, "('OpenMP threads: ', T30, I0)") omp_get_max_threads()
   #:endif
 
   #:if WITH_MPI and WITH_OMP
     if (omp_get_max_threads() > 1 .and. .not. input%ctrl%parallelOpts%tOmpThreads) then
-      write(stdOut, *)
+      write(env%stdOut, *)
       call error("You must explicitely enable OpenMP threads (UseOmpThreads = Yes) if you wish to&
           & run an MPI-parallelised binary with OpenMP threads. If not, make sure that the&
           & environment variable OMP_NUM_THREADS is set to 1.")
-      write(stdOut, *)
+      write(env%stdOut, *)
     end if
   #:endif
 
   #:if WITH_SCALAPACK
     if (.not. (this%isHybridXc .and. this%tRealHS .and. this%tPeriodic)) then
-      write(stdOut, "('BLACS orbital grid size:', T30, I0, ' x ', I0)")env%blacs%orbitalGrid%nRow,&
+      write(env%stdOut, "('BLACS orbital grid size:', T30, I0, ' x ', I0)")env%blacs%orbitalGrid%nRow,&
           & env%blacs%orbitalGrid%nCol
-      write(stdOut, "('BLACS atom grid size:', T30, I0, ' x ', I0)")env%blacs%atomGrid%nRow,&
+      write(env%stdOut, "('BLACS atom grid size:', T30, I0, ' x ', I0)")env%blacs%atomGrid%nRow,&
           & env%blacs%atomGrid%nCol
     end if
   #:endif
 
     if (tRandomSeed) then
-      write(stdOut, "(A,':',T30,I0)") "Chosen random seed", iSeed
+      write(env%stdOut, "(A,':',T30,I0)") "Chosen random seed", iSeed
     else
-      write(stdOut, "(A,':',T30,I0)") "Specified random seed", iSeed
+      write(env%stdOut, "(A,':',T30,I0)") "Specified random seed", iSeed
     end if
 
-    call checkStackSize(env)
+    call checkStackSize(env%stdOut)
 
     if (input%ctrl%tMd) then
       select case(input%ctrl%thermostatInp%thermostatType)
       case (thermostatTypes%none)
         if (this%geometryChanges%tBarostat) then
-          write(stdOut, "('Mode:',T30,A,/,T30,A)") 'MD without scaling of velocities',&
+          write(env%stdOut, "('Mode:',T30,A,/,T30,A)") 'MD without scaling of velocities',&
               & '(a.k.a. "NPE" ensemble)'
         else
-          write(stdOut, "('Mode:',T30,A,/,T30,A)") 'MD without scaling of velocities',&
+          write(env%stdOut, "('Mode:',T30,A,/,T30,A)") 'MD without scaling of velocities',&
               & '(a.k.a. NVE ensemble)'
         end if
       case (thermostatTypes%andersen)
         if (this%geometryChanges%tBarostat) then
-          write(stdOut, "('Mode:',T30,A,/,T30,A)")&
+          write(env%stdOut, "('Mode:',T30,A,/,T30,A)")&
               & "MD with re-selection of velocities according to temperature",&
               & "(a.k.a. NPT ensemble using Andersen thermostating + Berensen barostat)"
         else
-          write(stdOut, "('Mode:',T30,A,/,T30,A)")&
+          write(env%stdOut, "('Mode:',T30,A,/,T30,A)")&
               & "MD with re-selection of velocities according to temperature",&
               & "(a.k.a. NVT ensemble using Andersen thermostating)"
         end if
       case(thermostatTypes%berendsen)
         if (this%geometryChanges%tBarostat) then
-          write(stdOut, "('Mode:',T30,A,/,T30,A)")&
+          write(env%stdOut, "('Mode:',T30,A,/,T30,A)")&
               & "MD with scaling of velocities according to temperature",&
               & "(a.k.a. 'not' NVP ensemble using Berendsen thermostating and barostat)"
         else
-          write(stdOut, "('Mode:',T30,A,/,T30,A)")&
+          write(env%stdOut, "('Mode:',T30,A,/,T30,A)")&
               & "MD with scaling of velocities according to temperature",&
               & "(a.k.a. 'not' NVT ensemble using Berendsen thermostating)"
         end if
@@ -3456,10 +3459,10 @@ contains
         end if
       case(thermostatTypes%nhc)
         if (this%geometryChanges%tBarostat) then
-          write(stdOut, "('Mode:',T30,A,/,T30,A)")"MD with scaling of velocities according to",&
+          write(env%stdOut, "('Mode:',T30,A,/,T30,A)")"MD with scaling of velocities according to",&
               & "Nose-Hoover-Chain thermostat + Berensen barostat"
         else
-          write(stdOut, "('Mode:',T30,A,/,T30,A)")"MD with scaling of velocities according to",&
+          write(env%stdOut, "('Mode:',T30,A,/,T30,A)")"MD with scaling of velocities according to",&
               & "Nose-Hoover-Chain thermostat"
         end if
 
@@ -3477,80 +3480,80 @@ contains
       tGeoOptRequiresEgy = .true.
       select case (input%ctrl%iGeoOpt)
       case (geoOptTypes%steepestDesc)
-        write(stdOut, "('Mode:',T30,A)")'Steepest descent' // trim(strTmp)
+        write(env%stdOut, "('Mode:',T30,A)")'Steepest descent' // trim(strTmp)
       case (geoOptTypes%conjugateGrad)
-        write(stdOut, "('Mode:',T30,A)") 'Conjugate gradient relaxation' // trim(strTmp)
+        write(env%stdOut, "('Mode:',T30,A)") 'Conjugate gradient relaxation' // trim(strTmp)
       case (geoOptTypes%diis)
-        write(stdOut, "('Mode:',T30,A)") 'Modified gDIIS relaxation' // trim(strTmp)
+        write(env%stdOut, "('Mode:',T30,A)") 'Modified gDIIS relaxation' // trim(strTmp)
         tGeoOptRequiresEgy = .false.
       case (geoOptTypes%lbfgs)
-        write(stdout, "('Mode:',T30,A)") 'LBFGS relaxation' // trim(strTmp)
+        write(env%stdOut, "('Mode:',T30,A)") 'LBFGS relaxation' // trim(strTmp)
       case (geoOptTypes%fire)
-        write(stdout, "('Mode:',T30,A)") 'FIRE relaxation' // trim(strTmp)
+        write(env%stdOut, "('Mode:',T30,A)") 'FIRE relaxation' // trim(strTmp)
         tGeoOptRequiresEgy = .false.
       case (geoOptTypes%geometryoptimisation)
-        write(stdout, "('Mode:',T30,A)") 'Geometry optimisation relaxation'
+        write(env%stdout, "('Mode:',T30,A)") 'Geometry optimisation relaxation'
       case default
         call error("Unknown optimisation mode")
       end select
       if (tGeoOptRequiresEgy .neqv. this%electronicSolver%providesFreeEnergy) then
-        call warning("This geometry optimisation method requires force related energies for&
+        call warning(env%stdOut, "This geometry optimisation method requires force related energies for&
             & accurate minimisation.")
       end if
     elseif (this%geometryChanges%tDerivs) then
-      write(stdOut, "('Mode:',T30,A)") "2nd derivatives calculation"
-      write(stdOut, "('Mode:',T30,A)") "Calculated for atoms:"
-      write(stdOut, *) this%indDerivAtom
+      write(env%stdOut, "('Mode:',T30,A)") "2nd derivatives calculation"
+      write(env%stdOut, "('Mode:',T30,A)") "Calculated for atoms:"
+      write(env%stdOut, *) this%indDerivAtom
       if (size(this%indDerivAtom) > size(this%indMovedAtom)) then
-        write(stdOut, "('Mode:',T30,A)") "Moved atoms:"
-        write(stdOut, *) this%indMovedAtom
+        write(env%stdOut, "('Mode:',T30,A)") "Moved atoms:"
+        write(env%stdOut, *) this%indMovedAtom
       end if
     elseif (this%tSocket) then
-      write(stdOut, "('Mode:',T30,A)") "Socket controlled calculation"
+      write(env%stdOut, "('Mode:',T30,A)") "Socket controlled calculation"
     else
-      write(stdOut, "('Mode:',T30,A)") "Static calculation"
+      write(env%stdOut, "('Mode:',T30,A)") "Static calculation"
     end if
 
     if (this%tSccCalc) then
       if (.not. this%tRestartNoSC) then
-        write(stdOut, "(A,':',T30,A)") "Self consistent charges", "Yes"
-        write(stdOut, "(A,':',T30,E14.6)") "SCC-tolerance", this%sccTol
-        write(stdOut, "(A,':',T30,I14)") "Max. scc iterations", this%maxSccIter
+        write(env%stdOut, "(A,':',T30,A)") "Self consistent charges", "Yes"
+        write(env%stdOut, "(A,':',T30,E14.6)") "SCC-tolerance", this%sccTol
+        write(env%stdOut, "(A,':',T30,I14)") "Max. scc iterations", this%maxSccIter
       end if
       !if (this%tPeriodic) then
-      !  write(stdout, "(A,':',T30,E14.6)") "Ewald alpha parameter", this%scc%getEwaldPar()
+      !  write(env%stdout, "(A,':',T30,E14.6)") "Ewald alpha parameter", this%scc%getEwaldPar()
       !end if
       if (this%isMdftb) then
-        write(stdOut, "(A,':',T30,A)") "Multipole expansion", "Yes"
+        write(env%stdOut, "(A,':',T30,A)") "Multipole expansion", "Yes"
       end if
       if (input%ctrl%tShellResolved) then
-         write(stdOut, "(A,':',T30,A)") "Shell resolved Hubbard", "Yes"
+         write(env%stdOut, "(A,':',T30,A)") "Shell resolved Hubbard", "Yes"
       else
-         write(stdOut, "(A,':',T30,A)") "Shell resolved Hubbard", "No"
+         write(env%stdOut, "(A,':',T30,A)") "Shell resolved Hubbard", "No"
       end if
       if (allocated(this%dftbU)) then
-        write(stdOut, "(A,':',T35,A)")"Orbitally dependant functional", "Yes"
-        write(stdOut, "(A,':',T30,A)")"Orbital functional", this%dftbU%funcName()
+        write(env%stdOut, "(A,':',T35,A)")"Orbitally dependant functional", "Yes"
+        write(env%stdOut, "(A,':',T30,A)")"Orbital functional", this%dftbU%funcName()
       end if
       if (allocated(this%onSiteElements)) then
-        write(stdOut, "(A,':',T35,A)")"On-site corrections", "Yes"
+        write(env%stdOut, "(A,':',T35,A)")"On-site corrections", "Yes"
       end if
     else
-      write(stdOut, "(A,':',T30,A)") "Self consistent charges", "No"
+      write(env%stdOut, "(A,':',T30,A)") "Self consistent charges", "No"
     end if
 
     if (allocated(this%reks)) then
-      write(stdOut, "(A,':',T30,A)") "Spin polarisation", "No"
-      write(stdOut, "(A,':',T30,F12.6,/,A,':',T30,F12.6)") "Nr. of up electrons",&
+      write(env%stdOut, "(A,':',T30,A)") "Spin polarisation", "No"
+      write(env%stdOut, "(A,':',T30,F12.6,/,A,':',T30,F12.6)") "Nr. of up electrons",&
           & 0.5_dp*this%nEl(1), "Nr. of down electrons", 0.5_dp*this%nEl(1)
     else
       select case (this%nSpin)
       case(1)
-        write(stdOut, "(A,':',T30,A)") "Spin polarisation", "No"
+        write(env%stdOut, "(A,':',T30,A)") "Spin polarisation", "No"
       case(2)
-        write(stdOut, "(A,':',T30,A)") "Spin polarisation", "Yes"
+        write(env%stdOut, "(A,':',T30,A)") "Spin polarisation", "Yes"
       case(4)
-        write(stdOut, "(A,':',T30,A)") "Non-collinear calculation", "Yes"
+        write(env%stdOut, "(A,':',T30,A)") "Non-collinear calculation", "Yes"
       end select
       if (any(this%electronicSolver%iSolver ==&
           & [electronicSolverTypes%GF,electronicSolverTypes%onlyTransport]) .or. this%tFixEf) then
@@ -3558,44 +3561,44 @@ contains
       else
         select case (this%nSpin)
         case(1)
-          write(stdOut, "(A,':',T30,F12.6,/,A,':',T30,F12.6)") "Nr. of up electrons",&
+          write(env%stdOut, "(A,':',T30,F12.6,/,A,':',T30,F12.6)") "Nr. of up electrons",&
               & 0.5_dp*this%nEl(1), "Nr. of down electrons", 0.5_dp*this%nEl(1)
         case(2)
           if (this%tSpinSharedEf) then
-            write(stdOut, "(A,':',T30,F12.6,/,A,':',T30,F12.6)") "Initial nr. of up electrons",&
+            write(env%stdOut, "(A,':',T30,F12.6,/,A,':',T30,F12.6)") "Initial nr. of up electrons",&
                 & this%nEl(1), "Initial Nr. of down electrons", this%nEl(2)
           else
-            write(stdOut, "(A,':',T30,F12.6,/,A,':',T30,F12.6)") "Nr. of up electrons",&
+            write(env%stdOut, "(A,':',T30,F12.6,/,A,':',T30,F12.6)") "Nr. of up electrons",&
                 & this%nEl(1), "Nr. of down electrons", this%nEl(2)
           end if
         case(4)
-          write(stdOut, "(A,':',T30,F12.6)") "Nr. of electrons", this%nEl(1)
+          write(env%stdOut, "(A,':',T30,F12.6)") "Nr. of electrons", this%nEl(1)
         end select
       end if
     end if
 
     if (this%tPeriodic) then
-      write(stdOut, "(A,':',T30,A)") "Periodic boundaries", "Yes"
+      write(env%stdOut, "(A,':',T30,A)") "Periodic boundaries", "Yes"
       if (this%geometryChanges%tLatOpt) then
-        write(stdOut, "(A,':',T30,A)") "Lattice optimisation", "Yes"
-        write(stdOut, "(A,':',T30,f12.6)") "Pressure", this%extPressure
+        write(env%stdOut, "(A,':',T30,A)") "Lattice optimisation", "Yes"
+        write(env%stdOut, "(A,':',T30,f12.6)") "Pressure", this%extPressure
       end if
     else if (this%tHelical) then
-      write (stdOut, "(A,':',T30,A)") "Helical boundaries", "Yes"
+      write (env%stdOut, "(A,':',T30,A)") "Helical boundaries", "Yes"
       if (this%geometryChanges%tLatOpt) then
-        write (stdOut, "(A,':',T30,A)") "Lattice optimisation", "Yes"
+        write (env%stdOut, "(A,':',T30,A)") "Lattice optimisation", "Yes"
       end if
     else
-      write(stdOut, "(A,':',T30,A)") "Periodic boundaries", "No"
+      write(env%stdOut, "(A,':',T30,A)") "Periodic boundaries", "No"
     end if
 
     if (.not.this%tRestartNoSC) then
-      write(stdOut, "(A,':',T30,A)") "Electronic solver", this%electronicSolver%getSolverName()
+      write(env%stdOut, "(A,':',T30,A)") "Electronic solver", this%electronicSolver%getSolverName()
     end if
 
     if (this%electronicSolver%iSolver == electronicSolverTypes%magmaGvd) then
       #:if WITH_MAGMA
-        call env%initGpu()
+        call env%initGpu(env%stdOut)
       #:else
         call error("Magma-solver selected, but program was compiled without MAGMA")
       #:endif
@@ -3606,9 +3609,9 @@ contains
       case (linrespSolverTypes%None)
         call error("Casida solver has not been selected")
       case (linrespSolverTypes%Arpack)
-        write(stdOut, "(A,':',T30,A)") "Casida solver", "Arpack"
+        write(env%stdOut, "(A,':',T30,A)") "Casida solver", "Arpack"
       case (linrespSolverTypes%Stratmann)
-        write(stdOut, "(A,':',T30,A,i4)") "Casida solver", "Stratmann, SubSpace: ",&
+        write(env%stdOut, "(A,':',T30,A,i4)") "Casida solver", "Stratmann, SubSpace: ",&
             & input%ctrl%lrespini%subSpaceFactorStratmann
       case default
         call error("Unknown Casida solver")
@@ -3619,42 +3622,42 @@ contains
       if (.not. allocated(this%reks)) then
         associate (inp => input%ctrl%mixerInp)
           if (allocated(inp%simpleMixerInp)) then
-              write(stdOut, "(A,':',T30,A,' ',A)") "Mixer", "Simple", "mixer"
-              write(stdOut, "(A,':',T30,F14.6)") "Mixing parameter", inp%simpleMixerInp%mixParam
+              write(env%stdOut, "(A,':',T30,A,' ',A)") "Mixer", "Simple", "mixer"
+              write(env%stdOut, "(A,':',T30,F14.6)") "Mixing parameter", inp%simpleMixerInp%mixParam
             else if (allocated(inp%andersonMixerInp)) then
-              write(stdOut, "(A,':',T30,A,' ',A)") "Mixer", "Anderson", "mixer"
-              write(stdOut, "(A,':',T30,F14.6)") "Mixing parameter", inp%andersonMixerInp%mixParam
-              write(stdOut, "(A,':',T30,I14)") "Nr. of chrg. vectors to mix",&
+              write(env%stdOut, "(A,':',T30,A,' ',A)") "Mixer", "Anderson", "mixer"
+              write(env%stdOut, "(A,':',T30,F14.6)") "Mixing parameter", inp%andersonMixerInp%mixParam
+              write(env%stdOut, "(A,':',T30,I14)") "Nr. of chrg. vectors to mix",&
                   & inp%andersonMixerInp%iGenerations
             else if (allocated(inp%broydenMixerInp)) then
-              write(stdOut, "(A,':',T30,A,' ',A)") "Mixer", "Broyden", "mixer"
-              write(stdOut, "(A,':',T30,F14.6)") "Mixing parameter", inp%broydenMixerInp%mixParam
-              write(stdOut, "(A,':',T30,I14)") "Nr. of chrg. vec. in memory", this%maxSccIter
+              write(env%stdOut, "(A,':',T30,A,' ',A)") "Mixer", "Broyden", "mixer"
+              write(env%stdOut, "(A,':',T30,F14.6)") "Mixing parameter", inp%broydenMixerInp%mixParam
+              write(env%stdOut, "(A,':',T30,I14)") "Nr. of chrg. vec. in memory", this%maxSccIter
             else if (allocated(inp%diisMixerInp)) then
-              write(stdOut, "(A,':',T30,A,' ',A)") "Mixer", "DIIS", "mixer"
-              write(stdOut, "(A,':',T30,F14.6)") "Mixing parameter", inp%diisMixerInp%initMixParam
-              write(stdOut, "(A,':',T30,I14)") "Nr. of chrg. vectors to mix",&
+              write(env%stdOut, "(A,':',T30,A,' ',A)") "Mixer", "DIIS", "mixer"
+              write(env%stdOut, "(A,':',T30,F14.6)") "Mixing parameter", inp%diisMixerInp%initMixParam
+              write(env%stdOut, "(A,':',T30,I14)") "Nr. of chrg. vectors to mix",&
                   & inp%diisMixerInp%iGenerations
           end if
         end associate
       end if
-      write(stdOut, "(A,':',T30,I14)") "Max. SCC-cycles", this%maxSccIter
+      write(env%stdOut, "(A,':',T30,I14)") "Max. SCC-cycles", this%maxSccIter
     end if
 
     if (this%geometryChanges%tCoordOpt) then
-      write(stdOut, "(A,':',T30,I14)") "Nr. of moved atoms", this%nMovedAtom
+      write(env%stdOut, "(A,':',T30,I14)") "Nr. of moved atoms", this%nMovedAtom
     end if
     if (this%geometryChanges%isGeoOpt .or. allocated(this%geoOpt)) then
       if (this%nGeoSteps == hugeIterations) then
-        write(stdOut, "(A,':',T30,I14)") "Max. nr. of geometry steps", -1
+        write(env%stdOut, "(A,':',T30,I14)") "Max. nr. of geometry steps", -1
       else
-        write(stdOut, "(A,':',T30,I14)") "Max. nr. of geometry steps", this%nGeoSteps
+        write(env%stdOut, "(A,':',T30,I14)") "Max. nr. of geometry steps", this%nGeoSteps
       end if
     end if
     if (this%geometryChanges%isGeoOpt) then
-      write(stdOut, "(A,':',T30,E14.6)") "Force tolerance", input%ctrl%maxForce
+      write(env%stdOut, "(A,':',T30,E14.6)") "Force tolerance", input%ctrl%maxForce
       if (input%ctrl%iGeoOpt == geoOptTypes%steepestDesc) then
-        write(stdOut, "(A,':',T30,E14.6)") "Step size", this%deltaT
+        write(env%stdOut, "(A,':',T30,E14.6)") "Step size", this%deltaT
       end if
     end if
 
@@ -3669,7 +3672,7 @@ contains
             else
               write(strTmp, "(A)") ""
             end if
-            write(stdOut, "(A,T30,'At',I4,': ',3F10.6)") trim(strTmp), ii, (this%conVec(kk,jj),&
+            write(env%stdOut, "(A,T30,'At',I4,': ',3F10.6)") trim(strTmp), ii, (this%conVec(kk,jj),&
                 & kk=1,3)
           end if
         end do
@@ -3677,23 +3680,23 @@ contains
     end if
 
     if (allocated(this%tblite)) then
-      call writeTBLiteInfo(stdOut, this%tblite)
+      call writeTBLiteInfo(env%stdOut, this%tblite)
     end if
 
     if (.not. allocated(this%reks) .and. .not.this%tRestartNoSC) then
       if (.not.input%ctrl%tSetFillingTemp) then
-        write(stdOut, format2Ue) "Electronic temperature", this%tempElec, 'H',&
+        write(env%stdOut, format2Ue) "Electronic temperature", this%tempElec, 'H',&
             & Hartree__eV * this%tempElec, 'eV'
       end if
     end if
     if (this%geometryChanges%tMd) then
-      write(stdOut, "(A,':',T30,E14.6)") "Time step", this%deltaT
+      write(env%stdOut, "(A,':',T30,E14.6)") "Time step", this%deltaT
       if (input%ctrl%thermostatInp%thermostatType == thermostatTypes%none&
           & .and. .not.input%ctrl%tReadMDVelocities) then
-        write(stdOut, "(A,':',T30,E14.6)") "Temperature", input%ctrl%tempProfileInp%tempValues(1)
+        write(env%stdOut, "(A,':',T30,E14.6)") "Temperature", input%ctrl%tempProfileInp%tempValues(1)
       end if
       if (input%ctrl%thermostatInp%thermostatType == thermostatTypes%andersen) then
-        write(stdOut, "(A,':',T30,E14.6)") "Rescaling probability",&
+        write(env%stdOut, "(A,':',T30,E14.6)") "Rescaling probability",&
             & input%ctrl%thermostatInp%andersen%rescaleProb
       end if
     end if
@@ -3704,7 +3707,7 @@ contains
       else
         write (strTmp, "(A,E11.3,A)") "Set automatically (system chrg: ", input%ctrl%nrChrg, ")"
       end if
-      write(stdOut, "(A,':',T30,A)") "Initial charges", trim(strTmp)
+      write(env%stdOut, "(A,':',T30,A)") "Initial charges", trim(strTmp)
     end if
 
     do iSp = 1, this%nType
@@ -3721,13 +3724,13 @@ contains
           strTmp2 = trim(strTmp2) // ", " // trim(shellNamesTmp(jj))
         end if
       end do
-      write(stdOut, "(A,T29,A2,':  ',A)") trim(strTmp), trim(this%speciesName(iSp)), trim(strTmp2)
+      write(env%stdOut, "(A,T29,A2,':  ',A)") trim(strTmp), trim(this%speciesName(iSp)), trim(strTmp2)
       deallocate(shellNamesTmp)
     end do
 
     if (this%tMulliken) then
       if (allocated(input%ctrl%customOccAtoms)) then
-        call printCustomReferenceOccupations(this%orb, input%geom%species, &
+        call printCustomReferenceOccupations(env%stdOut, this%orb, input%geom%species, &
             & input%ctrl%customOccAtoms, input%ctrl%customOccFillings)
       end if
     end if
@@ -3739,20 +3742,20 @@ contains
         else
           write(strTmp, "(A)") ""
         end if
-        write(stdOut, "(A,T28,I6,':',3F10.6,3X,F10.6)") trim(strTmp), ii,&
+        write(env%stdOut, "(A,T28,I6,':',3F10.6,3X,F10.6)") trim(strTmp), ii,&
             & (this%kPoint(jj, ii), jj=1, 3), this%kWeight(ii)
       end do
-      write(stdout,*)
+      write(env%stdOut,*)
       do ii = 1, this%nKPoint
         if (ii == 1) then
           write(strTmp, "(A,':')") "K-points in absolute space"
         else
           write(strTmp, "(A)") ""
         end if
-        write(stdout, "(A,T28,I6,':',3F10.6)") trim(strTmp), ii,&
+        write(env%stdOut, "(A,T28,I6,':',3F10.6)") trim(strTmp), ii,&
             & matmul(this%invLatVec,this%kPoint(:,ii))
       end do
-      write(stdout, *)
+      write(env%stdOut, *)
     end if
 
     if (this%tHelical) then
@@ -3762,7 +3765,7 @@ contains
         else
           write(strTmp, "(A)") ""
         end if
-        write(stdOut,"(A,T28,I6,':',2F10.6,3X,F10.6)") trim(strTmp), ii, this%kPoint(:, ii),&
+        write(env%stdOut,"(A,T28,I6,':',2F10.6,3X,F10.6)") trim(strTmp), ii, this%kPoint(:, ii),&
             & this%kWeight(ii)
       end do
     end if
@@ -3770,18 +3773,18 @@ contains
     if (allocated(this%dispersion)) then
       select type (o=>this%dispersion)
       type is (TDispSlaKirk)
-        write(stdOut, "(A)") "Using Slater-Kirkwood dispersion corrections"
+        write(env%stdOut, "(A)") "Using Slater-Kirkwood dispersion corrections"
       type is (TDispUff)
-        write(stdOut, "(A)") "Using Lennard-Jones dispersion corrections"
+        write(env%stdOut, "(A)") "Using Lennard-Jones dispersion corrections"
       type is (TSDFTD3)
-        call writeSDFTD3Info(stdout, o)
+        call writeSDFTD3Info(env%stdOut, o)
       type is (TSimpleDftD3)
-        write(stdOut, "(A)") "Using simple DFT-D3 dispersion corrections"
+        write(env%stdOut, "(A)") "Using simple DFT-D3 dispersion corrections"
       type is (TDispDftD4)
-        call writeDftD4Info(stdOut, o)
+        call writeDftD4Info(env%stdOut, o)
     #:if WITH_MBD
       type is (TDispMbd)
-        call writeMbdInfo(input%ctrl%dispInp%mbd)
+        call writeMbdInfo(env%stdOut, input%ctrl%dispInp%mbd)
     #:endif
       class default
         call error("Unknown dispersion model - this should not happen!")
@@ -3789,11 +3792,11 @@ contains
     end if
 
     if (allocated(this%solvation)) then
-      call writeSolvationInfo(stdOut, this%solvation)
+      call writeSolvationInfo(env%stdOut, this%solvation)
       if (this%eFieldScaling%isRescaled) then
-        write(stdOut, "(A,':',T30,A)")"Solvated fields rescaled", "Yes"
+        write(env%stdOut, "(A,':',T30,A)")"Solvated fields rescaled", "Yes"
       else
-        write(stdOut, "(A,':',T30,A)")"Solvated fields rescaled", "No"
+        write(env%stdOut, "(A,':',T30,A)")"Solvated fields rescaled", "No"
       end if
     end if
 
@@ -3813,7 +3816,7 @@ contains
             else
               write(strTmp, "(A)") ""
             end if
-            write(stdOut, "(A,T30,A2,2X,I1,'(',A1,'): ',E14.6)") trim(strTmp),&
+            write(env%stdOut, "(A,T30,A2,2X,I1,'(',A1,'): ',E14.6)") trim(strTmp),&
                 & this%speciesName(iSp), jj, shellNames(this%orb%angShell(jj, iSp)+1),&
                 & hubbU(jj, iSp)
           end do
@@ -3833,12 +3836,12 @@ contains
               write(strTmp, "(A)") ""
             end if
             if (allocated(this%reks)) then
-              write(stdOut, "(A,T30,A2,2X,I1,'(',A1,')-',I1,'(',A1,'): ',E14.6)")trim(strTmp),&
+              write(env%stdOut, "(A,T30,A2,2X,I1,'(',A1,')-',I1,'(',A1,'): ',E14.6)")trim(strTmp),&
                   & this%speciesName(iSp), jj, shellNames(this%orb%angShell(jj, iSp)+1), kk,&
                   & shellNames(this%orb%angShell(kk, iSp)+1), this%spinW(kk, jj, iSp) /&
                   & this%reks%Tuning(iSp)
             else
-              write(stdOut, "(A,T30,A2,2X,I1,'(',A1,')-',I1,'(',A1,'): ',E14.6)")trim(strTmp),&
+              write(env%stdOut, "(A,T30,A2,2X,I1,'(',A1,')-',I1,'(',A1,'): ',E14.6)")trim(strTmp),&
                   & this%speciesName(iSp), jj, shellNames(this%orb%angShell(jj, iSp)+1), kk,&
                   & shellNames(this%orb%angShell(kk, iSp)+1), this%spinW(kk, jj, iSp)
             end if
@@ -3850,7 +3853,7 @@ contains
     tFirst = .true.
     if (this%tSpinOrbit) then
       if (this%tDualSpinOrbit) then
-        write(stdOut, "(A)")"Dual representation spin orbit"
+        write(env%stdOut, "(A)")"Dual representation spin orbit"
       end if
       do iSp = 1, this%nType
         do jj = 1, this%orb%nShell(iSp)
@@ -3860,7 +3863,7 @@ contains
           else
             write(strTmp, "(A)") ""
           end if
-          write(stdOut, "(A,T30,A2,2X,I1,'(',A1,'): ',E14.6)")trim(strTmp), this%speciesName(iSp),&
+          write(env%stdOut, "(A,T30,A2,2X,I1,'(',A1,'): ',E14.6)")trim(strTmp), this%speciesName(iSp),&
                 & jj, shellNames(this%orb%angShell(jj, iSp)+1), this%xi(jj, iSp)
           if (this%xi(jj, iSp) /= 0.0_dp .and. this%orb%angShell(jj, iSp) == 0) then
             call error("Program halt due to non-zero s-orbital spin-orbit coupling constant!")
@@ -3871,149 +3874,149 @@ contains
 
     if (this%tSccCalc) then
       if (this%t3rdFull) then
-        write(stdOut, "(A,T30,A)") "Full 3rd order correction", "Yes"
+        write(env%stdOut, "(A,T30,A)") "Full 3rd order correction", "Yes"
         if (input%ctrl%tShellResolved) then
-          write(stdOut, "(A,T30,A)") "Shell-resolved 3rd order", "Yes"
-          write(stdOut, "(A30)") "Shell-resolved Hubbard derivs:"
-          write(stdOut, "(A)") "        s-shell   p-shell   d-shell   f-shell"
+          write(env%stdOut, "(A,T30,A)") "Shell-resolved 3rd order", "Yes"
+          write(env%stdOut, "(A30)") "Shell-resolved Hubbard derivs:"
+          write(env%stdOut, "(A)") "        s-shell   p-shell   d-shell   f-shell"
           do iSp = 1, this%nType
-            write(stdOut, "(A3,A3,4F10.4)") "  ", trim(this%speciesName(iSp)),&
+            write(env%stdOut, "(A3,A3,4F10.4)") "  ", trim(this%speciesName(iSp)),&
                 & input%ctrl%hubDerivs(:this%orb%nShell(iSp),iSp)
           end do
         end if
       end if
       if (allocated(this%scc)) then
         if (any(shortGammaDamp%isDamped)) then
-          write(stdOut, "(A,T30,A)") "Damped SCC", "Yes"
+          write(env%stdOut, "(A,T30,A)") "Damped SCC", "Yes"
           ii = count(shortGammaDamp%isDamped)
           write(strTmp, "(A,I0,A)") "(A,T30,", ii, "(A,1X))"
-          write(stdOut, strTmp) "Damped species(s):", pack(this%speciesName,&
+          write(env%stdOut, strTmp) "Damped species(s):", pack(this%speciesName,&
               & shortGammaDamp%isDamped)
         end if
       end if
 
       if (allocated(input%ctrl%h5Input)) then
-        write(stdOut, "(A,T30,A)") "H-bond correction:", "H5"
+        write(env%stdOut, "(A,T30,A)") "H-bond correction:", "H5"
       end if
       if (tHHRepulsion) then
-        write(stdOut, "(A,T30,A)") "H-H repulsion correction:", "H5"
+        write(env%stdOut, "(A,T30,A)") "H-H repulsion correction:", "H5"
       end if
     end if
 
     if (this%isHybridXc) then
       if (input%ctrl%hybridXcInp%hybridXcType == hybridXcFunc%hyb) then
-        write(stdOut, "(A,':',T30,A)") "Global hybrid", "Yes"
-        write(stdOut, "(2X,A,':',T30,E14.6)") "Fraction of exchange",&
+        write(env%stdOut, "(A,':',T30,A)") "Global hybrid", "Yes"
+        write(env%stdOut, "(2X,A,':',T30,E14.6)") "Fraction of exchange",&
             & input%ctrl%hybridXcInp%camAlpha
       elseif (input%ctrl%hybridXcInp%hybridXcType == hybridXcFunc%lc) then
-        write(stdOut, "(A,':',T30,A)") "Long-range corrected hybrid", "Yes"
-        write(stdOut, "(2X,A,':',T30,E14.6)") "Screening parameter omega",&
+        write(env%stdOut, "(A,':',T30,A)") "Long-range corrected hybrid", "Yes"
+        write(env%stdOut, "(2X,A,':',T30,E14.6)") "Screening parameter omega",&
             & input%ctrl%hybridXcInp%omega
       elseif (input%ctrl%hybridXcInp%hybridXcType == hybridXcFunc%cam) then
-        write(stdOut, "(A,':',T30,A)") "CAM range-separated hybrid", "Yes"
-        write(stdOut, "(2X,A,':',T30,E14.6)") "Screening parameter omega",&
+        write(env%stdOut, "(A,':',T30,A)") "CAM range-separated hybrid", "Yes"
+        write(env%stdOut, "(2X,A,':',T30,E14.6)") "Screening parameter omega",&
             & input%ctrl%hybridXcInp%omega
-        write(stdOut, "(2X,A,':',T30,E14.6,E14.6)") "CAM parameters alpha/beta",&
+        write(env%stdOut, "(2X,A,':',T30,E14.6,E14.6)") "CAM parameters alpha/beta",&
             & input%ctrl%hybridXcInp%camAlpha, input%ctrl%hybridXcInp%camBeta
       end if
       if (this%tPeriodic) then
         if (input%ctrl%hybridXcInp%gammaType == hybridXcGammaTypes%full) then
-          write(stdOut, "(2X,A,':',T30,2X,A)") "Gamma function", "full"
+          write(env%stdOut, "(2X,A,':',T30,2X,A)") "Gamma function", "full"
         elseif (input%ctrl%hybridXcInp%gammaType == hybridXcGammaTypes%mic) then
-          write(stdOut, "(2X,A,':',T30,2X,A)") "Gamma function", "minimum image convention"
-          write(stdOut, "(2X,A,':',T30,2X,I0,A)") "Wigner-Seitz cell reduction",&
+          write(env%stdOut, "(2X,A,':',T30,2X,A)") "Gamma function", "minimum image convention"
+          write(env%stdOut, "(2X,A,':',T30,2X,I0,A)") "Wigner-Seitz cell reduction",&
               & this%cutOff%wignerSeitzReduction, " primitive cell(s)"
         elseif (input%ctrl%hybridXcInp%gammaType == hybridXcGammaTypes%truncated) then
-          write(stdOut, "(2X,A,':',T30,2X,A)") "Gamma function", "truncated"
+          write(env%stdOut, "(2X,A,':',T30,2X,A)") "Gamma function", "truncated"
         elseif (input%ctrl%hybridXcInp%gammaType == hybridXcGammaTypes%truncatedAndDamped) then
-          write(stdOut, "(2X,A,':',T30,2X,A)") "Gamma function", "truncated+poly5zero"
+          write(env%stdOut, "(2X,A,':',T30,2X,A)") "Gamma function", "truncated+poly5zero"
         end if
         if (input%ctrl%hybridXcInp%gammaType /= hybridXcGammaTypes%mic) then
-          write(stdOut, "(2X,A,':',T30,E14.6,A)") "G-Summation Cutoff",&
+          write(env%stdOut, "(2X,A,':',T30,E14.6,A)") "G-Summation Cutoff",&
               & this%cutOff%gSummationCutoff, " Bohr"
         end if
         if (input%ctrl%hybridXcInp%gammaType == hybridXcGammaTypes%truncated&
             & .or. input%ctrl%hybridXcInp%gammaType == hybridXcGammaTypes%truncatedAndDamped) then
-          write(stdOut, "(2X,A,':',T30,E14.6,A)") "Coulomb Truncation",&
+          write(env%stdOut, "(2X,A,':',T30,E14.6,A)") "Coulomb Truncation",&
               & this%cutOff%gammaCutoff, " Bohr"
         end if
       end if
 
       select case(input%ctrl%hybridXcInp%hybridXcAlg)
       case (hybridXcAlgo%neighbourBased)
-        write(stdOut, "(2X,A,':',T30,2X,A)") "Screening algorithm", "NeighbourBased"
-        write(stdOut, "(2X,A,':',T30,E14.6,A)") "Reduce neighlist cutoff by",&
+        write(env%stdOut, "(2X,A,':',T30,2X,A)") "Screening algorithm", "NeighbourBased"
+        write(env%stdOut, "(2X,A,':',T30,E14.6,A)") "Reduce neighlist cutoff by",&
             & input%ctrl%hybridXcInp%cutoffRed * Bohr__AA, " A"
         if (this%tPeriodic) then
-          write(stdOut, "(2X,A,':',T30,E14.6)") "Thresholded to",&
+          write(env%stdOut, "(2X,A,':',T30,E14.6)") "Thresholded to",&
               & input%ctrl%hybridXcInp%screeningThreshold
         end if
       case (hybridXcAlgo%thresholdBased)
-        write(stdOut, "(2X,A,':',T30,2X,A)") "Screening algorithm", "Thresholded"
-        write(stdOut, "(2X,A,':',T30,E14.6)") "Thresholded to",&
+        write(env%stdOut, "(2X,A,':',T30,2X,A)") "Screening algorithm", "Thresholded"
+        write(env%stdOut, "(2X,A,':',T30,E14.6)") "Thresholded to",&
             & input%ctrl%hybridXcInp%screeningThreshold
       case (hybridXcAlgo%matrixBased)
-        write(stdOut, "(2X,A,':',T30,2X,A)") "Screening algorithm", "MatrixBased"
+        write(env%stdOut, "(2X,A,':',T30,2X,A)") "Screening algorithm", "MatrixBased"
       case default
         call error("Unknown hybrid xc-functional screening algorithm")
       end select
     end if
 
-    write(stdOut, "(A,':')") "Extra options"
+    write(env%stdOut, "(A,':')") "Extra options"
     if (this%tPrintMulliken) then
-      write(stdOut, "(T30,A)") "Mulliken analysis"
+      write(env%stdOut, "(T30,A)") "Mulliken analysis"
     end if
     if (this%tPrintForces .and. .not. (this%geometryChanges%tMd .or. this%geometryChanges%isGeoOpt&
         & .or. this%geometryChanges%tDerivs)) then
-      write(stdOut, "(T30,A)") "Force calculation"
+      write(env%stdOut, "(T30,A)") "Force calculation"
     end if
     if (this%tForces) then
       select case (this%forceType)
       case(forceTypes%orig)
-        write(stdOut, "(A,T30,A)") "Force type", "original"
+        write(env%stdOut, "(A,T30,A)") "Force type", "original"
       case(forceTypes%dynamicT0)
-        write(stdOut, "(A,T30,A)") "Force type", "erho with re-diagonalised eigenvalues"
-        write(stdOut, "(A,T30,A)") "Force type", "erho with DHD-product (T_elec = 0K)"
+        write(env%stdOut, "(A,T30,A)") "Force type", "erho with re-diagonalised eigenvalues"
+        write(env%stdOut, "(A,T30,A)") "Force type", "erho with DHD-product (T_elec = 0K)"
       case(forceTypes%dynamicTFinite)
-        write(stdOut, "(A,T30,A)") "Force type", "erho with S^-1 H D (Te <> 0K)"
+        write(env%stdOut, "(A,T30,A)") "Force type", "erho with S^-1 H D (Te <> 0K)"
       end select
     end if
     if (this%tPrintEigVecs) then
-      write(stdOut, "(T30,A)") "Eigenvector printing"
+      write(env%stdOut, "(T30,A)") "Eigenvector printing"
     end if
     if (this%tExtChrg) then
-      write(stdOut, "(T30,A)") "External charges specified"
+      write(env%stdOut, "(T30,A)") "External charges specified"
     end if
 
     if (this%isExtField) then
 
       if (allocated(this%eField%EFieldStrength)) then
         if (this%eField%isTDEfield) then
-          write(stdOut, "(T30,A)") "External electric field specified"
-          write(stdOut, "(A,':',T30,E14.6)") "Angular frequency", this%eField%EfieldOmega
+          write(env%stdOut, "(T30,A)") "External electric field specified"
+          write(env%stdOut, "(A,':',T30,E14.6)") "Angular frequency", this%eField%EfieldOmega
         else
-          write(stdOut, "(T30,A)") "External static electric field specified"
+          write(env%stdOut, "(T30,A)") "External static electric field specified"
         end if
-        write(stdOut, "(A,':',T30,E14.6)") "Field strength", this%eField%EFieldStrength
-        write(stdOut, "(A,':',T30,3F9.6)") "Direction", this%eField%EfieldVector
+        write(env%stdOut, "(A,':',T30,E14.6)") "Field strength", this%eField%EFieldStrength
+        write(env%stdOut, "(A,':',T30,3F9.6)") "Direction", this%eField%EfieldVector
         if (this%tPeriodic) then
-          call warning("Saw tooth potential used for periodic geometry - make sure there is a&
+          call warning(env%stdOut, "Saw tooth potential used for periodic geometry - make sure there is a&
               & vacuum region!")
         end if
       end if
 
       if (allocated(input%ctrl%atomicExtPotential)) then
         if (allocated(input%ctrl%atomicExtPotential%iAtOnSite)) then
-          write(stdOut, "(A)")'Net on-site potentials at atoms (/ H)'
+          write(env%stdOut, "(A)")'Net on-site potentials at atoms (/ H)'
           do ii = 1, size(input%ctrl%atomicExtPotential%iAtOnSite)
-            write(stdOut,"(1X,I6,' : ',E14.6)")input%ctrl%atomicExtPotential%iAtOnSite(ii),&
+            write(env%stdOut,"(1X,I6,' : ',E14.6)")input%ctrl%atomicExtPotential%iAtOnSite(ii),&
                 & input%ctrl%atomicExtPotential%VextOnSite(ii)
           end do
         end if
         if (allocated(input%ctrl%atomicExtPotential%iAt)) then
-          write(stdOut, "(A)")'Gross on-site potentials at atoms (/ H)'
+          write(env%stdOut, "(A)")'Gross on-site potentials at atoms (/ H)'
           do ii = 1, size(input%ctrl%atomicExtPotential%iAt)
-            write(stdOut,"(1X,I6,' : ',E14.6)")input%ctrl%atomicExtPotential%iAt(ii),&
+            write(env%stdOut,"(1X,I6,' : ',E14.6)")input%ctrl%atomicExtPotential%iAt(ii),&
                 & input%ctrl%atomicExtPotential%Vext(ii)
           end do
         end if
@@ -4025,10 +4028,10 @@ contains
       do iSp = 1, this%nType
         if (this%dftbU%nUJ(iSp)>0) then
           write(strTmp, "(A,':')") "U-J coupling constants"
-          write(stdOut, "(A,T25,A2)")trim(strTmp), this%speciesName(iSp)
+          write(env%stdOut, "(A,T25,A2)")trim(strTmp), this%speciesName(iSp)
           do jj = 1, this%dftbU%nUJ(iSp)
             write(strTmp, "(A,I1,A)")'(A,',this%dftbU%niUJ(jj,iSp),'I2,T25,A,F6.4)'
-            write(stdOut, trim(strTmp)) 'Shells:',&
+            write(env%stdOut, trim(strTmp)) 'Shells:',&
                 & this%dftbU%iUJ(1:this%dftbU%niUJ(jj,iSp),jj,iSp), 'UJ:', this%dftbU%UJ(jj,iSp)
           end do
         end if
@@ -4052,7 +4055,7 @@ contains
               else
                 write(strTmp, "(A)") ""
               end if
-              write(stdOut, "(A,T30,A5,2X,I1,'(',A1,')-',I1,'(',A1,'): ',E14.6)")trim(strTmp),&
+              write(env%stdOut, "(A,T30,A5,2X,I1,'(',A1,')-',I1,'(',A1,'): ',E14.6)")trim(strTmp),&
                   & trim(this%speciesName(iSp))//trim(strTmp2), jj,&
                   & shellNames(this%orb%angShell(jj, iSp)+1), kk,&
                   & shellNames(this%orb%angShell(kk, iSp)+1),&
@@ -4069,21 +4072,21 @@ contains
           ! As this needs assurances that the DM is actually being read by the external code,
           ! leading to the external code making changes in the hamiltonian, otherwise SCC never
           ! converges.
-          call warning("ASI callback with model modification enabled does not support&
+          call warning(env%stdOut, "ASI callback with model modification enabled does not support&
               & self-consistent calculations at present")
           this%dangerousChanges%hamiltonian = .true.
         end if
         if (this%tForces) then
           ! Since if H and/or S is modified, the derivatives are not available via ASI at the
           ! moment.
-          call warning("ASI callback with model modification enabled does not support forces at&
-              & present")
+          call warning(env%stdOut, "ASI callback with model modification enabled does not support&
+              & forces at present")
           this%dangerousChanges%hamiltonian = .true.
           this%dangerousChanges%overlap = .true.
         end if
         if (this%tMulliken) then
-          call warning("ASI callback with model modification enabled does not support Mulliken&
-              & population analysis at present")
+          call warning(env%stdOut, "ASI callback with model modification enabled does not support&
+              & Mulliken population analysis at present")
           this%dangerousChanges%overlap = .true.
         end if
       end if
@@ -4287,7 +4290,7 @@ contains
 
       allocate(this%electronDynamics)
 
-      call TElecDynamics_init(this%electronDynamics, input%ctrl%elecDynInp, this%species0,&
+      call TElecDynamics_init(this%electronDynamics, env, input%ctrl%elecDynInp, this%species0,&
           & this%speciesName, this%tWriteAutotest, autotestTag, randomThermostat, this%cutOff,&
           & this%mass, this%nAtom, this%atomEigVal, this%dispersion, this%nonSccDeriv,&
           & this%tPeriodic, this%parallelKS, this%tRealHS, this%kPoint, this%kWeight,&
@@ -4298,7 +4301,7 @@ contains
     end if
 
     if (allocated(this%reks)) then
-      call printReksInitInfo(this%reks, this%orb, this%speciesName, this%nType)
+      call printReksInitInfo(env%stdOut, this%reks, this%orb, this%speciesName, this%nType)
     end if
 
     call env%globalTimer%stopTimer(globalTimers%globalInit)
@@ -4524,10 +4527,13 @@ contains
 
 
   !> Initialise partial charges
-  subroutine initializeCharges(this, errStatus, initialSpins, initialCharges, hybridXcAlg)
+  subroutine initializeCharges(this, env, errStatus, initialSpins, initialCharges, hybridXcAlg)
 
     !> Instance
     class(TDftbPlusMain), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Error status
     type(TStatus), intent(out) :: errStatus
@@ -4622,7 +4628,7 @@ contains
 
       if (this%tFixEf .or. this%tSkipChrgChecksum) then
         ! do not check charge or magnetisation from file
-        call initQFromFile(this%qInput, fCharges, this%tReadChrgAscii, this%orb, this%qBlockIn,&
+        call initQFromFile(env%stdOut, this%qInput, fCharges, this%tReadChrgAscii, this%orb, this%qBlockIn,&
             & this%qiBlockIn, this%densityMatrix, this%tRealHS, errStatus,&
             & multipoles=this%multipoleInp, hybridXcAlg=hybridXcAlg,&
             & coeffsAndShifts=this%supercellFoldingMatrix)
@@ -4630,14 +4636,14 @@ contains
       else
         ! check number of electrons in file
         if (this%nSpin /= 2) then
-          call initQFromFile(this%qInput, fCharges, this%tReadChrgAscii, this%orb, this%qBlockIn,&
+          call initQFromFile(env%stdOut, this%qInput, fCharges, this%tReadChrgAscii, this%orb, this%qBlockIn,&
               & this%qiBlockIn, this%densityMatrix, this%tRealHS, errStatus, nEl=sum(this%nEl),&
               & multipoles=this%multipoleInp, hybridXcAlg=hybridXcAlg,&
               & coeffsAndShifts=this%supercellFoldingMatrix)
           @:PROPAGATE_ERROR(errStatus)
         else
           ! check magnetisation in addition
-          call initQFromFile(this%qInput, fCharges, this%tReadChrgAscii, this%orb, this%qBlockIn,&
+          call initQFromFile(env%stdOut, this%qInput, fCharges, this%tReadChrgAscii, this%orb, this%qBlockIn,&
               & this%qiBlockIn, this%densityMatrix, this%tRealHS, errStatus, nEl=sum(this%nEl),&
               & magnetisation=this%nEl(1)-this%nEl(2), multipoles=this%multipoleInp,&
               & hybridXcAlg=hybridXcAlg, coeffsAndShifts=this%supercellFoldingMatrix)
@@ -4679,7 +4685,7 @@ contains
           write(message, "(A,G13.6,A,G13.6,A,A)") "Sum of initial charges does not match&
               & specified total charge. (", sum(initialCharges), " vs. ", this%nrChrg, ") ",&
               & "Your initial charge distribution will be rescaled."
-          call warning(message)
+          call warning(env%stdOut, message)
         end if
         call initQFromAtomChrg(this%qInput, initialCharges, this%referenceN0, this%species0,&
             & this%speciesName, this%orb)
@@ -5192,9 +5198,9 @@ contains
     logical :: isStopRequested
 
     if (env%tGlobalLead) then
-      write(stdOut, "(A,1X,A)") "Initialising for socket communication to host",&
+      write(env%stdOut, "(A,1X,A)") "Initialising for socket communication to host",&
           & trim(socketInput%host)
-      this%socket = IpiSocketComm(socketInput)
+      this%socket = IpiSocketComm(env, socketInput)
     end if
     call receiveGeometryFromSocket(env, this%socket, this%tPeriodic, this%coord0, this%latVec,&
         & this%tCoordsChanged, this%tLatticeChanged, isStopRequested)
@@ -5313,7 +5319,7 @@ contains
     end associate
 
     if (tNegf) then
-      write(stdOut,*) 'init negf'
+      write(env%stdOut,*) 'init negf'
 
       ! Some checks and initialization of GDFTB/NEGF
       call TNegfInt_init(negfInt, input%transpar, env, input%ginfo%greendens,&
@@ -5513,9 +5519,9 @@ contains
           end if
           this%isCIopt = this%linearResponse%isCIopt
           ! Currently always using Bearpark algorithm:
-          write(stdOut, "('Conical Intersection finder:',T30,A)") 'Bearpark'
-          write(stdOut, format2Ue) "CI finder level shift", this%linearResponse%energyShiftCI, 'H',&
-              & Hartree__eV * this%linearResponse%energyShiftCI, 'eV'
+          write(env%stdOut, "('Conical Intersection finder:',T30,A)") 'Bearpark'
+          write(env%stdOut, format2Ue) "CI finder level shift", this%linearResponse%energyShiftCI,&
+              & 'H', Hartree__eV * this%linearResponse%energyShiftCI, 'eV'
         end if
       end if
     end if
@@ -5655,8 +5661,11 @@ contains
 #:if WITH_TRANSPORT
 
   !> initialize arrays for tranpsport
-  subroutine initUploadArrays_(transpar, orb, nSpin, hasBlockCharges, shiftPerLUp, chargeUp,&
+  subroutine initUploadArrays_(env, transpar, orb, nSpin, hasBlockCharges, shiftPerLUp, chargeUp,&
       & blockUp)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Transport calculation parameters
     type(TTransPar), intent(inout) :: transpar
@@ -5687,7 +5696,7 @@ contains
     if (hasBlockCharges) then
       allocate(blockUp(orb%mOrb, orb%mOrb, nAtom, nSpin))
     end if
-    call readContactShifts(shiftPerLUp, chargeUp, transpar, orb, blockUp)
+    call readContactShifts(env%stdOut, shiftPerLUp, chargeUp, transpar, orb, blockUp)
 
   end subroutine initUploadArrays_
 
@@ -5865,21 +5874,24 @@ contains
 
 #:if WITH_MBD
   !> Writes MBD-related info
-  subroutine writeMbdInfo(input)
+  subroutine writeMbdInfo(output, input)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> MBD input parameters
     type(TDispMbdInp), intent(in) :: input
 
     character(lc) :: tmpStr
 
-    write(stdOut, "(A)") ''
+    write(output, "(A)") ''
     select case (input%method)
     case ('ts')
-      write(stdOut, "(A)") "Using TS dispersion corrections [Phys. Rev. B 80, 205414 (2009)]"
-      write(stdOut, "(A)") "PLEASE CITE: J. Chem. Phys. 144, 151101 (2016)"
+      write(output, "(A)") "Using TS dispersion corrections [Phys. Rev. B 80, 205414 (2009)]"
+      write(output, "(A)") "PLEASE CITE: J. Chem. Phys. 144, 151101 (2016)"
     case ('mbd-rsscs')
-      write(stdOut,"(A)") "Using MBD dispersion corrections [Phys. Rev. Lett. 108, 236402 (2012)]"
-      write(stdOut,"(A)") "PLEASE CITE: J. Chem. Phys. 144, 151101 (2016)"
+      write(output,"(A)") "Using MBD dispersion corrections [Phys. Rev. Lett. 108, 236402 (2012)]"
+      write(output,"(A)") "PLEASE CITE: J. Chem. Phys. 144, 151101 (2016)"
     end select
     select case (trim(input%vdw_params_kind))
     case ('tssurf')
@@ -5889,23 +5901,26 @@ contains
     end select
     select case (input%method)
     case ('mbd-rsscs')
-      write(stdOut, "(A,T30,A)") "  Parameters", tmpStr
+      write(output, "(A,T30,A)") "  Parameters", tmpStr
       write(tmpStr, "(3(I3,1X))") input%k_grid
-      write(stdOut,"(A,T30,A)") "  MBD k-Grid", trim(adjustl(tmpStr))
+      write(output,"(A,T30,A)") "  MBD k-Grid", trim(adjustl(tmpStr))
       write(tmpStr, "(3(F4.3,1X))") input%k_grid_shift
-      write(stdOut,"(A,T30,A)") "  MBD k-Grid shift", trim(adjustl(tmpStr))
+      write(output,"(A,T30,A)") "  MBD k-Grid shift", trim(adjustl(tmpStr))
       write(tmpStr, "(I3)") input%n_omega_grid
-      write(stdOut, "(A,T30,A)") "  Gridsize (frequencies)", trim(adjustl(tmpStr))
+      write(output, "(A,T30,A)") "  Gridsize (frequencies)", trim(adjustl(tmpStr))
     end select
-    write(stdOut,"(A)") ""
+    write(output,"(A)") ""
 
   end subroutine writeMbdInfo
 #:endif
 
 
   !> Check for compatibility between requested electronic solver and features of the calculation
-  subroutine ensureSolverCompatibility(iSolver, kPoints, parallelOpts, nIndepSpin, tempElec,&
+  subroutine ensureSolverCompatibility(env, iSolver, kPoints, parallelOpts, nIndepSpin, tempElec,&
       & isCallBackApiEnabled)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Solver number (see dftbp_elecsolvers_elecsolvertypes)
     integer, intent(in) :: iSolver
@@ -5930,7 +5945,7 @@ contains
 
     ! Temporary error test for PEXSI bug (July 2019)
     if (iSolver == electronicSolverTypes%pexsi .and. any(kPoints /= 0.0_dp)) then
-      call warning("A temporary PEXSI bug may prevent correct evaluation at general k-points.&
+      call warning(env%stdOut, "A temporary PEXSI bug may prevent correct evaluation at general k-points.&
           & This should be fixed soon.")
     end if
 
@@ -6018,7 +6033,10 @@ contains
 
 
   !> Print out the reference occupations for atoms
-  subroutine printCustomReferenceOccupations(orb, species, customOccAtoms, customOccFillings)
+  subroutine printCustomReferenceOccupations(output, orb, species, customOccAtoms, customOccFillings)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Atomic orbital information
     type(TOrbitals), intent(in) :: orb
@@ -6040,7 +6058,7 @@ contains
     if (nCustomBlock == 0) then
       return
     end if
-    write(stdout, "(A)") "Custom defined reference occupations:"
+    write(output, "(A)") "Custom defined reference occupations:"
     do iCustomBlock = 1, size(customOccAtoms)
       nAtom = size(customOccAtoms(iCustomBlock)%data)
       if (nAtom == 1) then
@@ -6049,7 +6067,7 @@ contains
         write(outStr, "(A)") "Atoms:"
       end if
       write(formstr, "(I0,A)") nAtom, "(I0,1X))"
-      write(stdout, "(A,T30,"//trim(formstr)//")") trim(outStr), customOccAtoms(iCustomBlock)%data
+      write(output, "(A,T30,"//trim(formstr)//")") trim(outStr), customOccAtoms(iCustomBlock)%data
       iSp = species(customOccAtoms(iCustomBlock)%data(1))
       nShell = orb%nShell(iSp)
       call getShellNames(iSp, orb, shellNamesTmp)
@@ -6061,7 +6079,7 @@ contains
         write(outStr,"(A,1X,A,F8.4)")trim(outStr), trim(shellNamesTmp(iSh)),&
             & customOccFillings(iSh, iCustomBlock)
       end do
-      write(stdout,"(A,T29,A)")"Fillings:",trim(outStr)
+      write(output,"(A,T29,A)")"Fillings:",trim(outStr)
       deallocate(shellNamesTmp)
     end do
   end subroutine printCustomReferenceOccupations
@@ -6233,8 +6251,11 @@ contains
 
   !> Stop if linear response module can not be invoked due to unimplemented combinations of
   !! features.
-  subroutine ensureLinRespConditions(tSccCalc, t3rd, tRealHS, tPeriodic, tCasidaForces, solvation,&
+  subroutine ensureLinRespConditions(output, tSccCalc, t3rd, tRealHS, tPeriodic, tCasidaForces, solvation,&
       & isHybLinResp, nSpin, tHelical, tSpinOrbit, isDftbU, tempElec, isOnsiteCorrected, input)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Is the calculation SCC?
     logical, intent(in) :: tSccCalc
@@ -6320,7 +6341,7 @@ contains
     if (tempElec > minTemp .and. tCasidaForces) then
       write(tmpStr, "(A,E12.4,A)")"Excited state forces are not implemented yet for fractional&
           & occupations, kT=", tempElec/Boltzmann,"K"
-      call warning(tmpStr)
+      call warning(output, tmpStr)
     end if
 
     if (input%ctrl%lrespini%nstat == 0 .and. (.not. input%ctrl%lrespini%tNaCoupling)) then
@@ -6368,10 +6389,10 @@ contains
         call error("hybrid functional excited states not available for window options.")
       end if
       if (input%ctrl%lrespini%sym == 'B' .or. input%ctrl%lrespini%sym == 'T') then
-        call warning("hybrid functional excited states not well tested for triplet excited states!")
+        call warning(output, "hybrid functional excited states not well tested for triplet excited states!")
       end if
       if (input%ctrl%tSpin) then
-        call warning("hybrid functional excited states not well tested for spin-polarized systems!")
+        call warning(output, "hybrid functional excited states not well tested for spin-polarized systems!")
       end if
     else
       if (input%ctrl%lrespini%energyWindow < 0.0_dp) then
@@ -6665,7 +6686,7 @@ contains
       write(strTmp, "(A,I0,A)") "PLUMED interface has not been tested with PLUMED API version < ",&
           & minApiVersion, ". Your PLUMED library provides API version ", apiVersion, ". Check your&
           & results carefully and consider to use a more recent PLUMED library if in doubt!"
-      call warning(strTmp)
+      call warning(env%stdOut, strTmp)
     end if
     call plumedCalc%sendCmdVal("setNatoms", this%nAtom)
     call plumedCalc%sendCmdVal("setPlumedDat", "plumed.dat")
@@ -6923,7 +6944,10 @@ contains
 
 
   !> Print information about a REKS calculation
-  subroutine printReksInitInfo(reks, orb, speciesName, nType)
+  subroutine printReksInitInfo(output, reks, orb, speciesName, nType)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Data type for REKS
     type(TReksCalc), intent(in) :: reks
@@ -6940,51 +6964,51 @@ contains
     integer :: ii, iType
     character(lc) :: strTmp
 
-    write(stdOut,*)
-    write(stdOut,*)
-    write(stdOut, "(A,':',T30,A)") "REKS Calculation", "Yes"
+    write(output,*)
+    write(output,*)
+    write(output, "(A,':',T30,A)") "REKS Calculation", "Yes"
 
     select case (reks%reksAlg)
     case (reksTypes%noReks)
     case (reksTypes%ssr22)
-      write(stdOut, "(A,':',T30,A)") "SSR(2,2) Calculation", "Yes"
+      write(output, "(A,':',T30,A)") "SSR(2,2) Calculation", "Yes"
       if (reks%Efunction == 1) then
-        write(stdOut, "(A,':',T30,A)") "Energy Functional", "PPS"
+        write(output, "(A,':',T30,A)") "Energy Functional", "PPS"
       else if (reks%Efunction == 2) then
-        write(stdOut, "(A,':',T30,A)") "Energy Functional", "(PPS+OSS)/2"
+        write(output, "(A,':',T30,A)") "Energy Functional", "(PPS+OSS)/2"
       end if
     case (reksTypes%ssr44)
       call error("SSR(4,4) is not implemented yet")
     end select
 
-    write(stdOut, "(A,':',T30,I14)") "Number of Core Orbitals", reks%Nc
-    write(stdOut, "(A,':',T30,I14)") "Number of Active Orbitals", reks%Na
-    write(stdOut, "(A,':',T30,I14)") "Number of Basis", orb%nOrb
-    write(stdOut, "(A,':',T30,I14)") "Number of States", reks%nstates
+    write(output, "(A,':',T30,I14)") "Number of Core Orbitals", reks%Nc
+    write(output, "(A,':',T30,I14)") "Number of Active Orbitals", reks%Na
+    write(output, "(A,':',T30,I14)") "Number of Basis", orb%nOrb
+    write(output, "(A,':',T30,I14)") "Number of States", reks%nstates
     do ii = 1, reks%SAstates
       if (ii == 1) then
         write(strTmp, "(A,':')") "State-Averaging Weight"
       else
         write(strTmp, "(A)") ""
       end if
-      write(stdOut, "(A,T30,F12.6)") trim(strTmp), reks%SAweight(ii)
+      write(output, "(A,T30,F12.6)") trim(strTmp), reks%SAweight(ii)
     end do
-    write(stdOut, "(A,':',T30,I14)") "State of Interest", reks%rstate
+    write(output, "(A,':',T30,I14)") "State of Interest", reks%rstate
 
     if (reks%tReadMO) then
-      write(stdOut, "(A,':',T30,A)") "Initial Guess", "Read Eigenvec.bin file"
+      write(output, "(A,':',T30,A)") "Initial Guess", "Read Eigenvec.bin file"
     else
-      write(stdOut, "(A,':',T30,A)") "Initial Guess", "Diagonalise H0 matrix"
+      write(output, "(A,':',T30,A)") "Initial Guess", "Diagonalise H0 matrix"
     end if
 
-    write(stdOut, "(A,':',T30,A)") "Newton-Raphson for FON opt", "Yes"
-    write(stdOut, "(A,':',T30,I14)") "NR max. Iterations", reks%FonMaxIter
+    write(output, "(A,':',T30,A)") "Newton-Raphson for FON opt", "Yes"
+    write(output, "(A,':',T30,I14)") "NR max. Iterations", reks%FonMaxIter
     if (reks%shift > epsilon(1.0_dp)) then
-      write(stdOut, "(A,':',T30,A)") "Level Shifting", "Yes"
+      write(output, "(A,':',T30,A)") "Level Shifting", "Yes"
     else
-      write(stdOut, "(A,':',T30,A)") "Level Shifting", "No"
+      write(output, "(A,':',T30,A)") "Level Shifting", "No"
     end if
-    write(stdOut, "(A,':',T30,F12.6)") "Shift Value", reks%shift
+    write(output, "(A,':',T30,F12.6)") "Shift Value", reks%shift
 
     do iType = 1, nType
       if (iType == 1) then
@@ -6992,53 +7016,53 @@ contains
       else
         write(strTmp, "(A)") ""
       end if
-      write(stdOut, "(A,T30,A3,'=',F12.6)") trim(strTmp), speciesName(iType), reks%Tuning(iType)
+      write(output, "(A,T30,A3,'=',F12.6)") trim(strTmp), speciesName(iType), reks%Tuning(iType)
     end do
 
     if (reks%tTDP) then
-      write(stdOut, "(A,':',T30,A)") "Transition Dipole", "Yes"
+      write(output, "(A,':',T30,A)") "Transition Dipole", "Yes"
     else
-      write(stdOut, "(A,':',T30,A)") "Transition Dipole", "No"
+      write(output, "(A,':',T30,A)") "Transition Dipole", "No"
     end if
 
     if (reks%tForces) then
 
       if (reks%Lstate > 0) then
-        write(stdOut, "(A,':',T30,A)") "Gradient of Microstate", "Yes"
-        write(stdOut, "(A,':',T30,I14)") "Index of Interest", reks%Lstate
+        write(output, "(A,':',T30,A)") "Gradient of Microstate", "Yes"
+        write(output, "(A,':',T30,I14)") "Index of Interest", reks%Lstate
       else
-        write(stdOut, "(A,':',T30,A)") "Gradient of Microstate", "No"
+        write(output, "(A,':',T30,A)") "Gradient of Microstate", "No"
       end if
 
       if (reks%Efunction /= 1) then
         if (reks%Glevel == 1) then
-          write(stdOut, "(A,':',T30,A)") "CP-REKS Solver", "Preconditioned Conjugate-Gradient"
-          write(stdOut, "(A,':',T30,I14)") "CG max. Iterations", reks%CGmaxIter
-          write(stdOut, "(A,':',T30,E14.6)") "CG Tolerance", reks%Glimit
+          write(output, "(A,':',T30,A)") "CP-REKS Solver", "Preconditioned Conjugate-Gradient"
+          write(output, "(A,':',T30,I14)") "CG max. Iterations", reks%CGmaxIter
+          write(output, "(A,':',T30,E14.6)") "CG Tolerance", reks%Glimit
           if (reks%tSaveMem) then
-            write(stdOut, "(A,':',T30,A)") "Memory for A and Hxc", "Save in Cache Memory"
+            write(output, "(A,':',T30,A)") "Memory for A and Hxc", "Save in Cache Memory"
           else
-            write(stdOut, "(A,':',T30,A)") "Memory for A and Hxc", "Direct Updating Without Saving"
+            write(output, "(A,':',T30,A)") "Memory for A and Hxc", "Direct Updating Without Saving"
           end if
         elseif (reks%Glevel == 2) then
-          write(stdOut, "(A,':',T30,A)") "CP-REKS Solver", "Conjugate-Gradient"
-          write(stdOut, "(A,':',T30,I14)") "CG max. Iterations", reks%CGmaxIter
-          write(stdOut, "(A,':',T30,E14.6)") "CG Tolerance", reks%Glimit
+          write(output, "(A,':',T30,A)") "CP-REKS Solver", "Conjugate-Gradient"
+          write(output, "(A,':',T30,I14)") "CG max. Iterations", reks%CGmaxIter
+          write(output, "(A,':',T30,E14.6)") "CG Tolerance", reks%Glimit
           if (reks%tSaveMem) then
-            write(stdOut, "(A,':',T30,A)") "Memory for A and Hxc", "Save in Cache Memory"
+            write(output, "(A,':',T30,A)") "Memory for A and Hxc", "Save in Cache Memory"
           else
-            write(stdOut, "(A,':',T30,A)") "Memory for A and Hxc", "Direct Updating Without Saving"
+            write(output, "(A,':',T30,A)") "Memory for A and Hxc", "Direct Updating Without Saving"
           end if
         elseif (reks%Glevel == 3) then
-          write(stdOut, "(A,':',T30,A)") "CP-REKS Solver", "Direct Matrix Multiplication"
+          write(output, "(A,':',T30,A)") "CP-REKS Solver", "Direct Matrix Multiplication"
         end if
         if (reks%tNAC) then
-          write(stdOut, "(A,':',T30,A)") "Non-Adiabatic Coupling", "Yes"
+          write(output, "(A,':',T30,A)") "Non-Adiabatic Coupling", "Yes"
         end if
       end if
 
       if (reks%tRD) then
-        write(stdOut, "(A,':',T30,A)") "Relaxed Density for QM/MM", "Yes"
+        write(output, "(A,':',T30,A)") "Relaxed Density for QM/MM", "Yes"
       end if
 
     end if

--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -3451,10 +3451,10 @@ contains
         end if
       case(thermostatTypes%langevin)
         if (this%geometryChanges%tBarostat) then
-          write(stdOut, "('Mode:',T30,A)")&
+          write(env%stdOut, "('Mode:',T30,A)")&
               & "MD with NVP ensemble using Langevin thermostating and barostat"
         else
-          write(stdOut, "('Mode:',T30,A)")&
+          write(env%stdOut, "('Mode:',T30,A)")&
               & "MD with NVT Langevin thermostating"
         end if
       case(thermostatTypes%nhc)

--- a/src/dftbp/dftbplus/input/geoopt.F90
+++ b/src/dftbp/dftbplus/input/geoopt.F90
@@ -8,6 +8,7 @@
 !> Module to read input from HSD tree
 module dftbp_dftbplus_input_geoopt
   use dftbp_common_accuracy, only : dp
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_unitconversion, only : energyUnits, forceUnits, lengthUnits, timeUnits
   use dftbp_extlibs_xmlf90, only : char, fnode, getNodeName, string
   use dftbp_geoopt_package, only : TFilterInput, TFireInput, TLbfgsInput, TOptimizerInput,&
@@ -47,7 +48,10 @@ module dftbp_dftbplus_input_geoopt
 contains
 
   !> General entry point to read geometry optimization
-  subroutine readGeoOptInput(node, geom, input, atomsRange)
+  subroutine readGeoOptInput(env, node, geom, input, atomsRange)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to get the information from
     type(fnode), pointer, intent(in) :: node
@@ -69,7 +73,7 @@ contains
     call getChildValue(node, "Optimiser", child, "Rational")
     call readOptimizerInput(child, input%optimiser)
 
-    call readFilterInput(node, geom, input%filter, atomsRange)
+    call readFilterInput(env, node, geom, input%filter, atomsRange)
 
     call getChild(node, "Convergence", child, requested=.false.)
     if (.not.associated(child)) then
@@ -126,7 +130,10 @@ contains
 
 
   !> Entry point for reading input for cartesian geometry transformation filter
-  subroutine readFilterInput(node, geom, input, atomsRange)
+  subroutine readFilterInput(env, node, geom, input, atomsRange)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to get the information from
     type(fnode), pointer, intent(in) :: node
@@ -154,7 +161,7 @@ contains
       call getChildValue(node, "Isotropic", input%isotropic, .false.)
     end if
     call getChildValue(node, "MovedAtoms", buffer, trim(atomsRange), multiple=.true., child=child)
-    call getSelectedAtomIndices(child, char(buffer), geom%speciesNames, geom%species, &
+    call getSelectedAtomIndices(env%stdOut, child, char(buffer), geom%speciesNames, geom%species, &
         & input%indMovedAtom)
 
   end subroutine readFilterInput

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -269,7 +269,7 @@ contains
 
       if (.not.this%tRestartNoSC .and.&
           & this%electronicSolver%iSolver /= electronicSolverTypes%OnlyTransport) then
-        call printEnergies(this%dftbEnergy, this%electronicSolver, this%deltaDftb, env%stdOut)
+        call printEnergies(env%stdOut, this%dftbEnergy, this%electronicSolver, this%deltaDftb)
       end if
 
       if (this%tStress) then
@@ -1026,10 +1026,13 @@ contains
 
 
   !> Write data from inside the SCC loop
-  subroutine sccLoopWriting(this, iGeoStep, iLatGeoStep, iSccIter, diffElec, sccErrorQ, output)
+  subroutine sccLoopWriting(this, output, iGeoStep, iLatGeoStep, iSccIter, diffElec, sccErrorQ)
 
     !> Global variables
     type(TDftbPlusMain), intent(inout) :: this
+
+    !> Output unit for human readable messages
+    integer, intent(in) :: output
 
     !> Current geometry step
     integer, intent(in) :: iGeoStep
@@ -1045,9 +1048,6 @@ contains
 
     !> Self-consistency error
     real(dp), intent(in) :: sccErrorQ
-
-    !> Output unit for human readable messages
-    integer, intent(in) :: output
 
      if (this%tSccCalc) then
       call printSccInfo(output, allocated(this%dftbU), iSccIter,&
@@ -1385,7 +1385,7 @@ contains
 
         if (tConverged .or. tStopScc) then
 
-          call printReksSAInfo(this%reks, this%dftbEnergy(1)%Eavg, env%stdOut)
+          call printReksSAInfo(this%reks, env%stdOut, this%dftbEnergy(1)%Eavg)
 
           call getStateInteraction(env, this%denseDesc, this%neighbourList, this%nNeighbourSK,&
               & this%iSparseStart, this%img2CentCell, this%coord, this%iAtInCentralRegion,&
@@ -1562,7 +1562,7 @@ contains
         end if
         call sumEnergies(this%dftbEnergy(this%deltaDftb%iDeterminant))
 
-        call sccLoopWriting(this, iGeoStep, iLatGeoStep, iSccIter, diffElec, sccErrorQ, env%stdOut)
+        call sccLoopWriting(this, env%stdOut, iGeoStep, iLatGeoStep, iSccIter, diffElec, sccErrorQ)
 
         if (tConverged .or. tStopScc) exit lpSCC
 
@@ -9074,7 +9074,7 @@ contains
     end do
 
     if (reks%Plevel >= 2) then
-      call printReksMicrostates(reks, energy%Erep, env%stdOut)
+      call printReksMicrostates(reks, env%stdOut, energy%Erep)
     end if
 
   end subroutine getHamiltonianLandEnergyL

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -1046,7 +1046,7 @@ contains
     !> Self-consistency error
     real(dp), intent(in) :: sccErrorQ
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
      if (this%tSccCalc) then
@@ -4775,7 +4775,7 @@ contains
   !> Checks for the presence of a stop file on disc.
   function hasStopFile(output, fileName) result(tStop)
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Name of file to check for
@@ -8276,7 +8276,7 @@ contains
   !> Prints information about maximal forces in the system.
   subroutine printMaxForces(output, derivs, constrLatDerivs, tCoordOpt, tLatOpt, indMovedAtoms)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Gradients on atoms ]3, nAtom]

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -14,7 +14,7 @@ module dftbp_dftbplus_main
   use dftbp_common_constants, only : pi
   use dftbp_common_environment, only : globalTimers, TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut, withMpi
+  use dftbp_common_globalenv, only : withMpi
   use dftbp_common_hamiltoniantypes, only : hamiltonianTypes
   use dftbp_common_status, only : TStatus
   use dftbp_derivs_numderivs2, only : dipoleAdd, getHessianMatrix, next, polAdd, TNumderivs
@@ -222,8 +222,8 @@ contains
           & this%restartFreq)
 
       if (.not. this%tRestartNoSC) then
-        call printGeoStepInfo(this%geometryChanges%tCoordOpt, this%geometryChanges%tLatOpt,&
-            & iLatGeoStep, iGeoStep)
+        call printGeoStepInfo(env%stdOut, this%geometryChanges%tCoordOpt,&
+            & this%geometryChanges%tLatOpt, iLatGeoStep, iGeoStep)
       end if
 
       ! DFTB Determinant Loop
@@ -231,7 +231,7 @@ contains
       lpDets : do iDet = 1, this%nDets
 
         if (this%nDets > 1) then
-          write(stdOut, "(1X,A,A)")"Determinant ", toupper(this%deltaDftb%determinantName(iDet))
+          write(env%stdOut, "(1X,A,A)")"Determinant ", toupper(this%deltaDftb%determinantName(iDet))
         end if
 
         this%deltaDftb%iDeterminant = iDet
@@ -261,7 +261,7 @@ contains
           & this%tripletStress, this%mixedStress, this%derivs, this%tripletderivs, this%mixedderivs)
 
       if (this%tWriteDetailedOut .and. this%deltaDftb%nDeterminant() > 1) then
-        call writeDetailedOut2Dets(this%fdDetailedOut, userOut, tAppendDetailedOut,&
+        call writeDetailedOut2Dets(env, this%fdDetailedOut, userOut, tAppendDetailedOut,&
             & this%dftbEnergy, this%electronicSolver, this%deltaDftb, this%q0, this%orb,&
             & this%qOutput, this%qDets, this%qBlockDets, this%species, this%iAtInCentralRegion,&
             & this%tPrintMulliken, this%cm5Cont)
@@ -269,14 +269,14 @@ contains
 
       if (.not.this%tRestartNoSC .and.&
           & this%electronicSolver%iSolver /= electronicSolverTypes%OnlyTransport) then
-        call printEnergies(this%dftbEnergy, this%electronicSolver, this%deltaDftb)
+        call printEnergies(this%dftbEnergy, this%electronicSolver, this%deltaDftb, env%stdOut)
       end if
 
       if (this%tStress) then
 
         ! MD case includes the atomic kinetic energy contribution, so print that later
         if (.not. (this%geometryChanges%tMd .or. this%tHelical)) then
-          call printPressureAndFreeEnergy(this%extPressure, this%intPressure,&
+          call printPressureAndFreeEnergy(env%stdOut, this%extPressure, this%intPressure,&
               & this%dftbEnergy(this%deltaDftb%iDeterminant)%EGibbs)
         end if
       end if
@@ -297,7 +297,7 @@ contains
         exit geoOpt
       end if
 
-      call printMaxForces(this%derivs, constrLatDerivs, this%geometryChanges%tCoordOpt,&
+      call printMaxForces(env%stdOut, this%derivs, constrLatDerivs, this%geometryChanges%tCoordOpt,&
           & this%geometryChanges%tLatOpt, this%indMovedAtom)
     #:if WITH_SOCKETS
       if (this%tSocket) then
@@ -314,7 +314,7 @@ contains
       if (this%isHybridXc .and. this%tRealHS) tWriteCharges = .false.
     #:endif
       if (tWriteCharges .and. .not. (this%isHybridXc .and. this%nSpin==4)) then
-        call writeCharges(fCharges, this%tWriteChrgAscii, this%orb, this%qInput, this%qBlockIn,&
+        call writeCharges(env%stdOut, fCharges, this%tWriteChrgAscii, this%orb, this%qInput, this%qBlockIn,&
             & this%qiBlockIn, this%densityMatrix, this%tRealHS, size(this%iAtInCentralRegion),&
             & this%hybridXcAlg, coeffsAndShifts=this%supercellFoldingMatrix,&
             & multipoles=this%multipoleInp)
@@ -347,7 +347,7 @@ contains
         exit geoOpt
       end if
 
-      tStopDriver = tStopScc .or. tStopDriver .or. hasStopFile(fStopDriver)
+      tStopDriver = tStopScc .or. tStopDriver .or. hasStopFile(env%stdOut, fStopDriver)
       if (tStopDriver) then
         call env%globalTimer%stopTimer(globalTimers%postSCC)
         exit geoOpt
@@ -379,12 +379,13 @@ contains
             & this%dipoleMessage, this%quadrupoleMoment)
       end if
 
-      call writeFinalDriverStatus(this%geometryChanges%isgeoopt .or. allocated(this%geoOpt),&
+      call writeFinalDriverStatus(env%stdOut,&
+          & this%geometryChanges%isgeoopt .or. allocated(this%geoOpt),&
           & tGeomEnd, this%geometryChanges%tMd, this%geometryChanges%tDerivs)
 
       if (this%geometryChanges%tMd) then
         call closeFile(this%fdMd)
-        write(stdOut, "(2A)") 'MD information accumulated in ', mdOut
+        write(env%stdOut, "(2A)") 'MD information accumulated in ', mdOut
       end if
     end if
 
@@ -402,12 +403,12 @@ contains
           call getHessianMatrix(this%derivDriver, pDynMatrix)
         end if
       end if
-      call writeHessianOut(hessianOut, pDynMatrix, this%indMovedAtom, errStatus)
+      call writeHessianOut(env%stdOut, hessianOut, pDynMatrix, this%indMovedAtom, errStatus)
       if (errStatus%hasError()) then
         call error(errStatus%message)
       end if
       if (this%tDipole) then
-        call writeBornChargesOut(bornChargesOut,&
+        call writeBornChargesOut(env%stdOut, bornChargesOut,&
             & this%eFieldScaling%scaledSoluteDipole(pDipDerivMatrix), this%indMovedAtom,&
             & size(this%indDerivAtom), errStatus)
         if (errStatus%hasError()) then
@@ -419,7 +420,7 @@ contains
         end if
       end if
       if (this%doPerturbEachGeom) then
-        call writeBornDerivs(bornDerivativesOut, pPolDerivMatrix, this%indMovedAtom,&
+        call writeBornDerivs(env%stdOut, bornDerivativesOut, pPolDerivMatrix, this%indMovedAtom,&
             & size(this%indDerivAtom), errStatus)
         if (errStatus%hasError()) then
           call error(errStatus%message)
@@ -436,7 +437,7 @@ contains
     end if
 
     if (this%tWriteShifts) then
-      call writeShifts(fShifts, this%orb, this%potential%intShell)
+      call writeShifts(env%stdOut, fShifts, this%orb, this%potential%intShell)
     end if
 
     ! Here time propagation is called
@@ -460,7 +461,7 @@ contains
 
     if (env%tGlobalLead .and. this%isAContactCalc) then
       ! Note: shift and charges are saved in QM representation (not UD)
-      call writeContactShifts(this%transpar%contacts(this%transpar%taskContInd)%name, this%orb,&
+      call writeContactShifts(env%stdOut, this%transpar%contacts(this%transpar%taskContInd)%name, this%orb,&
           & this%potential%coulombShell, this%qOutput, this%Ef, this%qBlockOut,&
           & .not.this%transpar%tWriteBinShift)
     end if
@@ -536,7 +537,7 @@ contains
           & this%dipoleMoment, this%multipoleOut, this%eFieldScaling, this%reks)
     end if
     if (this%tWriteCosmoFile .and. allocated(this%solvation)) then
-      call writeCosmoFile(this%solvation, this%species0, this%speciesName, this%coord0, &
+      call writeCosmoFile(env%stdOut, this%solvation, this%species0, this%speciesName, this%coord0, &
           & this%dftbEnergy(this%deltaDftb%iFinal)%EMermin)
     end if
     if (this%tWriteDetailedXML) then
@@ -551,7 +552,7 @@ contains
   #:if WITH_TRANSPORT
     if (this%electronicSolver%iSolver == electronicSolverTypes%GF .or. &
       & this%electronicSolver%iSolver == electronicSolverTypes%OnlyTransport) then
-      call TNegfInt_final(this%negfInt)
+      call TNegfInt_final(env%stdOut, this%negfInt)
     end if
   #:endif
 
@@ -951,7 +952,7 @@ contains
 
     if (this%tSccCalc) then
 
-      tStopScc = hasStopFile(fStopScc)
+      tStopScc = hasStopFile(env%stdOut, fStopScc)
 
       ! Mix charges Input/Output
       if (.not. this%isHybridXc) then
@@ -998,7 +999,7 @@ contains
 
       call getSccInfo(iSccIter, this%dftbEnergy(this%deltaDftb%iDeterminant)%Eelec, Eold,&
           & diffElec)
-      if (this%tNegf) call printSccHeader()
+      if (this%tNegf) call printSccHeader(env%stdOut)
 
       tWriteSccRestart = env%tGlobalLead .and. needsSccRestartWriting(this%restartFreq,&
           & iGeoStep, iSccIter, this%minSccIter, this%maxSccIter, this%geometryChanges%tMd,&
@@ -1013,7 +1014,7 @@ contains
       end if
     #:endif
       if (tWriteSccRestart .and. .not. (this%isHybridXc .and. this%nSpin==4)) then
-        call writeCharges(fCharges, this%tWriteChrgAscii, this%orb, this%qInput, this%qBlockIn,&
+        call writeCharges(env%stdOut, fCharges, this%tWriteChrgAscii, this%orb, this%qInput, this%qBlockIn,&
             & this%qiBlockIn, this%densityMatrix, this%tRealHS, size(this%iAtInCentralRegion),&
             & this%hybridXcAlg, coeffsAndShifts=this%supercellFoldingMatrix,&
             & multipoles=this%multipoleInp)
@@ -1025,7 +1026,7 @@ contains
 
 
   !> Write data from inside the SCC loop
-  subroutine sccLoopWriting(this, iGeoStep, iLatGeoStep, iSccIter, diffElec, sccErrorQ)
+  subroutine sccLoopWriting(this, iGeoStep, iLatGeoStep, iSccIter, diffElec, sccErrorQ, output)
 
     !> Global variables
     type(TDftbPlusMain), intent(inout) :: this
@@ -1045,11 +1046,14 @@ contains
     !> Self-consistency error
     real(dp), intent(in) :: sccErrorQ
 
+    !> Output for write processes
+    integer, intent(in) :: output
+
      if (this%tSccCalc) then
-      call printSccInfo(allocated(this%dftbU), iSccIter,&
+      call printSccInfo(output, allocated(this%dftbU), iSccIter,&
           & this%dftbEnergy(this%deltaDftb%iDeterminant)%Eelec, diffElec, sccErrorQ)
       if (this%tNegf) then
-        call printBlankLine()
+        call printBlankLine(output)
       end if
     end if
 
@@ -1157,7 +1161,7 @@ contains
     end if
 
     if (this%tLatticeChanged) then
-      call handleLatticeChange(this%latVec, this%scc, this%tblite, this, this%tStress,&
+      call handleLatticeChange(env, this%latVec, this%scc, this%tblite, this, this%tStress,&
           & this%extPressure, this%cutOff%mCutOff, this%repulsive, this%dispersion, this%solvation,&
           & this%cm5Cont, this%recVec, this%invLatVec, this%cellVol, this%recCellVol,&
           & this%extLatDerivs, this%cellVec, this%rCellVec, this%boundaryCond, this%transpar,&
@@ -1182,7 +1186,7 @@ contains
 
   #:if WITH_TRANSPORT
     if (this%tNegf .and. isFirstDet) then
-      call setupNegfStuff(this%negfInt, this%denseDesc, this%transpar, this%ginfo,&
+      call setupNegfStuff(env, this%negfInt, this%denseDesc, this%transpar, this%ginfo,&
           & this%neighbourList, this%nNeighbourSK, this%img2CentCell, this%orb)
     end if
   #:endif
@@ -1250,7 +1254,7 @@ contains
     end if
 
     if (allocated(this%halogenXCorrection)) then
-      call this%halogenXCorrection%getEnergies(this%dftbEnergy(&
+      call this%halogenXCorrection%getEnergies(env, this%dftbEnergy(&
           & this%deltaDftb%iDeterminant)%atomHalogenX, this%coord, this%species,&
           & this%neighbourList, this%img2CentCell)
     end if
@@ -1267,7 +1271,7 @@ contains
         call readShifts(fShifts, this%orb, this%nAtom, this%nSpin, this%potential%extShell)
       end if
 
-      call addUpExternalField(this%eField, this%tPeriodic, this%neighbourList, this%nNeighbourSk,&
+      call addUpExternalField(env%stdOut, this%eField, this%tPeriodic, this%neighbourList, this%nNeighbourSk,&
           & this%iCellVec, this%cellVec, this%deltaT, iGeoStep, this%coord0Fold, this%coord,&
           & this%potential)
 
@@ -1295,7 +1299,7 @@ contains
     end if
 
     if (.not.this%tRestartNoSC) then
-      call initSccLoop(this%tSccCalc, this%xlbomdIntegrator, this%minSccIter, this%maxSccIter,&
+      call initSccLoop(env, this%tSccCalc, this%xlbomdIntegrator, this%minSccIter, this%maxSccIter,&
           & this%sccTol, tConverged, this%tNegf, this%reks)
     else
       tConverged = .true.
@@ -1339,7 +1343,7 @@ contains
             & this%species0, this%referenceN0, this%qNetAtom, this%multipoleOut, this%mdftb,&
             & this%reks, errStatus)
         @:PROPAGATE_ERROR(errStatus)
-        call optimizeFONsAndWeights(this%eigvecsReal, this%filling, this%dftbEnergy(1), this%reks)
+        call optimizeFONsAndWeights(env, this%eigvecsReal, this%filling, this%dftbEnergy(1), this%reks)
 
         call getFockandDiag(env, this%denseDesc, this%neighbourList, this%nNeighbourSK,&
             & this%iSparseStart, this%img2CentCell, this%eigvecsReal, this%electronicSolver,&
@@ -1363,7 +1367,7 @@ contains
             & qNetAtom=this%qNetAtom, multipoles=this%multipoleOut, mdftb=this%mdftb)
 
         ! Check charge convergence and guess new eigenvectors
-        tStopScc = hasStopFile(fStopScc)
+        tStopScc = hasStopFile(env%stdOut, fStopScc)
         if (this%isHybridXc) then
           call getReksNextInputDensity(sccErrorQ, this%sccTol, tConverged, iSccIter,&
               & this%minSccIter, this%maxSccIter, iGeoStep, tStopScc, this%eigvecsReal,&
@@ -1376,12 +1380,12 @@ contains
         end if
 
         call getSccInfo(iSccIter, this%dftbEnergy(1)%Eavg, Eold, diffElec)
-        call printReksSccInfo(iSccIter, this%dftbEnergy(1)%Eavg, diffElec, sccErrorQ,&
+        call printReksSccInfo(env%stdOut, iSccIter, this%dftbEnergy(1)%Eavg, diffElec, sccErrorQ,&
             & this%reks)
 
         if (tConverged .or. tStopScc) then
 
-          call printReksSAInfo(this%reks, this%dftbEnergy(1)%Eavg)
+          call printReksSAInfo(this%reks, this%dftbEnergy(1)%Eavg, env%stdOut)
 
           call getStateInteraction(env, this%denseDesc, this%neighbourList, this%nNeighbourSK,&
               & this%iSparseStart, this%img2CentCell, this%coord, this%iAtInCentralRegion,&
@@ -1432,7 +1436,7 @@ contains
 
         if (allocated(this%elecConstraint)) then
           nConstrIter = this%elecConstraint%getMaxIter()
-          call printElecConstrHeader()
+          call printElecConstrHeader(env%stdOut)
           call this%elecConstraint%resetOptimizer()
         else
           nConstrIter = 1
@@ -1537,7 +1541,7 @@ contains
           end if
 
           if (allocated(this%elecConstraint)) then
-            call printElecConstrInfo(this%elecConstraint, iConstrIter,&
+            call printElecConstrInfo(env%stdOut, this%elecConstraint, iConstrIter,&
                 & this%dftbEnergy(this%deltaDftb%iDeterminant)%Eelec)
           end if
 
@@ -1552,13 +1556,13 @@ contains
         if (allocated(this%dispersion) .and. .not. tConverged) then
           call this%dispersion%updateOnsiteCharges(this%qNetAtom, this%orb, this%referenceN0,&
               & this%species0, tConverged)
-          call calcDispersionEnergy(this%dispersion,&
+          call calcDispersionEnergy(env, this%dispersion,&
               & this%dftbEnergy(this%deltaDftb%iDeterminant)%atomDisp,&
               & this%dftbEnergy(this%deltaDftb%iDeterminant)%Edisp, this%iAtInCentralRegion)
         end if
         call sumEnergies(this%dftbEnergy(this%deltaDftb%iDeterminant))
 
-        call sccLoopWriting(this, iGeoStep, iLatGeoStep, iSccIter, diffElec, sccErrorQ)
+        call sccLoopWriting(this, iGeoStep, iLatGeoStep, iSccIter, diffElec, sccErrorQ, env%stdOut)
 
         if (tConverged .or. tStopScc) exit lpSCC
 
@@ -1592,7 +1596,7 @@ contains
       ! non-converged SCC.
       call this%dispersion%updateOnsiteCharges(this%qNetAtom, this%orb, this%referenceN0,&
           & this%species0, tConverged .or. .not. this%isSccConvRequired)
-      call calcDispersionEnergy(this%dispersion,&
+      call calcDispersionEnergy(env, this%dispersion,&
           & this%dftbEnergy(this%deltaDftb%iDeterminant)%atomDisp,&
           & this%dftbEnergy(this%deltaDftb%iDeterminant)%Edisp,&
           & this%iAtInCentralRegion)
@@ -1642,7 +1646,7 @@ contains
 
     if (allocated(this%dispersion)) then
       if (.not. this%dispersion%energyAvailable()) then
-        call warning("Dispersion contributions are not included in the energy")
+        call warning(env%stdOut, "Dispersion contributions are not included in the energy")
       end if
     end if
 
@@ -1654,7 +1658,7 @@ contains
           if (this%elecConstraint%requiresConvergence()) then
             call error(msg)
           else
-            call warning(msg)
+            call warning(env%stdOut, msg)
           end if
         end block
       end if
@@ -1684,7 +1688,7 @@ contains
         if (this%isSccConvRequired) then
           call error(msg)
         else
-          call warning(msg)
+          call warning(env%stdOut, msg)
         end if
       end block
     end if
@@ -1802,7 +1806,7 @@ contains
         if (this%isCIopt) then
           call conicalIntersectionOptimizer(this%derivs, this%excitedDerivs,&
               & this%linearResponse%indNACouplings, this%linearResponse%energyShiftCI,&
-              & this%naCouplings, this%energiesCasida)
+              & this%naCouplings, this%energiesCasida, env%stdOut)
         else if (this%tCasidaForces) then
           if(this%linearResponse%tNaCoupling) then
             call writeExcitedStateForces(env, excFrcOut, this%derivs, this%excitedDerivs, &
@@ -2124,7 +2128,7 @@ contains
         ediff = energy - this%elast
         gnorm = norm2(this%gcurr)
         gamax = maxval(abs(this%gcurr))
-        write(stdOut, '(a)') stepSummary(energy, ediff, gnorm, gamax, dnorm, damax, 2)
+        write(env%stdOut, '(a)') stepSummary(energy, ediff, gnorm, gamax, dnorm, damax, 2)
 
         econv = ediff <= epsilon(0.0_dp) .and. abs(ediff) < this%optTol%energy
         dconv = dnorm / this%filter%nvar < this%optTol%dispNorm .and. damax < this%optTol%dispElem
@@ -2145,7 +2149,7 @@ contains
     else if (this%geometryChanges%isgeoopt) then
       this%tCoordsChanged = .true.
       if (tCoordStep) then
-        call getNextCoordinateOptStep(this%pGeoCoordOpt, this%dftbEnergy(this%deltaDftb%iFinal),&
+        call getNextCoordinateOptStep(env, this%pGeoCoordOpt, this%dftbEnergy(this%deltaDftb%iFinal),&
             & this%derivs, this%indMovedAtom, this%coord0, diffGeo, tCoordEnd,&
             & .not. this%tCasidaForces)
         if (.not. this%geometryChanges%tLatOpt) then
@@ -2155,7 +2159,7 @@ contains
           tCoordStep = .false.
         end if
       else
-        call getNextLatticeOptStep(this%pGeoLatOpt, this%dftbEnergy(this%deltaDftb%iFinal),&
+        call getNextLatticeOptStep(env, this%pGeoLatOpt, this%dftbEnergy(this%deltaDftb%iFinal),&
             & constrLatDerivs, this%origLatVec, this%geometryChanges%tLatOptFixAng,&
             & this%geometryChanges%tLatOptFixLen, this%geometryChanges%tLatOptIsotropic,&
             & this%indMovedAtom, this%latVec, this%coord0, diffGeo, tGeomEnd)
@@ -2171,7 +2175,7 @@ contains
         call env%globalTimer%stopTimer(globalTimers%postSCC)
         tExitGeoOpt = .true.
         if (this%geometryChanges%tLatOpt .and. this%isLatInfoPrinted) then
-          call printLatticeInfo(stdOut, this%geometryChanges, this%latVec, this%cellVol)
+          call printLatticeInfo(env%stdOut, this%geometryChanges, this%latVec, this%cellVol)
         end if
         return
       end if
@@ -2186,9 +2190,9 @@ contains
           & this%intPressure, this%totalStress, this%totalLatDeriv, this%velocities, tempIon)
       this%tCoordsChanged = .true.
       this%tLatticeChanged = this%geometryChanges%tBarostat
-      call printMdInfo(this%tSetFillingTemp, this%eField, this%tPeriodic, this%tempElec,&
-          & tempIon, this%intPressure, this%extPressure,&
-          & this%dftbEnergy(this%deltaDftb%iFinal))
+      call printMdInfo(env%stdOut, this%tSetFillingTemp, this%eField, this%tPeriodic,&
+          & this%tempElec, tempIon, this%intPressure, this%extPressure,&
+          & this%dftbEnergy(this%deltaDftb%iFinal), this%temperatureProfile)
       if (tWriteRestart) then
         if (this%tPeriodic) then
           this%cellVol = abs(determinant33(this%latVec))
@@ -2310,9 +2314,12 @@ contains
 
 
   !> Does the operations that are necessary after a lattice vector update
-  subroutine handleLatticeChange(latVecs, sccCalc, tblite, this, tStress, extPressure, mCutOff,&
-      & repulsive, dispersion, solvation, cm5Cont, recVecs, invLatVecs, cellVol, recCellVol,&
-      & extLatDerivs, cellVecs, rCellVecs, boundaryCond, transpar, errStatus)
+  subroutine handleLatticeChange(env, latVecs, sccCalc, tblite, this, tStress, extPressure,&
+      & mCutOff, repulsive, dispersion, solvation, cm5Cont, recVecs, invLatVecs, cellVol,&
+      & recCellVol, extLatDerivs, cellVecs, rCellVecs, boundaryCond, transpar, errStatus)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Lattice vectors
     real(dp), intent(in) :: latVecs(:,:)
@@ -2410,8 +2417,9 @@ contains
     end if
     call getCellTranslations(cellVecs, rCellVecs, latVecs, invLatVecs, mCutOff, boundaryCond)
 
-    if (this%isLatInfoPrinted) call printLatticeInfo(stdOut, this%geometryChanges, this%latVec,&
-        & this%cellVol)
+    if (this%isLatInfoPrinted) then
+      call printLatticeInfo(env%stdOut, this%geometryChanges, this%latVec, this%cellVol)
+    end if
 
   end subroutine handleLatticeChange
 
@@ -2579,7 +2587,7 @@ contains
       @:PROPAGATE_ERROR(errStatus)
     end if
 
-    call getNrOfNeighboursForAll(nNeighbourSK, neighbourList, cutoff%skCutOff)
+    call getNrOfNeighboursForAll(env%stdOut, nNeighbourSK, neighbourList, cutoff%skCutOff)
 
     call getSparseDescriptor(neighbourList%iNeighbour, nNeighbourSK, img2CentCell, orb,&
         & iSparseStart, sparseSize)
@@ -2587,7 +2595,7 @@ contains
 
     if (allocated(nNeighbourCam)) then
       ! count neighbours for CAM interactions (for non-symmetric neighbour list)
-      call getNrOfNeighboursForAll(nNeighbourCam, neighbourList, cutoff%camCutOff)
+      call getNrOfNeighboursForAll(env%stdOut, nNeighbourCam, neighbourList, cutoff%camCutOff)
     end if
 
     if (allocated(symNeighbourList)) then
@@ -2598,7 +2606,7 @@ contains
       @:PROPAGATE_ERROR(errStatus)
       if (allocated(nNeighbourCamSym)) then
         ! count neighbours for CAM interactions (for symmetric neighbour list)
-        call getNrOfNeighboursForAll(nNeighbourCamSym, symNeighbourList%neighbourList,&
+        call getNrOfNeighboursForAll(env%stdOut, nNeighbourCamSym, symNeighbourList%neighbourList,&
             & cutoff%camCutOff)
         call getSparseDescriptor(symNeighbourList%neighbourList%iNeighbour, nNeighbourCamSym,&
             & symNeighbourList%img2CentCell, orb, symNeighbourList%iPair,&
@@ -2619,7 +2627,7 @@ contains
     end if
 
     if (allocated(repulsive)) then
-      call repulsive%updateCoords(coord, species, img2CentCell, neighbourList)
+      call repulsive%updateCoords(env, coord, species, img2CentCell, neighbourList)
     end if
 
     if (allocated(dispersion)) then
@@ -2635,7 +2643,7 @@ contains
       end if
     end if
     if (allocated(thirdOrd)) then
-      call thirdOrd%updateCoords(neighbourList, species)
+      call thirdOrd%updateCoords(env, neighbourList, species)
     end if
     if (allocated(hybridXc)) then
       if (.not. tPeriodic) then
@@ -2649,7 +2657,7 @@ contains
       end if
     end if
     if (allocated(cm5Cont)) then
-       call cm5Cont%updateCoords(neighbourList, img2CentCell, coord, species)
+       call cm5Cont%updateCoords(env, neighbourList, img2CentCell, coord, species)
     end if
 
   end subroutine handleCoordinateChange
@@ -2658,8 +2666,11 @@ contains
 #:if WITH_TRANSPORT
 
   !> Initialise transport
-  subroutine setupNegfStuff(negfInt, denseDescr, transpar, ginfo, neighbourList, nNeighbourSK,&
+  subroutine setupNegfStuff(env, negfInt, denseDescr, transpar, ginfo, neighbourList, nNeighbourSK,&
       & img2CentCell, orb)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> NEGF interface
     type(TNegfInt), intent(inout) :: negfInt
@@ -2689,10 +2700,10 @@ contains
     call negfInt%setup_csr(denseDescr%iAtomStart, neighbourList%iNeighbour, nNeighbourSK,&
         & img2CentCell, orb)
 
-    call negfInt%setup_str(denseDescr, transpar, ginfo%greendens, neighbourList%iNeighbour,&
+    call negfInt%setup_str(env%stdOut, denseDescr, transpar, ginfo%greendens, neighbourList%iNeighbour,&
         & nNeighbourSK, img2CentCell)
 
-    call negfInt%setup_dephasing(ginfo%tundos)  !? why tundos
+    call negfInt%setup_dephasing(env%stdOut, ginfo%tundos)  !? why tundos
 
   end subroutine setupNegfStuff
 
@@ -2840,8 +2851,11 @@ contains
 
 
   !> Initialise basic variables before the scc loop.
-  subroutine initSccLoop(tSccCalc, xlbomdIntegrator, minSccIter, maxSccIter, sccTol, tConverged,&
+  subroutine initSccLoop(env, tSccCalc, xlbomdIntegrator, minSccIter, maxSccIter, sccTol, tConverged,&
       & tNegf, reks)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Is this an SCC calculation?
     logical, intent(in) :: tSccCalc
@@ -2875,11 +2889,11 @@ contains
 
     if (allocated(reks)) then
       if (tSccCalc) then
-        call printReksSccHeader(reks)
+        call printReksSccHeader(env%stdOut, reks)
       end if
     else
       if (tSccCalc .and. .not. tNegf) then
-        call printSccHeader()
+        call printSccHeader(env%stdOut)
       end if
     end if
 
@@ -3529,8 +3543,8 @@ contains
         end if
       endif
 
-      call diagDenseMtxBlacs(electronicSolver, 1, 'V', denseDesc%blacsOrbSqr, HSqrReal, SSqrReal,&
-          & eigen(:,iSpin), eigvecsReal(:,:,iKS), errStatus)
+      call diagDenseMtxBlacs(env, electronicSolver, 1, 'V', denseDesc%blacsOrbSqr, HSqrReal,&
+          & SSqrReal, eigen(:,iSpin), eigvecsReal(:,:,iKS), errStatus)
       @:PROPAGATE_ERROR(errStatus)
     #:else
       call env%globalTimer%startTimer(globalTimers%sparseToDense)
@@ -4759,7 +4773,10 @@ contains
 
 
   !> Checks for the presence of a stop file on disc.
-  function hasStopFile(fileName) result(tStop)
+  function hasStopFile(output, fileName) result(tStop)
+
+    !> Output for write processes
+    integer, intent(in) :: output
 
     !> Name of file to check for
     character(*), intent(in) :: fileName
@@ -4769,7 +4786,7 @@ contains
 
     inquire(file=fileName, exist=tStop)
     if (tStop) then
-      write(stdOut, "(3A)") "Stop file '" // fileName // "' found."
+      write(output, "(3A)") "Stop file '" // fileName // "' found."
     end if
 
   end function hasStopFile
@@ -6121,8 +6138,8 @@ contains
     allocate(hprime(sparseSize, 1))
     allocate(dipole(size(q0, dim=1), nAtom))
     allocate(potentialDerivative(nAtom, 1))
-    write(stdOut,*)
-    write(stdOut, "(A)", advance='no') 'Hellmann Feynman dipole:'
+    write(env%stdOut,*)
+    write(env%stdOut, "(A)", advance='no') 'Hellmann Feynman dipole:'
 
     if (nDipole > 0) then
       allocate(potentialGradDeriv(nDipole, nAtom))
@@ -6170,9 +6187,9 @@ contains
         dipole(1, iAt) = dipole(1, iAt) + sum(q0(:, iAt, 1)) *&
             & eFieldScaling%scaledExtEField(coord0(iCart, iAt))
       end do
-      write(stdOut, "(F16.8)", advance='no') sum(dipole)
+      write(env%stdOut, "(F16.8)", advance='no') sum(dipole)
     end do
-    write(stdOut, *) " au"
+    write(env%stdOut, *) " au"
 
   end subroutine checkDipoleViaHellmannFeynman
 
@@ -7359,7 +7376,7 @@ contains
     end if
 
     if (allocated(halogenXCorrection)) then
-      call halogenXCorrection%addGradients(derivs, coord, species, neighbourList, img2CentCell)
+      call halogenXCorrection%addGradients(env, derivs, coord, species, neighbourList, img2CentCell)
     end if
 
     if (allocated(hybridXc)) then
@@ -7655,7 +7672,7 @@ contains
     end if
 
     if (allocated(halogenXCorrection)) then
-      call halogenXCorrection%getStress(tmpStress, coord, neighbourList, species, img2CentCell,&
+      call halogenXCorrection%getStress(env, tmpStress, coord, neighbourList, species, img2CentCell,&
           & cellVol)
       totalStress(:,:) = totalStress + tmpStress
     end if
@@ -7889,8 +7906,11 @@ contains
 
 
   !> Returns the coordinates for the next coordinate optimisation step.
-  subroutine getNextCoordinateOptStep(pGeoCoordOpt, energy, derivss, indMovedAtom, coord0,&
+  subroutine getNextCoordinateOptStep(env, pGeoCoordOpt, energy, derivss, indMovedAtom, coord0,&
       & diffGeo, tCoordEnd, tRemoveExcitation)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Optimiser for atomic coordinates
     type(TGeoOpt), intent(inout) :: pGeoCoordOpt
@@ -7922,9 +7942,9 @@ contains
 
     derivssMoved(:) = reshape(derivss(:, indMovedAtom), [3 * size(indMovedAtom)])
     if (tRemoveExcitation) then
-      call next(pGeoCoordOpt, energy%EForceRelated, derivssMoved, newCoordsMoved, tCoordEnd)
+      call next(pGeoCoordOpt, env, energy%EForceRelated, derivssMoved, newCoordsMoved, tCoordEnd)
     else
-      call next(pGeoCoordOpt, energy%EForceRelated + energy%Eexcited, derivssMoved, newCoordsMoved,&
+      call next(pGeoCoordOpt, env, energy%EForceRelated + energy%Eexcited, derivssMoved, newCoordsMoved,&
           & tCoordEnd)
     end if
     pNewCoordsMoved(1:3, 1:size(indMovedAtom)) => newCoordsMoved(1 : 3 * size(indMovedAtom))
@@ -7935,8 +7955,11 @@ contains
 
 
   !> Returns the coordinates and lattice vectors for the next lattice optimisation step.
-  subroutine getNextLatticeOptStep(pGeoLatOpt, energy, constrLatDerivs, origLatVec, tLatOptFixAng,&
+  subroutine getNextLatticeOptStep(env, pGeoLatOpt, energy, constrLatDerivs, origLatVec, tLatOptFixAng,&
       & tLatOptFixLen, tLatOptIsotropic, indMovedAtom, latVec, coord0, diffGeo, tGeomEnd)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Lattice vector optimising object
     type(TGeoOpt), intent(inout) :: pGeoLatOpt
@@ -7976,7 +7999,7 @@ contains
 
     real(dp) :: newLatVecsFlat(9), newLatVecs(3, 3), oldMovedCoords(3, size(indMovedAtom))
 
-    call next(pGeoLatOpt, energy%EForceRelated, constrLatDerivs, newLatVecsFlat,tGeomEnd)
+    call next(pGeoLatOpt, env, energy%EForceRelated, constrLatDerivs, newLatVecsFlat,tGeomEnd)
     call unconstrainLatticeVectors(newLatVecsFlat, origLatVec, tLatOptFixAng, tLatOptFixLen,&
         & tLatOptIsotropic, newLatVecs)
     oldMovedCoords(:,:) = coord0(:, indMovedAtom)
@@ -8180,7 +8203,7 @@ contains
     nSpin = size(nEl)
 
     if (any(abs(mod(filling, real(3 - nSpin, dp))) > elecTolMax)) then
-      call warning("Fractional occupations allocated for electron localisation")
+      call warning(env%stdOut, "Fractional occupations allocated for electron localisation")
     end if
 
     if (allocated(eigvecsReal)) then
@@ -8196,12 +8219,12 @@ contains
         nFilledLev = nint(nEl(iSpin) / real(3 - nSpin, dp))
         localisation = pipekMezey%getLocalisation(eigvecsReal(:, 1:nFilledLev, iKS), SSqrReal,&
             & denseDesc%iAtomStart)
-        write(stdOut, "(A, E15.8)") 'Original localisation', localisation
-        call pipekMezey%calcCoeffs(eigvecsReal(:, 1:nFilledLev, iKS), SSqrReal,&
+        write(env%stdOut, "(A, E15.8)") 'Original localisation', localisation
+        call pipekMezey%calcCoeffs(env%stdOut, eigvecsReal(:, 1:nFilledLev, iKS), SSqrReal,&
             & denseDesc%iAtomStart)
         localisation = pipekMezey%getLocalisation(eigvecsReal(:,1:nFilledLev,iKS), SSqrReal,&
             & denseDesc%iAtomStart)
-        write(stdOut, "(A, E20.12)") 'Final localisation ', localisation
+        write(env%stdOut, "(A, E20.12)") 'Final localisation ', localisation
       end do
 
       call writeRealEigvecs(env, runId, neighbourList, nNeighbourSK, denseDesc, iSparseStart,&
@@ -8218,14 +8241,14 @@ contains
             & eigvecsCplx(:,:nFilledLev,iKS), SSqrCplx, ints%overlap, kpoint(:,iK), neighbourList,&
             & nNeighbourSK, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
       end do
-      write(stdOut, "(A, E20.12)") 'Original localisation', localisation
+      write(env%stdOut, "(A, E20.12)") 'Original localisation', localisation
 
       ! actual localisation calls
       do iKS = 1, parallelKS%nLocalKS
         iK = parallelKS%localKS(1, iKS)
         iSpin = parallelKS%localKS(2, iKS)
         nFilledLev = nint(nEl(iSpin) / real( 3 - nSpin, dp))
-        call pipekMezey%calcCoeffs(eigvecsCplx(:,:nFilledLev,iKS), SSqrCplx, ints%overlap,&
+        call pipekMezey%calcCoeffs(env%stdOut, eigvecsCplx(:,:nFilledLev,iKS), SSqrCplx, ints%overlap,&
             & kpoint(:,iK), neighbourList, nNeighbourSK, iCellVec, cellVec, denseDesc%iAtomStart,&
             & iSparseStart, img2CentCell)
       end do
@@ -8239,7 +8262,7 @@ contains
             & eigvecsCplx(:,:nFilledLev,iKS), SSqrCplx, ints%overlap, kpoint(:,iK), neighbourList,&
             & nNeighbourSK, iCellVec, cellVec, denseDesc%iAtomStart, iSparseStart, img2CentCell)
       end do
-      write(stdOut, "(A, E20.12)") 'Final localisation', localisation
+      write(env%stdOut, "(A, E20.12)") 'Final localisation', localisation
 
       call writeCplxEigvecs(env, runId, neighbourList, nNeighbourSK, cellVec, iCellVec, denseDesc,&
           & iSparseStart, img2CentCell, species, speciesName, orb, kPoint, ints%overlap,&
@@ -8251,7 +8274,10 @@ contains
 
 
   !> Prints information about maximal forces in the system.
-  subroutine printMaxForces(derivs, constrLatDerivs, tCoordOpt, tLatOpt, indMovedAtoms)
+  subroutine printMaxForces(output, derivs, constrLatDerivs, tCoordOpt, tLatOpt, indMovedAtoms)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Gradients on atoms ]3, nAtom]
     real(dp), intent(in), allocatable :: derivs(:,:)
@@ -8271,14 +8297,14 @@ contains
     real(dp) :: normedDeriv
 
     if (tCoordOpt) then
-      call printMaxForce(maxval(abs(derivs(:, indMovedAtoms))))
+      call printMaxForce(output, maxval(abs(derivs(:, indMovedAtoms))))
       normedDeriv = norm2(derivs(:, indMovedAtoms)) / sqrt(real(size(indMovedAtoms), dp))
-      call printForceNorm(normedDeriv)
+      call printForceNorm(output, normedDeriv)
     end if
     if (tLatOpt) then
-      call printMaxLatticeForce(maxval(abs(constrLatDerivs)))
+      call printMaxLatticeForce(output, maxval(abs(constrLatDerivs)))
       normedDeriv = norm2(constrLatDerivs) / sqrt(3.0_dp)
-      call printLatticeForceNorm(normedDeriv)
+      call printLatticeForceNorm(output, normedDeriv)
     end if
 
   end subroutine printMaxForces
@@ -8308,7 +8334,7 @@ contains
 
     if (env%tGlobalLead) then
       ! stress was computed above in the force evaluation block or is 0 if aperiodic
-      call socket%send(energy%ETotal - sum(energy%TS), -derivs, totalStress * cellVol)
+      call socket%send(env, energy%ETotal - sum(energy%TS), -derivs, totalStress * cellVol)
     end if
   end subroutine sendEnergyAndForces
 
@@ -9018,7 +9044,7 @@ contains
         end if
         call dispersion%updateOnsiteCharges(qNetAtom, orb, referenceN0,&
             & species0, tConverged)
-        call calcDispersionEnergy(dispersion, energy%atomDisp, energy%Edisp,&
+        call calcDispersionEnergy(env, dispersion, energy%atomDisp, energy%Edisp,&
             & iAtInCentralRegion)
       end if
       call sumEnergies(energy)
@@ -9048,7 +9074,7 @@ contains
     end do
 
     if (reks%Plevel >= 2) then
-      call printReksMicrostates(reks, energy%Erep)
+      call printReksMicrostates(reks, energy%Erep, env%stdOut)
     end if
 
   end subroutine getHamiltonianLandEnergyL
@@ -9057,7 +9083,10 @@ contains
   !> Optimize the fractional occupation numbers (FONs) and weights
   !> Swap the active orbitals when fa < fb
   !> Compute the several energy contributions
-  subroutine optimizeFONsAndWeights(eigvecs, filling, energy, reks)
+  subroutine optimizeFONsAndWeights(env, eigvecs, filling, energy, reks)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Eigenvectors
     real(dp), intent(inout) :: eigvecs(:,:,:)
@@ -9071,16 +9100,16 @@ contains
     !> Data type for REKS
     type(TReksCalc), intent(inout) :: reks
 
-    call optimizeFons(reks)
+    call optimizeFons(reks, env%stdOut)
     call calcWeights(reks)
 
-    call activeOrbSwap(reks, eigvecs(:,:,1))
+    call activeOrbSwap(env%stdOut, reks, eigvecs(:,:,1))
     call getFilling(reks, filling(:,1,1))
 
     call calcSaReksEnergy(reks, energy)
 
     if (reks%Plevel >= 2) then
-      call printSaReksEnergy(reks)
+      call printSaReksEnergy(reks, env%stdOut)
     end if
 
   end subroutine optimizeFONsAndWeights

--- a/src/dftbp/dftbplus/mainapi.F90
+++ b/src/dftbp/dftbplus/mainapi.F90
@@ -199,7 +199,7 @@ contains
     @:ASSERT(size(gradients,1) == 3)
 
     if (.not. main%tForces) then
-      call genericGradientInit(main, oldSettings)
+      call genericGradientInit(env, main, oldSettings)
     end if
 
     call recalcGeometry(env, main)
@@ -235,7 +235,7 @@ contains
     end if
 
     if (.not. main%tStress) then
-      call genericGradientInit(main, oldSettings)
+      call genericGradientInit(env, main, oldSettings)
       main%tLatticeChanged = .true.
       main%tStress = .true.
     end if
@@ -252,7 +252,10 @@ contains
 
 
   !> Generic initialisation for analytical first derivative data structures
-  subroutine genericGradientInit(main, oldSettings)
+  subroutine genericGradientInit(env, main, oldSettings)
+
+    !> Instance of computational environment
+    type(TEnvironment), intent(inout) :: env
 
     !> DFTB+ instance
     type(TDftbPlusMain), intent(inout) :: main
@@ -292,7 +295,8 @@ contains
     ! mark coordinates as tainted, forcing re-evaluation
     main%tCoordsChanged = .true.
 
-    call warning(["Generic derivatives settings initialised inside API an property request.",&
+    call warning(env%stdOut,&
+        & ["Generic derivatives settings initialised inside API an property request.",&
         & "For more control, setup forces at calculation initialisation.           "])
 
   end subroutine genericGradientInit
@@ -649,7 +653,7 @@ contains
     @:ASSERT(all(shape(chargeGradients) == [3, main%nExtChrg]))
 
     if (.not.main%tForces .or. .not.allocated(main%chrgForces)) then
-      call genericGradientInit(main, oldSettings)
+      call genericGradientInit(env, main, oldSettings)
       if (main%tPeriodic) main%tLatticeChanged = .true.
     end if
 
@@ -835,7 +839,7 @@ contains
         & main%qShell0)
     call initElectronNumber(main%q0, main%nrChrg, main%nrSpinPol, main%nSpin, main%orb,&
         & main%nEl0, main%nEl)
-    call main%initializeCharges(errStatus)
+    call main%initializeCharges(env, errStatus)
     if (errStatus%hasError()) then
       call error(errStatus%message)
     end if
@@ -1100,7 +1104,7 @@ contains
       end if
 
       if (.not. main%tForces) then
-        call genericGradientInit(main, oldSettings)
+        call genericGradientInit(env, main, oldSettings)
         call recalcGeometry(env, main)
       end if
 

--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -19,7 +19,7 @@ module dftbp_dftbplus_mainio
       & gfac, Hartree__eV, pi, quaternionName, spinName
   use dftbp_common_environment, only : TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : abortProgram, destructGlobalEnv, stdOut
+  use dftbp_common_globalenv, only : abortProgram, destructGlobalEnv
   use dftbp_common_status, only : TStatus
   use dftbp_dftb_densitymatrix, only : TDensityMatrix
   use dftbp_dftb_determinants, only : TDftbDeterminants
@@ -49,6 +49,7 @@ module dftbp_dftbplus_mainio
   use dftbp_math_eigensolver, only : heev
   use dftbp_md_mdcommon, only : TMDOutput
   use dftbp_md_mdintegrator, only : state, TMdIntegrator
+  use dftbp_md_tempprofile, only : TTempProfile
   use dftbp_reks_reks, only : reksTypes, setReksTargetEnergy, TReksCalc
   use dftbp_solvation_cm5, only : TChargeModel5
   use dftbp_solvation_cosmo, only : TCosmo
@@ -2611,7 +2612,10 @@ contains
 
 
   !> Write the energy second derivative matrix
-  subroutine writeHessianOut(fileName, pDynMatrix, indMovedAtoms, errStatus)
+  subroutine writeHessianOut(output, fileName, pDynMatrix, indMovedAtoms, errStatus)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> File name
     character(*), intent(in) :: fileName
@@ -2654,10 +2658,10 @@ contains
     end do
 
     if (tPartialHessian) then
-      write(stdOut, "(2A)") 'Hessian matrix written to ',&
+      write(output, "(2A)") 'Hessian matrix written to ',&
           & fileName//"."//trim(adjustl(suffix1))//"-"//trim(adjustl(suffix2))
     else
-      write(stdOut, "(2A)") 'Hessian matrix written to ', fileName
+      write(output, "(2A)") 'Hessian matrix written to ', fileName
     end if
 
     call closeFile(fd)
@@ -2665,8 +2669,11 @@ contains
   end subroutine writeHessianOut
 
 
-  !> Write the dipole derivative wrt.coordinates matrix (i.e. Born charges)
-  subroutine writeBornChargesOut(fileName, pBornMatrix, indMovedAtoms, nDerivAtoms, errStatus)
+  !> Write the dipole derivative wrt.coordinates matrix/Born charges
+  subroutine writeBornChargesOut(output, fileName, pBornMatrix, indMovedAtoms, nDerivAtoms, errStatus)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> File name
     character(*), intent(in) :: fileName
@@ -2710,17 +2717,20 @@ contains
     call closeFile(fd)
 
     if (tPartialMatrix) then
-      write(stdOut, "(2A)") 'Born charges matrix written to ',&
+      write(output, "(2A)") 'Born charges matrix written to ',&
           & fileName//"."//trim(adjustl(suffix1))//"-"//trim(adjustl(suffix2))
     else
-      write(stdOut, "(2A)") 'Born charges matrix written to ', fileName
+      write(output, "(2A)") 'Born charges matrix written to ', fileName
     end if
 
   end subroutine writeBornChargesOut
 
 
-  !> Write the Derivatives of the polarizability with respect to atom positions
-  subroutine writeBornDerivs(fileName, pdBornMatrix, indMovedAtoms, nDerivAtoms, errStatus)
+  !> Write the Derivatives of the polarizability
+  subroutine writeBornDerivs(output, fileName, pdBornMatrix, indMovedAtoms, nDerivAtoms, errStatus)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> File name
     character(*), intent(in) :: fileName
@@ -2763,7 +2773,7 @@ contains
     end do
 
     call closeFile(fd)
-    write(stdOut, "(2A)") 'Born charge derivative matrix written to ', file
+    write(output, "(2A)") 'Born charge derivative matrix written to ', file
 
   end subroutine writeBornDerivs
 
@@ -3231,9 +3241,12 @@ contains
 
   !> Wrapped call for detailedout2 and print energies, which can process multiple determinants,
   !> currently only for two spin channels
-  subroutine writeDetailedOut2Dets(fdDetailedOut, userOut, tAppendDetailedOut, dftbEnergy,&
+  subroutine writeDetailedOut2Dets(env, fdDetailedOut, userOut, tAppendDetailedOut, dftbEnergy,&
       & electronicSolver, deltaDftb, q0, orb, qOutput, qDets, qBlockDets, species,&
       & iAtInCentralRegion, tPrintMulliken, cm5Cont)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> File ID
     type(TFileDescr), intent(inout) :: fdDetailedOut
@@ -4316,8 +4329,11 @@ contains
 
 
   !> Write out charges.
-  subroutine writeCharges(fCharges, tWriteAscii, orb, qInput, qBlockIn, qiBlockIn, densityMatrix,&
+  subroutine writeCharges(output, fCharges, tWriteAscii, orb, qInput, qBlockIn, qiBlockIn, densityMatrix,&
       & tRealHS, nAtInCentralRegion, hybridXcAlg, coeffsAndShifts, multipoles)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> File name for charges to be written to
     character(*), intent(in) :: fCharges
@@ -4361,10 +4377,11 @@ contains
     call writeQToFile(qInput, fCharges, tWriteAscii, orb, qBlockIn, qiBlockIn, densityMatrix,&
         & tRealHS, nAtInCentralRegion, hybridXcAlg, coeffsAndShifts=coeffsAndShifts,&
         & multipoles=multipoles)
+
     if (tWriteAscii) then
-      write(stdOut, "(A,A)") '>> Charges saved for restart in ', trim(fCharges) // '.dat'
+      write(output, "(A,A)") '>> Charges saved for restart in ', trim(fCharges) // '.dat'
     else
-      write(stdOut, "(A,A)") '>> Charges saved for restart in ', trim(fCharges) // '.bin'
+      write(output, "(A,A)") '>> Charges saved for restart in ', trim(fCharges) // '.bin'
     end if
 
   end subroutine writeCharges
@@ -4435,7 +4452,7 @@ contains
     ! Write out matrices if necessary and quit.
     call writeHS(env, tWriteHS, tWriteRealHS, tRealHS, hamUpDown, over, neighbourList%iNeighbour,&
         & nNeighbourSK, iAtomStart, iPair, img2CentCell, kPoint, iCellVec, cellVec, iHam)
-    write(stdOut, "(A)") "Hamilton/Overlap written, exiting program."
+    write(env%stdOut, "(A)") "Hamilton/Overlap written, exiting program."
     call env%destruct()
     call destructGlobalEnv()
     call abortProgram()
@@ -4714,7 +4731,10 @@ contains
 
 
   !> Write out final status of the geometry driver.
-  subroutine writeFinalDriverStatus(tGeoOpt, tGeomEnd, tMd, tDerivs)
+  subroutine writeFinalDriverStatus(output, tGeoOpt, tGeomEnd, tMd, tDerivs)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Is the geometry being optimised?
     logical, intent(in) :: tGeoOpt
@@ -4730,21 +4750,21 @@ contains
 
     if (tGeoOpt) then
       if (tGeomEnd) then
-        write(stdOut, "(/, A)") "Geometry converged"
+        write(output, "(/, A)") "Geometry converged"
       else
-        call warning("!!! Geometry did NOT converge!")
+        call warning(output, "!!! Geometry did NOT converge!")
       end if
     elseif (tMD) then
       if (tGeomEnd) then
-        write(stdOut, "(/, A)") "Molecular dynamics completed"
+        write(output, "(/, A)") "Molecular dynamics completed"
       else
-        call warning("!!! Molecular dynamics terminated abnormally!")
+        call warning(output, "!!! Molecular dynamics terminated abnormally!")
       end if
     elseif (tDerivs) then
       if (tGeomEnd) then
-        write(stdOut, "(/, A)") "Second derivatives completed"
+        write(output, "(/, A)") "Second derivatives completed"
       else
-        call warning("!!! Second derivatives terminated abnormally!")
+        call warning(output, "!!! Second derivatives terminated abnormally!")
       end if
     end if
 
@@ -4752,7 +4772,10 @@ contains
 
 
   !> Prints geometry step information to standard out
-  subroutine printGeoStepInfo(tCoordOpt, tLatOpt, iLatGeoStep, iGeoStep)
+  subroutine printGeoStepInfo(output, tCoordOpt, tLatOpt, iLatGeoStep, iGeoStep)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Are coordinates being optimised
     logical, intent(in) :: tCoordOpt
@@ -4766,37 +4789,46 @@ contains
     !> How many lattice optimisation steps have occurred
     integer, intent(in) :: iLatGeoStep
 
-    write(stdOut, '(/, A)') repeat('-', 80)
+    write(output, '(/, A)') repeat('-', 80)
     if (tCoordOpt .and. tLatOpt) then
-      write(stdOut, "(/, A, I0, A, I0,/)") '***  Geometry step: ', iGeoStep, ', Lattice step: ',&
+      write(output, "(/, A, I0, A, I0,/)") '***  Geometry step: ', iGeoStep, ', Lattice step: ',&
           & iLatGeoStep
     else
-      write(stdOut, "(/, A, I0, /)") '***  Geometry step: ', iGeoStep
+      write(output, "(/, A, I0, /)") '***  Geometry step: ', iGeoStep
     end if
 
   end subroutine printGeoStepInfo
 
 
   !> Prints the line above the start of the SCC cycle data
-  subroutine printSccHeader()
+  subroutine printSccHeader(output)
 
-    write(stdOut, "(A5, A18, A18, A18)") "iSCC", " Total electronic ", "  Diff electronic ",&
+    !> output for write processes
+    integer, intent(in) :: output
+
+    write(output, "(A5, A18, A18, A18)") "iSCC", " Total electronic ", "  Diff electronic ",&
         & "     SCC error    "
 
   end subroutine printSccHeader
 
 
   !> Prints the line above the start of the electronic constraints cycle data
-  subroutine printElecConstrHeader()
+  subroutine printElecConstrHeader(output)
 
-    write(stdOut, "(A6,A5,3A18)") repeat(" ", 6), "iConst", "  Total electronic",&
+    !> output for write processes
+    integer, intent(in) :: output
+
+    write(output, "(A6,A5,3A18)") repeat(" ", 6), "iConst", "  Total electronic",&
         & "     max(dW/dVc)  ", "     dW           "
 
   end subroutine printElecConstrHeader
 
 
   !> Prints the line above the start of the REKS SCC cycle data
-  subroutine printReksSccHeader(reks)
+  subroutine printReksSccHeader(output, reks)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> data type for REKS
     type(TReksCalc), intent(in) :: reks
@@ -4804,7 +4836,7 @@ contains
     select case (reks%reksAlg)
     case (reksTypes%noReks)
     case (reksTypes%ssr22)
-      write(stdOut,"(1X,A5,A20,A20,A13,A15)") "iSCC", "       reks energy  ", &
+      write(output,"(1X,A5,A20,A20,A13,A15)") "iSCC", "       reks energy  ", &
           & "      Diff energy   ", "      x_a    ", "   SCC error   "
     case (reksTypes%ssr44)
       call error("SSR(4,4) is not implemented yet")
@@ -4813,13 +4845,20 @@ contains
   end subroutine printReksSccHeader
 
 
-  subroutine printBlankLine()
-    write(stdOut, *)
+  subroutine printBlankLine(output)
+
+    !> Output for write processes
+    integer, intent(in) :: output
+
+    write(output, *)
   end subroutine printBlankLine
 
 
   !> Prints info about scc convergence.
-  subroutine printSccInfo(tDftbU, iSccIter, Eelec, diffElec, sccErrorQ)
+  subroutine printSccInfo(output, tDftbU, iSccIter, Eelec, diffElec, sccErrorQ)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Are orbital potentials being used
     logical, intent(in) :: tDftbU
@@ -4837,16 +4876,19 @@ contains
     real(dp), intent(in) :: sccErrorQ
 
     if (tDFTBU) then
-      write(stdOut, "(I5,E18.8,E18.8,E18.8)") iSCCIter, Eelec, diffElec, sccErrorQ
+      write(output, "(I5,E18.8,E18.8,E18.8)") iSCCIter, Eelec, diffElec, sccErrorQ
     else
-      write(stdOut, "(I5,E18.8,E18.8,E18.8)") iSCCIter, Eelec, diffElec, sccErrorQ
+      write(output, "(I5,E18.8,E18.8,E18.8)") iSCCIter, Eelec, diffElec, sccErrorQ
     end if
 
   end subroutine printSccInfo
 
 
   !> Prints info about electronic constraint convergence.
-  subroutine printElecConstrInfo(elecConstraint, iConstrIter, Eelec)
+  subroutine printElecConstrInfo(output, elecConstraint, iConstrIter, Eelec)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Represents electronic contraints
     type(TElecConstraint), intent(in) :: elecConstraint
@@ -4869,13 +4911,16 @@ contains
     ! Get maximum derivative of energy functional with respect to Vc
     dWdVcMax = elecConstraint%getMaxEnergyDerivWrtVc()
 
-    write(stdOut, "(T6,I5,3E18.8)") iConstrIter, Eelec, dWdVcMax, deltaWTotal
+    write(output, "(T6,I5,3E18.8)") iConstrIter, Eelec, deltaWTotal, dWdVcMax
 
   end subroutine printElecConstrInfo
 
 
   !> Prints info about scc convergence.
-  subroutine printReksSccInfo(iSccIter, Eavg, diffTotal, sccErrorQ, reks)
+  subroutine printReksSccInfo(output, iSccIter, Eavg, diffTotal, sccErrorQ, reks)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Iteration count
     integer, intent(in) :: iSccIter
@@ -4896,7 +4941,7 @@ contains
     select case (reks%reksAlg)
     case (reksTypes%noReks)
     case (reksTypes%ssr22)
-      write(stdOut,"(I5,4x,F16.10,3x,F16.10,3x,F10.6,3x,F11.8)") iSCCIter, Eavg,&
+      write(output,"(I5,4x,F16.10,3x,F16.10,3x,F10.6,3x,F11.8)") iSCCIter, Eavg,&
           & diffTotal, reks%FONs(1,1) * 0.5_dp, sccErrorQ
     case (reksTypes%ssr44)
       call error("SSR(4,4) is not implemented yet")
@@ -4918,109 +4963,101 @@ contains
     type(TDftbDeterminants), intent(in) :: deltaDftb
 
     !> Optional unit to print out the results
-    integer, intent(in), optional :: outUnit
+    integer, intent(in) :: outUnit
 
-    integer :: iUnit
-
-    if (present(outUnit)) then
-      iUnit = outUnit
-    else
-      iUnit = stdOut
-    end if
-
-    write(iUnit, *)
+    write(outUnit, *)
 
     if (deltaDftb%iGround > 0) then
 
       if (deltaDftb%isNonAufbau) then
-        write(iUnit, format2U) "Ground State Total Energy", energy(deltaDftb%iGround)%Etotal,"H",&
+        write(outUnit, format2U) "Ground State Total Energy", energy(deltaDftb%iGround)%Etotal,"H",&
             & Hartree__eV * energy(deltaDftb%iGround)%Etotal,"eV"
         if (electronicSolver%providesEigenvals) then
-          write(iUnit, format2U) "Ground State Extrapolated to 0K",&
+          write(outUnit, format2U) "Ground State Extrapolated to 0K",&
               & energy(deltaDftb%iGround)%Ezero, "H",&
               & Hartree__eV * energy(deltaDftb%iGround)%Ezero, "eV"
         end if
         if (electronicSolver%providesElectronEntropy) then
-          write(iUnit, format2U) "Total Ground State Mermin egy",&
+          write(outUnit, format2U) "Total Ground State Mermin egy",&
               & energy(deltaDftb%iGround)%EMermin, "H",&
               & Hartree__eV * energy(deltaDftb%iGround)%EMermin, "eV"
         end if
         if (electronicSolver%providesFreeEnergy) then
-          write(iUnit, format2U) 'Ground State Force related egy',&
+          write(outUnit, format2U) 'Ground State Force related egy',&
               & energy(deltaDftb%iGround)%EForceRelated, 'H',&
               & energy(deltaDftb%iGround)%EForceRelated * Hartree__eV, 'eV'
         end if
       else
-        write(iUnit, format2U) "Total Energy", energy(deltaDftb%iGround)%Etotal,"H",&
+        write(outUnit, format2U) "Total Energy", energy(deltaDftb%iGround)%Etotal,"H",&
             & Hartree__eV * energy(deltaDftb%iGround)%Etotal,"eV"
         if (electronicSolver%providesEigenvals) then
-          write(iUnit, format2U) "Extrapolated to 0K", energy(deltaDftb%iGround)%Ezero,&
+          write(outUnit, format2U) "Extrapolated to 0K", energy(deltaDftb%iGround)%Ezero,&
               & "H", Hartree__eV * energy(deltaDftb%iGround)%Ezero, "eV"
         end if
         if (electronicSolver%providesElectronEntropy) then
-          write(iUnit, format2U) "Total Mermin free energy", energy(deltaDftb%iGround)%EMermin,&
+          write(outUnit, format2U) "Total Mermin free energy", energy(deltaDftb%iGround)%EMermin,&
               & "H", Hartree__eV * energy(deltaDftb%iGround)%EMermin, "eV"
         end if
         if (electronicSolver%providesFreeEnergy) then
-          write(iUnit, format2U) 'Force related energy', energy(deltaDftb%iGround)%EForceRelated,&
+          write(outUnit, format2U) 'Force related energy', energy(deltaDftb%iGround)%EForceRelated,&
               & 'H', energy(deltaDftb%iGround)%EForceRelated * Hartree__eV, 'eV'
         end if
       end if
-      write(iUnit,*)
+      write(outUnit,*)
     end if
 
     if (deltaDftb%iTriplet > 0) then
 
-      write(iUnit, format2U) "Triplet State Total Energy", energy(deltaDftb%iTriplet)%Etotal,"H",&
+      write(outUnit, format2U) "Triplet State Total Energy", energy(deltaDftb%iTriplet)%Etotal,"H",&
           & Hartree__eV * energy(deltaDftb%iTriplet)%Etotal,"eV"
       if (electronicSolver%providesEigenvals) then
-        write(iUnit, format2U) "Triplet State Extrapolated to 0K",&
+        write(outUnit, format2U) "Triplet State Extrapolated to 0K",&
             & energy(deltaDftb%iTriplet)%Ezero, "H",&
             & Hartree__eV * energy(deltaDftb%iTriplet)%Ezero, "eV"
       end if
       if (electronicSolver%providesElectronEntropy) then
-        write(iUnit, format2U) "Triplet State Mermin free egy",&
+        write(outUnit, format2U) "Triplet State Mermin free egy",&
             & energy(deltaDftb%iTriplet)%EMermin, "H",&
             & Hartree__eV * energy(deltaDftb%iTriplet)%EMermin, "eV"
       end if
       if (electronicSolver%providesFreeEnergy) then
-        write(iUnit, format2U) 'Triplet State Force related egy',&
+        write(outUnit, format2U) 'Triplet State Force related egy',&
             & energy(deltaDftb%iTriplet)%EForceRelated, 'H',&
             & energy(deltaDftb%iTriplet)%EForceRelated * Hartree__eV, 'eV'
       end if
-      write(iUnit,*)
+      write(outUnit,*)
     end if
 
     if (deltaDftb%iMixed > 0) then
 
       if (deltaDftb%isSpinPurify) then
 
-        write(iUnit, format2U) "Purified State Total Energy", energy(deltaDftb%iFinal)%Etotal,"H",&
+        write(outUnit, format2U) "Purified State Total Energy", energy(deltaDftb%iFinal)%Etotal,"H",&
             & Hartree__eV * energy(deltaDftb%iFinal)%Etotal,"eV"
         if (electronicSolver%providesEigenvals) then
-          write(iUnit, format2U) "Purified Extrapolated 0K",&
+          write(outUnit, format2U) "Purified Extrapolated 0K",&
               & energy(deltaDftb%iFinal)%Ezero, "H",&
               & Hartree__eV * energy(deltaDftb%iFinal)%Ezero, "eV"
         end if
         if (electronicSolver%providesElectronEntropy) then
-          write(iUnit, format2U) "Purified State Mermin free egy",&
+          write(outUnit, format2U) "Purified State Mermin free egy",&
               & energy(deltaDftb%iFinal)%EMermin, "H",&
               & Hartree__eV * energy(deltaDftb%iFinal)%EMermin, "eV"
         end if
         if (electronicSolver%providesFreeEnergy) then
-          write(iUnit, format2U) 'Purified Force related egy',&
+          write(outUnit, format2U) 'Purified Force related egy',&
               & energy(deltaDftb%iFinal)%EForceRelated, 'H',&
               & energy(deltaDftb%iFinal)%EForceRelated * Hartree__eV, 'eV'
         end if
 
         if (deltaDftb%iGround > 0) then
-          write(iUnit, *)
-          write(iUnit, format2U) 'S0 -> T1',&
+          write(outUnit, *)
+          write(outUnit, format2U) 'S0 -> T1',&
               & energy(deltaDftb%iTriplet)%EForceRelated&
               & - energy(deltaDftb%iGround)%EForceRelated, 'H',&
               & (energy(deltaDftb%iTriplet)%EForceRelated&
               & - energy(deltaDftb%iGround)%EForceRelated) * Hartree__eV, 'eV'
-          write(iUnit, format2U) 'S0 -> S1',&
+          write(outUnit, format2U) 'S0 -> S1',&
               & energy(deltaDftb%iFinal)%EForceRelated - energy(deltaDftb%iGround)%EForceRelated,&
               & 'H',&
               & (energy(deltaDftb%iFinal)%EForceRelated - energy(deltaDftb%iGround)%EForceRelated)&
@@ -5029,27 +5066,27 @@ contains
 
       else
 
-        write(iUnit, format2U) "Mixed State Total Energy", energy(deltaDftb%iMixed)%Etotal,"H",&
+        write(outUnit, format2U) "Mixed State Total Energy", energy(deltaDftb%iMixed)%Etotal,"H",&
             & Hartree__eV * energy(deltaDftb%iMixed)%Etotal,"eV"
         if (electronicSolver%providesEigenvals) then
-          write(iUnit, format2U) "Mixed Extrapolated to 0K",&
+          write(outUnit, format2U) "Mixed Extrapolated to 0K",&
               & energy(deltaDftb%iMixed)%Ezero, "H",&
               & Hartree__eV * energy(deltaDftb%iMixed)%Ezero, "eV"
         end if
         if (electronicSolver%providesElectronEntropy) then
-          write(iUnit, format2U) "Mixed State Mermin free egy",&
+          write(outUnit, format2U) "Mixed State Mermin free egy",&
               & energy(deltaDftb%iMixed)%EMermin, "H",&
               & Hartree__eV * energy(deltaDftb%iMixed)%EMermin, "eV"
         end if
         if (electronicSolver%providesFreeEnergy) then
-          write(iUnit, format2U) 'Mixed State Force related egy',&
+          write(outUnit, format2U) 'Mixed State Force related egy',&
               & energy(deltaDftb%iMixed)%EForceRelated, 'H',&
               & energy(deltaDftb%iMixed)%EForceRelated * Hartree__eV, 'eV'
         end if
 
       end if
 
-      write(iUnit,*)
+      write(outUnit,*)
 
     end if
 
@@ -5094,7 +5131,10 @@ contains
 
 
   !> Prints pressure and free energy.
-  subroutine printPressureAndFreeEnergy(pressure, cellPressure, EGibbs)
+  subroutine printPressureAndFreeEnergy(output, pressure, cellPressure, EGibbs)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> applied external pressure
     real(dp), intent(in) :: pressure
@@ -5105,61 +5145,76 @@ contains
     !> Gibbs free energy (E -TS_elec +pV)
     real(dp), intent(in) :: EGibbs
 
-    write(stdOut, format2Ue) 'Pressure', cellPressure, 'au', cellPressure * au__pascal, 'Pa'
+    write(output, format2Ue) 'Pressure', cellPressure, 'au', cellPressure * au__pascal, 'Pa'
     if (abs(pressure) > epsilon(1.0_dp)) then
-      write(stdOut, format2U) "Gibbs free energy", EGibbs, 'H', Hartree__eV * EGibbs, 'eV'
+      write(output, format2U) "Gibbs free energy", EGibbs, 'H', Hartree__eV * EGibbs, 'eV'
     end if
 
   end subroutine printPressureAndFreeEnergy
 
 
   !> Writes maximal force component.
-  subroutine printMaxForce(maxForce)
+  subroutine printMaxForce(output, maxForce)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> maximum of the atomic forces
     real(dp), intent(in) :: maxForce
 
-    write(stdOut, "(A, ':', T30, E20.6)") "Maximal force component", maxForce
+    write(output, "(A, ':', T30, E20.6)") "Maximal force component", maxForce
 
   end subroutine printMaxForce
 
 
   !> Writes norm of the force
-  subroutine printForceNorm(forceNorm)
+  subroutine printForceNorm(output, forceNorm)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Norm of the force
     real(dp), intent(in) :: forceNorm
 
-    write(stdOut, "(A, ':', T30, E20.6)") "Averaged force norm", forceNorm
+    write(output, "(A, ':', T30, E20.6)") "Averaged force norm", forceNorm
 
   end subroutine printForceNorm
 
 
   !> Print maximal lattice force component
-  subroutine printMaxLatticeForce(maxLattForce)
+  subroutine printMaxLatticeForce(output, maxLattForce)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Maximum energy derivative with respect to lattice vectors
     real(dp), intent(in) :: maxLattForce
 
-    write(stdOut, format1Ue) "Maximal Lattice force component", maxLattForce, 'au'
+    write(output, format1Ue) "Maximal Lattice force component", maxLattForce, 'au'
 
   end subroutine printMaxLatticeForce
 
 
   !> Print norm of lattice force
-  subroutine printLatticeForceNorm(lattForceNorm)
+  subroutine printLatticeForceNorm(output, lattForceNorm)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Norm of the lattice force
     real(dp), intent(in) :: lattForceNorm
 
-    write(stdOut, format1Ue) "Averaged lattice force norm", lattForceNorm, 'au'
+    write(output, format1Ue) "Averaged lattice force norm", lattForceNorm, 'au'
 
   end subroutine printLatticeForceNorm
 
 
   !> Prints out info about current MD step.
-  subroutine printMdInfo(tSetFillingTemp, eField, tPeriodic, tempElec, tempIon, cellPressure,&
-      & pressure, energy)
+  subroutine printMdInfo(output, tSetFillingTemp, eField, tPeriodic, tempElec, tempIon,&
+      & cellPressure, pressure, energy, tempProfile)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Is the electronic temperature set by the thermostat method?
     logical, intent(in) :: tSetFillingTemp
@@ -5185,23 +5240,33 @@ contains
     !> data type for energy components and total
     type(TEnergies), intent(in) :: energy
 
+    !> Temperature profile in MD
+    type(TTempProfile), allocatable, intent(in) :: tempProfile
+
+    real(dp) :: temp
+
+    if (allocated(tempProfile)) then
+      call tempProfile%getTemperature(temp)
+      write(output, format2U)"Target MD temperature", temp, 'a.u.', temp / Boltzmann, 'K'
+    end if
+
     if (tSetFillingTemp) then
-      write(stdOut, format2U) 'Electronic Temperature', tempElec, 'H', tempElec / Boltzmann, 'K'
+      write(output, format2U) 'Electronic Temperature', tempElec, 'H', tempElec / Boltzmann, 'K'
     end if
     if (allocated(eField)) then
       if (allocated(eField%EFieldStrength)) then
-        write(stdOut, format1U1e) 'External E field', eField%absEField, 'au',&
+        write(output, format1U1e) 'External E field', eField%absEField, 'au',&
             & eField%absEField * au__V_m, 'V/m'
       end if
     end if
-    write(stdOut, format2U) "MD Temperature", tempIon, "H", tempIon / Boltzmann, "K"
-    write(stdOut, format2U) "MD Kinetic Energy", energy%Ekin, "H", Hartree__eV * energy%Ekin, "eV"
-    write(stdOut, format2U) "Total MD Energy", energy%EMerminKin, "H",&
+    write(output, format2U) "MD Temperature", tempIon, "H", tempIon / Boltzmann, "K"
+    write(output, format2U) "MD Kinetic Energy", energy%Ekin, "H", Hartree__eV * energy%Ekin, "eV"
+    write(output, format2U) "Total MD Energy", energy%EMerminKin, "H",&
         & Hartree__eV * energy%EMerminKin, "eV"
     if (tPeriodic) then
-      write(stdOut, format2Ue) 'Pressure', cellPressure, 'au', cellPressure * au__pascal, 'Pa'
+      write(output, format2Ue) 'Pressure', cellPressure, 'au', cellPressure * au__pascal, 'Pa'
       if (abs(pressure) < epsilon(1.0_dp)) then
-        write(stdOut, format2U) 'Gibbs free energy including KE', energy%EGibbsKin, 'H',&
+        write(output, format2U) 'Gibbs free energy including KE', energy%EGibbsKin, 'H',&
             & Hartree__eV * energy%EGibbsKin, 'eV'
       end if
     end if
@@ -5244,7 +5309,7 @@ contains
     @:ASSERT(env%tGlobalLead .eqv. allocated(socket))
 
     if (env%tGlobalLead) then
-      call socket%receive(coord0, tmpLatVecs, tStopDriver)
+      call socket%receive(env, coord0, tmpLatVecs, tStopDriver)
     end if
     tCoordsChanged = .true.
     if (tPeriodic .and. .not. tStopDriver) then
@@ -6168,7 +6233,10 @@ contains
 
 
   !> Write cavity information as cosmo file
-  subroutine writeCosmoFile(solvation, species0, speciesNames, coords0, energy)
+  subroutine writeCosmoFile(output, solvation, species0, speciesNames, coords0, energy)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Instance of the solvation model
     class(TSolvation), intent(in) :: solvation
@@ -6189,7 +6257,7 @@ contains
 
     select type(solvation)
     class is (TCosmo)
-      write(stdOut, '(*(a:, 1x))') "Cavity information written to", cosmoFile
+      write(output, '(*(a:, 1x))') "Cavity information written to", cosmoFile
       call openFile(file, cosmoFile, mode="w")
       call solvation%writeCosmoFile(file%unit, species0, speciesNames, coords0, energy)
       call closeFile(file)
@@ -6204,33 +6272,25 @@ contains
     !> quadrupole moment
     real(dp), intent(in), allocatable :: quadrupoleMoment(:,:)
 
-    !> Optional unit to print out the quadrupoleMoment
-    integer, intent(in), optional :: outUnit
+    !> Unit to print out the quadrupoleMoment
+    integer, intent(in) :: outUnit
 
-    integer :: iUnit
-
-    if (present(outUnit)) then
-      iUnit = outUnit
-    else
-      iUnit = stdOut
-    end if
-
-    write(iUnit, "(A)") ' Traceless Quadrupole moment in au'
-    write(iUnit, "(A, F14.8, A, F14.8, A, F14.8)") ' XX', quadrupoleMoment(1,1), ' YY',&
+    write(outUnit, "(A)") ' Traceless Quadrupole moment in au'
+    write(outUnit, "(A, F14.8, A, F14.8, A, F14.8)") ' XX', quadrupoleMoment(1,1), ' YY',&
         & quadrupoleMoment(2,2), ' ZZ', quadrupoleMoment(3,3)
-    write(iUnit, "(A, F14.8, A, F14.8, A, F14.8)") ' XY', quadrupoleMoment(1,2), ' XZ',&
+    write(outUnit, "(A, F14.8, A, F14.8, A, F14.8)") ' XY', quadrupoleMoment(1,2), ' XZ',&
         & quadrupoleMoment(1,3), ' YZ', quadrupoleMoment(2,3)
 
-    write(iUnit, "(A)") ' Traceless Quadrupole moment in Buckingham or Debye*Ang'
-    write(iUnit, "(A, F14.8, A, F14.8, A, F14.8)") ' XX',&
+    write(outUnit, "(A)") ' Traceless Quadrupole moment in Buckingham or Debye*Ang'
+    write(outUnit, "(A, F14.8, A, F14.8, A, F14.8)") ' XX',&
         & quadrupoleMoment(1,1) * au__Debye * Bohr__AA, ' YY',&
         & quadrupoleMoment(2,2) * au__Debye * Bohr__AA, ' ZZ',&
         & quadrupoleMoment(3,3) * au__Debye * Bohr__AA
-    write(iUnit, "(A, F14.8, A, F14.8, A, F14.8)") ' XY',&
+    write(outUnit, "(A, F14.8, A, F14.8, A, F14.8)") ' XY',&
         & quadrupoleMoment(1,2) * au__Debye * Bohr__AA, ' XZ',&
         & quadrupoleMoment(1,3) * au__Debye * Bohr__AA, ' YZ',&
         & quadrupoleMoment(2,3) * au__Debye * Bohr__AA
-    write(iUnit, *)
+    write(outUnit, *)
 
   end subroutine printQuadrupoleMoment
 

--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -3334,7 +3334,7 @@ contains
         & .false., tPrintMulliken, orbitalL, blockTmp, 2, allocated(blockTmp), iAtInCentralRegion,&
         & cm5Cont)
 
-    call printEnergies(dftbEnergy, electronicSolver, deltaDftb, fdDetailedOut%unit)
+    call printEnergies(fdDetailedOut%unit, dftbEnergy, electronicSolver, deltaDftb)
 
   end subroutine writeDetailedOut2Dets
 
@@ -3490,7 +3490,7 @@ contains
       end if
 
       if (isMdftb) then
-        call writeMdftbEnergies(energy, fd)
+        call writeMdftbEnergies(fd, energy)
       end if
 
       if (tDFTBU) then
@@ -3930,7 +3930,7 @@ contains
     end if
 
     if (allocated(quadrupoleMoment)) then
-      call printQuadrupoleMoment(quadrupoleMoment, fd)
+      call printQuadrupoleMoment(fd, quadrupoleMoment)
     end if
 
     if (allocated(eField)) then
@@ -4318,11 +4318,11 @@ contains
     end if
 
     if (deltaDftb%nDeterminant() > 1) then
-      call printEnergies(dftbEnergy, electronicSolver, deltaDftb, fd)
+      call printEnergies(fd, dftbEnergy, electronicSolver, deltaDftb)
     end if
 
     if (allocated(quadrupoleMoment)) then
-      call printQuadrupoleMoment(quadrupoleMoment, fd)
+      call printQuadrupoleMoment(fd, quadrupoleMoment)
     end if
 
   end subroutine writeMdOut2
@@ -4951,7 +4951,10 @@ contains
 
 
   !> Prints current total energies
-  subroutine printEnergies(energy, electronicSolver, deltaDftb, outUnit)
+  subroutine printEnergies(output, energy, electronicSolver, deltaDftb)
+
+    !> Output unit where results should be written to
+    integer, intent(in) :: output
 
     !> energy components, potentially from multiple determinants
     type(TEnergies), intent(in) :: energy(:)
@@ -4962,102 +4965,99 @@ contains
     !> type for DFTB determinants
     type(TDftbDeterminants), intent(in) :: deltaDftb
 
-    !> Optional unit to print out the results
-    integer, intent(in) :: outUnit
-
-    write(outUnit, *)
+    write(output, *)
 
     if (deltaDftb%iGround > 0) then
 
       if (deltaDftb%isNonAufbau) then
-        write(outUnit, format2U) "Ground State Total Energy", energy(deltaDftb%iGround)%Etotal,"H",&
+        write(output, format2U) "Ground State Total Energy", energy(deltaDftb%iGround)%Etotal,"H",&
             & Hartree__eV * energy(deltaDftb%iGround)%Etotal,"eV"
         if (electronicSolver%providesEigenvals) then
-          write(outUnit, format2U) "Ground State Extrapolated to 0K",&
+          write(output, format2U) "Ground State Extrapolated to 0K",&
               & energy(deltaDftb%iGround)%Ezero, "H",&
               & Hartree__eV * energy(deltaDftb%iGround)%Ezero, "eV"
         end if
         if (electronicSolver%providesElectronEntropy) then
-          write(outUnit, format2U) "Total Ground State Mermin egy",&
+          write(output, format2U) "Total Ground State Mermin egy",&
               & energy(deltaDftb%iGround)%EMermin, "H",&
               & Hartree__eV * energy(deltaDftb%iGround)%EMermin, "eV"
         end if
         if (electronicSolver%providesFreeEnergy) then
-          write(outUnit, format2U) 'Ground State Force related egy',&
+          write(output, format2U) 'Ground State Force related egy',&
               & energy(deltaDftb%iGround)%EForceRelated, 'H',&
               & energy(deltaDftb%iGround)%EForceRelated * Hartree__eV, 'eV'
         end if
       else
-        write(outUnit, format2U) "Total Energy", energy(deltaDftb%iGround)%Etotal,"H",&
+        write(output, format2U) "Total Energy", energy(deltaDftb%iGround)%Etotal,"H",&
             & Hartree__eV * energy(deltaDftb%iGround)%Etotal,"eV"
         if (electronicSolver%providesEigenvals) then
-          write(outUnit, format2U) "Extrapolated to 0K", energy(deltaDftb%iGround)%Ezero,&
+          write(output, format2U) "Extrapolated to 0K", energy(deltaDftb%iGround)%Ezero,&
               & "H", Hartree__eV * energy(deltaDftb%iGround)%Ezero, "eV"
         end if
         if (electronicSolver%providesElectronEntropy) then
-          write(outUnit, format2U) "Total Mermin free energy", energy(deltaDftb%iGround)%EMermin,&
+          write(output, format2U) "Total Mermin free energy", energy(deltaDftb%iGround)%EMermin,&
               & "H", Hartree__eV * energy(deltaDftb%iGround)%EMermin, "eV"
         end if
         if (electronicSolver%providesFreeEnergy) then
-          write(outUnit, format2U) 'Force related energy', energy(deltaDftb%iGround)%EForceRelated,&
+          write(output, format2U) 'Force related energy', energy(deltaDftb%iGround)%EForceRelated,&
               & 'H', energy(deltaDftb%iGround)%EForceRelated * Hartree__eV, 'eV'
         end if
       end if
-      write(outUnit,*)
+      write(output,*)
     end if
 
     if (deltaDftb%iTriplet > 0) then
 
-      write(outUnit, format2U) "Triplet State Total Energy", energy(deltaDftb%iTriplet)%Etotal,"H",&
+      write(output, format2U) "Triplet State Total Energy", energy(deltaDftb%iTriplet)%Etotal,"H",&
           & Hartree__eV * energy(deltaDftb%iTriplet)%Etotal,"eV"
       if (electronicSolver%providesEigenvals) then
-        write(outUnit, format2U) "Triplet State Extrapolated to 0K",&
+        write(output, format2U) "Triplet State Extrapolated to 0K",&
             & energy(deltaDftb%iTriplet)%Ezero, "H",&
             & Hartree__eV * energy(deltaDftb%iTriplet)%Ezero, "eV"
       end if
       if (electronicSolver%providesElectronEntropy) then
-        write(outUnit, format2U) "Triplet State Mermin free egy",&
+        write(output, format2U) "Triplet State Mermin free egy",&
             & energy(deltaDftb%iTriplet)%EMermin, "H",&
             & Hartree__eV * energy(deltaDftb%iTriplet)%EMermin, "eV"
       end if
       if (electronicSolver%providesFreeEnergy) then
-        write(outUnit, format2U) 'Triplet State Force related egy',&
+        write(output, format2U) 'Triplet State Force related egy',&
             & energy(deltaDftb%iTriplet)%EForceRelated, 'H',&
             & energy(deltaDftb%iTriplet)%EForceRelated * Hartree__eV, 'eV'
       end if
-      write(outUnit,*)
+      write(output,*)
     end if
 
     if (deltaDftb%iMixed > 0) then
 
       if (deltaDftb%isSpinPurify) then
 
-        write(outUnit, format2U) "Purified State Total Energy", energy(deltaDftb%iFinal)%Etotal,"H",&
+        write(output, format2U) "Purified State Total Energy", energy(deltaDftb%iFinal)%Etotal,"H",&
             & Hartree__eV * energy(deltaDftb%iFinal)%Etotal,"eV"
         if (electronicSolver%providesEigenvals) then
-          write(outUnit, format2U) "Purified Extrapolated 0K",&
+          write(output, format2U) "Purified Extrapolated 0K",&
               & energy(deltaDftb%iFinal)%Ezero, "H",&
               & Hartree__eV * energy(deltaDftb%iFinal)%Ezero, "eV"
         end if
         if (electronicSolver%providesElectronEntropy) then
-          write(outUnit, format2U) "Purified State Mermin free egy",&
+          write(output, format2U) "Purified State Mermin free egy",&
               & energy(deltaDftb%iFinal)%EMermin, "H",&
               & Hartree__eV * energy(deltaDftb%iFinal)%EMermin, "eV"
         end if
         if (electronicSolver%providesFreeEnergy) then
-          write(outUnit, format2U) 'Purified Force related egy',&
+          write(output, format2U) 'Purified Force related egy',&
               & energy(deltaDftb%iFinal)%EForceRelated, 'H',&
               & energy(deltaDftb%iFinal)%EForceRelated * Hartree__eV, 'eV'
         end if
 
         if (deltaDftb%iGround > 0) then
-          write(outUnit, *)
-          write(outUnit, format2U) 'S0 -> T1',&
+          write(output, *)
+          write(output, format2U) 'S0 -> T1',&
               & energy(deltaDftb%iTriplet)%EForceRelated&
               & - energy(deltaDftb%iGround)%EForceRelated, 'H',&
               & (energy(deltaDftb%iTriplet)%EForceRelated&
               & - energy(deltaDftb%iGround)%EForceRelated) * Hartree__eV, 'eV'
-          write(outUnit, format2U) 'S0 -> S1',&
+          write(output, format2U) 'S0 -> S1',&
               & energy(deltaDftb%iFinal)%EForceRelated - energy(deltaDftb%iGround)%EForceRelated,&
               & 'H',&
               & (energy(deltaDftb%iFinal)%EForceRelated - energy(deltaDftb%iGround)%EForceRelated)&
@@ -5066,27 +5066,27 @@ contains
 
       else
 
-        write(outUnit, format2U) "Mixed State Total Energy", energy(deltaDftb%iMixed)%Etotal,"H",&
+        write(output, format2U) "Mixed State Total Energy", energy(deltaDftb%iMixed)%Etotal,"H",&
             & Hartree__eV * energy(deltaDftb%iMixed)%Etotal,"eV"
         if (electronicSolver%providesEigenvals) then
-          write(outUnit, format2U) "Mixed Extrapolated to 0K",&
+          write(output, format2U) "Mixed Extrapolated to 0K",&
               & energy(deltaDftb%iMixed)%Ezero, "H",&
               & Hartree__eV * energy(deltaDftb%iMixed)%Ezero, "eV"
         end if
         if (electronicSolver%providesElectronEntropy) then
-          write(outUnit, format2U) "Mixed State Mermin free egy",&
+          write(output, format2U) "Mixed State Mermin free egy",&
               & energy(deltaDftb%iMixed)%EMermin, "H",&
               & Hartree__eV * energy(deltaDftb%iMixed)%EMermin, "eV"
         end if
         if (electronicSolver%providesFreeEnergy) then
-          write(outUnit, format2U) 'Mixed State Force related egy',&
+          write(output, format2U) 'Mixed State Force related egy',&
               & energy(deltaDftb%iMixed)%EForceRelated, 'H',&
               & energy(deltaDftb%iMixed)%EForceRelated * Hartree__eV, 'eV'
         end if
 
       end if
 
-      write(outUnit,*)
+      write(output,*)
 
     end if
 
@@ -6164,7 +6164,7 @@ contains
       end if
 
       if (isMdftb) then
-        call writeMdftbEnergies(energy, fd)
+        call writeMdftbEnergies(fd, energy)
       end if
 
     end if
@@ -6267,60 +6267,59 @@ contains
 
 
   !> Prints out the total quadrupole moment of the system
-  subroutine printQuadrupoleMoment(quadrupoleMoment, outUnit)
+  subroutine printQuadrupoleMoment(output, quadrupoleMoment)
+
+    !> Unit to print out the quadrupoleMoment
+    integer, intent(in) :: output
 
     !> quadrupole moment
     real(dp), intent(in), allocatable :: quadrupoleMoment(:,:)
 
-    !> Unit to print out the quadrupoleMoment
-    integer, intent(in) :: outUnit
-
-    write(outUnit, "(A)") ' Traceless Quadrupole moment in au'
-    write(outUnit, "(A, F14.8, A, F14.8, A, F14.8)") ' XX', quadrupoleMoment(1,1), ' YY',&
+    write(output, "(A)") ' Traceless Quadrupole moment in au'
+    write(output, "(A, F14.8, A, F14.8, A, F14.8)") ' XX', quadrupoleMoment(1,1), ' YY',&
         & quadrupoleMoment(2,2), ' ZZ', quadrupoleMoment(3,3)
-    write(outUnit, "(A, F14.8, A, F14.8, A, F14.8)") ' XY', quadrupoleMoment(1,2), ' XZ',&
+    write(output, "(A, F14.8, A, F14.8, A, F14.8)") ' XY', quadrupoleMoment(1,2), ' XZ',&
         & quadrupoleMoment(1,3), ' YZ', quadrupoleMoment(2,3)
 
-    write(outUnit, "(A)") ' Traceless Quadrupole moment in Buckingham or Debye*Ang'
-    write(outUnit, "(A, F14.8, A, F14.8, A, F14.8)") ' XX',&
+    write(output, "(A)") ' Traceless Quadrupole moment in Buckingham or Debye*Ang'
+    write(output, "(A, F14.8, A, F14.8, A, F14.8)") ' XX',&
         & quadrupoleMoment(1,1) * au__Debye * Bohr__AA, ' YY',&
         & quadrupoleMoment(2,2) * au__Debye * Bohr__AA, ' ZZ',&
         & quadrupoleMoment(3,3) * au__Debye * Bohr__AA
-    write(outUnit, "(A, F14.8, A, F14.8, A, F14.8)") ' XY',&
+    write(output, "(A, F14.8, A, F14.8, A, F14.8)") ' XY',&
         & quadrupoleMoment(1,2) * au__Debye * Bohr__AA, ' XZ',&
         & quadrupoleMoment(1,3) * au__Debye * Bohr__AA, ' YZ',&
         & quadrupoleMoment(2,3) * au__Debye * Bohr__AA
-    write(outUnit, *)
+    write(output, *)
 
   end subroutine printQuadrupoleMoment
 
 
   !> Writes the mdftb energy components.
-  subroutine writeMdftbEnergies(energy, iUnit)
+  subroutine writeMdftbEnergies(output, energy)
+
+    !> File unit to write out the mdftb energy components
+    integer, intent(in) :: output
 
     !> Energy terms in the system
     type(TEnergies), intent(in) :: energy
 
-    !> File unit to write out the mdftb energy components
-    integer, intent(in) :: iUnit
-
-
-    write(iUnit, format2U) 'Energy Monopole-Dipole', energy%EMdftbMD, 'H',&
+    write(output, format2U) 'Energy Monopole-Dipole', energy%EMdftbMD, 'H',&
         & energy%EMdftbMD * Hartree__eV, 'eV'
 
-    write(iUnit, format2U) 'Energy Dipole-Dipole', energy%EMdftbDD, 'H',&
+    write(output, format2U) 'Energy Dipole-Dipole', energy%EMdftbDD, 'H',&
         & energy%EMdftbDD * Hartree__eV, 'eV'
 
-    write(iUnit, format2U) 'Energy Monopole-Quadrupole', energy%EMdftbMQ, 'H',&
+    write(output, format2U) 'Energy Monopole-Quadrupole', energy%EMdftbMQ, 'H',&
         & energy%EMdftbMQ * Hartree__eV, 'eV'
 
-    write(iUnit, format2U) 'Energy Dipole-Quadrupole', energy%EMdftbDQ, 'H',&
+    write(output, format2U) 'Energy Dipole-Quadrupole', energy%EMdftbDQ, 'H',&
         & energy%EMdftbDQ * Hartree__eV, 'eV'
 
-    write(iUnit, format2U) 'Energy Quadrupole-Quadrupole', energy%EMdftbQQ, 'H',&
+    write(output, format2U) 'Energy Quadrupole-Quadrupole', energy%EMdftbQQ, 'H',&
         & energy%EMdftbQQ * Hartree__eV, 'eV'
 
-    write(iUnit, format2U) 'Energy Multipole', energy%EMdftb, 'H',&
+    write(output, format2U) 'Energy Multipole', energy%EMdftb, 'H',&
         & energy%EMdftb * Hartree__eV, 'eV'
 
   end subroutine writeMdftbEnergies

--- a/src/dftbp/dftbplus/mainio.F90
+++ b/src/dftbp/dftbplus/mainio.F90
@@ -2614,7 +2614,7 @@ contains
   !> Write the energy second derivative matrix
   subroutine writeHessianOut(output, fileName, pDynMatrix, indMovedAtoms, errStatus)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> File name
@@ -2672,7 +2672,7 @@ contains
   !> Write the dipole derivative wrt.coordinates matrix/Born charges
   subroutine writeBornChargesOut(output, fileName, pBornMatrix, indMovedAtoms, nDerivAtoms, errStatus)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> File name
@@ -2729,7 +2729,7 @@ contains
   !> Write the Derivatives of the polarizability
   subroutine writeBornDerivs(output, fileName, pdBornMatrix, indMovedAtoms, nDerivAtoms, errStatus)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> File name
@@ -4332,7 +4332,7 @@ contains
   subroutine writeCharges(output, fCharges, tWriteAscii, orb, qInput, qBlockIn, qiBlockIn, densityMatrix,&
       & tRealHS, nAtInCentralRegion, hybridXcAlg, coeffsAndShifts, multipoles)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> File name for charges to be written to
@@ -4733,7 +4733,7 @@ contains
   !> Write out final status of the geometry driver.
   subroutine writeFinalDriverStatus(output, tGeoOpt, tGeomEnd, tMd, tDerivs)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Is the geometry being optimised?
@@ -4774,7 +4774,7 @@ contains
   !> Prints geometry step information to standard out
   subroutine printGeoStepInfo(output, tCoordOpt, tLatOpt, iLatGeoStep, iGeoStep)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Are coordinates being optimised
@@ -4803,7 +4803,7 @@ contains
   !> Prints the line above the start of the SCC cycle data
   subroutine printSccHeader(output)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     write(output, "(A5, A18, A18, A18)") "iSCC", " Total electronic ", "  Diff electronic ",&
@@ -4815,7 +4815,7 @@ contains
   !> Prints the line above the start of the electronic constraints cycle data
   subroutine printElecConstrHeader(output)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     write(output, "(A6,A5,3A18)") repeat(" ", 6), "iConst", "  Total electronic",&
@@ -4827,7 +4827,7 @@ contains
   !> Prints the line above the start of the REKS SCC cycle data
   subroutine printReksSccHeader(output, reks)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> data type for REKS
@@ -4847,7 +4847,7 @@ contains
 
   subroutine printBlankLine(output)
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     write(output, *)
@@ -4857,7 +4857,7 @@ contains
   !> Prints info about scc convergence.
   subroutine printSccInfo(output, tDftbU, iSccIter, Eelec, diffElec, sccErrorQ)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Are orbital potentials being used
@@ -4887,7 +4887,7 @@ contains
   !> Prints info about electronic constraint convergence.
   subroutine printElecConstrInfo(output, elecConstraint, iConstrIter, Eelec)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Represents electronic contraints
@@ -4919,7 +4919,7 @@ contains
   !> Prints info about scc convergence.
   subroutine printReksSccInfo(output, iSccIter, Eavg, diffTotal, sccErrorQ, reks)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Iteration count
@@ -5133,7 +5133,7 @@ contains
   !> Prints pressure and free energy.
   subroutine printPressureAndFreeEnergy(output, pressure, cellPressure, EGibbs)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> applied external pressure
@@ -5156,7 +5156,7 @@ contains
   !> Writes maximal force component.
   subroutine printMaxForce(output, maxForce)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> maximum of the atomic forces
@@ -5170,7 +5170,7 @@ contains
   !> Writes norm of the force
   subroutine printForceNorm(output, forceNorm)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Norm of the force
@@ -5184,7 +5184,7 @@ contains
   !> Print maximal lattice force component
   subroutine printMaxLatticeForce(output, maxLattForce)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Maximum energy derivative with respect to lattice vectors
@@ -5198,7 +5198,7 @@ contains
   !> Print norm of lattice force
   subroutine printLatticeForceNorm(output, lattForceNorm)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Norm of the lattice force
@@ -5213,7 +5213,7 @@ contains
   subroutine printMdInfo(output, tSetFillingTemp, eField, tPeriodic, tempElec, tempIon,&
       & cellPressure, pressure, energy, tempProfile)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Is the electronic temperature set by the thermostat method?
@@ -6235,7 +6235,7 @@ contains
   !> Write cavity information as cosmo file
   subroutine writeCosmoFile(output, solvation, species0, speciesNames, coords0, energy)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Instance of the solvation model

--- a/src/dftbp/dftbplus/oldcompat.F90
+++ b/src/dftbp/dftbplus/oldcompat.F90
@@ -47,7 +47,7 @@ contains
   !> Converts an HSD input for an older parser to the current format
   subroutine convertOldHSD(output, root, oldVersion, curVersion)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
@@ -142,7 +142,7 @@ contains
   !> Converts input from version 2 to 3. (Version 3 introduced in Nov. 2006)
   subroutine convert_2_3(output, root)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
@@ -218,7 +218,7 @@ contains
   !> Converts input from version 3 to 4. (Version 4 introduced in Mar. 2010)
   subroutine convert_3_4(output, root)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
@@ -261,7 +261,7 @@ contains
   !> Helper function for Range keyword in convert_3_4
   subroutine replaceRange(output, node)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> node to process
@@ -288,7 +288,7 @@ contains
   !> Converts input from version 4 to 5. (Version 5 introduced in Dec. 2014)
   subroutine convert_4_5(output, root)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
@@ -397,7 +397,7 @@ contains
   !> Converts input from version 5 to 6. (Version 6 introduced in May. 2018)
   subroutine convert_5_6(output, root)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
@@ -454,7 +454,7 @@ contains
   !> Converts input from version 6 to 7. (Version 7 introduced in April 2019)
   subroutine convert_6_7(output, root)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
@@ -481,7 +481,7 @@ contains
   !> Converts input from version 7 to 8. (Version 8 introduced in October 2019)
   subroutine convert_7_8(output, root)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
@@ -534,7 +534,7 @@ contains
   !> Converts input from version 8 to 9. (Version 9 introduced in August 2020)
   subroutine convert_8_9(output, root)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
@@ -588,7 +588,7 @@ contains
   !> Converts input from version 9 to 10. (Version 10 introduced in November 2021)
   subroutine convert_9_10(output, root)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
@@ -769,7 +769,7 @@ contains
   !> Converts input from version 10 to 11. (Version 11 introduced in April 2022)
   subroutine convert_10_11(output, root)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
@@ -801,7 +801,7 @@ contains
   !> Converts input from version 11 to 12. (Version 12 introduced in June 2022)
   subroutine convert_11_12(output, root)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
@@ -832,7 +832,7 @@ contains
   !> Converts input from version 12 to 13. (Version 13 introduced in February 2023)
   subroutine convert_12_13(output, root)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
@@ -896,7 +896,7 @@ contains
   !> Converts input from version 13 to 14. (Version 14 introduced in August 2023)
   subroutine convert_13_14(output, root)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
@@ -987,7 +987,7 @@ contains
   !> Converts input from version 14 to 15. (Version 15 introduced in December 2025)
   subroutine convert_14_15(output, root)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
@@ -1047,7 +1047,7 @@ contains
   !> Update values in the DftD3 block to match behaviour of v6 parser
   subroutine handleD3Defaults(output, root)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root node of the HSD-tree
@@ -1081,7 +1081,7 @@ contains
   !> Helper routine to update values in the DftD3 block to match behaviour of v6 parser
   subroutine useDftb3Default(output, root, option, default)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root node of the HSD-tree

--- a/src/dftbp/dftbplus/oldcompat.F90
+++ b/src/dftbp/dftbplus/oldcompat.F90
@@ -45,7 +45,10 @@ contains
 
 
   !> Converts an HSD input for an older parser to the current format
-  subroutine convertOldHSD(root, oldVersion, curVersion)
+  subroutine convertOldHSD(output, root, oldVersion, curVersion)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
@@ -66,43 +69,43 @@ contains
         call convert_1_2(root)
         version = 2
       case(2)
-        call convert_2_3(root)
+        call convert_2_3(output, root)
         version = 3
       case (3)
-        call convert_3_4(root)
+        call convert_3_4(output, root)
         version = 4
       case (4)
-        call convert_4_5(root)
+        call convert_4_5(output, root)
         version = 5
       case (5)
-        call convert_5_6(root)
+        call convert_5_6(output, root)
         version = 6
       case (6)
-        call convert_6_7(root)
+        call convert_6_7(output, root)
         version = 7
       case (7)
-        call convert_7_8(root)
+        call convert_7_8(output, root)
         version = 8
       case (8)
-        call convert_8_9(root)
+        call convert_8_9(output, root)
         version = 9
       case (9)
-        call convert_9_10(root)
+        call convert_9_10(output, root)
         version = 10
       case (10)
-        call convert_10_11(root)
+        call convert_10_11(output, root)
         version = 11
       case (11)
-        call convert_11_12(root)
+        call convert_11_12(output, root)
         version = 12
       case (12)
-        call convert_12_13(root)
+        call convert_12_13(output, root)
         version = 13
       case (13)
-        call convert_13_14(root)
+        call convert_13_14(output, root)
         version = 14
       case (14)
-        call convert_14_15(root)
+        call convert_14_15(output, root)
         version = 15
       end select
     end do
@@ -137,7 +140,10 @@ contains
 
 
   !> Converts input from version 2 to 3. (Version 3 introduced in Nov. 2006)
-  subroutine convert_2_3(root)
+  subroutine convert_2_3(output, root)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
@@ -149,7 +155,7 @@ contains
         &"Driver/VelocityVerlet/Thermostat/Andersen/RescalingProbability", &
         &ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword renamed to 'ReselectProbability'.")
+      call detailedWarning(output, ch1, "Keyword renamed to 'ReselectProbability'.")
       call setNodeName(ch1, "ReselectProbability")
     end if
 
@@ -157,7 +163,7 @@ contains
         &"Driver/VelocityVerlet/Thermostat/Andersen/RescaleIndividually", &
         &ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword renamed to 'ReselectIndividually'.")
+      call detailedWarning(output, ch1, "Keyword renamed to 'ReselectIndividually'.")
       call setNodeName(ch1, "ReselectIndividually")
     end if
 
@@ -169,7 +175,7 @@ contains
         call detailedError(ch1, "Sorry, non-variational energy calculation &
             &is not supported any more!")
       else
-        call detailedWarning(ch1, "Energy calculation is made only variational, option removed.")
+        call detailedWarning(output, ch1, "Energy calculation is made only variational, option removed.")
         call destroyNode(ch1)
       end if
     end if
@@ -181,27 +187,27 @@ contains
       if (tValue) then
         call setChildValue(par, "OrbitalResolvedSCC", .true., child=ch2)
         call setUnprocessed(ch2)
-        call detailedWarning(ch2, "Calculations are not orbital resolved &
+        call detailedWarning(output, ch2, "Calculations are not orbital resolved &
             &per default any more. Keyword 'OrbitalResolvedSCC' added.")
       end if
     end if
 
     call getDescendant(root, "Options/PrintEigenvectors", ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword converted to 'WriteEigenvectors'")
+      call detailedWarning(output, ch1, "Keyword converted to 'WriteEigenvectors'")
       call setNodeName(ch1, "WriteEigenvectors")
     end if
 
     call getDescendant(root, "Options/WriteTaggedOut", ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword converted to 'WriteAutotestTag'. &
+      call detailedWarning(output, ch1, "Keyword converted to 'WriteAutotestTag'. &
           &Output file name changed to 'autotest.out'")
       call setNodeName(ch1, "WriteAutotestTag")
     end if
 
     call getDescendant(root, "Options/WriteBandDat", ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword converted to 'WriteBandOut'. &
+      call detailedWarning(output, ch1, "Keyword converted to 'WriteBandOut'. &
           &Output file name changed to 'band.out'")
       call setNodeName(ch1, "WriteBandOut")
     end if
@@ -210,7 +216,10 @@ contains
 
 
   !> Converts input from version 3 to 4. (Version 4 introduced in Mar. 2010)
-  subroutine convert_3_4(root)
+  subroutine convert_3_4(output, root)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
@@ -221,13 +230,13 @@ contains
 
     ! Replace range operator with short start:end syntax
     call getDescendant(root, "Driver/SteepestDescent/MovedAtoms", node)
-    call replaceRange(node)
+    call replaceRange(output, node)
     call getDescendant(root, "Driver/ConjugateGradient/MovedAtoms", node)
-    call replaceRange(node)
+    call replaceRange(output, node)
     call getDescendant(root, "Driver/SecondDerivatives/Atoms", node)
-    call replaceRange(node)
+    call replaceRange(output, node)
     call getDescendant(root, "Driver/VelocityVerlet/MovedAtoms", node)
-    call replaceRange(node)
+    call replaceRange(output, node)
     call getDescendant(root, "Hamiltonian/DFTB/SpinPolarisation/Colinear&
         &/InitialSpin", node)
     if (associated(node)) then
@@ -235,7 +244,7 @@ contains
       do ii = 1, getLength(children)
         call getItem1(children, ii, node2)
         call getChild(node2, "Atoms", node3)
-        call replaceRange(node3)
+        call replaceRange(output, node3)
       end do
       call destroyNodeList(children)
     end if
@@ -243,14 +252,17 @@ contains
     call getDescendant(root, "Hamiltonian/DFTB/SpinPolarisation/Colinear&
         &/InitialSpin", node)
     if (associated(node)) then
-      call detailedWarning(node, "Keyword renamed to 'InitialSpins'.")
+      call detailedWarning(output, node, "Keyword renamed to 'InitialSpins'.")
       call setNodeName(node, "InitialSpins")
     end if
 
   end subroutine convert_3_4
 
   !> Helper function for Range keyword in convert_3_4
-  subroutine replaceRange(node)
+  subroutine replaceRange(output, node)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> node to process
     type(fnode), pointer :: node
@@ -265,7 +277,7 @@ contains
         call removeChildNodes(node)
         call setChildValue(node, "", &
             &i2c(bounds(1)) // ":" // i2c(bounds(2)), replace=.true.)
-        call detailedWarning(node, "Specification 'Range { start end }' &
+        call detailedWarning(output, node, "Specification 'Range { start end }' &
             &not supported any more, using 'start:end' instead")
       end if
     end if
@@ -274,7 +286,10 @@ contains
 
 
   !> Converts input from version 4 to 5. (Version 5 introduced in Dec. 2014)
-  subroutine convert_4_5(root)
+  subroutine convert_4_5(output, root)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
@@ -284,14 +299,14 @@ contains
 
     call getDescendant(root, "Hamiltonian/DFTB/Eigensolver/Standard", ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword renamed to 'QR'.")
+      call detailedWarning(output, ch1, "Keyword renamed to 'QR'.")
       call setNodeName(ch1, "QR")
     end if
 
     call getDescendant(root, "Options/MullikenAnalysis", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(ch1, "", tVal)
-      call detailedWarning(ch1, "Keyword moved to Analysis block.")
+      call detailedWarning(output, ch1, "Keyword moved to Analysis block.")
       tmpNodeRef => removeChild(par, ch1)
       call destroyNode(ch1)
       call getChildValue(root, "Analysis", tmpNodeRef, "", child=ch1, list=.true., &
@@ -306,7 +321,7 @@ contains
     call getDescendant(root, "Options/AtomResolvedEnergies", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(par, "AtomResolvedEnergies", tVal)
-      call detailedWarning(ch1, "Keyword moved to Analysis block.")
+      call detailedWarning(output, ch1, "Keyword moved to Analysis block.")
       tmpNodeRef => removeChild(par,ch1)
       call destroyNode(ch1)
       call getChildValue(root, "Analysis", tmpNodeRef, "", child=ch1, list=.true., &
@@ -321,7 +336,7 @@ contains
     call getDescendant(root, "Options/WriteEigenvectors", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(par, "WriteEigenvectors", tVal)
-      call detailedWarning(ch1, "Keyword moved to Analysis block.")
+      call detailedWarning(output, ch1, "Keyword moved to Analysis block.")
       tmpNodeRef => removeChild(par, ch1)
       call destroyNode(ch1)
       call getChildValue(root, "Analysis", tmpNodeRef, "", child=ch1, list=.true., &
@@ -336,7 +351,7 @@ contains
     call getDescendant(root, "Options/WriteBandOut", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(par, "WriteBandOut", tVal)
-      call detailedWarning(ch1, "Keyword moved to Analysis block.")
+      call detailedWarning(output, ch1, "Keyword moved to Analysis block.")
       tmpNodeRef => removeChild(par, ch1)
       call destroyNode(ch1)
       call getChildValue(root, "Analysis", tmpNodeRef, "", child=ch1, list=.true., &
@@ -351,7 +366,7 @@ contains
     call getDescendant(root, "Options/CalculateForces", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(par, "CalculateForces", tVal)
-      call detailedWarning(ch1, "Keyword moved to Analysis block.")
+      call detailedWarning(output, ch1, "Keyword moved to Analysis block.")
       tmpNodeRef => removeChild(par,ch1)
       call destroyNode(ch1)
       call getChildValue(root, "Analysis", tmpNodeRef, "", child=ch1, list=.true., &
@@ -368,7 +383,7 @@ contains
       call setChild(ch1, "Differentiation", ch2)
       call setChild(ch2, "FiniteDiff", ch3)
       call setChildValue(ch3, "Delta", 1.0e-2_dp)
-      call detailedWarning(ch2, "Adding legacy step size for finite difference&
+      call detailedWarning(output, ch2, "Adding legacy step size for finite difference&
           & differentiation")
     end if
 
@@ -380,7 +395,10 @@ contains
   end subroutine convert_4_5
 
   !> Converts input from version 5 to 6. (Version 6 introduced in May. 2018)
-  subroutine convert_5_6(root)
+  subroutine convert_5_6(output, root)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
@@ -391,13 +409,13 @@ contains
 
     call getDescendant(root, "Analysis/Localise/PipekMezey/Tollerance", ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword converted to 'Tolerance'.")
+      call detailedWarning(output, ch1, "Keyword converted to 'Tolerance'.")
       call setNodeName(ch1, "Tolerance")
     end if
 
     call getDescendant(root, "Analysis/Localise/PipekMezey/SparseTollerances", ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword converted to 'SparseTollerances'.")
+      call detailedWarning(output, ch1, "Keyword converted to 'SparseTollerances'.")
       call setNodeName(ch1, "SparseTolerances")
     end if
 
@@ -411,7 +429,7 @@ contains
       if (associated(ch2)) then
         call getChildValue(par, "DampXHExponent", rTmp)
       end if
-      call detailedWarning(ch1, "Keyword DampXH moved to HCorrection block")
+      call detailedWarning(output, ch1, "Keyword DampXH moved to HCorrection block")
       tmpNodeRef => removeChild(par,ch1)
       call destroyNode(ch1)
       tmpNodeRef => removeChild(par,ch2)
@@ -427,14 +445,17 @@ contains
       call setChild(ch2, "HCorrection", ch3)
       call setChild(ch3, "Damping", ch4)
       call setChildValue(ch4, "Exponent", rTmp)
-      call detailedWarning(ch3, "Adding Damping to HCorrection")
+      call detailedWarning(output, ch3, "Adding Damping to HCorrection")
     end if
 
   end subroutine convert_5_6
 
 
   !> Converts input from version 6 to 7. (Version 7 introduced in April 2019)
-  subroutine convert_6_7(root)
+  subroutine convert_6_7(output, root)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
@@ -443,14 +464,14 @@ contains
 
     call getDescendant(root, "Hamiltonian/DFTB/OrbitalResolvedSCC", ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword converted to 'ShellResolvedSCC'.")
+      call detailedWarning(output, ch1, "Keyword converted to 'ShellResolvedSCC'.")
       call setNodeName(ch1, "ShellResolvedSCC")
     end if
-    call handleD3Defaults(root)
+    call handleD3Defaults(output, root)
 
     call getDescendant(root, "Hamiltonian/DFTB/Eigensolver", ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword renamed to 'Solver'.")
+      call detailedWarning(output, ch1, "Keyword renamed to 'Solver'.")
       call setNodeName(ch1, "Solver")
     end if
 
@@ -458,7 +479,10 @@ contains
 
 
   !> Converts input from version 7 to 8. (Version 8 introduced in October 2019)
-  subroutine convert_7_8(root)
+  subroutine convert_7_8(output, root)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
@@ -470,7 +494,7 @@ contains
 
     call getDescendant(root, "Analysis/EigenvectorsAsTxt", ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword converted to 'EigenvectorsAsText'.")
+      call detailedWarning(output, ch1, "Keyword converted to 'EigenvectorsAsText'.")
       call setNodeName(ch1, "EigenvectorsAsText")
     end if
 
@@ -496,10 +520,10 @@ contains
       call getChildValue(ch1, "", tVal)
       call setUnprocessed(ch1)
       if (tVal) then
-        call detailedWarning(ch1, "Sorry, XML export of the dftb_in.hsd is not supported any more&
+        call detailedWarning(output, ch1, "Sorry, XML export of the dftb_in.hsd is not supported any more&
             & so is removed")
       else
-        call detailedWarning(ch1, "XML export option is removed.")
+        call detailedWarning(output, ch1, "XML export option is removed.")
       end if
       call destroyNode(ch1)
     end if
@@ -508,7 +532,10 @@ contains
 
 
   !> Converts input from version 8 to 9. (Version 9 introduced in August 2020)
-  subroutine convert_8_9(root)
+  subroutine convert_8_9(output, root)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
@@ -533,13 +560,13 @@ contains
       if (tVal1 .and. .not.tVal2) then
         call getDescendant(root, "Hamiltonian/DFTB/Filling", ch1)
         if (associated(ch1)) then
-          call detailedWarning(ch1, "Restarted electronDynamics does not require Filling{}&
+          call detailedWarning(output, ch1, "Restarted electronDynamics does not require Filling{}&
               & settings unless projected onto ground state")
           call destroyNode(ch1)
         end if
         call getDescendant(root, "Analysis", ch1)
         if (associated(ch1)) then
-          call detailedWarning(ch1, "Restarted electronDynamics does not use the Analysis{} block")
+          call detailedWarning(output, ch1, "Restarted electronDynamics does not use the Analysis{} block")
           call destroyNode(ch1)
         end if
       end if
@@ -549,17 +576,20 @@ contains
     if (associated(ch1)) then
       call setChildValue(ch1, "LineSearch", .true., child=ch2)
       call setUnprocessed(ch2)
-      call detailedWarning(ch2, "Set 'LineSearch = Yes'")
+      call detailedWarning(output, ch2, "Set 'LineSearch = Yes'")
       call setChildValue(ch1, "oldLineSearch", .true., child=ch2)
       call setUnprocessed(ch2)
-      call detailedWarning(ch2, "Set 'oldLineSearch = Yes'")
+      call detailedWarning(output, ch2, "Set 'oldLineSearch = Yes'")
     end if
 
   end subroutine convert_8_9
 
 
   !> Converts input from version 9 to 10. (Version 10 introduced in November 2021)
-  subroutine convert_9_10(root)
+  subroutine convert_9_10(output, root)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
@@ -573,7 +603,7 @@ contains
       tmpNodeRef => removeChild(ch1, ch2)
       call getChildValue(ch1, "TestArnoldi", tVal2, default=.false., child=ch2)
       tmpNodeRef => removeChild(ch1, ch2)
-      call detailedWarning(ch1, "Keyword moved to Diagonaliser block.")
+      call detailedWarning(output, ch1, "Keyword moved to Diagonaliser block.")
       call setUnprocessed(ch1)
       call setChild(ch1, "Diagonaliser", ch2)
       call setUnprocessed(ch2)
@@ -590,7 +620,7 @@ contains
     call getDescendant(root, "Hamiltonian/Dispersion/Ts/ConvergentSCCOnly", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(par, "ConvergentSCCOnly", tVal1)
-      call detailedWarning(ch1, "Keyword Moved to Hamiltonian {}.")
+      call detailedWarning(output, ch1, "Keyword Moved to Hamiltonian {}.")
       tmpNodeRef => removeChild(par, ch1)
       call destroyNode(ch1)
       call getDescendant(root, "Hamiltonian", ch1)
@@ -601,7 +631,7 @@ contains
     call getDescendant(root, "Hamiltonian/Dispersion/Mbd/ConvergentSCCOnly", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(par, "ConvergentSCCOnly", tVal1)
-      call detailedWarning(ch1, "Keyword Moved to Hamiltonian {}.")
+      call detailedWarning(output, ch1, "Keyword Moved to Hamiltonian {}.")
       tmpNodeRef => removeChild(par, ch1)
       call destroyNode(ch1)
       call getDescendant(root, "Hamiltonian/ConvergentSCCOnly", ch3)
@@ -616,7 +646,7 @@ contains
     call getDescendant(root, "Driver/ConjugateGradient/ConvergentForcesOnly", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(par, "ConvergentForcesOnly", tVal1)
-      call detailedWarning(ch1, "Keyword Moved to Hamiltonian {}.")
+      call detailedWarning(output, ch1, "Keyword Moved to Hamiltonian {}.")
       tmpNodeRef => removeChild(par, ch1)
       call destroyNode(ch1)
       call getDescendant(root, "Hamiltonian/ConvergentSCCOnly", ch3)
@@ -631,7 +661,7 @@ contains
     call getDescendant(root, "Driver/VelocityVerlet/ConvergentForcesOnly", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(par, "ConvergentForcesOnly", tVal1)
-      call detailedWarning(ch1, "Keyword Moved to Hamiltonian {}.")
+      call detailedWarning(output, ch1, "Keyword Moved to Hamiltonian {}.")
       tmpNodeRef => removeChild(par, ch1)
       call destroyNode(ch1)
       call getDescendant(root, "Hamiltonian/ConvergentSCCOnly", ch3)
@@ -646,7 +676,7 @@ contains
     call getDescendant(root, "Driver/SteepestDescent/ConvergentForcesOnly", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(par, "ConvergentForcesOnly", tVal1)
-      call detailedWarning(ch1, "Keyword Moved to Hamiltonian {}.")
+      call detailedWarning(output, ch1, "Keyword Moved to Hamiltonian {}.")
       tmpNodeRef => removeChild(par, ch1)
       call destroyNode(ch1)
       call getDescendant(root, "Hamiltonian/ConvergentSCCOnly", ch3)
@@ -661,7 +691,7 @@ contains
     call getDescendant(root, "Driver/gDiis/ConvergentForcesOnly", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(par, "ConvergentForcesOnly", tVal1)
-      call detailedWarning(ch1, "Keyword Moved to Hamiltonian {}.")
+      call detailedWarning(output, ch1, "Keyword Moved to Hamiltonian {}.")
       tmpNodeRef => removeChild(par, ch1)
       call destroyNode(ch1)
       call getDescendant(root, "Hamiltonian/ConvergentSCCOnly", ch3)
@@ -676,7 +706,7 @@ contains
     call getDescendant(root, "Driver/LBfgs/ConvergentForcesOnly", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(par, "ConvergentForcesOnly", tVal1)
-      call detailedWarning(ch1, "Keyword Moved to Hamiltonian {}.")
+      call detailedWarning(output, ch1, "Keyword Moved to Hamiltonian {}.")
       tmpNodeRef => removeChild(par, ch1)
       call destroyNode(ch1)
       call getDescendant(root, "Hamiltonian/ConvergentSCCOnly", ch3)
@@ -691,7 +721,7 @@ contains
     call getDescendant(root, "Driver/Fire/ConvergentForcesOnly", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(par, "ConvergentForcesOnly", tVal1)
-      call detailedWarning(ch1, "Keyword Moved to Hamiltonian {}.")
+      call detailedWarning(output, ch1, "Keyword Moved to Hamiltonian {}.")
       tmpNodeRef => removeChild(par, ch1)
       call destroyNode(ch1)
       call getDescendant(root, "Hamiltonian/ConvergentSCCOnly", ch3)
@@ -706,7 +736,7 @@ contains
     call getDescendant(root, "Driver/SecondDerivatives/ConvergentForcesOnly", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(par, "ConvergentForcesOnly", tVal1)
-      call detailedWarning(ch1, "Keyword Moved to Hamiltonian {}.")
+      call detailedWarning(output, ch1, "Keyword Moved to Hamiltonian {}.")
       tmpNodeRef => removeChild(par, ch1)
       call destroyNode(ch1)
       call getDescendant(root, "Hamiltonian/ConvergentSCCOnly", ch3)
@@ -721,7 +751,7 @@ contains
     call getDescendant(root, "Driver/Socket/ConvergentForcesOnly", ch1, parent=par)
     if (associated(ch1)) then
       call getChildValue(par, "ConvergentForcesOnly", tVal1)
-      call detailedWarning(ch1, "Keyword Moved to Hamiltonian {}.")
+      call detailedWarning(output, ch1, "Keyword Moved to Hamiltonian {}.")
       tmpNodeRef => removeChild(par, ch1)
       call destroyNode(ch1)
       call getDescendant(root, "Hamiltonian/ConvergentSCCOnly", ch3)
@@ -737,7 +767,10 @@ contains
 
 
   !> Converts input from version 10 to 11. (Version 11 introduced in April 2022)
-  subroutine convert_10_11(root)
+  subroutine convert_10_11(output, root)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
@@ -746,19 +779,19 @@ contains
 
     call getDescendant(root, "Hamiltonian/DFTB/Solvation/GeneralizedBorn", ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "Set solvated field scaling (RescaleSolvatedFields) to No.")
+      call detailedWarning(output, ch1, "Set solvated field scaling (RescaleSolvatedFields) to No.")
       call setChildValue(ch1, "RescaleSolvatedFields", .false., child=ch2, replace=.true.)
     end if
 
     call getDescendant(root, "Hamiltonian/DFTB/Solvation/Cosmo", ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "Set solvated field scaling (RescaleSolvatedFields) to No.")
+      call detailedWarning(output, ch1, "Set solvated field scaling (RescaleSolvatedFields) to No.")
       call setChildValue(ch1, "RescaleSolvatedFields", .false., child=ch2, replace=.true.)
     end if
 
     call getDescendant(root, "Hamiltonian/DFTB/Solvation/Sasa", ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "Set solvated field scaling (RescaleSolvatedFields) to No.")
+      call detailedWarning(output, ch1, "Set solvated field scaling (RescaleSolvatedFields) to No.")
       call setChildValue(ch1, "RescaleSolvatedFields", .false., child=ch2, replace=.true.)
     end if
 
@@ -766,7 +799,10 @@ contains
 
 
   !> Converts input from version 11 to 12. (Version 12 introduced in June 2022)
-  subroutine convert_11_12(root)
+  subroutine convert_11_12(output, root)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
@@ -783,7 +819,7 @@ contains
         call getDescendant(root, "Hamiltonian/${LABEL}$/Charge", ch1)
         if (associated(ch1)) then
           call setUnprocessed(ch1)
-          call detailedWarning(ch1, "Device region charge cannot be set if contacts are present.")
+          call detailedWarning(output, ch1, "Device region charge cannot be set if contacts are present.")
           call destroyNode(ch1)
         end if
       #:endfor
@@ -794,7 +830,10 @@ contains
 
 
   !> Converts input from version 12 to 13. (Version 13 introduced in February 2023)
-  subroutine convert_12_13(root)
+  subroutine convert_12_13(output, root)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
@@ -815,13 +854,13 @@ contains
 
       call getDescendant(root, "Analysis/Eta", ch1)
       if (associated(ch1)) then
-        call detailedWarning(ch1, "Keyword renamed to 'PerturbEta'.")
+        call detailedWarning(output, ch1, "Keyword renamed to 'PerturbEta'.")
         call setNodeName(ch1, "PerturbEta")
       end if
 
       call getDescendant(root, "Analysis/DegeneracyTolerance", ch1)
       if (associated(ch1)) then
-        call detailedWarning(ch1, "Keyword renamed to 'PertubDegenTol'.")
+        call detailedWarning(output, ch1, "Keyword renamed to 'PertubDegenTol'.")
         call setNodeName(ch1, "PertubDegenTol")
       end if
 
@@ -855,7 +894,10 @@ contains
 
 
   !> Converts input from version 13 to 14. (Version 14 introduced in August 2023)
-  subroutine convert_13_14(root)
+  subroutine convert_13_14(output, root)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
@@ -869,13 +911,13 @@ contains
 
     call getDescendant(root, "Analysis/CalculateForces", ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "Keyword renamed to 'PrintForces'.")
+      call detailedWarning(output, ch1, "Keyword renamed to 'PrintForces'.")
       call setNodeName(ch1, "PrintForces")
     end if
 
     call getDescendant(root, "Hamiltonian/DFTB/Rangeseparated", ch1)
     if (associated(ch1)) then
-      call detailedWarning(ch1, "'Hamiltonian/DFTB/Rangeseparated' block renamed to&
+      call detailedWarning(output, ch1, "'Hamiltonian/DFTB/Rangeseparated' block renamed to&
           & 'Hamiltonian/DFTB/Hybrid'.")
       call setNodeName(ch1, "Hybrid")
     end if
@@ -891,13 +933,13 @@ contains
         if (iOrder > 1) then
           write(strtmp,"(A,I0,A,I0,A)")"Older Methfessel-Paxton requested order of ", iOrder,&
               & " is now equivalent to ", (iOrder -1), " from parser version 14."
-          call detailedWarning(ch2, strTmp)
+          call detailedWarning(output, ch2, strTmp)
         elseif (iOrder == 1) then
           write(strtmp,"(A)")"Older Methfessel-Paxton requested order of 1 is now&
               & equivalent to Gaussian smearing (order 0) from parser version 14." // newline //&
               & "   Please test your calculation carefully, due to a (corrected) error for array&
               & bounds in this case. "
-          call detailedWarning(ch2, strTmp)
+          call detailedWarning(output, ch2, strTmp)
         else
           write(strtmp,"(A,I0,A,I0,A)")"Older Methfessel-Paxton requested order of ", iOrder,&
               & " is now equivalent to a negative order of ", (iOrder -1), " from parser version 14&
@@ -909,7 +951,7 @@ contains
         iOrder = iOrder - 1
         call setChildValue(ch1, "Order", iOrder, child=ch2)
       else
-        call detailedWarning(ch1, "The default (i.e. unspecified) Methfessel-Paxton order in old&
+        call detailedWarning(output, ch1, "The default (i.e. unspecified) Methfessel-Paxton order in old&
             & code versions was equivalent to Order=1." // newline //&
             & "   This order is now the current default order from parser version 14.")
       end if
@@ -936,14 +978,17 @@ contains
       tmpNodeRef => removeChild(par,ch1)
       call destroyNode(ch1)
       call setChildValue(par, "PerturbDegenTol", rTol * epsilon(0.0_dp), child=ch1)
-      call detailedWarning(par, "Keyword renamed to 'PerturbDegenTol'.")
+      call detailedWarning(output, par, "Keyword renamed to 'PerturbDegenTol'.")
     end if
 
   end subroutine convert_13_14
 
 
   !> Converts input from version 14 to 15. (Version 15 introduced in December 2025)
-  subroutine convert_14_15(root)
+  subroutine convert_14_15(output, root)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root tag of the HSD-tree
     type(fnode), pointer :: root
@@ -954,7 +999,7 @@ contains
     call getDescendant(root, "Hamiltonian/xTB/SpinConstants", ch1)
     if (associated(ch1)) then
       call setChildValue(ch1, "FromParameters", .false., child=ch2)
-      call detailedWarning(ch1, 'Keyword "FromParameters" for xTB set as false.')
+      call detailedWarning(output, ch1, 'Keyword "FromParameters" for xTB set as false.')
       call setUnprocessed(ch2)
     end if
 
@@ -967,7 +1012,7 @@ contains
           & ch1, parent=par)
       if (associated(ch1)) then
         call getChildValue(par, "RecomputeAfterDensity", isRecomputed)
-        call detailedWarning(ch1, "Keyword Moved to Hamiltonian {} block.")
+        call detailedWarning(output, ch1, "Keyword Moved to Hamiltonian {} block.")
         tmpNodeRef => removeChild(par, ch1)
         call destroyNode(ch1)
       else
@@ -984,14 +1029,14 @@ contains
     call getDescendant(root, "Hamiltonian/DFTB/Dispersion/Ts/EnergyAccuracy", ch1)
     if (associated(ch1)) then
       call setUnprocessed(ch1)
-      call detailedWarning(ch1, "The energy accuracy setting will be ignored as it is not&
+      call detailedWarning(output, ch1, "The energy accuracy setting will be ignored as it is not&
           & supported/need by libMBD any more")
       call destroyNode(ch1)
     end if
     call getDescendant(root, "Hamiltonian/DFTB/Dispersion/Ts/ForceAccuracy", ch1)
     if (associated(ch1)) then
       call setUnprocessed(ch1)
-      call detailedWarning(ch1, "The force accuracy setting will be ignored as it is not&
+      call detailedWarning(output, ch1, "The force accuracy setting will be ignored as it is not&
           & supported/need by libMBD any more")
       call destroyNode(ch1)
     end if
@@ -1000,7 +1045,10 @@ contains
 
 
   !> Update values in the DftD3 block to match behaviour of v6 parser
-  subroutine handleD3Defaults(root)
+  subroutine handleD3Defaults(output, root)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root node of the HSD-tree
     type(fnode), pointer :: root
@@ -1013,8 +1061,8 @@ contains
       return
     end if
 
-    call useDftb3Default(pD3, "s6", 1.0_dp)
-    call useDftb3Default(pD3, "s8", 0.5883_dp)
+    call useDftb3Default(output, pD3, "s6", 1.0_dp)
+    call useDftb3Default(output, pD3, "s8", 0.5883_dp)
 
     call getChildValue(pD3, "Damping", pDampMethod, default="BeckeJohnson", child=pChild)
     call setUnprocessed(pChild)
@@ -1023,15 +1071,18 @@ contains
 
     select case (char(buffer))
     case ("beckejohnson")
-      call useDftb3Default(pDampMethod, "a1", 0.5719_dp)
-      call useDftb3Default(pDampMethod, "a2", 3.6017_dp)
+      call useDftb3Default(output, pDampMethod, "a1", 0.5719_dp)
+      call useDftb3Default(output, pDampMethod, "a2", 3.6017_dp)
     end select
 
   end subroutine handleD3Defaults
 
 
   !> Helper routine to update values in the DftD3 block to match behaviour of v6 parser
-  subroutine useDftb3Default(root, option, default)
+  subroutine useDftb3Default(output, root, option, default)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root node of the HSD-tree
     type(fnode), pointer, intent(in) :: root
@@ -1047,7 +1098,7 @@ contains
     call getChild(root, option, pChild, requested=.false.)
     if (.not. associated(pChild)) then
       call setChildValue(root, option, default, child=pChild)
-      call detailedWarning(pChild, "Using DFTB3 optimised default value for parameter " // option)
+      call detailedWarning(output, pChild, "Using DFTB3 optimised default value for parameter " // option)
     end if
     call setUnprocessed(pChild)
 

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -2652,7 +2652,7 @@ contains
     !> Default temperature for filling
     real(dp), intent(in) :: temperatureDefault
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     type(fnode), pointer :: value1, child, child2, child3, field
@@ -2745,7 +2745,7 @@ contains
     !> Poisson solver paramenters
     type(TPoissonInfo), intent(inout) :: poisson
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     type(fnode), pointer :: value1, child
@@ -3014,7 +3014,7 @@ contains
   !> Set the maximum number of SCC cycles, depending on k-point behaviour
   subroutine maxSelfConsIterations(output, node, ctrl, label, maxSccIter)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Relevant node in input tree
@@ -5861,7 +5861,7 @@ contains
     !> Atomic geometry of the system, including atomic species information
     type(TGeometry), intent(in) :: geom
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     type(fnode), pointer :: value1, value2, child, child2
@@ -5979,7 +5979,7 @@ contains
     !> Atomic geometry of the system, including atomic species information
     type(TGeometry), intent(in) :: geom
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     select case(ctrl%hamiltonian)

--- a/src/dftbp/dftbplus/parser.F90
+++ b/src/dftbp/dftbplus/parser.F90
@@ -12,9 +12,10 @@
 module dftbp_dftbplus_parser
   use dftbp_common_accuracy, only : distFudge, distFudgeOld, dp, lc, mc, minTemp, sc
   use dftbp_common_constants, only : Bohr__AA, boltzmann, maxL, pi, shellNames, symbolToNumber
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
   use dftbp_common_filesystem, only : findFile, getParamSearchPaths, joinPathsPrettyErr
-  use dftbp_common_globalenv, only : abortProgram, stdout, withMpi, withScalapack
+  use dftbp_common_globalenv, only : abortProgram, withMpi, withScalapack
   use dftbp_common_hamiltoniantypes, only : hamiltonianTypes
   use dftbp_common_status, only : TStatus
   use dftbp_common_unitconversion, only : angularUnits, chargeUnits, dipoleUnits, EFieldUnits,&
@@ -144,7 +145,10 @@ contains
 
 
   !> Parse input from an HSD file
-  subroutine parseHsdTree(hsdTree, input, parserFlags)
+  subroutine parseHsdTree(env, hsdTree, input, parserFlags)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Tree representation of the input
     type(fnode), pointer :: hsdTree
@@ -161,26 +165,26 @@ contains
     logical :: tReadAnalysis
     integer, allocatable :: implicitParserVersion
 
-    write(stdout, '(A,1X,I0,/)') 'Parser version:', parserVersion
-    write(stdout, "(A)") repeat("-", 80)
+    write(env%stdOut, '(A,1X,I0,/)') 'Parser version:', parserVersion
+    write(env%stdOut, "(A)") repeat("-", 80)
 
     call getChild(hsdTree, rootTag, root)
 
     call handleInputVersion(root, implicitParserVersion)
     call getChildValue(root, "ParserOptions", placeholder, "", child=child, list=.true.,&
         & allowEmptyValue=.true., dontMarkProcessed=.true.)
-    call readParserOptions(child, root, parserFlags, implicitParserVersion)
+    call readParserOptions(env, child, root, parserFlags, implicitParserVersion)
 
     ! Read the geometry unless the list of atoms has been provided through the API
     if (.not. allocated(input%geom%coords)) then
       call getChild(root, "Geometry", tmp)
-      call readGeometry(tmp, input)
+      call readGeometry(env, tmp, input)
     end if
     input%geom%areContactsPresent = .false.
 
     ! Hamiltonian settings that need to know settings from the REKS block
     call getChildValue(root, "Reks", placeholder, "None", child=child)
-    call readReks(placeholder, child, input%ctrl, input%geom)
+    call readReks(env, placeholder, child, input%ctrl, input%geom)
 
     call getChild(root, "Transport", child, requested=.false.)
 
@@ -188,7 +192,7 @@ contains
 
     ! Read in transport and modify geometry if it is only a contact calculation
     if (associated(child)) then
-      call readTransportGeometry(child, input%geom, input%transpar)
+      call readTransportGeometry(env, child, input%geom, input%transpar)
     else
       input%transpar%ncont=0
       allocate(input%transpar%contacts(0))
@@ -204,7 +208,7 @@ contains
 
     ! electronic Hamiltonian
     call getChildValue(root, "Hamiltonian", hamNode)
-    call readHamiltonian(hamNode, input%ctrl, input%geom, input%slako, input%transpar,&
+    call readHamiltonian(env, hamNode, input%ctrl, input%geom, input%slako, input%transpar,&
         & input%ginfo%greendens, input%poisson, errStatus)
 
   #:else
@@ -215,7 +219,7 @@ contains
 
     ! electronic Hamiltonian
     call getChildValue(root, "Hamiltonian", hamNode)
-    call readHamiltonian(hamNode, input%ctrl, input%geom, input%slako, input%poisson, errStatus)
+    call readHamiltonian(env, hamNode, input%ctrl, input%geom, input%slako, input%poisson, errStatus)
 
   #:endif
 
@@ -225,16 +229,16 @@ contains
 
     call getChildValue(root, "Driver", driverNode, "", child=child, allowEmptyValue=.true.)
   #:if WITH_TRANSPORT
-    call readDriver(driverNode, child, input%geom, input%ctrl, input%transpar)
+    call readDriver(env, driverNode, child, input%geom, input%ctrl, input%transpar)
   #:else
-    call readDriver(driverNode, child, input%geom, input%ctrl)
+    call readDriver(env, driverNode, child, input%geom, input%ctrl)
   #:endif
 
     tReadAnalysis = .true.
     call getChild(root, "ElectronDynamics", child=child, requested=.false.)
     if (associated(child)) then
       allocate(input%ctrl%elecDynInp)
-      call readElecDynamics(child, input%ctrl%elecDynInp, input%geom, input%ctrl%masses)
+      call readElecDynamics(env, child, input%ctrl%elecDynInp, input%geom, input%ctrl%masses)
       if (input%ctrl%elecDynInp%tReadRestart .and. .not.input%ctrl%elecDynInp%tPopulations) then
         tReadAnalysis = .false.
       end if
@@ -247,12 +251,12 @@ contains
           & allowEmptyValue=.true., dontMarkProcessed=.true.)
 
     #:if WITH_TRANSPORT
-      call readAnalysis(analysisNode, input%ctrl, input%geom, input%slako%orb, input%transpar, &
+      call readAnalysis(env, analysisNode, input%ctrl, input%geom, input%slako%orb, input%transpar, &
           & input%ginfo%tundos)
 
       call finalizeNegf(input)
     #:else
-      call readAnalysis(analysisNode, input%ctrl, input%geom)
+      call readAnalysis(env, analysisNode, input%ctrl, input%geom)
     #:endif
 
     end if
@@ -262,11 +266,11 @@ contains
     call readExcited(child, input%geom, input%ctrl)
 
     ! Hamiltonian settings that need to know about settings from the blocks above
-    call readLaterHamiltonian(hamNode, input%ctrl, driverNode, input%geom)
+    call readLaterHamiltonian(hamNode, input%ctrl, driverNode, input%geom, env%stdOut)
 
     call getChildValue(root, "Options", placeholder, "", child=child, list=.true.,&
         & allowEmptyValue=.true., dontMarkProcessed=.true.)
-    call readOptions(child, input%ctrl, input%geom)
+    call readOptions(env, child, input%ctrl, input%geom)
 
     ! W values if needed by Hamiltonian or excited state calculation
     if (allocated(input%ctrl%tbliteInp)) then
@@ -282,7 +286,7 @@ contains
     end if
 
     ! read parallel calculation settings
-    call readParallel(root, input)
+    call readParallel(env, root, input)
 
     ! input data strucutre has been initialised
     input%tInitialized = .true.
@@ -316,7 +320,10 @@ contains
 
 
   !> Read in parser options (options not passed to the main code)
-  subroutine readParserOptions(node, root, flags, implicitVersion)
+  subroutine readParserOptions(env, node, root, flags, implicitVersion)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to get the information from
     type(fnode), pointer :: node
@@ -336,9 +343,9 @@ contains
 
     call getChild(node, "ParserVersion", child, requested=.false.)
     if (.not. associated(child) .and. .not. present(implicitVersion)) then
-      call detailedWarning(root, "Input containing neither InputVersion nor ParserVersion is&
-          & DEPRECATED!(!!) Specify the InputVersion keyword in your input to ensure that future&
-          & versions of DFTB+ can also parse it.")
+      call detailedWarning(env%stdOut, root, "Input containing neither InputVersion nor&
+          & ParserVersion is DEPRECATED!(!!) Specify the InputVersion keyword in your input to&
+          & ensure that future versions of DFTB+ can also parse it.")
       inputVersion = parserVersion
       call setChildValue(node, "ParserVersion", inputVersion)
     else if (.not. associated(child) .and. present(implicitVersion)) then
@@ -361,15 +368,15 @@ contains
           & "Sorry, no compatibility mode for parser version " // i2c(inputVersion)&
           & // " (too old)")
     else if (inputVersion /= parserVersion) then
-      write(stdout, "(A,I2,A,I2,A)") "***  Converting input from parser version ",&
+      write(env%stdOut, "(A,I2,A,I2,A)") "***  Converting input from parser version ",&
           & inputVersion, " to parser version ", parserVersion, " ..."
-      call convertOldHSD(root, inputVersion, parserVersion)
-      write(stdout, "(A,/)") "***  Done."
+      call convertOldHSD(env%stdOut, root, inputVersion, parserVersion)
+      write(env%stdOut, "(A,/)") "***  Done."
     end if
 
     call getChildValue(node, "WriteHSDInput", flags%tWriteHSD, .true.)
     if (.not. flags%tWriteHSD) then
-      call detailedWarning(node, "WriteHSDInput turned off. You are not guaranteed" // newline // &
+      call detailedWarning(env%stdOut, node, "WriteHSDInput turned off. You are not guaranteed" // newline // &
           &" to able to obtain the same results with a later version of the code!" // newline // &
           & "(the dftb_pin.hsd file DOES guarantee this)")
     end if
@@ -381,7 +388,10 @@ contains
 
 
   !> Read in Geometry
-  subroutine readGeometry(node, input)
+  subroutine readGeometry(env, node, input)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to get the information from
     type(fnode), pointer :: node
@@ -398,13 +408,13 @@ contains
     input%geom%tHelical = .false.
     select case (char(buffer))
     case ("genformat")
-      call readTGeometryGen(value1, input%geom)
+      call readTGeometryGen(env, value1, input%geom)
     case ("xyzformat")
       call readTGeometryXyz(value1, input%geom)
     case ("vaspformat")
-      call readTGeometryVasp(value1, input%geom)
+      call readTGeometryVasp(env, value1, input%geom)
     case ("lammpsformat")
-      call readTGeometryLammps(value1, input%geom)
+      call readTGeometryLammps(env, value1, input%geom)
     case default
       call setUnprocessed(value1)
       call readTGeometryHSD(child, input%geom)
@@ -415,10 +425,13 @@ contains
 
   !> Read in driver properties
 #:if WITH_TRANSPORT
-  subroutine readDriver(node, parent, geom, ctrl, transpar)
+  subroutine readDriver(env, node, parent, geom, ctrl, transpar)
 #:else
-  subroutine readDriver(node, parent, geom, ctrl)
+  subroutine readDriver(env, node, parent, geom, ctrl)
 #:endif
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to get the information from
     type(fnode), pointer :: node
@@ -484,7 +497,7 @@ contains
 
       allocate(ctrl%geoOpt)
 
-      call readGeoOptInput(node, geom, ctrl%geoOpt, atomsRange)
+      call readGeoOptInput(env, node, geom, ctrl%geoOpt, atomsRange)
 
       call getChildValue(node, "AppendGeometries", ctrl%tAppendGeo, .false.)
 
@@ -496,29 +509,29 @@ contains
     case ("steepestdescent")
 
       modeName = "geometry relaxation"
-      call detailedWarning(node, "This driver is deprecated and will be removed in future&
+      call detailedWarning(env%stdOut, node, "This driver is deprecated and will be removed in future&
           & versions."//new_line('a')//&
           & "Please use the GeometryOptimisation driver instead.")
 
       ! Steepest downhill optimisation
       ctrl%iGeoOpt = geoOptTypes%steepestDesc
 
-      call commonGeoOptions(node, ctrl, geom, atomsRange)
+      call commonGeoOptions(env, node, ctrl, geom, atomsRange)
 
     case ("conjugategradient")
 
       modeName = "geometry relaxation"
-      call detailedWarning(node, "This driver is deprecated and will be removed in future&
+      call detailedWarning(env%stdOut, node, "This driver is deprecated and will be removed in future&
           & versions."//new_line('a')// "Please use the GeometryOptimisation driver instead.")
 
       ! Conjugate gradient location optimisation
       ctrl%iGeoOpt = geoOptTypes%conjugateGrad
-      call commonGeoOptions(node, ctrl, geom, atomsRange)
+      call commonGeoOptions(env, node, ctrl, geom, atomsRange)
 
     case("gdiis")
 
       modeName = "geometry relaxation"
-      call detailedWarning(node, "This driver is deprecated and will be removed in future&
+      call detailedWarning(env%stdOut, node, "This driver is deprecated and will be removed in future&
           & versions."//new_line('a')//&
           & "Please use the GeometryOptimisation driver instead.")
 
@@ -526,12 +539,12 @@ contains
       ctrl%iGeoOpt = geoOptTypes%diis
       call getChildValue(node, "alpha", ctrl%deltaGeoOpt, 1.0E-1_dp)
       call getChildValue(node, "Generations", ctrl%iGenGeoOpt, 8)
-      call commonGeoOptions(node, ctrl, geom, atomsRange)
+      call commonGeoOptions(env, node, ctrl, geom, atomsRange)
 
     case ("lbfgs")
 
       modeName = "geometry relaxation"
-      call detailedWarning(node, "This driver is deprecated and will be removed in future&
+      call detailedWarning(env%stdOut, node, "This driver is deprecated and will be removed in future&
           & versions."//new_line('a')//&
           & "Please use the GeometryOptimisation driver instead.")
 
@@ -550,19 +563,19 @@ contains
         call getChildValue(node, "oldLineSearch", ctrl%lbfgsInp%isOldLS, .false.)
       end if
 
-      call commonGeoOptions(node, ctrl, geom, atomsRange,&
+      call commonGeoOptions(env, node, ctrl, geom, atomsRange,&
           & isMaxAtStepNeeded=ctrl%lbfgsInp%isLineSearch,&
           & isMaxLatStepNeeded=ctrl%lbfgsInp%isLineSearch)
 
     case ("fire")
 
       modeName = "geometry relaxation"
-      call detailedWarning(node, "This driver is deprecated and will be removed in future&
+      call detailedWarning(env%stdOut, node, "This driver is deprecated and will be removed in future&
           & versions."//new_line('a')//&
           & "Please use the GeometryOptimisation driver instead.")
 
       ctrl%iGeoOpt = geoOptTypes%fire
-      call commonGeoOptions(node, ctrl, geom, atomsRange, isMaxAtStepNeeded=.false.)
+      call commonGeoOptions(env, node, ctrl, geom, atomsRange, isMaxAtStepNeeded=.false.)
       call getChildValue(node, "TimeStep", ctrl%deltaT, 1.0_dp, modifier=modifier, child=field)
       call convertUnitHsd(char(modifier), timeUnits, field, ctrl%deltaT)
 
@@ -575,8 +588,8 @@ contains
       ctrl%tForces = .true.
 
       call getChildValue(node, "Atoms", buffer2, trim(atomsRange), child=child, multiple=.true.)
-      call getSelectedAtomIndices(child, char(buffer2), geom%speciesNames, geom%species,&
-          & ctrl%indDerivAtom)
+      call getSelectedAtomIndices(env%stdOut, child, char(buffer2), geom%speciesNames,&
+          & geom%species, ctrl%indDerivAtom)
       if (size(ctrl%indDerivAtom) == 0) then
         call error("No atoms specified for derivatives calculation.")
       end if
@@ -588,7 +601,7 @@ contains
             & "Atoms for calculation of partial Hessian must be a contiguous range.")
         end if
         call getChildValue(child, "", buffer2, child=child2, multiple=.true.)
-        call getSelectedAtomIndices(child2, char(buffer2), geom%speciesNames, geom%species, &
+        call getSelectedAtomIndices(env%stdOut, child2, char(buffer2), geom%speciesNames, geom%species, &
            & ctrl%indMovedAtom)
         if (.not. isContiguousRange(ctrl%indMovedAtom)) then
           call detailedError(child2, "MovedAtoms for calculation of partial Hessian must be a &
@@ -617,7 +630,7 @@ contains
       call getChildValue(node, "MDRestartFrequency", ctrl%restartFreq, 1)
       call getChildValue(node, "MovedAtoms", buffer2, trim(atomsRange), child=child, &
           &multiple=.true.)
-      call getSelectedAtomIndices(child, char(buffer2), geom%speciesNames, geom%species, &
+      call getSelectedAtomIndices(env%stdOut, child, char(buffer2), geom%speciesNames, geom%species, &
           & ctrl%indMovedAtom)
       ctrl%nrMoved = size(ctrl%indMovedAtom)
       if (ctrl%nrMoved == 0) then
@@ -700,7 +713,7 @@ contains
         call readXlbomdOptions(node, ctrl%xlbomd)
       end if
 
-      call getInputMasses(node, geom, ctrl%masses)
+      call getInputMasses(env, node, geom, ctrl%masses)
 
     case ("socket")
       ! external socket control of the run (once initialised from input)
@@ -832,7 +845,12 @@ contains
 
 
   !> Common geometry optimisation settings for various drivers
-  subroutine commonGeoOptions(node, ctrl, geom, atomsRange, isMaxAtStepNeeded, isMaxLatStepNeeded)
+  subroutine commonGeoOptions(env, node, ctrl, geom, atomsRange, isMaxAtStepNeeded,&
+      & isMaxLatStepNeeded)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
+
 
     !> Node to get the information from
     type(fnode), pointer :: node
@@ -884,7 +902,7 @@ contains
       end if
     end if
     call getChildValue(node, "MovedAtoms", buffer2, trim(atomsRange), child=child, multiple=.true.)
-    call getSelectedAtomIndices(child, char(buffer2), geom%speciesNames, geom%species,&
+    call getSelectedAtomIndices(env%stdOut, child, char(buffer2), geom%speciesNames, geom%species,&
         & ctrl%indMovedAtom)
 
     ctrl%nrMoved = size(ctrl%indMovedAtom)
@@ -1071,7 +1089,11 @@ contains
 
 
   !> Reads atomic masses from input file, eventually overwriting those in the SK files
-  subroutine getInputMasses(node, geom, masses)
+  subroutine getInputMasses(env, node, geom, masses)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
+
 
     !> Relevant node of input data
     type(fnode), pointer :: node
@@ -1104,13 +1126,14 @@ contains
     do ii = 1, getLength(children)
       call getItem1(children, ii, child2)
       call getChildValue(child2, "Atoms", buffer, child=child3, multiple=.true.)
-      call getSelectedAtomIndices(child3, char(buffer), geom%speciesNames, geom%species, pTmpI1)
+      call getSelectedAtomIndices(env%stdOut, child3, char(buffer), geom%speciesNames,&
+          & geom%species, pTmpI1)
       call getChildValue(child2, "MassPerAtom", rTmp, modifier=modifier, child=child)
       call convertUnitHsd(char(modifier), massUnits, child, rTmp)
       do jj = 1, size(pTmpI1)
         iAt = pTmpI1(jj)
         if (masses(iAt) >= 0.0_dp) then
-          call detailedWarning(child3, "Previous setting for the mass  of atom" // i2c(iAt) //&
+          call detailedWarning(env%stdOut, child3, "Previous setting for the mass  of atom" // i2c(iAt) //&
               & " overwritten")
         end if
         masses(iAt) = rTmp
@@ -1124,10 +1147,13 @@ contains
 
   !> Reads Hamiltonian
 #:if WITH_TRANSPORT
-  subroutine readHamiltonian(node, ctrl, geom, slako, tp, greendens, poisson, errStatus)
+  subroutine readHamiltonian(env, node, ctrl, geom, slako, tp, greendens, poisson, errStatus)
 #:else
-  subroutine readHamiltonian(node, ctrl, geom, slako, poisson, errStatus)
+  subroutine readHamiltonian(env, node, ctrl, geom, slako, poisson, errStatus)
 #:endif
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to get the information from
     type(fnode), pointer :: node
@@ -1162,16 +1188,16 @@ contains
     select case (char(buffer))
     case ("dftb")
   #:if WITH_TRANSPORT
-      call readDFTBHam(node, ctrl, geom, slako, tp, greendens, poisson, errStatus)
+      call readDFTBHam(env, node, ctrl, geom, slako, tp, greendens, poisson, errStatus)
   #:else
-      call readDFTBHam(node, ctrl, geom, slako, poisson, errStatus)
+      call readDFTBHam(env, node, ctrl, geom, slako, poisson, errStatus)
   #:endif
       @:PROPAGATE_ERROR(errStatus)
     case ("xtb")
   #:if WITH_TRANSPORT
-      call readXTBHam(node, ctrl, geom, tp, greendens, poisson, errStatus)
+      call readXTBHam(env, node, ctrl, geom, tp, greendens, poisson, errStatus)
   #:else
-      call readXTBHam(node, ctrl, geom, poisson, errStatus)
+      call readXTBHam(env, node, ctrl, geom, poisson, errStatus)
   #:endif
       @:PROPAGATE_ERROR(errStatus)
     case default
@@ -1192,10 +1218,13 @@ contains
 
   !> Reads DFTB-Hamiltonian
 #:if WITH_TRANSPORT
-  subroutine readDFTBHam(node, ctrl, geom, slako, tp, greendens, poisson, errStatus)
+  subroutine readDFTBHam(env, node, ctrl, geom, slako, tp, greendens, poisson, errStatus)
 #:else
-  subroutine readDFTBHam(node, ctrl, geom, slako, poisson, errStatus)
+  subroutine readDFTBHam(env, node, ctrl, geom, slako, poisson, errStatus)
 #:endif
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to get the information from
     type(fnode), pointer :: node
@@ -1399,18 +1428,18 @@ contains
     if (.not. allocated(ctrl%hybridXcInp)) then
       call getChild(node, "TruncateSKRange", child, requested=.false.)
       if (associated(child)) then
-        call warning("Artificially truncating the SK table, this is normally a bad idea!")
+        call warning(env%stdOut, "Artificially truncating the SK table, this is normally a bad idea!")
         call SKTruncations(child, rSKCutOff, skInterMeth)
-        call readSKFiles(skFiles, geom%nSpecies, slako, slako%orb, angShells, ctrl%tShellResolved,&
-            & skInterMeth, repPoly, rSKCutOff)
+        call readSKFiles(env, skFiles, geom%nSpecies, slako, slako%orb, angShells,&
+            & ctrl%tShellResolved, skInterMeth, repPoly, rSKCutOff)
       else
         rSKCutOff = 0.0_dp
-        call readSKFiles(skFiles, geom%nSpecies, slako, slako%orb, angShells, ctrl%tShellResolved,&
-            & skInterMeth, repPoly)
+        call readSKFiles(env, skFiles, geom%nSpecies, slako, slako%orb, angShells,&
+            & ctrl%tShellResolved, skInterMeth, repPoly)
       end if
     else
-      call readSKFiles(skFiles, geom%nSpecies, slako, slako%orb, angShells, ctrl%tShellResolved,&
-          & skInterMeth, repPoly, hybridXcSK=hybridXcSK)
+      call readSKFiles(env, skFiles, geom%nSpecies, slako, slako%orb, angShells,&
+          & ctrl%tShellResolved, skInterMeth, repPoly, hybridXcSK=hybridXcSK)
       ctrl%hybridXcInp%omega = hybridXcSK%omega
       ctrl%hybridXcInp%camAlpha = hybridXcSK%camAlpha
       ctrl%hybridXcInp%camBeta = hybridXcSK%camBeta
@@ -1430,7 +1459,7 @@ contains
     ifSCC: if (ctrl%tSCC) then
 
       ! get charge mixing options
-      call readSccOptions(node, ctrl, geom)
+      call readSccOptions(env, node, ctrl, geom)
 
       ! DFTB hydrogen bond corrections
       call readHCorrection(node, geom, ctrl)
@@ -1452,12 +1481,12 @@ contains
     end if ifSCC
 
     ! Customize the reference atomic charges for virtual doping
-    call readCustomReferenceOcc(node, slako%orb, slako%skOcc, geom, &
+    call readCustomReferenceOcc(env, node, slako%orb, slako%skOcc, geom, &
         & ctrl%customOccAtoms, ctrl%customOccFillings)
 
     ! Spin calculation
     if (ctrl%reksInp%reksAlg == reksTypes%noReks  .and. .not.ctrl%isNonAufbau) then
-      call readSpinPolarisation(node, ctrl, geom)
+      call readSpinPolarisation(env, node, ctrl, geom)
     end if
 
     ! temporararily removed until debugged
@@ -1469,14 +1498,14 @@ contains
     ctrl%tReadShifts = .false.
 
     ! External fields and potentials
-    call readExternal(node, ctrl, geom)
+    call readExternal(env, node, ctrl, geom)
 
     ! Non-self-consistent spin-orbit coupling
     call readSpinOrbit(node, ctrl, geom, slako%orb)
 
     ! Electronic solver
   #:if WITH_TRANSPORT
-    call readSolver(node, ctrl, geom, tp, greendens, poisson)
+    call readSolver(node, ctrl, geom, tp, greendens, poisson, env%stdOut)
 
     if (tp%taskUpload) then
       ! Initialise variable, but unused
@@ -1486,14 +1515,14 @@ contains
       call getChildValue(node, "Charge", ctrl%nrChrg, 0.0_dp)
     end if
   #:else
-    call readSolver(node, ctrl, geom, poisson)
+    call readSolver(node, ctrl, geom, poisson, env%stdOut)
 
     ! Charge
     call getChildValue(node, "Charge", ctrl%nrChrg, 0.0_dp)
   #:endif
 
     ! K-Points
-    call readKPoints(node, ctrl, geom, errStatus)
+    call readKPoints(env, node, ctrl, geom, errStatus)
     @:PROPAGATE_ERROR(errStatus)
 
     if (ctrl%tscc) then
@@ -1598,11 +1627,11 @@ contains
                 & iTmpN(ctrl%dftbUInp%iUJ(1:ctrl%dftbUInp%niUJ(ii,iSp1),ii,iSp1)) + 1
           end do
           if (any(iTmpN(:)>1)) then
-            write(stdout, *)'Multiple copies of shells present in OrbitalPotential!'
-            write(stdout, "(A,A3,A,I2)") &
+            write(env%stdOut, *)'Multiple copies of shells present in OrbitalPotential!'
+            write(env%stdOut, "(A,A3,A,I2)") &
                 & 'The count for the occurrence of shells of species ', &
                 & trim(geom%speciesNames(iSp1)),' are:'
-            write(stdout, *)iTmpN(1:slako%orb%nShell(iSp1))
+            write(env%stdOut, *)iTmpN(1:slako%orb%nShell(iSp1))
             call abortProgram()
           end if
         end do
@@ -1630,7 +1659,7 @@ contains
         & dontMarkProcessed=.true.)
     if (associated(value1)) then
       allocate(ctrl%dispInp)
-      call readDispersion(child, geom, ctrl%dispInp, ctrl%nrChrg, ctrl%tSCC)
+      call readDispersion(env, child, geom, ctrl%dispInp, ctrl%nrChrg, ctrl%tSCC)
     end if
 
     ! Solvation
@@ -1638,7 +1667,7 @@ contains
         & dontMarkProcessed=.true.)
     if (associated(value1)) then
       allocate(ctrl%solvInp)
-      call readSolvation(child, geom, ctrl%solvInp)
+      call readSolvation(env, child, geom, ctrl%solvInp)
       call getChildValue(value1, "RescaleSolvatedFields", ctrl%isSolvatedFieldRescaled, .true.)
     end if
 
@@ -1647,9 +1676,10 @@ contains
         & allowEmptyValue=.true., dontMarkProcessed=.true., list=.true.)
     if (associated(value1)) then
       allocate(ctrl%elecConstraintInp)
-      call readElecConstraintInput(child, geom, ctrl%tSpin, ctrl%t2Component, ctrl%elecConstraintInp)
+      call readElecConstraintInput(env, child, geom, ctrl%tSpin, ctrl%t2Component,&
+          & ctrl%elecConstraintInp)
       if (.not. allocated(ctrl%elecConstraintInp%mullikenConstrs)) then
-        call detailedWarning(child, "No electronic constraint specified")
+        call detailedWarning(env%stdOut, child, "No electronic constraint specified")
         deallocate(ctrl%elecConstraintInp)
       end if
     end if
@@ -1736,10 +1766,13 @@ contains
 
   !> Reads xTB-Hamiltonian
 #:if WITH_TRANSPORT
-  subroutine readXTBHam(node, ctrl, geom, tp, greendens, poisson, errStatus)
+  subroutine readXTBHam(env, node, ctrl, geom, tp, greendens, poisson, errStatus)
 #:else
-  subroutine readXTBHam(node, ctrl, geom, poisson, errStatus)
+  subroutine readXTBHam(env, node, ctrl, geom, poisson, errStatus)
 #:endif
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to get the information from
     type(fnode), pointer :: node
@@ -1802,7 +1835,7 @@ contains
         call getParamSearchPaths(searchPath)
         call findFile(searchPath, paramFile, paramTmp)
         if (allocated(paramTmp)) call move_alloc(paramTmp, paramFile)
-        write(stdOut, '(a)') "Using parameter file '"//paramFile//"' for xTB Hamiltonian"
+        write(env%stdOut, '(a)') "Using parameter file '"//paramFile//"' for xTB Hamiltonian"
         call ctrl%tbliteInp%setupCalculator(paramFile)
       else
         call detailedError(node, "Either a Method or ParameterFile must be specified for xTB")
@@ -1816,7 +1849,7 @@ contains
     ifSCC: if (ctrl%tSCC) then
 
       ! get charge mixing options etc.
-      call readSccOptions(node, ctrl, geom)
+      call readSccOptions(env, node, ctrl, geom)
 
       !> TI-DFTB varibles for Delta DFTB
       call getChild(node, "NonAufbau", child, requested=.false.)
@@ -1836,7 +1869,7 @@ contains
 
     ! Spin calculation
     if (ctrl%reksInp%reksAlg == reksTypes%noReks .and. .not.ctrl%isNonAufbau .and. ctrl%tSCC) then
-      call readSpinPolarisation(node, ctrl, geom)
+      call readSpinPolarisation(env, node, ctrl, geom)
     end if
 
     ! temporararily removed until debugged
@@ -1848,7 +1881,7 @@ contains
     ctrl%tReadShifts = .false.
 
     ! External fields and potentials
-    call readExternal(node, ctrl, geom)
+    call readExternal(env, node, ctrl, geom)
 
     ! Non-self-consistent spin-orbit coupling
     call ctrl%tbliteInp%setupOrbitals(geom%species, orb)
@@ -1856,7 +1889,7 @@ contains
 
     ! Electronic solver
   #:if WITH_TRANSPORT
-    call readSolver(node, ctrl, geom, tp, greendens, poisson)
+    call readSolver(node, ctrl, geom, tp, greendens, poisson, env%stdOut)
 
     if (tp%taskUpload) then
       ! Initialise, but unused
@@ -1866,14 +1899,14 @@ contains
       call getChildValue(node, "Charge", ctrl%nrChrg, 0.0_dp)
     end if
   #:else
-    call readSolver(node, ctrl, geom, poisson)
+    call readSolver(node, ctrl, geom, poisson, env%stdOut)
 
     ! Charge
     call getChildValue(node, "Charge", ctrl%nrChrg, 0.0_dp)
   #:endif
 
     ! K-Points
-    call readKPoints(node, ctrl, geom, errStatus)
+    call readKPoints(env, node, ctrl, geom, errStatus)
     @:PROPAGATE_ERROR(errStatus)
 
     ! Dispersion
@@ -1881,7 +1914,7 @@ contains
         & dontMarkProcessed=.true.)
     if (associated(value1)) then
       allocate(ctrl%dispInp)
-      call readDispersion(child, geom, ctrl%dispInp, ctrl%nrChrg, ctrl%tSCC)
+      call readDispersion(env, child, geom, ctrl%dispInp, ctrl%nrChrg, ctrl%tSCC)
     end if
 
     ! Solvation
@@ -1889,7 +1922,7 @@ contains
         & dontMarkProcessed=.true.)
     if (associated(value1)) then
       allocate(ctrl%solvInp)
-      call readSolvation(child, geom, ctrl%solvInp)
+      call readSolvation(env, child, geom, ctrl%solvInp)
       call getChildValue(value1, "RescaleSolvatedFields", ctrl%isSolvatedFieldRescaled, .true.)
     end if
 
@@ -1921,7 +1954,8 @@ contains
         & allowEmptyValue=.true., dontMarkProcessed=.true., list=.true.)
     if (associated(value1)) then
       allocate(ctrl%elecConstraintInp)
-      call readElecConstraintInput(child, geom, ctrl%tSpin, ctrl%t2Component, ctrl%elecConstraintInp)
+      call readElecConstraintInput(env, child, geom, ctrl%tSpin, ctrl%t2Component,&
+          & ctrl%elecConstraintInp)
     end if
 
   end subroutine readXTBHam
@@ -2309,7 +2343,10 @@ contains
 
 
   !> Spin calculation
-  subroutine readSpinPolarisation(node, ctrl, geom)
+  subroutine readSpinPolarisation(env, node, ctrl, geom)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Relevant node in input tree
     type(fnode), pointer :: node
@@ -2338,14 +2375,14 @@ contains
       call getChildValue(value1, 'UnpairedElectrons', ctrl%nrSpinPol, 0.0_dp)
       call getChildValue(value1, 'RelaxTotalSpin', ctrl%tSpinSharedEf, .false.)
       if (.not. ctrl%tReadChrg) then
-        call getInitialSpins(value1, geom, 1, ctrl%initialSpins)
+        call getInitialSpins(env, value1, geom, 1, ctrl%initialSpins)
       end if
 
     case ("noncolinear", "noncollinear")
       ctrl%tSpin = .true.
       ctrl%t2Component = .true.
       if (.not. ctrl%tReadChrg) then
-        call getInitialSpins(value1, geom, 3, ctrl%initialSpins)
+        call getInitialSpins(env, value1, geom, 3, ctrl%initialSpins)
       end if
 
     case default
@@ -2358,7 +2395,10 @@ contains
 
 
   ! External field(s) and potential(s)
-  subroutine readExternal(node, ctrl, geom)
+  subroutine readExternal(env, node, ctrl, geom)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Relevant node in input tree
     type(fnode), pointer :: node
@@ -2509,7 +2549,7 @@ contains
         ctrl%tNetAtomCharges = .true.
         do ii = 1, getLength(children)
           call getItem1(children, ii, child2)
-          call readExternalAtom_(child2, geom, ctrl%atomicExtPotential%iAtOnSite,&
+          call readExternalAtom_(env, child2, geom, ctrl%atomicExtPotential%iAtOnSite,&
               & ctrl%atomicExtPotential%VextOnSite)
         end do
       end if
@@ -2519,7 +2559,7 @@ contains
         ! atomic
         do ii = 1, getLength(children)
           call getItem1(children, ii, child2)
-          call readExternalAtom_(child2, geom, ctrl%atomicExtPotential%iAt,&
+          call readExternalAtom_(env, child2, geom, ctrl%atomicExtPotential%iAt,&
               & ctrl%atomicExtPotential%Vext)
         end do
       end if
@@ -2530,7 +2570,10 @@ contains
 
 
   !> Read affected atom(s) and external potential(s)
-  subroutine readExternalAtom_(node, geom, iAt, Vext)
+  subroutine readExternalAtom_(env, node, geom, iAt, Vext)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Relevant node in input tree
     type(fnode), pointer :: node
@@ -2554,7 +2597,8 @@ contains
     @:ASSERT(allocated(iAt) .eqv. allocated(Vext))
 
     call getChildValue(node, "Atoms", buffer, child=child, multiple=.true.)
-    call getSelectedAtomIndices(child, char(buffer), geom%speciesNames, geom%species, iAt_)
+    call getSelectedAtomIndices(env%stdOut, child, char(buffer), geom%speciesNames, geom%species,&
+        & iAt_)
     call init(lr)
     call getChildValue(node, "Vext", lr, modifier=modifier, child=child)
 
@@ -2594,7 +2638,7 @@ contains
 
 
   !> Filling of electronic levels
-  subroutine readFilling(node, ctrl, geom, temperatureDefault)
+  subroutine readFilling(node, ctrl, geom, temperatureDefault, output)
 
     !> Relevant node in input tree
     type(fnode), pointer :: node
@@ -2607,6 +2651,9 @@ contains
 
     !> Default temperature for filling
     real(dp), intent(in) :: temperatureDefault
+
+    !> Output for write processes
+    integer, intent(in) :: output
 
     type(fnode), pointer :: value1, child, child2, child3, field
     type(string) :: buffer, modifier
@@ -2629,7 +2676,7 @@ contains
         case (0)
           write(errorStr, "(A)")"Methfessel-Paxton filling order 0 is equivalent to gaussian&
               & smearing"
-          call detailedWarning(child, errorStr)
+          call detailedWarning(output, child, errorStr)
         case default
           write(errorStr, "(A,A,A,I4)")"Filling order must be above zero '", char(buffer),"' :",&
               &ctrl%iDistribFn
@@ -2672,9 +2719,9 @@ contains
 
   !> Electronic Solver
 #:if WITH_TRANSPORT
-  subroutine readSolver(node, ctrl, geom, tp, greendens, poisson)
+  subroutine readSolver(node, ctrl, geom, tp, greendens, poisson, output)
 #:else
-  subroutine readSolver(node, ctrl, geom, poisson)
+  subroutine readSolver(node, ctrl, geom, poisson, output)
 #:endif
 
     !> Relevant node in input tree
@@ -2697,6 +2744,9 @@ contains
 
     !> Poisson solver paramenters
     type(TPoissonInfo), intent(inout) :: poisson
+
+    !> Output for write processes
+    integer, intent(in) :: output
 
     type(fnode), pointer :: value1, child
     type(string) :: buffer, modifier
@@ -2841,7 +2891,7 @@ contains
     case ("greensfunction")
       ctrl%solver%isolver = electronicSolverTypes%GF
       ! need electronic temperature to be read for this solver:
-      call readElectronicFilling(node, ctrl, geom)
+      call readElectronicFilling(node, ctrl, geom, output)
       if (tp%defined .and. .not.tp%taskUpload) then
         call detailederror(node, "greensfunction solver cannot be used "// &
             &  "when task = contactHamiltonian")
@@ -2906,7 +2956,11 @@ contains
 
 
   !> K-Points
-  subroutine readKPoints(node, ctrl, geom, errStatus)
+  subroutine readKPoints(env, node, ctrl, geom, errStatus)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
+
 
     !> Relevant node in input tree
     type(fnode), pointer :: node
@@ -2929,22 +2983,22 @@ contains
 
     ! K-Points
     if (geom%tPeriodic) then
-      call getEuclideanKSampling(ctrl, node, geom, errStatus)
+      call getEuclideanKSampling(env, ctrl, node, geom, errStatus)
       @:PROPAGATE_ERROR(errStatus)
     elseif (geom%tHelical) then
       call getHelicalKSampling(ctrl, node, geom)
     end if
 
-    call maxSelfConsIterations(node, ctrl, "MaxSCCIterations", ctrl%maxSccIter)
+    call maxSelfConsIterations(env%stdOut, node, ctrl, "MaxSCCIterations", ctrl%maxSccIter)
     ! Eventually, perturbation routines should also have restart reads:
     if (ctrl%poorKSampling .and. ctrl%tSCC .and. .not.ctrl%tReadChrg) then
-      call warning("It is strongly suggested you use the ReadInitialCharges option.")
+      call warning(env%stdOut, "It is strongly suggested you use the ReadInitialCharges option.")
     end if
 
     ! Check if hybrid calculation needs to be stopped due to invalid k-point sampling
     if (ctrl%checkStopHybridCalc) then
       if (ctrl%maxSccIter == 1) then
-        call warning("Restarting a hybrid xc-functional run with what appears to be&
+        call warning(env%stdOut, "Restarting a hybrid xc-functional run with what appears to be&
             & a poor k-point sampling that does probably" // NEW_LINE('A') // " not match the&
             & original sampling (however fine for bandstructure calculations).")
       else
@@ -2958,7 +3012,10 @@ contains
 
 
   !> Set the maximum number of SCC cycles, depending on k-point behaviour
-  subroutine maxSelfConsIterations(node, ctrl, label, maxSccIter)
+  subroutine maxSelfConsIterations(output, node, ctrl, label, maxSccIter)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Relevant node in input tree
     type(fnode), pointer :: node
@@ -2991,7 +3048,7 @@ contains
     if (ctrl%poorKSampling .and. maxSccIter /= 1) then
       write(warningStr, "(A,I3)") "A self-consistent cycle with these k-points probably will&
           & not correctly calculate many properties, maximum iterations set to:", maxSccIter
-      call warning(warningStr)
+      call warning(output, warningStr)
     end if
 
   end subroutine maxSelfConsIterations
@@ -3023,7 +3080,10 @@ contains
 
 
   !> The k-points in Euclidean space
-  subroutine getEuclideanKSampling(ctrl, node, geom, errStatus)
+  subroutine getEuclideanKSampling(env, ctrl, node, geom, errStatus)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Relevant node in input tree
     type(fnode), pointer :: node
@@ -3061,8 +3121,8 @@ contains
     case ("supercellfolding")
       call getChildValue(node, "ReduceKPointsByInversion", ctrl%tReduceByInversion, .true.)
       if(ctrl%tReduceByInversion .and. ctrl%tSpinOrbit) then
-        call detailedWarning(node, "Kpoints will not be reduced by inversion as Spin-Orbit & 
-            & is requested.")
+        call detailedWarning(env%stdOut, node, "Kpoints will not be reduced by inversion as&
+            & Spin-Orbit is requested.")
       end if
       ctrl%tReduceByInversion = ctrl%tReduceByInversion .and. .not.ctrl%tSpinOrbit
       ctrl%poorKSampling = .false.
@@ -3338,7 +3398,10 @@ contains
 
 
   !> SCC options that are need for different hamiltonian choices
-  subroutine readSccOptions(node, ctrl, geom)
+  subroutine readSccOptions(env, node, ctrl, geom)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Relevant node in input tree
     type(fnode), pointer :: node
@@ -3353,7 +3416,7 @@ contains
 
     call getChildValue(node, "ReadInitialCharges", ctrl%tReadChrg, .false.)
     if (.not. ctrl%tReadChrg) then
-      call getInitialCharges(node, geom, ctrl%initialCharges)
+      call getInitialCharges(env, node, geom, ctrl%initialCharges)
     end if
 
     call getChildValue(node, "SCCTolerance", ctrl%sccTol, 1.0e-5_dp)
@@ -3448,7 +3511,10 @@ contains
 
 
   !> Reads initial charges
-  subroutine getInitialCharges(node, geom, initCharges)
+  subroutine getInitialCharges(env, node, geom, initCharges)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> relevant node in input tree
     type(fnode), pointer :: node
@@ -3483,12 +3549,13 @@ contains
       do ii = 1, getLength(children)
         call getItem1(children, ii, child2)
         call getChildValue(child2, "Atoms", buffer, child=child3, multiple=.true.)
-        call getSelectedAtomIndices(child3, char(buffer), geom%speciesNames, geom%species, pTmpI1)
+        call getSelectedAtomIndices(env%stdOut, child3, char(buffer), geom%speciesNames,&
+            & geom%species, pTmpI1)
         call getChildValue(child2, "ChargePerAtom", rTmp)
         do jj = 1, size(pTmpI1)
           iAt = pTmpI1(jj)
           if (initCharges(iAt) /= 0.0_dp) then
-            call detailedWarning(child3, "Previous setting for the charge &
+            call detailedWarning(env%stdOut, child3, "Previous setting for the charge &
                 &of atom" // i2c(iAt) // " overwritten")
           end if
           initCharges(iAt) = rTmp
@@ -3502,7 +3569,10 @@ contains
 
 
   !> Reads initial spins
-  subroutine getInitialSpins(node, geom, nSpin, initSpins)
+  subroutine getInitialSpins(env, node, geom, nSpin, initSpins)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> relevant node in input data
     type(fnode), pointer :: node
@@ -3543,12 +3613,13 @@ contains
       do ii = 1, getLength(children)
         call getItem1(children, ii, child2)
         call getChildValue(child2, "Atoms", buffer, child=child3, multiple=.true.)
-        call getSelectedAtomIndices(child3, char(buffer), geom%speciesNames, geom%species, pTmpI1)
+        call getSelectedAtomIndices(env%stdOut, child3, char(buffer), geom%speciesNames,&
+            & geom%species, pTmpI1)
         call getChildValue(child2, "SpinPerAtom", rTmp)
         do jj = 1, size(pTmpI1)
           iAt = pTmpI1(jj)
           if (any(initSpins(:,iAt) /= 0.0_dp)) then
-            call detailedWarning(child3, "Previous setting for the spin of atom" // i2c(iAt) //&
+            call detailedWarning(env%stdOut, child3, "Previous setting for the spin of atom" // i2c(iAt) //&
                 & " overwritten")
           end if
           initSpins(:,iAt) = rTmp
@@ -3666,8 +3737,11 @@ contains
   !> Reads Slater-Koster files.
   !> Should be replaced with a more sophisticated routine, once the new SK-format has been
   !> established.
-  subroutine readSKFiles(skFiles, nSpecies, slako, orb, angShells, orbRes, skInterMeth, repPoly,&
+  subroutine readSKFiles(env, skFiles, nSpecies, slako, orb, angShells, orbRes, skInterMeth, repPoly,&
       & truncationCutOff, hybridXcSK)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> List of SK file names to read in for every interaction
     type(TListCharLc), intent(inout) :: skFiles(:,:)
@@ -3733,7 +3807,7 @@ contains
     call init(slako%skOverCont, nSpecies)
     allocate(slako%pairRepulsives(nSpecies, nSpecies))
 
-    write(stdout, "(A)") "Reading SK-files:"
+    write(env%stdOut, "(A)") "Reading SK-files:"
     lpSp1: do iSp1 = 1, nSpecies
       nSK1 = len(angShells(iSp1))
       lpSp2: do iSp2 = iSp1, nSpecies
@@ -3746,7 +3820,7 @@ contains
             readRep = (iSK1 == 1 .and. iSK2 == 1)
             readAtomic = (iSp1 == iSp2 .and. iSK1 == iSK2)
             call get(skFiles(iSp2, iSp1), fileName, ind)
-            write(stdOut, "(a)") trim(fileName)
+            write(env%stdOut, "(a)") trim(fileName)
             if (.not. present(hybridXcSK)) then
               if (readRep .and. repPoly(iSp2, iSp1)) then
                 call readFromFile(skData12(iSK2,iSK1), fileName, readAtomic, polyRepInp=repPolyIn1)
@@ -3882,7 +3956,7 @@ contains
         end if
       end do lpSp2
     end do lpSp1
-    write(stdout, "(A)") "Done."
+    write(env%stdOut, "(A)") "Done."
 
   end subroutine readSKFiles
 
@@ -4132,7 +4206,10 @@ contains
 
 
   !> Reads the option block
-  subroutine readOptions(node, ctrl, geom)
+  subroutine readOptions(env, node, ctrl, geom)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to parse
     type(fnode), pointer :: node
@@ -4192,7 +4269,7 @@ contains
     call localiseName(node, "MinimizeMemoryUsage", "MinimiseMemoryUsage")
     call getChildValue(node, "MinimiseMemoryUsage", ctrl%tMinMemory, .false., child=child)
     if (ctrl%tMinMemory) then
-      call detailedWarning(child, "Memory minimisation is not working currently, normal calculation&
+      call detailedWarning(env%stdOut, child, "Memory minimisation is not working currently, normal calculation&
           & will be used instead")
     end if
     call getChildValue(node, "ShowFoldedCoords", ctrl%tShowFoldedCoord, .false.)
@@ -4226,7 +4303,10 @@ contains
 
 
   !> Reads in dispersion related settings
-  subroutine readDispersion(node, geom, input, nrChrg, tSCC)
+  subroutine readDispersion(env, node, geom, input, nrChrg, tSCC)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to parse
     type(fnode), pointer :: node
@@ -4257,17 +4337,17 @@ contains
       call readDispVdWUFF(dispModel, geom, input%uff)
     case ("dftd3")
       allocate(input%dftd3)
-      call readDFTD3(dispModel, geom, input%dftd3)
+      call readDFTD3(env, dispModel, geom, input%dftd3)
     case ("simpledftd3")
       allocate(input%sdftd3)
       call readSimpleDFTD3(dispModel, geom, input%sdftd3)
     case ("dftd4")
       allocate(input%dftd4)
-      call readDispDFTD4(dispModel, geom, input%dftd4, nrChrg)
+      call readDispDFTD4(env, dispModel, geom, input%dftd4, nrChrg)
     case ("ts")
   #:if WITH_MBD
       allocate(input%mbd)
-      call readDispTs(dispModel, input%mbd)
+      call readDispTs(env, dispModel, input%mbd)
   #:else
       call detailedError(node, "Program must be compiled with the mbd library for TS-dispersion")
   #:endif
@@ -4467,7 +4547,10 @@ contains
 
 
   !> Reads in initialization data for the DFTD3 dispersion module
-  subroutine readDFTD3(node, geom, input)
+  subroutine readDFTD3(env, node, geom, input)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to process.
     type(fnode), pointer :: node
@@ -4538,7 +4621,7 @@ contains
     do iSp = 1, size(geom%speciesNames)
       if (input%izp(iSp) <= 0 .or. input%izp(iSp) > d3MaxNum) then
         unknownSpecies = .true.
-        call warning("Species '"//trim(geom%speciesNames(iSp))// &
+        call warning(env%stdOut, "Species '"//trim(geom%speciesNames(iSp))// &
           & "' is not supported by DFT-D3")
       end if
     end do
@@ -4587,7 +4670,10 @@ contains
   !> Here we additionally require a s9, since the non-addititive contributions
   !> tend to be expensive especially in the tight-binding context, s9 = 0.0_dp
   !> will disable the calculation.
-  subroutine readDispDFTD4(node, geom, input, nrChrg)
+  subroutine readDispDFTD4(env, node, geom, input, nrChrg)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to process.
     type(fnode), pointer :: node
@@ -4668,7 +4754,7 @@ contains
     do iSp = 1, size(geom%speciesNames)
       if (input%izp(iSp) <= 0 .or. input%izp(iSp) > d4MaxNum) then
         unknownSpecies = .true.
-        call warning("Species '"//trim(geom%speciesNames(iSp))// &
+        call warning(env%stdOut, "Species '"//trim(geom%speciesNames(iSp))// &
           & "' is not supported by DFT-D4")
       end if
     end do
@@ -4867,7 +4953,10 @@ contains
 #:if WITH_MBD
 
   !> Reads in settings for Tkatchenko-Scheffler dispersion
-  subroutine readDispTs(node, input)
+  subroutine readDispTs(env, node, input)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> data to parse
     type(fnode), pointer, intent(in) :: node
@@ -5229,10 +5318,13 @@ contains
 
   !> Reads the analysis block
 #:if WITH_TRANSPORT
-  subroutine readAnalysis(node, ctrl, geom, orb, transpar, tundos)
+  subroutine readAnalysis(env, node, ctrl, geom, orb, transpar, tundos)
 #:else
-  subroutine readAnalysis(node, ctrl, geom)
+  subroutine readAnalysis(env, node, ctrl, geom)
 #:endif
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to parse
     type(fnode), pointer :: node
@@ -5306,7 +5398,8 @@ contains
 
           call getItem1(children, 1, child3)
           call getChildValue(child3, "Atoms", buffer, child=child4, multiple=.true.)
-          call getSelectedAtomIndices(child4, char(buffer), geom%speciesNames, geom%species, pTmpI1)
+          call getSelectedAtomIndices(env%stdOut, child4, char(buffer), geom%speciesNames,&
+              & geom%species, pTmpI1)
 
           nReg = size(pTmpI1)
           ctrl%tProjEigenvecs = (nReg > 0)
@@ -5343,8 +5436,8 @@ contains
             do iReg = 1, nReg
               call getItem1(children, iReg, child2)
               call getChildValue(child2, "Atoms", buffer, child=child3, multiple=.true.)
-              call getSelectedAtomIndices(child3, char(buffer), geom%speciesNames, geom%species,&
-                  & pTmpI1)
+              call getSelectedAtomIndices(env%stdOut, child3, char(buffer), geom%speciesNames,&
+                  & geom%species, pTmpI1)
               call append(ctrl%iAtInRegion, pTmpI1)
               call getChildValue(child2, "ShellResolved", ctrl%tShellResInRegion(iReg), .false.,&
                   & child=child3)
@@ -5460,7 +5553,7 @@ contains
           call getChild(child, "WrtCharges", child2, requested=.false.)
           if (associated(child2)) then
             call getChildValue(child2, "", buffer)
-            call getSelectedIndices(child, char(buffer), [1, ctrl%nExtChrg],&
+            call getSelectedIndices(env%stdOut, child, char(buffer), [1, ctrl%nExtChrg],&
                 & ctrl%perturbInp%indWrtCharges)
             if (size(ctrl%perturbInp%indWrtCharges) == 0) then
               call error("No charges specified for derivatives calculation.")
@@ -5487,8 +5580,8 @@ contains
         call getChild(child, "WrtAtoms", child2, requested=.false.)
         if (associated(child2)) then
           call getChildValue(child2, "", buffer)
-          call getSelectedAtomIndices(child, char(buffer), geom%speciesNames, geom%species,&
-              & ctrl%perturbInp%indWrtAtoms, indexRange=[1,geom%nAtom])
+          call getSelectedAtomIndices(env%stdOut, child, char(buffer), geom%speciesNames,&
+              & geom%species, ctrl%perturbInp%indWrtAtoms, indexRange=[1,geom%nAtom])
           if (size(ctrl%perturbInp%indWrtAtoms) == 0) then
             call error("No atoms specified for derivatives calculation.")
           else
@@ -5541,7 +5634,7 @@ contains
       end if
 
       if (allocated(ctrl%perturbInp)) then
-        call maxSelfConsIterations(node, ctrl, "MaxPerturbIter", ctrl%perturbInp%maxPerturbIter)
+        call maxSelfConsIterations(env%stdOut, node, ctrl, "MaxPerturbIter", ctrl%perturbInp%maxPerturbIter)
         if (ctrl%tScc) then
           call getChildValue(node, "PerturbSccTol", ctrl%perturbInp%perturbSccTol, 1.0e-5_dp)
           ! self consistency required, or not, to proceed with perturbation
@@ -5614,7 +5707,7 @@ contains
         call error("Orbital information from SK-files missing (xTB Hamiltonian not compatible&
             & with transport yet)")
       end if
-      call readTunAndDos(child, orb, geom, tundos, transpar, ctrl%tempElec)
+      call readTunAndDos(env, child, orb, geom, tundos, transpar, ctrl%tempElec)
     else
       if (ctrl%solver%isolver == electronicSolverTypes%OnlyTransport) then
         call detailedError(node, "The TransportOnly solver requires a TunnelingAndDos block to be&
@@ -5754,7 +5847,7 @@ contains
 
 
   !> Read in hamiltonian settings that are influenced by those read from REKS{}, electronDynamics{}
-  subroutine readLaterHamiltonian(hamNode, ctrl, driverNode, geom)
+  subroutine readLaterHamiltonian(hamNode, ctrl, driverNode, geom, output)
 
     !> Hamiltonian node to parse
     type(fnode), pointer :: hamNode
@@ -5767,6 +5860,9 @@ contains
 
     !> Atomic geometry of the system, including atomic species information
     type(TGeometry), intent(in) :: geom
+
+    !> Output for write processes
+    integer, intent(in) :: output
 
     type(fnode), pointer :: value1, value2, child, child2
     type(string) :: buffer, buffer2
@@ -5862,7 +5958,7 @@ contains
       end if
 
       if (ctrl%solver%isolver /= electronicSolverTypes%GF) then
-        call readElectronicFilling(hamNode, ctrl, geom)
+        call readElectronicFilling(hamNode, ctrl, geom, output)
       end if
 
     end if hamNeedsT
@@ -5872,7 +5968,7 @@ contains
 
   !> Parses for electronic filling temperature (should only read if not either REKS or electron
   !> dynamics from a supplied density matrix)
-  subroutine readElectronicFilling(hamNode, ctrl, geom)
+  subroutine readElectronicFilling(hamNode, ctrl, geom, output)
 
     !> Relevant node in input tree
     type(fnode), pointer :: hamNode
@@ -5883,11 +5979,14 @@ contains
     !> Atomic geometry of the system, including atomic species information
     type(TGeometry), intent(in) :: geom
 
+    !> Output for write processes
+    integer, intent(in) :: output
+
     select case(ctrl%hamiltonian)
     case(hamiltonianTypes%xtb)
-      call readFilling(hamNode, ctrl, geom, 300.0_dp*Boltzmann)
+      call readFilling(hamNode, ctrl, geom, 300.0_dp*Boltzmann, output)
     case(hamiltonianTypes%dftb)
-      call readFilling(hamNode, ctrl, geom, 0.0_dp)
+      call readFilling(hamNode, ctrl, geom, 0.0_dp, output)
     end select
 
   end subroutine readElectronicFilling
@@ -6073,7 +6172,10 @@ contains
 
 
   !> Reads the electron dynamics block
-  subroutine readElecDynamics(node, input, geom, masses)
+  subroutine readElecDynamics(env, node, input, geom, masses)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> input data to parse
     type(fnode), pointer :: node
@@ -6191,7 +6293,7 @@ contains
       call getChildValue(value1, "Phase", input%phase, 0.0_dp, modifier=modifier, child=child)
       call convertUnitHsd(char(modifier), angularUnits, child, input%phase)
       call getChildValue(value1, "ExcitedAtoms", buffer, "1:-1", child=child, multiple=.true.)
-      call getSelectedAtomIndices(child, char(buffer), geom%speciesNames, geom%species,&
+      call getSelectedAtomIndices(env%stdOut, child, char(buffer), geom%speciesNames, geom%species,&
           & input%indExcitedAtom)
 
       input%nExcitedAtom = size(input%indExcitedAtom)
@@ -6217,7 +6319,7 @@ contains
       call convertUnitHsd(char(modifier), EFieldUnits, child, input%tdLaserField)
 
       call getChildValue(value1, "ExcitedAtoms", buffer, "1:-1", child=child, multiple=.true.)
-      call getSelectedAtomIndices(child, char(buffer), geom%speciesNames, geom%species,&
+      call getSelectedAtomIndices(env%stdOut, child, char(buffer), geom%speciesNames, geom%species,&
           & input%indExcitedAtom)
       input%nExcitedAtom = size(input%indExcitedAtom)
       if (input%nExcitedAtom == 0) then
@@ -6283,7 +6385,7 @@ contains
     call getChildValue(node, "IonDynamics", input%tIons, .false.)
     if (input%tIons) then
       call getChildValue(node, "MovedAtoms", buffer, "1:-1", child=child, multiple=.true.)
-      call getSelectedAtomIndices(child, char(buffer), geom%speciesNames, geom%species,&
+      call getSelectedAtomIndices(env%stdOut, child, char(buffer), geom%speciesNames, geom%species,&
           & input%indMovedAtom)
 
       input%nMovedAtom = size(input%indMovedAtom)
@@ -6297,7 +6399,7 @@ contains
           ! previously lower limit was minTemp:
           call readMDInitTemp(node, input%tempAtom, 0.0_dp)
         end if
-        call getInputMasses(node, geom, masses)
+        call getInputMasses(env, node, geom, masses)
       end if
     end if
 
@@ -6407,7 +6509,10 @@ contains
 
 #:if WITH_TRANSPORT
   !> Read geometry information for transport calculation
-  subroutine readTransportGeometry(root, geom, transpar)
+  subroutine readTransportGeometry(env, root, geom, transpar)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Root node containing the current block
     type(fnode), pointer :: root
@@ -6449,7 +6554,7 @@ contains
     call getChildren(root, "Contact", pNodeList)
     transpar%ncont = getLength(pNodeList)
     allocate(transpar%contacts(transpar%ncont))
-    call readContacts(pNodeList, transpar%contacts, geom, char(buffer), transpar%contactLayerTol)
+    call readContacts(env, pNodeList, transpar%contacts, geom, char(buffer), transpar%contactLayerTol)
 
     ! check for atoms in multiple contact ranges/device or atoms missing from any of these regions
     allocate(atomInRegion(geom%nAtom), source=.false.)
@@ -7106,8 +7211,11 @@ contains
 
 #:if WITH_TRANSPORT
   !> Correctness checking of atom ranges and returning contact vector and direction.
-  subroutine getContactVector(atomrange, geom, id, name, pContact, contactLayerTol, contactVec,&
+  subroutine getContactVector(env, atomrange, geom, id, name, pContact, contactLayerTol, contactVec,&
       & contactDir)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Range of atoms in the contact
     integer, intent(in) :: atomrange(2)
@@ -7161,19 +7269,19 @@ contains
     if (any(sum( (geom%coords(:,iStart:iStart2-1) - geom%coords(:,iStart2:iEnd)&
         & - spread(contactVec, dim=2, ncopies=iStart2-iStart))**2, dim=1) > contactLayerTol**2))&
         & then
-      write(stdout,"(1X,A,I0,A,I0)")'Contact vector defined from atoms ', iStart, ' and ',iStart2
-      write(stdout,"(1X,A,I0,'-',I0)")'Contact layer 1 atoms: ',iStart, iStart2-1
-      write(stdout,"(1X,A,I0,'-',I0)")'Contact layer 2 atoms: ',iStart2, iEnd
+      write(env%stdOut,"(1X,A,I0,A,I0)")'Contact vector defined from atoms ', iStart, ' and ',iStart2
+      write(env%stdOut,"(1X,A,I0,'-',I0)")'Contact layer 1 atoms: ',iStart, iStart2-1
+      write(env%stdOut,"(1X,A,I0,'-',I0)")'Contact layer 2 atoms: ',iStart2, iEnd
       do ii = 0, iStart2 -1 -iStart
         if (sum((geom%coords(:,ii+iStart)-geom%coords(:,ii+iStart2) - contactVec)**2)&
             & > contactLayerTol**2) then
-          write(stdout,"(1X,A,I0,A,I0,A)")'Atoms ',iStart+ii, ' and ', iStart2+ii,&
+          write(env%stdOut,"(1X,A,I0,A,I0,A)")'Atoms ',iStart+ii, ' and ', iStart2+ii,&
               & ' inconsistent with the contact vector.'
           exit
         end if
       end do
-      write(stdout,*)'Mismatches in atomic positions in the two layers:'
-      write(stdout,"(3F20.12)")((geom%coords(:,iStart:iStart2-1) - geom%coords(:,iStart2:iEnd)&
+      write(env%stdOut,*)'Mismatches in atomic positions in the two layers:'
+      write(env%stdOut,"(3F20.12)")((geom%coords(:,iStart:iStart2-1) - geom%coords(:,iStart2:iEnd)&
           & - spread(contactVec(:), dim=2, ncopies=iStart2-iStart))) * Bohr__AA
 
       write (errorStr,"('Contact ',A,' (',A,') does not consist of two rigidly shifted layers')")&
@@ -7185,7 +7293,7 @@ contains
     ! Determine to which axis the contact vector is parallel.
     mask(:) = (abs(abs(contactVec) - sqrt(sum(contactVec**2))) < 1.0e-8_dp)
     if (count(mask) /= 1) then
-      call warning("Contact vector " // i2c(id) // " not parallel to any coordinate axis.")
+      call warning(env%stdOut, "Contact vector " // i2c(id) // " not parallel to any coordinate axis.")
       contactDir = 0
     else
       contactDir = findloc(mask, .true., 1)
@@ -7195,7 +7303,10 @@ contains
 
 
   !> Read Tunneling and Dos options from analysis block
-  subroutine readTunAndDos(root, orb, geom, tundos, transpar, tempElec)
+  subroutine readTunAndDos(env, root, orb, geom, tundos, transpar, tempElec)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Root node containing the current block
     type(fnode), pointer :: root
@@ -7331,7 +7442,7 @@ contains
       call convertUnitHsd(char(modifier), energyUnits, field, &
           &tundos%broadeningDelta)
 
-      call readPDOSRegions(root, geom, transpar%idxdevice, iAtInRegion, &
+      call readPDOSRegions(env, root, geom, transpar%idxdevice, iAtInRegion, &
           & tShellResInRegion, regionLabelPrefixes)
 
       if (allocated(iAtInRegion)) then
@@ -7344,7 +7455,10 @@ contains
 
 
   !> Read bias information, used in Analysis and Green's function eigensolver
-  subroutine readContacts(pNodeList, contacts, geom, task, contactLayerTol)
+  subroutine readContacts(env, pNodeList, contacts, geom, task, contactLayerTol)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to process
     type(fnodeList), pointer :: pNodeList
@@ -7387,7 +7501,7 @@ contains
       call convertUnitHsd(char(modifier), lengthUnits, field, contactLayerTol)
 
       call getChildValue(pNode, "AtomRange", contacts(ii)%idxrange, child=pTmp)
-      call getContactVector(contacts(ii)%idxrange, geom, ii, contacts(ii)%name, pTmp,&
+      call getContactVector(env, contacts(ii)%idxrange, geom, ii, contacts(ii)%name, pTmp,&
         & contactLayerTol, contacts(ii)%lattice, contacts(ii)%dir)
       contacts(ii)%length = sqrt(sum(contacts(ii)%lattice**2))
 
@@ -7441,7 +7555,7 @@ contains
         call getNodeName2(child1, buffer)
         if (char(buffer) == "") then
           contacts(ii)%tFermiSet = .false.
-          call detailedWarning(pNode, "Missing Fermi level - required to be set in solver block or&
+          call detailedWarning(env%stdOut, pNode, "Missing Fermi level - required to be set in solver block or&
               & read from a contact shift file")
         else
           call init(fermiBuffer)
@@ -7569,7 +7683,11 @@ contains
 
 
   !> Read the names of regions to calculate PDOS for
-  subroutine readPDOSRegions(node, geom, idxdevice, iAtInregion, tShellResInRegion, regionLabels)
+  subroutine readPDOSRegions(env, node, geom, idxdevice, iAtInregion, tShellResInRegion,&
+      & regionLabels)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to be parsed
     type(fnode), pointer, intent(in) :: node
@@ -7613,7 +7731,7 @@ contains
       if (.not. associated(child2)) then
         call detailedError(eachAtomNode, "EachAtom requires an 'Atoms' specification")
       end if
-      call getSelectedAtomIndices(child2, char(buffer), geom%speciesNames,&
+      call getSelectedAtomIndices(env%stdOut, child2, char(buffer), geom%speciesNames,&
           & geom%species(idxdevice(1) : idxdevice(2)), pTmpI1,&
           & selectionRange=[idxdevice(1), idxdevice(2)], indexRange=[1, geom%nAtom])
 
@@ -7661,7 +7779,7 @@ contains
       do iReg = 1, nReg
         call getItem1(children, iReg, child)
         call getChildValue(child, "Atoms", buffer, child=child2, multiple=.true.)
-        call getSelectedAtomIndices(child2, char(buffer), geom%speciesNames,&
+        call getSelectedAtomIndices(env%stdOut, child2, char(buffer), geom%speciesNames,&
             & geom%species(idxdevice(1) : idxdevice(2)), tmpI1,&
             & selectionRange=[idxdevice(1), idxdevice(2)], indexRange=[1, geom%nAtom])
         iAtInRegion(iReg)%data = tmpI1
@@ -7747,7 +7865,10 @@ contains
 
 
   !> This subroutine overrides the neutral (reference) atom electronic occupation
-  subroutine readCustomReferenceOcc(root, orb, referenceOcc, geom, iAtInRegion, customOcc)
+  subroutine readCustomReferenceOcc(env, root, orb, referenceOcc, geom, iAtInRegion, customOcc)
+    
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to be parsed
     type(fnode), pointer, intent(in) :: root
@@ -7792,7 +7913,7 @@ contains
     do iCustomOcc = 1, nCustomOcc
       call getItem1(nodes, iCustomOcc, node)
       call getChildValue(node, "Atoms", buffer, child=child, multiple=.true.)
-      call getSelectedAtomIndices(child, char(buffer), geom%speciesNames, geom%species,&
+      call getSelectedAtomIndices(env%stdOut, child, char(buffer), geom%speciesNames, geom%species,&
           & iAtInRegion(iCustomOcc)%data)
       if (any(atomOverriden(iAtInRegion(iCustomOcc)%data))) then
         call detailedError(child, "Atom region contains atom(s) which have already been overridden")
@@ -7816,7 +7937,10 @@ contains
 
 
   !> Reads the parallel block.
-  subroutine readParallel(root, input)
+  subroutine readParallel(env, root, input)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Root node eventually containing the current block
     type(fnode), pointer, intent(in) :: root
@@ -7829,20 +7953,23 @@ contains
     call getChild(root, "Parallel", child=node, requested=.false., emptyIfMissing=withMpi)
     if (associated(node)) then
       if (.not. withMpi) then
-        call detailedWarning(node, "Settings will be read but ignored (compiled without MPI&
+        call detailedWarning(env%stdOut, node, "Settings will be read but ignored (compiled without MPI&
             & support)")
       end if
       allocate(input%ctrl%parallelOpts)
       call getChildValue(node, "Groups", input%ctrl%parallelOpts%nGroup, 1, child=pTmp)
       call getChildValue(node, "UseOmpThreads", input%ctrl%parallelOpts%tOmpThreads, .not. withMpi)
-      call readBlacs(node, input%ctrl%parallelOpts%blacsOpts)
+      call readBlacs(env, node, input%ctrl%parallelOpts%blacsOpts)
     end if
 
   end subroutine readParallel
 
 
   !> Reads the blacs block
-  subroutine readBlacs(root, blacsOpts)
+  subroutine readBlacs(env, root, blacsOpts)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Root node eventually containing the current block
     type(fnode), pointer, intent(in) :: root
@@ -7855,7 +7982,7 @@ contains
     call getChild(root, "Blacs", child=node, requested=.false., emptyIfMissing=withScalapack)
     if (associated(node)) then
       if (.not. withScalapack) then
-        call detailedWarning(node, "Settings will be read but ignored (compiled without SCALAPACK&
+        call detailedWarning(env%stdOut, node, "Settings will be read but ignored (compiled without SCALAPACK&
             & support)")
       end if
       call getChildValue(node, "BlockSize", blacsOpts%blockSize, 32)
@@ -8245,7 +8372,10 @@ contains
 
 
   !> Reads the REKS block
-  subroutine readReks(node, child, ctrl, geom)
+  subroutine readReks(env, node, child, ctrl, geom)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to parse
     type(fnode), pointer, intent(in) :: node
@@ -8269,7 +8399,7 @@ contains
       ctrl%reksInp%reksAlg = reksTypes%noReks
     case ("ssr22")
       ctrl%reksInp%reksAlg = reksTypes%ssr22
-      call readSSR22(node, ctrl, geom)
+      call readSSR22(env, node, ctrl, geom)
     case ("ssr44")
       ctrl%reksInp%reksAlg = reksTypes%ssr44
       call detailedError(child, "SSR(4,4) is not implemented yet.")
@@ -8282,7 +8412,10 @@ contains
 
 
   !> Reads the SSR(2,2) block
-  subroutine readSSR22(node, ctrl, geom)
+  subroutine readSSR22(env, node, ctrl, geom)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to parse
     type(fnode), pointer, intent(in) :: node
@@ -8299,7 +8432,6 @@ contains
     character(sc), allocatable :: tmpFunc(:)
     integer :: ii, nFunc
     logical :: tFunc = .true.
-
 
     !> Read 'Energy' block
     call getChild(node, "Energy", child=child1)
@@ -8332,12 +8464,12 @@ contains
     end if
 
     if (.not. tFunc) then
-      write(stdOut,'(A)',advance="no") "Current Functional : "
+      write(env%stdOut,'(A)',advance="no") "Current Functional : "
       do ii = 1, nFunc
         if (ii == nFunc) then
-          write(stdOut,'(A)') "'" // trim(tmpFunc(ii)) // "'"
+          write(env%stdOut,'(A)') "'" // trim(tmpFunc(ii)) // "'"
         else
-          write(stdOut,'(A)',advance="no") "'" // trim(tmpFunc(ii)) // "' "
+          write(env%stdOut,'(A)',advance="no") "'" // trim(tmpFunc(ii)) // "' "
         end if
       end do
       call detailedError(child1, "Invalid Functional")

--- a/src/dftbp/dftbplus/transportio.F90
+++ b/src/dftbp/dftbplus/transportio.F90
@@ -32,7 +32,7 @@ contains
   !> Write the Hamiltonian self consistent shifts to file
   subroutine writeShifts(output, fShifts, orb, shiftPerL)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> filename where shifts are stored
@@ -118,7 +118,7 @@ contains
   !> Writes the contact potential shifts per shell (for transport)
   subroutine writeContactShifts(output, filename, orb, shiftPerL, charges, Ef, blockCharges, tWriteAscii)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> filename where shifts are written
@@ -222,7 +222,7 @@ contains
   !> Read contact potential shifts from file
   subroutine readContactShifts(output, shiftPerL, charges, tp, orb, blockUp)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> shifts for atoms in contacts

--- a/src/dftbp/dftbplus/transportio.F90
+++ b/src/dftbp/dftbplus/transportio.F90
@@ -11,7 +11,6 @@ module dftbp_dftbplus_transportio
   use dftbp_common_accuracy, only : dp, lc
   use dftbp_common_constants, only : Hartree__eV
   use dftbp_common_file, only : closeFile, fileExists, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_io_message, only : error
   use dftbp_type_orbitals, only : TOrbitals
 #:if WITH_TRANSPORT
@@ -31,7 +30,10 @@ module dftbp_dftbplus_transportio
 contains
 
   !> Write the Hamiltonian self consistent shifts to file
-  subroutine writeShifts(fShifts, orb, shiftPerL)
+  subroutine writeShifts(output, fShifts, orb, shiftPerL)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> filename where shifts are stored
     character(*), intent(in) :: fShifts
@@ -63,7 +65,7 @@ contains
     end do
     call closeFile(fdHS)
 
-    write(stdOut,*) ">> Shifts saved for restart in shifts.dat"
+    write(output,*) ">> Shifts saved for restart in shifts.dat"
 
   end subroutine writeShifts
 
@@ -114,7 +116,10 @@ contains
 
 
   !> Writes the contact potential shifts per shell (for transport)
-  subroutine writeContactShifts(filename, orb, shiftPerL, charges, Ef, blockCharges, tWriteAscii)
+  subroutine writeContactShifts(output, filename, orb, shiftPerL, charges, Ef, blockCharges, tWriteAscii)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> filename where shifts are written
     character(*), intent(in) :: filename
@@ -178,7 +183,7 @@ contains
         write(fdHS%unit, formatFermiWrite) 'Fermi level :', Ef(1), "H", Hartree__eV * Ef(1), 'eV'
       end if
 
-      write(stdOut,*) 'shiftcont_' // trim(filename) // '.dat written to file'
+      write(output,*) 'shiftcont_' // trim(filename) // '.dat written to file'
 
     else
 
@@ -202,7 +207,7 @@ contains
 
       write(fdHS%unit) Ef(:)
 
-      write(stdOut,*) 'shiftcont_' // trim(filename) // '.bin written to file'
+      write(output,*) 'shiftcont_' // trim(filename) // '.bin written to file'
 
     end if
 
@@ -215,7 +220,10 @@ contains
 #:if WITH_TRANSPORT
 
   !> Read contact potential shifts from file
-  subroutine readContactShifts(shiftPerL, charges, tp, orb, blockUp)
+  subroutine readContactShifts(output, shiftPerL, charges, tp, orb, blockUp)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> shifts for atoms in contacts
     real(dp), intent(out) :: shiftPerL(:,:)
@@ -314,7 +322,7 @@ contains
 
         case default
 
-          write(stdOut,*) "Error reading file contact file " // fileName
+          write(output,*) "Error reading file contact file " // fileName
           call error(trim(buffer))
 
         end select

--- a/src/dftbp/elecsolvers/elsisolver.F90
+++ b/src/dftbp/elecsolvers/elsisolver.F90
@@ -564,7 +564,7 @@ contains
   !> Checks for supported ELSI api version, ideally 2.6.2, but 2.5.0 can also be used with warnings.
   subroutine supportedVersionNumber(output, version)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Version value components inside the structure

--- a/src/dftbp/elecsolvers/elsisolver.F90
+++ b/src/dftbp/elecsolvers/elsisolver.F90
@@ -11,7 +11,6 @@
 module dftbp_elecsolvers_elsisolver
   use dftbp_common_accuracy, only : dp, lc
   use dftbp_common_environment, only : globalTimers, TEnvironment
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_common_version, only : TVersion
   use dftbp_dftb_energytypes, only : TEnergies
   use dftbp_dftb_etemp, only : fillingTypes
@@ -363,7 +362,7 @@ contains
     integer :: version(3)
 
     call elsi_get_version(version(1), version(2), version(3))
-    call supportedVersionNumber(TVersion(version(1), version(2), version(3)))
+    call supportedVersionNumber(env%stdOut, TVersion(version(1), version(2), version(3)))
 
     this%iSolver = inp%iSolver
 
@@ -563,7 +562,10 @@ contains
 
 
   !> Checks for supported ELSI api version, ideally 2.6.2, but 2.5.0 can also be used with warnings.
-  subroutine supportedVersionNumber(version)
+  subroutine supportedVersionNumber(output, version)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Version value components inside the structure
     type(TVersion), intent(in) :: version
@@ -576,11 +578,11 @@ contains
     if (.not. isPartSupported) then
       call error("Unsuported ELSI version for DFTB+ (requires release >= 2.5.0)")
     else if (.not. isSupported) then
-      call warning("ELSI version 2.5 is only partially supported due to changes in default solver&
+      call warning(output, "ELSI version 2.5 is only partially supported due to changes in default solver&
           & behaviour for PEXSI at 2.6.0")
     end if
 
-    write(stdOut,"(A,T30,I0,'.',I0,'.',I0)") 'ELSI library version :', version%numbers
+    write(output,"(A,T30,I0,'.',I0,'.',I0)") 'ELSI library version :', version%numbers
 
   end subroutine supportedVersionNumber
 
@@ -980,7 +982,7 @@ contains
     if (nSpin /= 4) then
       if (tRealHS) then
         if (this%isSparse) then
-          call getDensityRealSparse(this, parallelKS, ham, over, neighbourList%iNeighbour,&
+          call getDensityRealSparse(this, env, parallelKS, ham, over, neighbourList%iNeighbour,&
               & nNeighbourSK, denseDesc%iAtomStart, iSparseStart, img2CentCell, tHelical, orb,&
               & species, coord, rhoPrim, Eband)
         else
@@ -990,7 +992,7 @@ contains
         end if
       else
         if (this%isSparse) then
-          call getDensityCmplxSparse(this, parallelKS, kPoint(:,iK), kWeight(iK), iCellVec,&
+          call getDensityCmplxSparse(this, env, parallelKS, kPoint(:,iK), kWeight(iK), iCellVec,&
               & cellVec, ham, over, neighbourList%iNeighbour, nNeighbourSK, denseDesc%iAtomStart,&
               & iSparseStart, img2CentCell, tHelical, orb, species, coord, rhoPrim, Eband)
         else
@@ -1378,7 +1380,7 @@ contains
       call elsi_write_mat_real(this%rwHandle, "ELSI_Hreal.bin", HSqrReal)
       call elsi_write_mat_real(this%rwHandle, "ELSI_Sreal.bin", SSqrReal)
       call elsi_finalize_rw(this%rwHandle)
-      call cleanShutdown("Finished dense matrix write")
+      call cleanShutdown(env%stdOut, "Finished dense matrix write")
     end if
     call elsi_dm_real(this%handle, HSqrReal, SSqrReal, rhoSqrReal, Eband(iS))
 
@@ -1508,7 +1510,7 @@ contains
       call elsi_write_mat_complex(this%rwHandle, "ELSI_Scmplx.bin",&
           & SSqrCplx)
       call elsi_finalize_rw(this%rwHandle)
-      call cleanShutdown("Finished dense matrix write")
+      call cleanShutdown(env%stdOut, "Finished dense matrix write")
     end if
     call elsi_dm_complex(this%handle, HSqrCplx, SSqrCplx, rhoSqrCplx,&
         & Eband(iS))
@@ -1666,7 +1668,7 @@ contains
       call elsi_write_mat_complex(this%rwHandle, "ELSI_Scmplx.bin",&
           & SSqrCplx)
       call elsi_finalize_rw(this%rwHandle)
-      call cleanShutdown("Finished dense matrix write")
+      call cleanShutdown(env%stdOut, "Finished dense matrix write")
     end if
     call elsi_dm_complex(this%handle, HSqrCplx, SSqrCplx, rhoSqrCplx,&
         & Eband(iS))
@@ -1695,11 +1697,14 @@ contains
 
 
   !> Calculates density matrix using the elsi routine.
-  subroutine getDensityRealSparse(this, parallelKS, ham, over, iNeighbour, nNeighbourSK,&
+  subroutine getDensityRealSparse(this, env, parallelKS, ham, over, iNeighbour, nNeighbourSK,&
       & iAtomStart, iSparseStart, img2CentCell, tHelical, orb, species, coord, rho, Eband)
 
     !> Electronic solver information
     type(TElsiSolver), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Contains (iK, iS) tuples to be processed in parallel by various processor groups
     type(TParallelKS), intent(in) :: parallelKS
@@ -1784,7 +1789,7 @@ contains
       call elsi_write_mat_real_sparse(this%rwHandle, "ELSI_SrealSparse.bin",&
           & this%elsiCsc%rowIndLocal, this%elsiCsc%colPtrLocal, SnzValLocal)
       call elsi_finalize_rw(this%rwHandle)
-      call cleanShutdown("Finished matrix write")
+      call cleanShutdown(env%stdOut, "Finished matrix write")
     end if
 
     call elsi_dm_real_sparse(this%handle, HnzValLocal, SnzValLocal, DMnzValLocal,&
@@ -1804,12 +1809,15 @@ contains
 
 
   !> Calculates density matrix using the elsi routine.
-  subroutine getDensityCmplxSparse(this, parallelKS, kPoint, kWeight, iCellVec, cellVec, ham,&
+  subroutine getDensityCmplxSparse(this, env, parallelKS, kPoint, kWeight, iCellVec, cellVec, ham,&
       & over, iNeighbour, nNeighbourSK, iAtomStart, iSparseStart, img2CentCell, tHelical, orb,&
       & species, coord, rho, Eband)
 
     !> Electronic solver information
     type(TElsiSolver), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Contains (iK, iS) tuples to be processed in parallel by various processor groups
     type(TParallelKS), intent(in) :: parallelKS
@@ -1905,7 +1913,7 @@ contains
       call elsi_write_mat_complex_sparse(this%rwHandle, "ELSI_ScmplxSparse.bin",&
           & this%elsiCsc%rowIndLocal, this%elsiCsc%colPtrLocal, SnzValLocal)
       call elsi_finalize_rw(this%rwHandle)
-      call cleanShutdown("Finished matrix write")
+      call cleanShutdown(env%stdOut, "Finished matrix write")
     end if
 
     call elsi_dm_complex_sparse(this%handle, HnzValLocal, SnzValLocal, DMnzValLocal, Eband(iS))

--- a/src/dftbp/extlibs/poisson.F90
+++ b/src/dftbp/extlibs/poisson.F90
@@ -17,7 +17,6 @@ module dftbp_extlibs_poisson
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : pi
   use dftbp_common_environment, only : globalTimers, TEnvironment
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_io_message, only : error
   use dftbp_type_commontypes, only : TOrbitals
 #:if WITH_MPI
@@ -69,6 +68,11 @@ module dftbp_extlibs_poisson
 
     ! Stores the shift vector to use in order to upload the shell potential
     real(dp), allocatable :: shellPotUpload_(:,:)
+
+    logical :: isInitialised_ = .false.
+
+    !> output for write processes
+    integer :: output
 
   contains
 
@@ -330,6 +334,8 @@ contains
 
     integer :: nAtom
 
+    this%output = env%stdOut
+
     if (nInstances_ > 0) then
       call error("Internal error: There exists already an instance of PoissonSolver")
     end if
@@ -346,6 +352,7 @@ contains
   #:else
     call poiss_init_(env, input%poissonStruct, orb, input%hubbU, input%poissonInfo, success)
   #:endif
+    this%isInitialised_ = .true.
 
   end subroutine TPoisson_init
 
@@ -363,7 +370,8 @@ contains
   subroutine finalize_(this)
     type(TPoisson), intent(inout) :: this
 
-    call poiss_destroy_()
+    if (.not. this%isInitialised_) return
+    call poiss_destroy_(this%output)
     nInstances_ = nInstances_ - 1
 
   end subroutine finalize_
@@ -532,10 +540,10 @@ contains
     call mpifx_barrier(env%mpi%globalComm, iErr)
   #:endif
 
-    write(stdOut,*)
-    write(stdOut,*) 'Poisson Initialisation:'
-    write(stdOut,'(a,i0,a)') ' Poisson parallelized on ', numprocs, ' node(s)'
-    write(stdOut,*)
+    write(env%stdOut,*)
+    write(env%stdOut,*) 'Poisson Initialisation:'
+    write(env%stdOut,'(a,i0,a)') ' Poisson parallelized on ', numprocs, ' node(s)'
+    write(env%stdOut,*)
 
     ! Directory for temporary files
     call set_scratch(poissoninfo%scratch)
@@ -543,7 +551,7 @@ contains
   #:if WITH_TRANSPORT
     if (id0 .and. transpar%ncont > 0) then
       ! only use a scratch folder on the lead node
-      call create_directory_(trim(scratchfolder),iErr)
+      call create_directory_(env%stdOut, trim(scratchfolder),iErr)
     end if
   #:endif
 
@@ -551,17 +559,17 @@ contains
       ! processors over which the right hand side of the Poisson equation is parallelised
 
       iErr = 0
-      call init_structure(structure%nAtom, structure%nSpecies, structure%specie0, structure%x0,&
+      call init_structure(env%stdOut, structure%nAtom, structure%nSpecies, structure%specie0, structure%x0,&
           & structure%latVecs, structure%isperiodic)
 
-      call init_skdata(orb%nShell, orb%angShell, hubbU)
+      call init_skdata(env%stdOut, orb%nShell, orb%angShell, hubbU)
 
-      call init_charges()
+      call init_charges(env%stdOut)
 
       ! Initialise renormalization factors for grid projection
 
       if (iErr.ne.0) then
-        call poiss_destroy_()
+        call poiss_destroy_(env%stdOut)
         initinfo = .false.
         return
       endif
@@ -633,15 +641,15 @@ contains
 
       ! if deltaR_max > 0 is a radius cutoff, if < 0 a tolerance
       if (deltaR_max < 0.0_dp) then
-        write(stdOut,*) "Atomic density tolerance: ", -deltaR_max
+        write(env%stdOut,*) "Atomic density tolerance: ", -deltaR_max
         deltaR_max = getAtomDensityCutoff_(-deltaR_max, uhubb)
       end if
 
-      write(stdOut,*) "Atomic density cutoff: ", deltaR_max, "a.u."
+      write(env%stdOut,*) "Atomic density cutoff: ", deltaR_max, "a.u."
 
     #:if WITH_TRANSPORT
       if (ncont /= 0 .and. poissoninfo%cutoffcheck) then
-        call checkDensityCutoff_(deltaR_max, transpar%contacts(:)%length)
+        call checkDensityCutoff_(env, deltaR_max, transpar%contacts(:)%length)
       end if
     #:endif
 
@@ -687,19 +695,19 @@ contains
       fixed_renorm = .not.(poissoninfo%numericNorm)
 
       ! Performs parameters checks
-      call check_biasdir(iErr)
+      call check_biasdir(env%stdOut, iErr)
       if  (iErr /= 0) then
         call error("Unable to build box for Poisson solver")
       end if
-      call check_poisson_box(iErr)
+      call check_poisson_box(env%stdOut, iErr)
       if  (iErr /= 0) then
         call error("Unable to build box for Poisson solver")
       end if
       period = period .and. all(overrideBC == poissonBCsEnum%periodic)
       call check_parameters()
-      call check_localbc()
-      call write_parameters()
-      call check_contacts(iErr)
+      call check_localbc(env%stdOut)
+      call write_parameters(env%stdOut)
+      call check_contacts(env%stdOut, iErr)
       if  (iErr /= 0) then
         call error("Unable to build contact potentials for Poisson solver")
       end if
@@ -711,14 +719,17 @@ contains
       ! DoTip,tip_atom,base_atom1,base_atom2
       !-----------------------------------------------------------------------------+
 
-      write(stdOut,'(79(">"))')
+      write(env%stdOut,'(79(">"))')
 
     endif
 
   end subroutine poiss_init_
 
 
-  subroutine create_directory_(dirName, iErr)
+  subroutine create_directory_(output, dirName, iErr)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     character(*), intent(in) :: dirName
 
@@ -734,21 +745,24 @@ contains
     call execute_command_line("mkdir "//trim(dirName), exitstat=iErr, cmdstat=cstat,&
         & cmdmsg=cmsg)
     if (iErr /= 0) then
-      write (stdOut,*) 'error status of mkdir: ', iErr
-      write (stdOut,*) 'command status: ', cstat
-      write (stdOut,*) "command msg:  ", trim(cmsg)
+      write (output,*) 'error status of mkdir: ', iErr
+      write (output,*) 'command status: ', cstat
+      write (output,*) "command msg:  ", trim(cmsg)
     end if
 
   end subroutine create_directory_
 
 
   !> Release gDFTB varibles in Poisson library
-  subroutine poiss_destroy_()
+  subroutine poiss_destroy_(output)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     if (active_id) then
-      write(stdOut,'(A)')
-      write(stdOut,'(A)') 'Release Poisson Memory:'
-      call poiss_freepoisson()
+      write(output,'(A)')
+      write(output,'(A)') 'Release Poisson Memory:'
+      call poiss_freepoisson(output)
     endif
 
   end subroutine poiss_destroy_
@@ -789,12 +803,12 @@ contains
       select case(PoissFlag)
       case(0)
         if (verbose.gt.30) then
-          write(stdOut,*)
-          write(stdOut,'(80("="))')
-          write(stdOut,*) '                       SOLVING POISSON EQUATION         '
-          write(stdOut,'(80("="))')
+          write(env%stdOut,*)
+          write(env%stdOut,'(80("="))')
+          write(env%stdOut,*) '                       SOLVING POISSON EQUATION         '
+          write(env%stdOut,'(80("="))')
         end if
-        call init_PoissBox(iErr)
+        call init_PoissBox(env, iErr)
         if (iErr /= 0) then
           call error("Failure during initialisation of the Poisson box")
         end if
@@ -804,7 +818,7 @@ contains
       end select
 
       if (verbose.gt.30) then
-        write(stdOut,'(80("*"))')
+        write(env%stdOut,'(80("*"))')
       end if
     end if
 
@@ -916,7 +930,10 @@ contains
 #:if WITH_TRANSPORT
 
   !> Checks whether density cutoff fits into the PLs and stop if not.
-  subroutine checkDensityCutoff_(rr, pllens)
+  subroutine checkDensityCutoff_(env, rr, pllens)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Density cutoff.
     real(dp), intent(in) :: rr
@@ -930,9 +947,9 @@ contains
     ! have a factor 2 in front of pllens
     do ii = 1, size(pllens)
       if (rr > 2.0_dp * pllens(ii) + 1e-12_dp) then
-        write(stdOut,"(A,I0,A)") "!!! ERROR: Atomic density cutoff incompatible with the principle&
+        write(env%stdOut,"(A,I0,A)") "!!! ERROR: Atomic density cutoff incompatible with the principle&
             & layer width in contact ", ii, "."
-        write(stdOut,"(A,G10.3,A,G10.3,A)") "  (", rr, ">", pllens(ii), ")"
+        write(env%stdOut,"(A,G10.3,A,G10.3,A)") "  (", rr, ">", pllens(ii), ")"
         call error("Either enlarge PL width in the contact or increase AtomDensityCutoff or&
             & AtomDensityTolerance.")
       end if

--- a/src/dftbp/extlibs/poisson.F90
+++ b/src/dftbp/extlibs/poisson.F90
@@ -71,7 +71,7 @@ module dftbp_extlibs_poisson
 
     logical :: isInitialised_ = .false.
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer :: output
 
   contains
@@ -704,7 +704,7 @@ contains
         call error("Unable to build box for Poisson solver")
       end if
       period = period .and. all(overrideBC == poissonBCsEnum%periodic)
-      call check_parameters()
+      call check_parameters(env%stdOut)
       call check_localbc(env%stdOut)
       call write_parameters(env%stdOut)
       call check_contacts(env%stdOut, iErr)
@@ -728,7 +728,7 @@ contains
 
   subroutine create_directory_(output, dirName, iErr)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     character(*), intent(in) :: dirName
@@ -756,7 +756,7 @@ contains
   !> Release gDFTB varibles in Poisson library
   subroutine poiss_destroy_(output)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     if (active_id) then

--- a/src/dftbp/extlibs/sdftd3.F90
+++ b/src/dftbp/extlibs/sdftd3.F90
@@ -244,7 +244,7 @@ contains
         & this%energy, this%gradient, this%sigma)
 
     if (allocated(this%hydrogen)) then
-      call addHHRepulsion(this, coords, neigh, img2CentCell)
+      call addHHRepulsion(this, env%stdOut, coords, neigh, img2CentCell)
     end if
   #:else
     call notImplementedError
@@ -356,10 +356,13 @@ contains
 
 
   !> Add the additional H-H repulsion for D3H5 (Note: this routine does not belong here...)
-  subroutine addHHRepulsion(this, coords, neigh, img2CentCell)
+  subroutine addHHRepulsion(this, output, coords, neigh, img2CentCell)
 
     !> Instance of DFTD3 data
     class(TSDFTD3), intent(inout) :: this
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Current coordinates
     real(dp), intent(in) :: coords(:,:)
@@ -381,7 +384,7 @@ contains
 
     nAtom = size(neigh%nNeighbour)
     allocate(nNeigh(nAtom))
-    call getNrOfNeighboursForAll(nNeigh, neigh, HHRepCutOff)
+    call getNrOfNeighboursForAll(output, nNeigh, neigh, HHRepCutOff)
 
     repE = 0.0_dp
     do iAt1 = 1, nAtom

--- a/src/dftbp/extlibs/sdftd3.F90
+++ b/src/dftbp/extlibs/sdftd3.F90
@@ -361,7 +361,7 @@ contains
     !> Instance of DFTD3 data
     class(TSDFTD3), intent(inout) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Current coordinates

--- a/src/dftbp/geoopt/filter.F90
+++ b/src/dftbp/geoopt/filter.F90
@@ -76,10 +76,13 @@ contains
 
 
   !> Create new transformation filter
-  subroutine TFilter_init(this, input, coord0, latVec, stat)
+  subroutine TFilter_init(this, output, input, coord0, latVec, stat)
 
     !> Instance of the transformation filter
     type(TFilter), intent(out) :: this
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Input to create transformation filter
     type(TFilterInput), intent(in) :: input
@@ -114,7 +117,7 @@ contains
     this%isotropic = input%isotropic
     if (this%lattice .and. present(latVec)) then
       if (size(coord0) > this%nvar) then
-        @:ERROR_HANDLING(stat, 1, &
+        @:ERROR_HANDLING(output, stat, 1, &
             & "Subset of optimising atoms not currently possible with lattice optimisation.")
       end if
       this%nvar = this%nvar + size(latVec)

--- a/src/dftbp/geoopt/filter.F90
+++ b/src/dftbp/geoopt/filter.F90
@@ -81,7 +81,7 @@ contains
     !> Instance of the transformation filter
     type(TFilter), intent(out) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Input to create transformation filter

--- a/src/dftbp/geoopt/geoopt.F90
+++ b/src/dftbp/geoopt/geoopt.F90
@@ -7,6 +7,7 @@
 
 !> General interface for the optimization algorithms
 module dftbp_geoopt_geoopt
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp
   use dftbp_geoopt_conjgrad, only : init, next, reset, TConjGrad
   use dftbp_geoopt_deprecated_steepdesc, only : init, next, reset, TSteepDescDepr
@@ -171,10 +172,13 @@ contains
 
   !> Delivers the next point in the geometry optimization. When calling the first time, function
   !> value and gradient for the starting point of the minimization should be passed.
-  subroutine GeoOpt_next(this, fx, dx, xNew, tConverged)
+  subroutine GeoOpt_next(this, env, fx, dx, xNew, tConverged)
 
     !> Optimiser object
     type(Tgeoopt), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Function value for last point returned by this routine
     real(dp), intent(in) :: fx
@@ -196,7 +200,7 @@ contains
     case (geoOptTypes%diis)
       call next(this%pDiis, dx, xNew, tConverged)
     case (geoOptTypes%lbfgs)
-      call this%pLbfgs%next(fx, dx, xNew, tConverged)
+      call this%pLbfgs%next(env, fx, dx, xNew, tConverged)
     case (geoOptTypes%fire)
       call this%pFire%next(dx, xNew, tConverged)
     end select

--- a/src/dftbp/geoopt/lbfgs.F90
+++ b/src/dftbp/geoopt/lbfgs.F90
@@ -17,6 +17,7 @@
 !>
 module dftbp_geoopt_lbfgs
   use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp
   use dftbp_geoopt_linemin, only : TLineMin, TLineMin_init
   use dftbp_io_message, only : error, warning
@@ -277,10 +278,13 @@ contains
 
   !> Passes calculated function value and gradient to the minimizer and
   !> gives a new coordinate back.
-  subroutine TLbfgs_next(this, fx, dx, xNew, tConverged)
+  subroutine TLbfgs_next(this, env, fx, dx, xNew, tConverged)
 
     !> LBFGS Instance.
     class(TLbfgs), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Function value in the last point
     real(dp), intent(in)  :: fx
@@ -312,7 +316,7 @@ contains
     if (this%isLineSearch) then
       if (this%iter > 0) then
         if (this%isOldLSUsed) then
-          call this%lineSearch%next(fx, dx, this%xx, tLineConverged)
+          call this%lineSearch%next(env, fx, dx, this%xx, tLineConverged)
         else
           call this%lineMin%next(fx, dx, this%xx, tLineConverged)
         end if
@@ -330,13 +334,13 @@ contains
     end if
 
     ! Calculate new search direction
-    call TLbfgs_calcDirection(this, this%xx, dxTemp)
+    call TLbfgs_calcDirection(this, env%stdOut, this%xx, dxTemp)
 
     if (this%isLineSearch) then
       this%alpha = 1.0_dp
       if (this%isOldLSUsed) then
         call this%lineSearch%reset(this%xx, this%dir, this%alpha)
-        call this%lineSearch%next(fx, dx, this%xx, tLineConverged)
+        call this%lineSearch%next(env, fx, dx, this%xx, tLineConverged)
       else
         call this%lineMin%reset(this%xx, this%dir, this%alpha)
         call this%lineMin%next(fx, dx, this%xx, tLineConverged)
@@ -381,10 +385,13 @@ contains
 
 
   !> Calculates next search direction
-  subroutine TLbfgs_calcDirection(this, xx, gg, diagIn)
+  subroutine TLbfgs_calcDirection(this, output, xx, gg, diagIn)
 
     !> lbfgs instance
     class(TLbfgs), intent(inout) :: this
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Point
     real(dp), intent(in) :: xx(:)
@@ -419,12 +426,12 @@ contains
 
     ! Checks whether new x is different to last iteration
     if (maxval(abs(xx - this%xOld)) < epsilon(1.0_dp)) then
-      call warning("Error: x need to be different in each iteration. (LBFGS Minimizer)")
+      call warning(output, "Error: x need to be different in each iteration. (LBFGS Minimizer)")
     end if
 
     ! Checks whether new gradient is different to last iteration
     if (maxval(abs(gg - this%gg)) < epsilon(1.0_dp)) then
-      call warning("Error: g need to be different in each iteration. (LBFGS Minimizer)")
+      call warning(output, "Error: g need to be different in each iteration. (LBFGS Minimizer)")
     end if
 
     ! Save new ss, yy and rho
@@ -584,10 +591,13 @@ contains
   !> When calling this subroutine the first time, function value and gradient for the starting point
   !> of the minimization should be passed.
   !>
-  subroutine TLineSearch_next(this, fx, dx, xNew, tConverged)
+  subroutine TLineSearch_next(this, env, fx, dx, xNew, tConverged)
 
     !> Line minimizer instance
     class(TLineSearch), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Function value for the last returned point
     real(dp), intent(in) :: fx
@@ -613,10 +623,10 @@ contains
     dphi = dot_product(dx, this%d0)
 
     if (.not. this%tZoom) then
-      call TLineSearch_getOptimalStep(this, phi, dphi, dx, xNew, tConverged)
+      call TLineSearch_getOptimalStep(this, env%stdOut, phi, dphi, dx, xNew, tConverged)
     end if
     if (this%tZoom) then
-      call TLineSearch_zoom(this, phi, dphi, dx, xNew, tConverged)
+      call TLineSearch_zoom(this, env%stdOut, phi, dphi, dx, xNew, tConverged)
     end if
 
     this%iter = this%iter + 1
@@ -697,10 +707,13 @@ contains
 
 
   !> Tries to find the optimal or a bracket containing the optimal step.
-  subroutine TLineSearch_getOptimalStep(this, phi, dphi, dx, xNew, tConverged)
+  subroutine TLineSearch_getOptimalStep(this, output, phi, dphi, dx, xNew, tConverged)
 
     !> Instance.
     type(TLineSearch), intent(inout) :: this
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Function value at current point
     real(dp), intent(in) :: phi
@@ -776,7 +789,7 @@ contains
       this%dxLo(:) = dx
 
       if (abs(this%alphaNew - this%maxAlpha) < epsilon(1.0_dp)) then
-        call warning("Line Search hit maximum border.")
+        call warning(output, "Line Search hit maximum border.")
         tConverged = .true.
         xNew(:) = this%xNew
       else if ((this%alphaNew > this%maxAlpha) .and. this%iter > 0) then
@@ -793,10 +806,13 @@ contains
 
 
   !> Finds the optimal step by zooming into the brackets.
-  subroutine TLineSearch_zoom(this, phi, dphi, dx, xNew, tConverged)
+  subroutine TLineSearch_zoom(this, output, phi, dphi, dx, xNew, tConverged)
 
     !> Instance.
     type(TLineSearch), intent(inout) :: this
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Function value at current point
     real(dp), intent(in) :: phi
@@ -840,7 +856,7 @@ contains
       end if
       xNew(:) = this%x0 + this%alphaLo * this%d0
 
-      call warning("LineSearch did not Converged. (zoom)")
+      call warning(output, "LineSearch did not Converged. (zoom)")
       tConverged = .true.
       return
     end if

--- a/src/dftbp/geoopt/lbfgs.F90
+++ b/src/dftbp/geoopt/lbfgs.F90
@@ -390,7 +390,7 @@ contains
     !> lbfgs instance
     class(TLbfgs), intent(inout) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Point
@@ -712,7 +712,7 @@ contains
     !> Instance.
     type(TLineSearch), intent(inout) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Function value at current point
@@ -811,7 +811,7 @@ contains
     !> Instance.
     type(TLineSearch), intent(inout) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Function value at current point

--- a/src/dftbp/include/error.fypp
+++ b/src/dftbp/include/error.fypp
@@ -17,7 +17,7 @@
 
 #! Macro to return an error flag if return variable available or throw
 #! an error and shut down otherwise
-#:def ERROR_HANDLING(errVar, errNumber, msg)
+#:def ERROR_HANDLING(output, errVar, errNumber, msg)
   block
     use dftbp_common_accuracy, only : lc
     use dftbp_io_message, only : error, warning
@@ -27,7 +27,7 @@
     write(stringTmp,"(A)")${msg}$
     if (present(${errVar}$)) then
       ${errVar}$ = ${errNumber}$
-      call warning(stringTmp)
+      call warning(${output}$, stringTmp)
       return
     else
       call error(stringTmp)
@@ -38,7 +38,7 @@
 
 #! Macro to return an error flag if return variable available or throw
 #! an error and shut down otherwise
-#:def FORMATTED_ERROR_HANDLING(errVar, errNumber, formating, *variables)
+#:def FORMATTED_ERROR_HANDLING(output, errVar, errNumber, formating, *variables)
   block
     use dftbp_common_accuracy, only : lc
     use dftbp_io_message, only : error, warning
@@ -48,7 +48,7 @@
     write(stringTmp,${formating}$) ${ ",".join(variables) }$
     if (present(${errVar}$)) then
       ${errVar}$ = ${errNumber}$
-      call warning(stringTmp)
+      call warning(${output}$, stringTmp)
       return
     else
       call error(stringTmp)

--- a/src/dftbp/io/formatout.F90
+++ b/src/dftbp/io/formatout.F90
@@ -380,7 +380,7 @@ contains
   !> Writes the greeting message of dftb+ code(s) on env%stdout
   subroutine printDFTBHeader(output, text, year)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Additional text to print next to project name

--- a/src/dftbp/io/formatout.F90
+++ b/src/dftbp/io/formatout.F90
@@ -13,7 +13,7 @@ module dftbp_io_formatout
   use dftbp_common_constants, only : au__fs, Bohr__AA, Hartree__eV, pi
   use dftbp_common_environment, only : TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut, tIoProc, withMpi
+  use dftbp_common_globalenv, only : tIoProc, withMpi
   use dftbp_dftb_sparse2dense, only : unpackHS
   use dftbp_io_message, only : error
   use dftbp_math_matrixops, only : adjointLowerTriangle
@@ -377,8 +377,11 @@ contains
   end subroutine writeXYZFormat_fid
 
 
-  !> Writes the greeting message of dftb+ code(s) on stdout
-  subroutine printDFTBHeader(text, year)
+  !> Writes the greeting message of dftb+ code(s) on env%stdout
+  subroutine printDFTBHeader(output, text, year)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Additional text to print next to project name
     character(len=*), intent(in) :: text
@@ -390,29 +393,29 @@ contains
     character, parameter :: horizontalBar = '='
     integer, parameter :: headerWidth = 80
 
-    write(stdOut, '(2A,/,A)') verticalBar, repeat(horizontalBar, headerWidth - 1), verticalBar
-    write(stdOut, '(3A)') verticalBar, '  DFTB+ ', trim(text)
-    write(stdOut, '(A)') verticalBar
-    write(stdOut, '(2A,I0,A)') verticalBar, '  Copyright (C) 2006 - ', year,&
+    write(output, '(2A,/,A)') verticalBar, repeat(horizontalBar, headerWidth - 1), verticalBar
+    write(output, '(3A)') verticalBar, '  DFTB+ ', trim(text)
+    write(output, '(A)') verticalBar
+    write(output, '(2A,I0,A)') verticalBar, '  Copyright (C) 2006 - ', year,&
         & '  DFTB+ developers group'
-    write(stdOut, '(A,/,2A,/,A)') verticalBar, verticalBar, repeat(horizontalBar, headerWidth - 1),&
+    write(output, '(A,/,2A,/,A)') verticalBar, verticalBar, repeat(horizontalBar, headerWidth - 1),&
         & verticalBar
-    write(stdOut, '(2A)') verticalBar,&
+    write(output, '(2A)') verticalBar,&
         & '  When publishing results obtained with DFTB+, please cite the following',&
         & verticalBar, '  reference:'
-    write(stdOut, '(A)') verticalBar
-    write(stdOut, '(2A)') verticalBar,&
+    write(output, '(A)') verticalBar
+    write(output, '(2A)') verticalBar,&
         & '    Recent Developments in DFTB+, a Software Package for Efficient Atomistic',&
         & verticalBar,&
         & '    Quantum Mechanical Simulations, J. Phys. Chem. A 129, 5373−5390 (2025).',&
         & verticalBar, '    [https://doi.org/10.1021/acs.jpca.5c01146]'
-    write(stdOut, '(A)') verticalBar
-    write(stdOut, '(2A,2(/,2A))') verticalBar,&
+    write(output, '(A)') verticalBar
+    write(output, '(2A,2(/,2A))') verticalBar,&
         & '  You should also cite additional publications crediting the parametrization',&
         & verticalBar,&
         & '  data you use. Please consult the documentation of the SK-files for the', verticalBar,&
         & '  references.'
-    write(stdOut, '(A,/,2A,/)') verticalBar, verticalBar, repeat(horizontalBar, headerWidth - 1)
+    write(output, '(A,/,2A,/)') verticalBar, verticalBar, repeat(horizontalBar, headerWidth - 1)
 
   end subroutine printDFTBHeader
 

--- a/src/dftbp/io/hsdutils.F90
+++ b/src/dftbp/io/hsdutils.F90
@@ -1844,7 +1844,7 @@ contains
   subroutine getSelectedAtomIndices(output, node, selectionExpr, speciesNames, species, selectedIndices,&
         & selectionRange, indexRange)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Top node for detailed errors.
@@ -1898,7 +1898,7 @@ contains
   !> Converts a string containing indices and ranges to a list of indices.
   subroutine getSelectedIndices(output, node, selectionExpr, selectionRange, selectedIndices, indexRange)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Top node for detailed errors.
@@ -3606,7 +3606,7 @@ contains
   !> Prints detailed warning, including line number and path
   subroutine detailedWarning(output, node, msg)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Node where the error occurred.

--- a/src/dftbp/io/hsdutils.F90
+++ b/src/dftbp/io/hsdutils.F90
@@ -1841,8 +1841,11 @@ contains
 
 
   !> Converts a string containing atom indices, ranges and species names to a list of atom indices.
-  subroutine getSelectedAtomIndices(node, selectionExpr, speciesNames, species, selectedIndices,&
+  subroutine getSelectedAtomIndices(output, node, selectionExpr, speciesNames, species, selectedIndices,&
         & selectionRange, indexRange)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Top node for detailed errors.
     type(fnode), pointer, intent(in) :: node
@@ -1886,14 +1889,17 @@ contains
     end if
     selectedIndices = pack([(ii, ii = selectionRange_(1), selectionRange_(2))], selected)
     if (size(selectedIndices) == 0) then
-      call detailedWarning(node, "Atom index selection expression selected no atoms")
+      call detailedWarning(output, node, "Atom index selection expression selected no atoms")
     end if
 
   end subroutine getSelectedAtomIndices
 
 
   !> Converts a string containing indices and ranges to a list of indices.
-  subroutine getSelectedIndices(node, selectionExpr, selectionRange, selectedIndices, indexRange)
+  subroutine getSelectedIndices(output, node, selectionExpr, selectionRange, selectedIndices, indexRange)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Top node for detailed errors.
     type(fnode), pointer, intent(in) :: node
@@ -1924,7 +1930,7 @@ contains
     end if
     selectedIndices = pack([(ii, ii = selectionRange(1), selectionRange(2))], selected)
     if (size(selectedIndices) == 0) then
-      call detailedWarning(node, "Atom index selection expression selected no atoms")
+      call detailedWarning(output, node, "Atom index selection expression selected no atoms")
     end if
 
   end subroutine getSelectedIndices
@@ -3598,7 +3604,10 @@ contains
 
 
   !> Prints detailed warning, including line number and path
-  subroutine detailedWarning(node, msg)
+  subroutine detailedWarning(output, node, msg)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Node where the error occurred.
     type(fnode), pointer :: node
@@ -3610,7 +3619,7 @@ contains
 
     str = trim(msg)
     call appendPathAndLine(node, str)
-    call warning(char(str) // newline)
+    call warning(output, char(str) // newline)
 
   end subroutine detailedWarning
 

--- a/src/dftbp/io/hsdutils2.F90
+++ b/src/dftbp/io/hsdutils2.F90
@@ -119,7 +119,7 @@ contains
   !> Prints a warning message about unprocessed nodes
   subroutine warnUnprocessedNodes(output, node, tIgnoreUnprocessed, nodeList)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Root element of the tree to investigate

--- a/src/dftbp/io/hsdutils2.F90
+++ b/src/dftbp/io/hsdutils2.F90
@@ -117,7 +117,10 @@ contains
 
 
   !> Prints a warning message about unprocessed nodes
-  subroutine warnUnprocessedNodes(node, tIgnoreUnprocessed, nodeList)
+  subroutine warnUnprocessedNodes(output, node, tIgnoreUnprocessed, nodeList)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Root element of the tree to investigate
     type(fnode), pointer :: node
@@ -145,7 +148,7 @@ contains
         call appendPathAndLine(child, msg)
         call append_to_string(msg, newline)
       end do
-      call warning(char(msg))
+      call warning(output, char(msg))
     end if
     if (present(nodeList)) then
       nodeList => list

--- a/src/dftbp/io/intrinsicpr.F90
+++ b/src/dftbp/io/intrinsicpr.F90
@@ -8,7 +8,6 @@
 !> Module to print data types
 module dftbp_io_intrinsicpr
   use dftbp_common_accuracy, only : dp, lc
-  use dftbp_common_globalenv, only : stdOut
 
   private
   public :: printContent
@@ -38,7 +37,10 @@ contains
 
 
   !> print real values
-  subroutine printArrayRealR1(array, omitHeader)
+  subroutine printArrayRealR1(unit, array, omitHeader)
+
+    !> output unit
+    integer, intent(in) :: unit
 
     !> data to print
     real(dp), intent(in) :: array(:)
@@ -51,13 +53,16 @@ contains
     if (.not. present(omitHeader)) then
       print *, " Shape: ", shape(array)
     end if
-    write(stdout, *) (array(ii), ii = lbound(array, 1), ubound(array, 1))
+    write(unit, *) (array(ii), ii = lbound(array, 1), ubound(array, 1))
 
   end subroutine printArrayRealR1
 
 
   !> print real values
-  subroutine printArrayRealR2(array, omitHeader)
+  subroutine printArrayRealR2(unit, array, omitHeader)
+
+    !> output unit
+    integer, intent(in) :: unit
 
     !> data to print
     real(dp), intent(in) :: array(:, :)
@@ -72,14 +77,17 @@ contains
     end if
     do ii = lbound(array, 2), ubound(array, 2)
       print *, "--2------", ii, "------"
-      call printContent(array(:, ii), .true.)
+      call printContent(unit, array(:, ii), .true.)
     end do
 
   end subroutine printArrayRealR2
 
 
   !> print real values
-  subroutine printArrayRealR3(array, omitHeader)
+  subroutine printArrayRealR3(unit, array, omitHeader)
+
+    !> output unit
+    integer, intent(in) :: unit
 
     !> data to print
     real(dp), intent(in) :: array(:, :, :)
@@ -94,14 +102,17 @@ contains
     end if
     do ii = lbound(array, 3), ubound(array, 3)
       print *, "--3------", ii, "------"
-      call printContent(array(:, :, ii), .true.)
+      call printContent(unit, array(:, :, ii), .true.)
     end do
 
   end subroutine printArrayRealR3
 
 
   !> print real values
-  subroutine printArrayRealR4(array, omitHeader)
+  subroutine printArrayRealR4(unit, array, omitHeader)
+
+    !> output unit
+    integer, intent(in) :: unit
 
     !> data to print
     real(dp), intent(in) :: array(:, :, :, :)
@@ -116,7 +127,7 @@ contains
     end if
     do ii = lbound(array, 4), ubound(array, 4)
       print *, "--4------", ii, "------"
-      call printContent(array(:, :, :, ii), .true.)
+      call printContent(unit, array(:, :, :, ii), .true.)
     end do
 
   end subroutine printArrayRealR4
@@ -125,7 +136,10 @@ contains
 
 
   !> print complex values
-  subroutine printArrayComplexR1(array, omitHeader)
+  subroutine printArrayComplexR1(unit, array, omitHeader)
+
+    !> output unit
+    integer, intent(in) :: unit
 
     !> data to print
     !> data to print
@@ -139,13 +153,16 @@ contains
     if (.not. present(omitHeader)) then
       print *, " Shape: ", shape(array)
     end if
-    write(stdout, *) (array(ii), ii = lbound(array, 1), ubound(array, 1))
+    write(unit, *) (array(ii), ii = lbound(array, 1), ubound(array, 1))
 
   end subroutine printArrayComplexR1
 
 
   !> print complex values
-  subroutine printArrayComplexR2(array, omitHeader)
+  subroutine printArrayComplexR2(unit, array, omitHeader)
+
+    !> output unit
+    integer, intent(in) :: unit
 
     !> data to print
     complex(dp), intent(in) :: array(:, :)
@@ -160,14 +177,17 @@ contains
     end if
     do ii = lbound(array, 2), ubound(array, 2)
       print *, "--2------", ii, "------"
-      call printContent(array(:, ii), .true.)
+      call printContent(unit, array(:, ii), .true.)
     end do
 
   end subroutine printArrayComplexR2
 
 
   !> print complex values
-  subroutine printArrayComplexR3(array, omitHeader)
+  subroutine printArrayComplexR3(unit, array, omitHeader)
+
+    !> output unit
+    integer, intent(in) :: unit
 
     !> data to print
     complex(dp), intent(in) :: array(:, :, :)
@@ -182,14 +202,17 @@ contains
     end if
     do ii = lbound(array, 3), ubound(array, 3)
       print *, "--3------", ii, "------"
-      call printContent(array(:, :, ii), .true.)
+      call printContent(unit, array(:, :, ii), .true.)
     end do
 
   end subroutine printArrayComplexR3
 
 
   !> print complex values
-  subroutine printArrayComplexR4(array, omitHeader)
+  subroutine printArrayComplexR4(unit, array, omitHeader)
+
+    !> output unit
+    integer, intent(in) :: unit
 
     !> data to print
     complex(dp), intent(in) :: array(:, :, :, :)
@@ -204,7 +227,7 @@ contains
     end if
     do ii = lbound(array, 4), ubound(array, 4)
       print *, "--4------", ii, "------"
-      call printContent(array(:, :, :, ii), .true.)
+      call printContent(unit, array(:, :, :, ii), .true.)
     end do
 
   end subroutine printArrayComplexR4
@@ -213,7 +236,10 @@ contains
 
 
   !> print integer values
-  subroutine printArrayIntR1(array, omitHeader)
+  subroutine printArrayIntR1(unit, array, omitHeader)
+
+    !> output unit
+    integer, intent(in) :: unit
 
     !> data to print
     integer, intent(in) :: array(:)
@@ -226,13 +252,16 @@ contains
     if (.not. present(omitHeader)) then
       print *, " Shape: ", shape(array)
     end if
-    write(stdout, *) (array(ii), ii = lbound(array, 1), ubound(array, 1))
+    write(unit, *) (array(ii), ii = lbound(array, 1), ubound(array, 1))
 
   end subroutine printArrayIntR1
 
 
   !> print integer values
-  subroutine printArrayIntR2(array, omitHeader)
+  subroutine printArrayIntR2(unit, array, omitHeader)
+
+    !> output unit
+    integer, intent(in) :: unit
 
     !> data to print
     integer, intent(in) :: array(:, :)
@@ -247,14 +276,17 @@ contains
     end if
     do ii = lbound(array, 2), ubound(array, 2)
       print *, "--2------", ii, "------"
-      call printContent(array(:, ii), .true.)
+      call printContent(unit, array(:, ii), .true.)
     end do
 
   end subroutine printArrayIntR2
 
 
   !> print integer values
-  subroutine printArrayIntR3(array, omitHeader)
+  subroutine printArrayIntR3(unit, array, omitHeader)
+
+    !> output unit
+    integer, intent(in) :: unit
 
     !> data to print
     integer, intent(in) :: array(:, :, :)
@@ -269,14 +301,17 @@ contains
     end if
     do ii = lbound(array, 3), ubound(array, 3)
       print *, "--3------", ii, "------"
-      call printContent(array(:, :, ii), .true.)
+      call printContent(unit, array(:, :, ii), .true.)
     end do
 
   end subroutine printArrayIntR3
 
 
   !> print integer values
-  subroutine printArrayIntR4(array, omitHeader)
+  subroutine printArrayIntR4(unit, array, omitHeader)
+
+    !> output unit
+    integer, intent(in) :: unit
 
     !> data to print
     integer, intent(in) :: array(:, :, :, :)
@@ -291,7 +326,7 @@ contains
     end if
     do ii = lbound(array, 4), ubound(array, 4)
       print *, "--4------", ii, "------"
-      call printContent(array(:, :, :, ii), .true.)
+      call printContent(unit, array(:, :, :, ii), .true.)
     end do
 
   end subroutine printArrayIntR4
@@ -300,7 +335,10 @@ contains
 
 
   !> print character values
-  subroutine printArrayCharR1(array, omitHeader)
+  subroutine printArrayCharR1(unit, array, omitHeader)
+
+    !> output unit
+    integer, intent(in) :: unit
 
     !> data to print
     character(lc), intent(in) :: array(:)
@@ -313,13 +351,16 @@ contains
     if (.not. present(omitHeader)) then
       print *, " Shape: ", shape(array)
     end if
-    write(stdout, *) (trim(array(ii)), ii = lbound(array, 1), ubound(array, 1))
+    write(unit, *) (trim(array(ii)), ii = lbound(array, 1), ubound(array, 1))
 
   end subroutine printArrayCharR1
 
 
   !> print character values
-  subroutine printArrayCharR2(array, omitHeader)
+  subroutine printArrayCharR2(unit, array, omitHeader)
+
+    !> output unit
+    integer, intent(in) :: unit
 
     !> data to print
     character(lc), intent(in) :: array(:, :)
@@ -334,7 +375,7 @@ contains
     end if
     do ii = lbound(array, 2), ubound(array, 2)
       print *, "--2------", ii, "------"
-      call printContent(array(:, ii), .true.)
+      call printContent(unit, array(:, ii), .true.)
     end do
 
   end subroutine printArrayCharR2

--- a/src/dftbp/io/intrinsicpr.F90
+++ b/src/dftbp/io/intrinsicpr.F90
@@ -37,10 +37,10 @@ contains
 
 
   !> print real values
-  subroutine printArrayRealR1(unit, array, omitHeader)
+  subroutine printArrayRealR1(output, array, omitHeader)
 
     !> output unit
-    integer, intent(in) :: unit
+    integer, intent(in) :: output
 
     !> data to print
     real(dp), intent(in) :: array(:)
@@ -53,16 +53,16 @@ contains
     if (.not. present(omitHeader)) then
       print *, " Shape: ", shape(array)
     end if
-    write(unit, *) (array(ii), ii = lbound(array, 1), ubound(array, 1))
+    write(output, *) (array(ii), ii = lbound(array, 1), ubound(array, 1))
 
   end subroutine printArrayRealR1
 
 
   !> print real values
-  subroutine printArrayRealR2(unit, array, omitHeader)
+  subroutine printArrayRealR2(output, array, omitHeader)
 
     !> output unit
-    integer, intent(in) :: unit
+    integer, intent(in) :: output
 
     !> data to print
     real(dp), intent(in) :: array(:, :)
@@ -77,17 +77,17 @@ contains
     end if
     do ii = lbound(array, 2), ubound(array, 2)
       print *, "--2------", ii, "------"
-      call printContent(unit, array(:, ii), .true.)
+      call printContent(output, array(:, ii), .true.)
     end do
 
   end subroutine printArrayRealR2
 
 
   !> print real values
-  subroutine printArrayRealR3(unit, array, omitHeader)
+  subroutine printArrayRealR3(output, array, omitHeader)
 
     !> output unit
-    integer, intent(in) :: unit
+    integer, intent(in) :: output
 
     !> data to print
     real(dp), intent(in) :: array(:, :, :)
@@ -102,17 +102,17 @@ contains
     end if
     do ii = lbound(array, 3), ubound(array, 3)
       print *, "--3------", ii, "------"
-      call printContent(unit, array(:, :, ii), .true.)
+      call printContent(output, array(:, :, ii), .true.)
     end do
 
   end subroutine printArrayRealR3
 
 
   !> print real values
-  subroutine printArrayRealR4(unit, array, omitHeader)
+  subroutine printArrayRealR4(output, array, omitHeader)
 
     !> output unit
-    integer, intent(in) :: unit
+    integer, intent(in) :: output
 
     !> data to print
     real(dp), intent(in) :: array(:, :, :, :)
@@ -127,7 +127,7 @@ contains
     end if
     do ii = lbound(array, 4), ubound(array, 4)
       print *, "--4------", ii, "------"
-      call printContent(unit, array(:, :, :, ii), .true.)
+      call printContent(output, array(:, :, :, ii), .true.)
     end do
 
   end subroutine printArrayRealR4
@@ -136,10 +136,10 @@ contains
 
 
   !> print complex values
-  subroutine printArrayComplexR1(unit, array, omitHeader)
+  subroutine printArrayComplexR1(output, array, omitHeader)
 
     !> output unit
-    integer, intent(in) :: unit
+    integer, intent(in) :: output
 
     !> data to print
     !> data to print
@@ -153,16 +153,16 @@ contains
     if (.not. present(omitHeader)) then
       print *, " Shape: ", shape(array)
     end if
-    write(unit, *) (array(ii), ii = lbound(array, 1), ubound(array, 1))
+    write(output, *) (array(ii), ii = lbound(array, 1), ubound(array, 1))
 
   end subroutine printArrayComplexR1
 
 
   !> print complex values
-  subroutine printArrayComplexR2(unit, array, omitHeader)
+  subroutine printArrayComplexR2(output, array, omitHeader)
 
     !> output unit
-    integer, intent(in) :: unit
+    integer, intent(in) :: output
 
     !> data to print
     complex(dp), intent(in) :: array(:, :)
@@ -177,17 +177,17 @@ contains
     end if
     do ii = lbound(array, 2), ubound(array, 2)
       print *, "--2------", ii, "------"
-      call printContent(unit, array(:, ii), .true.)
+      call printContent(output, array(:, ii), .true.)
     end do
 
   end subroutine printArrayComplexR2
 
 
   !> print complex values
-  subroutine printArrayComplexR3(unit, array, omitHeader)
+  subroutine printArrayComplexR3(output, array, omitHeader)
 
     !> output unit
-    integer, intent(in) :: unit
+    integer, intent(in) :: output
 
     !> data to print
     complex(dp), intent(in) :: array(:, :, :)
@@ -202,17 +202,17 @@ contains
     end if
     do ii = lbound(array, 3), ubound(array, 3)
       print *, "--3------", ii, "------"
-      call printContent(unit, array(:, :, ii), .true.)
+      call printContent(output, array(:, :, ii), .true.)
     end do
 
   end subroutine printArrayComplexR3
 
 
   !> print complex values
-  subroutine printArrayComplexR4(unit, array, omitHeader)
+  subroutine printArrayComplexR4(output, array, omitHeader)
 
     !> output unit
-    integer, intent(in) :: unit
+    integer, intent(in) :: output
 
     !> data to print
     complex(dp), intent(in) :: array(:, :, :, :)
@@ -227,7 +227,7 @@ contains
     end if
     do ii = lbound(array, 4), ubound(array, 4)
       print *, "--4------", ii, "------"
-      call printContent(unit, array(:, :, :, ii), .true.)
+      call printContent(output, array(:, :, :, ii), .true.)
     end do
 
   end subroutine printArrayComplexR4
@@ -236,10 +236,10 @@ contains
 
 
   !> print integer values
-  subroutine printArrayIntR1(unit, array, omitHeader)
+  subroutine printArrayIntR1(output, array, omitHeader)
 
     !> output unit
-    integer, intent(in) :: unit
+    integer, intent(in) :: output
 
     !> data to print
     integer, intent(in) :: array(:)
@@ -252,16 +252,16 @@ contains
     if (.not. present(omitHeader)) then
       print *, " Shape: ", shape(array)
     end if
-    write(unit, *) (array(ii), ii = lbound(array, 1), ubound(array, 1))
+    write(output, *) (array(ii), ii = lbound(array, 1), ubound(array, 1))
 
   end subroutine printArrayIntR1
 
 
   !> print integer values
-  subroutine printArrayIntR2(unit, array, omitHeader)
+  subroutine printArrayIntR2(output, array, omitHeader)
 
     !> output unit
-    integer, intent(in) :: unit
+    integer, intent(in) :: output
 
     !> data to print
     integer, intent(in) :: array(:, :)
@@ -276,17 +276,17 @@ contains
     end if
     do ii = lbound(array, 2), ubound(array, 2)
       print *, "--2------", ii, "------"
-      call printContent(unit, array(:, ii), .true.)
+      call printContent(output, array(:, ii), .true.)
     end do
 
   end subroutine printArrayIntR2
 
 
   !> print integer values
-  subroutine printArrayIntR3(unit, array, omitHeader)
+  subroutine printArrayIntR3(output, array, omitHeader)
 
     !> output unit
-    integer, intent(in) :: unit
+    integer, intent(in) :: output
 
     !> data to print
     integer, intent(in) :: array(:, :, :)
@@ -301,17 +301,17 @@ contains
     end if
     do ii = lbound(array, 3), ubound(array, 3)
       print *, "--3------", ii, "------"
-      call printContent(unit, array(:, :, ii), .true.)
+      call printContent(output, array(:, :, ii), .true.)
     end do
 
   end subroutine printArrayIntR3
 
 
   !> print integer values
-  subroutine printArrayIntR4(unit, array, omitHeader)
+  subroutine printArrayIntR4(output, array, omitHeader)
 
     !> output unit
-    integer, intent(in) :: unit
+    integer, intent(in) :: output
 
     !> data to print
     integer, intent(in) :: array(:, :, :, :)
@@ -326,7 +326,7 @@ contains
     end if
     do ii = lbound(array, 4), ubound(array, 4)
       print *, "--4------", ii, "------"
-      call printContent(unit, array(:, :, :, ii), .true.)
+      call printContent(output, array(:, :, :, ii), .true.)
     end do
 
   end subroutine printArrayIntR4
@@ -335,10 +335,10 @@ contains
 
 
   !> print character values
-  subroutine printArrayCharR1(unit, array, omitHeader)
+  subroutine printArrayCharR1(output, array, omitHeader)
 
     !> output unit
-    integer, intent(in) :: unit
+    integer, intent(in) :: output
 
     !> data to print
     character(lc), intent(in) :: array(:)
@@ -351,16 +351,16 @@ contains
     if (.not. present(omitHeader)) then
       print *, " Shape: ", shape(array)
     end if
-    write(unit, *) (trim(array(ii)), ii = lbound(array, 1), ubound(array, 1))
+    write(output, *) (trim(array(ii)), ii = lbound(array, 1), ubound(array, 1))
 
   end subroutine printArrayCharR1
 
 
   !> print character values
-  subroutine printArrayCharR2(unit, array, omitHeader)
+  subroutine printArrayCharR2(output, array, omitHeader)
 
     !> output unit
-    integer, intent(in) :: unit
+    integer, intent(in) :: output
 
     !> data to print
     character(lc), intent(in) :: array(:, :)
@@ -375,7 +375,7 @@ contains
     end if
     do ii = lbound(array, 2), ubound(array, 2)
       print *, "--2------", ii, "------"
-      call printContent(unit, array(:, ii), .true.)
+      call printContent(output, array(:, ii), .true.)
     end do
 
   end subroutine printArrayCharR2

--- a/src/dftbp/io/ipisocket.F90
+++ b/src/dftbp/io/ipisocket.F90
@@ -10,6 +10,7 @@
 !> Routines to make socket contact with an external code and
 !! communicate data back and forward from DFTB+ to the external code.
 module dftbp_io_ipisocket
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp, lc, rdp
   use dftbp_extlibs_fsockets, only : close_socket, connect_inet_socket, connect_unix_socket,&
       & readbuffer, writebuffer
@@ -102,10 +103,13 @@ contains
 
   !> Construct IpiSocketComm instance.
   !!
-  subroutine IpiSocketComm_init(this, input)
+  subroutine IpiSocketComm_init(this, env, input)
 
     !> Instance.
     type(IpiSocketComm), intent(out) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Input data.
     type(IpiSocketCommInp), intent(in) :: input
@@ -124,24 +128,24 @@ contains
       write(msg, '(A,1X,I0)') 'Unknown message protocol', input%protocol
     end if
 
-    call this%logger%write('socketCreate: Opening socket for two-way&
+    call this%logger%write(env%stdOut, 'socketCreate: Opening socket for two-way&
         & communication with a server.', 1)
 
     ! If port > 0: internet port, otherwise local Unix socket
     tUnix = input%port < 1
     if (tUnix) then
-      call this%logger%write('Establishing UNIX socket connection to'&
+      call this%logger%write(env%stdOut, 'Establishing UNIX socket connection to'&
           & // trim(input%host), 1)
       call connect_unix_socket(this%socket, input%host)
     else
-      call this%logger%write('Establishing an internet connection to', 1)
-      call this%logger%write('Host: ' // trim(input%host), 1)
+      call this%logger%write(env%stdOut, 'Establishing an internet connection to', 1)
+      call this%logger%write(env%stdOut, 'Host: ' // trim(input%host), 1)
       write(msg, '(A,I0)') 'Port: ', input%port
-      call this%logger%write(msg, 1)
+      call this%logger%write(env%stdOut, msg, 1)
       call connect_inet_socket(this%socket, input%host, input%port)
     end if
 
-    call this%logger%write('socketCreate: ...Done', 1)
+    call this%logger%write(env%stdOut, 'socketCreate: ...Done', 1)
     this%tInit = .true.
 
   end subroutine IpiSocketComm_init
@@ -149,7 +153,10 @@ contains
 
   !> Construct IpiSocketComm instance.
   !!
-  function construct(input) result(this)
+  function construct(env, input) result(this)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Input data
     type(IpiSocketCommInp), intent(in) :: input
@@ -157,7 +164,7 @@ contains
     !> Instance
     type(IpiSocketComm) :: this
 
-    call IpiSocketComm_init(this, input)
+    call IpiSocketComm_init(this, env, input)
 
   end function construct
 
@@ -167,10 +174,13 @@ contains
   !! All data in atomic units, and currently assumes the number
   !! of atoms is the same as passed at construction/initialisation.
   !!
-  subroutine receive(this, coord, cell, tStop)
+  subroutine receive(this, env, coord, cell, tStop)
 
     !> Instance.
     class(IpiSocketComm), intent(in) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Atomic coordinates.
     real(dp), intent(inout) :: coord(:,:)
@@ -202,20 +212,20 @@ contains
     end if
 
     allocate(commsBuffer1(this%nAtom * 3))
-    call this%logger%write('socketRetrieve: Retrieving data from socket... ', 1)
+    call this%logger%write(env%stdOut, 'socketRetrieve: Retrieving data from socket... ', 1)
 
     ! wait for anything other than 'STATUS' state from the interface, returning state 'READY' in the
     ! meanwhile
     do while (.true.)
       call readbuffer(this%socket, header)
-      call this%logger%write('ipisocket%receive: read from socket: ' // trim(header), 3)
+      call this%logger%write(env%stdOut, 'ipisocket%receive: read from socket: ' // trim(header), 3)
       if (trim(header) /= 'STATUS') then
         exit
       end if
 
       buffer = 'READY'
       call writebuffer(this%socket, buffer)
-      call this%logger%write('ipisocket%receive: write to socket: READY', 3)
+      call this%logger%write(env%stdOut, 'ipisocket%receive: write to socket: READY', 3)
     end do
 
     ! expecting positions data
@@ -223,7 +233,7 @@ contains
     case ('POSDATA')
       ! expected return during run
     case ('EXIT')
-      call warning("ipisocket%receive: EXIT. Halting DFTB+.")
+      call warning(env%stdOut, "ipisocket%receive: EXIT. Halting DFTB+.")
       tStop = .true.
       return
     case default
@@ -235,18 +245,18 @@ contains
     call readbuffer(this%socket, commsBuffer2)
     cell(:,:) = transpose(reshape(commsBuffer2, [3, 3]))
 
-    call this%logger%write('ipisocket%receive: read from socket: cell', 3)
-    call this%logger%write(cell, 4, '(f12.6)')
+    call this%logger%write(env%stdOut, 'ipisocket%receive: read from socket: cell', 3)
+    call this%logger%write(env%stdOut, cell, 4, '(f12.6)')
 
     ! inverse lattice vectors
     call readbuffer(this%socket, commsBuffer2)
-    call this%logger%write('ipisocket%receive: read from socket: inverse of cell', 3)
+    call this%logger%write(env%stdOut, 'ipisocket%receive: read from socket: inverse of cell', 3)
 
     ! number of atomic coordinates
     call readbuffer(this%socket, natom)
-    call this%logger%write('ipisocket%receive: read from socket: number of atoms', 3)
+    call this%logger%write(env%stdOut, 'ipisocket%receive: read from socket: number of atoms', 3)
     write(msg, '(I0)') nAtom
-    call this%logger%write(msg, 4)
+    call this%logger%write(env%stdOut, msg, 4)
 
     if (nAtom /= this%nAtom) then
       write(msg, '(1X,A,2I4)')'Mismatch in number of atoms received', nAtom,this%nAtom
@@ -256,9 +266,9 @@ contains
     ! read actual coordinates
     call readbuffer(this%socket, commsBuffer1)
     coord = reshape(commsBuffer1, [3, natom])
-    call this%logger%write('ipisocket%receive: read from socket: atomic positions', 3)
-    call this%logger%write(coord, 5, '(f12.6)')
-    call this%logger%write('ipisocket%receive: Done', 1)
+    call this%logger%write(env%stdOut, 'ipisocket%receive: read from socket: atomic positions', 3)
+    call this%logger%write(env%stdOut, coord, 5, '(f12.6)')
+    call this%logger%write(env%stdOut, 'ipisocket%receive: Done', 1)
 
   end subroutine receive
 
@@ -268,12 +278,14 @@ contains
   !! All data in atomic units, and currently assumes the number
   !! of atoms is the same as passed at construction/initialisation.
   !!
-  subroutine send(this, energy, forces, stress)
+  subroutine send(this, env, energy, forces, stress)
 
 
     !> Instance
     class(IpiSocketComm), intent(inout) :: this
 
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Total energy
     real(dp), intent(in) :: energy
@@ -299,13 +311,13 @@ contains
       call error(msg)
     end if
 
-    call this%logger%write('ipisocket%send: Sending data to socket... ', 1)
+    call this%logger%write(env%stdOut, 'ipisocket%send: Sending data to socket... ', 1)
 
     ! wait for anything other than a 'STATUS' state from the interface,
     ! returning state 'HAVEDATA' in the meanwhile
     listen: do while (.true.)
       call readbuffer(this%socket, header)
-      call this%logger%write('ipisocket%send: read from socket: ' // trim(header), 3)
+      call this%logger%write(env%stdOut, 'ipisocket%send: read from socket: ' // trim(header), 3)
 
       if (trim(header)/='STATUS') then
         exit listen
@@ -314,7 +326,7 @@ contains
       ! announce that we have available data
       buffer = 'HAVEDATA'
       call writebuffer(this%socket, buffer)
-      call this%logger%write('ipisocket%send: write to socket: HAVEDATA', 3)
+      call this%logger%write(env%stdOut, 'ipisocket%send: write to socket: HAVEDATA', 3)
     end do listen
 
     ! expecting to send force data
@@ -325,36 +337,36 @@ contains
 
     buffer = 'FORCEREADY'
     call writebuffer(this%socket, buffer)
-    call this%logger%write('ipisocket%send: write to socket: FORCEREADY', 3)
+    call this%logger%write(env%stdOut, 'ipisocket%send: write to socket: FORCEREADY', 3)
 
     ! transmit total energy
     call writebuffer(this%socket, energy)
-    call this%logger%write('ipisocket%send: write to socket: energy', 3)
+    call this%logger%write(env%stdOut, 'ipisocket%send: write to socket: energy', 3)
     write(msg, *) energy
-    call this%logger%write(msg, 4)
+    call this%logger%write(env%stdOut, msg, 4)
 
     ! transmit number of atoms we have
     call writebuffer(this%socket, natom)
-    call this%logger%write('ipisocket%send: write to socket: natom', 3)
+    call this%logger%write(env%stdOut, 'ipisocket%send: write to socket: natom', 3)
 
     ! transmit forces
     call writebuffer(this%socket, reshape(forces, [3 * natom]))
-    call this%logger%write('ipisocket%send: write to socket: forces', 3)
-    call this%logger%write(forces, 5, '(f12.6)')
+    call this%logger%write(env%stdOut, 'ipisocket%send: write to socket: forces', 3)
+    call this%logger%write(env%stdOut, forces, 5, '(f12.6)')
 
     ! transmit stress
     ! The (virial) stress tensor is symmetric, so no transpose needed.
     call writebuffer(this%socket, reshape(stress, [9]))
-    call this%logger%write('ipisocket%send: write to socket: stress', 3)
-    call this%logger%write(stress, 4, '(f12.6)')
+    call this%logger%write(env%stdOut, 'ipisocket%send: write to socket: stress', 3)
+    call this%logger%write(env%stdOut, stress, 4, '(f12.6)')
 
     ! i-pi can also receive an arbitrary string, that will be printed out to the 'extra' trajectory
     ! file. this is useful if you want to return additional information, e.g.  atomic charges,
     ! wannier centres, etc. one must return the number of characters, then the string. here we just
     ! send back zero characters.
     call writebuffer(this%socket, 0)
-    call this%logger%write('ipisocket%send: 0: nothing else to send', 3)
-    call this%logger%write('ipisocket%send: Done', 1)
+    call this%logger%write(env%stdOut, 'ipisocket%send: 0: nothing else to send', 3)
+    call this%logger%write(env%stdOut, 'ipisocket%send: Done', 1)
 
   end subroutine send
 

--- a/src/dftbp/io/logger.F90
+++ b/src/dftbp/io/logger.F90
@@ -8,7 +8,6 @@
 !> Contains a simple logger which helps to avoid direct write statements.
 module dftbp_io_logger
   use dftbp_common_accuracy, only : dp
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_common_optarg, only : getOptionalArg
   implicit none
 
@@ -96,12 +95,14 @@ contains
 
 
   !> Writes a message into the log (string).
-  subroutine writeStr(this, msg, verbosity, formStr)
+  subroutine writeStr(this, output, msg, verbosity, formStr)
 
 
     !> Instance
     class(LogWriter), intent(in) :: this
 
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Message to write
     character(*), intent(in) :: msg
@@ -121,19 +122,21 @@ contains
     call getOptionalArg(DEFAULT_VERBOSITY, verbosity0, verbosity)
     call getOptionalArg(DEFAULT_FORM_STR, formStr0, formStr)
     if (verbosity0 <= this%verbosity) then
-      write(stdout, formStr0) msg
+      write(output, formStr0) msg
     end if
 
   end subroutine writeStr
 
 
   !> Writes a message into the log (int).
-  subroutine writeInt(this, msg, verbosity, formStr)
+  subroutine writeInt(this, output, msg, verbosity, formStr)
 
 
     !> Instance
     class(LogWriter), intent(in) :: this
 
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Message to write
     integer, intent(in) :: msg
@@ -153,19 +156,21 @@ contains
     call getOptionalArg(DEFAULT_VERBOSITY, verbosity0, verbosity)
     call getOptionalArg(DEFAULT_FORM_STR, formStr0, formStr)
     if (verbosity0 <= this%verbosity) then
-      write(stdout, formStr0) msg
+      write(output, formStr0) msg
     end if
 
   end subroutine writeInt
 
 
   !> Writes a message into the log (real).
-  subroutine writeReal(this, msg, verbosity, formStr)
+  subroutine writeReal(this, output, msg, verbosity, formStr)
 
 
     !> Instance
     class(LogWriter), intent(in) :: this
 
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Message to write
     real(dp), intent(in) :: msg
@@ -185,19 +190,21 @@ contains
     call getOptionalArg(DEFAULT_VERBOSITY, verbosity0, verbosity)
     call getOptionalArg(DEFAULT_FORM_STR, formStr0, formStr)
     if (verbosity0 <= this%verbosity) then
-      write(stdout, formStr0) msg
+      write(output, formStr0) msg
     end if
 
   end subroutine writeReal
 
 
   !> Writes a message into the log (real1).
-  subroutine writeReal1(this, msg, verbosity, formStr, columnwise)
+  subroutine writeReal1(this, output, msg, verbosity, formStr, columnwise)
 
 
     !> Instance
     class(LogWriter), intent(in) :: this
 
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Message to write
     real(dp), intent(in) :: msg(:)
@@ -226,10 +233,10 @@ contains
     if (verbosity0 <= this%verbosity) then
       if (columnwise0) then
         call getRowFormat(formStr0, 1, formStrRow)
-        write(stdout, formStrRow) msg
+        write(output, formStrRow) msg
       else
         call getRowFormat(formStr0, size(msg), formStrRow)
-        write(stdout, formStrRow) msg
+        write(output, formStrRow) msg
       end if
     end if
 
@@ -237,12 +244,14 @@ contains
 
 
   !> Writes a message into the log (real2).
-  subroutine writeReal2(this, msg, verbosity, formStr, columnwise)
+  subroutine writeReal2(this, output, msg, verbosity, formStr, columnwise)
 
 
     !> Instance
     class(LogWriter), intent(in) :: this
 
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Message to write
     real(dp), intent(in) :: msg(:,:)
@@ -269,11 +278,11 @@ contains
     if (verbosity0 <= this%verbosity) then
       if (columnwise0) then
         do ii = 1, size(msg, dim=1)
-          call this%write(msg(ii,:), verbosity, formStr, .false.)
+          call this%write(output, msg(ii,:), verbosity, formStr, .false.)
         end do
       else
         do ii = 1, size(msg, dim=2)
-          call this%write(msg(:,ii), verbosity, formStr, .false.)
+          call this%write(output, msg(:,ii), verbosity, formStr, .false.)
         end do
       end if
     end if

--- a/src/dftbp/io/logger.F90
+++ b/src/dftbp/io/logger.F90
@@ -101,7 +101,7 @@ contains
     !> Instance
     class(LogWriter), intent(in) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Message to write
@@ -135,7 +135,7 @@ contains
     !> Instance
     class(LogWriter), intent(in) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Message to write
@@ -169,7 +169,7 @@ contains
     !> Instance
     class(LogWriter), intent(in) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Message to write
@@ -203,7 +203,7 @@ contains
     !> Instance
     class(LogWriter), intent(in) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Message to write
@@ -250,7 +250,7 @@ contains
     !> Instance
     class(LogWriter), intent(in) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Message to write

--- a/src/dftbp/io/message.F90
+++ b/src/dftbp/io/message.F90
@@ -10,7 +10,7 @@
 !> Provides routines to call with a string or array of strings if problems occur of a fatal (error)
 !> or recoverable (warning) nature.
 module dftbp_io_message
-  use dftbp_common_globalenv, only : abortProgram, stdOut, synchronizeAll
+  use dftbp_common_globalenv, only : abortProgram, stdOut0, synchronizeAll
   implicit none
 
   private
@@ -39,32 +39,39 @@ module dftbp_io_message
 
   public :: warning, error, cleanShutdown
 
+
 contains
 
 
   !> Gives a warning message.
-  subroutine warning_single(message)
+  subroutine warning_single(output, message)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Warning message to print to standard out.
     character (len=*), intent(in) :: message
 
-    write(stdOut, '(1a)') 'WARNING!'
-    write(stdOut, '(2a)') '-> ', trim(message)
+    write(output, '(1a)') 'WARNING!'
+    write(output, '(2a)') '-> ', trim(message)
 
   end subroutine warning_single
 
 
   !> Gives a warning message.
-  subroutine warning_array(messages)
+  subroutine warning_array(output, messages)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Lines of the error message to print to standard out.
     character(len=*), intent(in) :: messages(:)
 
     integer :: ii
 
-    write(stdOut, '(1a)') 'WARNING!'
+    write(output, '(1a)') 'WARNING!'
     do ii = 1, size(messages)
-      write(stdOut, '(2a)') '-> ', trim(messages(ii))
+      write(output, '(2a)') '-> ', trim(messages(ii))
     end do
 
   end subroutine warning_array
@@ -76,9 +83,9 @@ contains
     !> Error message to print to standard out.
     character (len=*), intent(in) :: message
 
-    write(stdOut, '(1a)') 'ERROR!'
-    write(stdOut, '(2a)') '-> ', trim(message)
-    flush(stdOut)
+    write(stdOut0, '(1a)') 'ERROR!'
+    write(stdOut0, '(2a)') '-> ', trim(message)
+    flush(stdOut0)
     call abortProgram()
 
   end subroutine error_single
@@ -92,24 +99,27 @@ contains
 
     integer :: ii
 
-    write(stdOut, '(1a)') 'ERROR!'
+    write(stdOut0, '(1a)') 'ERROR!'
     do ii = 1, size(messages)
-      write(stdOut, '(2a)') '-> ', trim(messages(ii))
+      write(stdOut0, '(2a)') '-> ', trim(messages(ii))
     end do
-    flush(stdOut)
+    flush(stdOut0)
     call abortProgram()
 
   end subroutine error_array
 
 
   !> Prints a message and stops the code cleanly.
-  subroutine shutdown_single(message)
+  subroutine shutdown_single(output, message)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Shutdown message to print to standard out.
     character (len=*), intent(in) :: message
 
-    write(stdOut, '(A)') trim(message)
-    flush(stdOut)
+    write(output, '(A)') trim(message)
+    flush(output)
     call synchronizeAll()
     call abortProgram()
 
@@ -117,7 +127,10 @@ contains
 
 
   !> Prints messages and stops the code cleanly.
-  subroutine shutdown_array(messages)
+  subroutine shutdown_array(output, messages)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Lines of the shutdown message to print to standard out.
     character(len=*), intent(in) :: messages(:)
@@ -125,9 +138,9 @@ contains
     integer :: ii
 
     do ii = 1, size(messages)
-      write(stdOut, '(A)') trim(messages(ii))
+      write(output, '(A)') trim(messages(ii))
     end do
-    flush(stdOut)
+    flush(output)
     call synchronizeAll()
     call abortProgram()
 

--- a/src/dftbp/io/message.F90
+++ b/src/dftbp/io/message.F90
@@ -46,7 +46,7 @@ contains
   !> Gives a warning message.
   subroutine warning_single(output, message)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Warning message to print to standard out.
@@ -61,7 +61,7 @@ contains
   !> Gives a warning message.
   subroutine warning_array(output, messages)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Lines of the error message to print to standard out.
@@ -112,7 +112,7 @@ contains
   !> Prints a message and stops the code cleanly.
   subroutine shutdown_single(output, message)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Shutdown message to print to standard out.
@@ -129,7 +129,7 @@ contains
   !> Prints messages and stops the code cleanly.
   subroutine shutdown_array(output, messages)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Lines of the shutdown message to print to standard out.

--- a/src/dftbp/md/tempprofile.F90
+++ b/src/dftbp/md/tempprofile.F90
@@ -11,9 +11,7 @@
 module dftbp_md_tempprofile
   use dftbp_common_accuracy, only : dp, minTemp
   use dftbp_common_constants, only : Boltzmann
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_io_charmanip, only : tolower
-  use dftbp_io_commonformats, only : format2U
   implicit none
 
   private
@@ -186,8 +184,6 @@ contains
     real(dp), intent(out) :: temp
 
     temp = this%curTemp
-    write(stdOut, format2U)"Target MD temperature", this%curTemp, 'a.u.', this%curTemp / Boltzmann,&
-        & 'K'
 
   end subroutine getTemperature
 

--- a/src/dftbp/md/xlbomd.F90
+++ b/src/dftbp/md/xlbomd.F90
@@ -11,6 +11,7 @@
 !> Aradi et al. Extended lagrangian density functional tight-binding molecular dynamics for
 !> molecules and solids. J. Chem. Theory Comput. 11:3357-3363, 2015
 module dftbp_md_xlbomd
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp
   use dftbp_md_extlagrangian, only : ExtLagrangian, ExtLagrangian_init, ExtLagrangianInp
   implicit none
@@ -70,10 +71,13 @@ contains
 
 
   !> Initializes the Xlbomd instance.
-  subroutine Xlbomd_init(this, input, nElems)
+  subroutine Xlbomd_init(this, env, input, nElems)
 
     !> Instance.
     type(TXLBOMD), intent(out) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Basic input parameters.
     type(TXLBOMDInp), intent(in) :: input

--- a/src/dftbp/poisson/bulkpot.F90
+++ b/src/dftbp/poisson/bulkpot.F90
@@ -16,10 +16,10 @@
 #:include "error.fypp"
 
 module dftbp_poisson_bulkpot
+ use dftbp_common_environment, only : TEnvironment
  use dftbp_common_accuracy, only : dp
  use dftbp_common_constants, only : Bohr__AA
  use dftbp_common_file, only : closeFile, fileExists, openFile, TFileDescr
- use dftbp_common_globalenv, only : stdOut
  use dftbp_io_message, only : warning
  use dftbp_poisson_boundaryconditions, only : poissonBCsEnum
  use dftbp_poisson_gallocation, only : log_gallocate, log_gdeallocate
@@ -53,49 +53,61 @@ module dftbp_poisson_bulkpot
 contains
 
  !%--------------------------------------------------------------------------
- subroutine create_super_array(SA,na,nb,nc)
+ subroutine create_super_array(output, SA,na,nb,nc)
+
+   !> output for write processes
+   integer, intent(in) :: output
 
    type(super_array) :: SA
    integer :: na,nb,nc
 
-   call log_gallocate(SA%val,na,nb,nc)
+   call log_gallocate(output, SA%val,na,nb,nc)
 
    SA%ibsize=na*nb*nc
 
  end subroutine create_super_array
 
  !%--------------------------------------------------------------------------
- subroutine destroy_super_array(SA)
+ subroutine destroy_super_array(output, SA)
+
+   !> output for write processes
+   integer, intent(in) :: output
 
    type(super_array) :: SA
 
-   call log_gdeallocate(SA%val)
+   call log_gdeallocate(output, SA%val)
 
  end subroutine destroy_super_array
  !%--------------------------------------------------------------------------
 
 
- subroutine write_super_array(SA)
+ subroutine write_super_array(output, SA)
+
+   !> output for write processes
+   integer, intent(in) :: output
 
    type(super_array) :: SA
 
    character(*), parameter :: formatStr = '(a, ":", t30, g14.10)'
 
-   write(stdOut,"(I0,1X,I0,1X,I0)") SA%a,SA%b,SA%c
-   write(stdOut,"(3E20.12)") SA%dla,SA%dlb,SA%dlc
+   write(output,"(I0,1X,I0,1X,I0)") SA%a,SA%b,SA%c
+   write(output,"(3E20.12)") SA%dla,SA%dlb,SA%dlc
 
-   write(stdOut, formatStr) 'size',SA%ibsize
-   write(stdOut, formatStr) 'iparm',SA%iparm
-   write(stdOut, formatStr) 'fparm',SA%fparm
-   write(stdOut, formatStr) 'natm_PL',SA%natm_PL
-   write(stdOut, formatStr) 'L_PL',SA%L_PL
-   write(stdOut, formatStr) 'rhs',size(SA%rhs)
-   write(stdOut, formatStr) 'val',size(SA%val)
+   write(output, formatStr) 'size',SA%ibsize
+   write(output, formatStr) 'iparm',SA%iparm
+   write(output, formatStr) 'fparm',SA%fparm
+   write(output, formatStr) 'natm_PL',SA%natm_PL
+   write(output, formatStr) 'L_PL',SA%L_PL
+   write(output, formatStr) 'rhs',size(SA%rhs)
+   write(output, formatStr) 'val',size(SA%val)
 
  end subroutine write_super_array
 
  !%--------------------------------------------------------------------------
- subroutine create_phi_bulk(phi_bulk,iparm,dlx,dly,dlz,cont_mem)
+ subroutine create_phi_bulk(output, phi_bulk,iparm,dlx,dly,dlz,cont_mem)
+
+ !> output for write processes
+ integer, intent(in) :: output
 
  type(super_array) :: phi_bulk(:)
  integer :: iparm(23)
@@ -279,7 +291,7 @@ contains
    phi_bulk(m)%iparm(19) = 0            ! Gauss-Siedel
    phi_bulk(m)%iparm(20) = 7*(na+2)*(nb+2)*(nc+2)/2
 
-   call log_gallocate(phi_bulk(m)%rhs,na,nb,nc)
+   call log_gallocate(output, phi_bulk(m)%rhs,na,nb,nc)
 
    cont_mem = na*nb*nc
 
@@ -287,7 +299,7 @@ contains
 
    phi_bulk(m)%ibsize = cont_mem
 
-   call log_gallocate(phi_bulk(m)%val,na,nb,nc)
+   call log_gallocate(output, phi_bulk(m)%val,na,nb,nc)
 
    phi_bulk(m)%val(1:na,1:nb,1:nc)=0.d0
 
@@ -297,21 +309,28 @@ end subroutine create_phi_bulk
 
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-subroutine destroy_phi_bulk(phi_bulk)
+subroutine destroy_phi_bulk(output, phi_bulk)
+
+ !> output for write processes
+ integer, intent(in) :: output
 
   type(super_array) :: phi_bulk(:)
   integer :: m
 
   do m=1,ncont
-    call log_gdeallocate(phi_bulk(m)%val)
-    call log_gdeallocate(phi_bulk(m)%rhs)
+    call log_gdeallocate(output, phi_bulk(m)%val)
+    call log_gdeallocate(output, phi_bulk(m)%rhs)
   enddo
 
 end subroutine destroy_phi_bulk
 
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 !%--------------------------------------------------------------------------
-Subroutine readbulk_pot(phi_bulk, iErr)
+Subroutine readbulk_pot(env, phi_bulk, iErr)
+
+  !> Environment
+  type(TEnvironment), intent(in) :: env
+
   type(super_array) :: phi_bulk(:)
 
   integer, intent(out), optional :: iErr
@@ -333,7 +352,7 @@ Subroutine readbulk_pot(phi_bulk, iErr)
     write(m_id,'(i2.2)') m
     fileName = 'contacts/BulkPot_' // m_id //'.dat'
     if (.not. fileExists(fileName)) then
-      @:ERROR_HANDLING(iErr, -1, 'File contacts/BulkPot_'//m_id//'.dat not found')
+      @:ERROR_HANDLING(env%stdOut, iErr, -1, 'File contacts/BulkPot_'//m_id//'.dat not found')
     else
       call openFile(fp, fileName, mode="r")
     endif
@@ -343,7 +362,7 @@ Subroutine readbulk_pot(phi_bulk, iErr)
     if (a.ne.phi_bulk(m)%iparm(14) .or. &
       b.ne.phi_bulk(m)%iparm(15) .or. &
       c.ne.phi_bulk(m)%iparm(16)) then
-      call warning('incompatible BulkPot: will be recomputed')
+      call warning(env%stdOut, 'incompatible BulkPot: will be recomputed')
       ReadBulk = .false.
       call closeFile(fp)
       return
@@ -367,17 +386,25 @@ Subroutine readbulk_pot(phi_bulk, iErr)
 end subroutine  readbulk_pot
 !%--------------------------------------------------------------------------
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-subroutine compbulk_pot(phi_bulk,iparm,fparm)
+subroutine compbulk_pot(env, phi_bulk,iparm,fparm)
+
+  !> Environment
+  type(TEnvironment), intent(in) :: env
+
   type(super_array) :: phi_bulk(:)
   integer :: iparm(23)
   real(dp) :: fparm(8)
 
-  call compbulk_pot_mud(phi_bulk,iparm,fparm)
+  call compbulk_pot_mud(env, phi_bulk,iparm,fparm)
 
 end subroutine compbulk_pot
 
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Subroutine compbulk_pot_ewald(phi_bulk, m)
+Subroutine compbulk_pot_ewald(env, phi_bulk, m)
+
+  !> Environment
+  type(TEnvironment), intent(in) :: env
+
   type(super_array) :: phi_bulk(:)
   integer :: m
 
@@ -440,7 +467,7 @@ Subroutine compbulk_pot_ewald(phi_bulk, m)
       stepb=nb-1 ! Ewalds is computed on 1 and nb
   endif
 
-  call log_gallocate( phi_bulk_PAR,na,nb,nc)
+  call log_gallocate(env%stdOut, phi_bulk_PAR,na,nb,nc)
 
   phi_bulk_PAR(:,:,:) = 0.d0
 
@@ -464,7 +491,7 @@ Subroutine compbulk_pot_ewald(phi_bulk, m)
               nsh = nshells(izp(atom))
 
               ! Compute L-independent part:
-              call long_pot(distR,basis,recbasis,alpha,vol,tol,lng_pot)
+              call long_pot(env%stdOut, distR,basis,recbasis,alpha,vol,tol,lng_pot)
               ! total atomic charge
               deltaQ = sum(dQmat(1:nsh,atom))
               phi_bulk_PAR(i,j,k) = phi_bulk_PAR(i,j,k) + deltaQ*lng_pot
@@ -474,7 +501,7 @@ Subroutine compbulk_pot_ewald(phi_bulk, m)
                  deltaQ = dQmat(l,atom)
                  uhatm = uhubb(l,izp(atom))
 
-                 call short_pot(distR,basis,uhatm,deltaQ,tol,sh_pot)
+                 call short_pot(env%stdOut, distR,basis,uhatm,deltaQ,tol,sh_pot)
 
                  !OMP CRITICAL
                  phi_bulk_PAR(i,j,k) = phi_bulk_PAR(i,j,k) - sh_pot
@@ -488,7 +515,7 @@ Subroutine compbulk_pot_ewald(phi_bulk, m)
 
   phi_bulk(m)%val(:,:,:)=phi_bulk_PAR(:,:,:)
 
-  call log_gdeallocate(phi_bulk_PAR)
+  call log_gdeallocate(env%stdOut, phi_bulk_PAR)
 
 
 end subroutine  compbulk_pot_ewald
@@ -550,7 +577,11 @@ end subroutine save_bulkpot
 
 
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Subroutine compbulk_pot_mud(phi_bulk,iparm,fparm, iErr)
+Subroutine compbulk_pot_mud(env, phi_bulk,iparm,fparm, iErr)
+
+  !> Environment
+  type(TEnvironment), intent(in) :: env
+
   type(super_array) :: phi_bulk(:)
   integer :: iparm(23)
   real(dp) :: fparm(8)
@@ -587,7 +618,7 @@ Subroutine compbulk_pot_mud(phi_bulk,iparm,fparm, iErr)
 
     ! call Ewald sums to set Dirichlet BC on two faces
     if (phi_bulk(m)%doEwald) then
-      call compbulk_pot_ewald(phi_bulk,m)
+      call compbulk_pot_ewald(env, phi_bulk,m)
     endif
 
     ! set charge density (rhs of poisson)
@@ -596,7 +627,7 @@ Subroutine compbulk_pot_mud(phi_bulk,iparm,fparm, iErr)
 
     ! solve poisson for bulkpot
 
-    call log_gallocate(work,phi_bulk(m)%iparm(20))
+    call log_gallocate(env%stdOut, work,phi_bulk(m)%iparm(20))
 
     mgopt(1) = 0
 
@@ -608,18 +639,18 @@ Subroutine compbulk_pot_mud(phi_bulk,iparm,fparm, iErr)
                 &  bulk_bndyc,phi_bulk(m)%rhs,phi_bulk(m)%val,mgopt,err )
 
       if (err.ne.0 .and. err.ne.9) then
-        @:FORMATTED_ERROR_HANDLING(iErr, -1, '(A,I0)', 'Poisson solver error n=', err)
+        @:FORMATTED_ERROR_HANDLING(env%stdOut, iErr, -1, '(A,I0)', 'Poisson solver error n=', err)
       endif
       if(err.eq.9) then
-         call log_gdeallocate(work)
-         call log_gallocate(work,phi_bulk(m)%iparm(21))
+         call log_gdeallocate(env%stdOut, work)
+         call log_gallocate(env%stdOut, work,phi_bulk(m)%iparm(21))
       endif
     enddo
 
-    call log_gdeallocate(work)
+    call log_gdeallocate(env%stdOut, work)
 
     if (phi_bulk(m)%iparm(22).eq.phi_bulk(m)%iparm(18)) then
-      @:FORMATTED_ERROR_HANDLING(iErr, -2, '(A,E12.4)', 'Bulk potential not converged! Error:',&
+      @:FORMATTED_ERROR_HANDLING(env%stdOut, iErr, -2, '(A,E12.4)', 'Bulk potential not converged! Error:',&
           & phi_bulk(m)%fparm(8))
     endif
 

--- a/src/dftbp/poisson/bulkpot.F90
+++ b/src/dftbp/poisson/bulkpot.F90
@@ -55,7 +55,7 @@ contains
  !%--------------------------------------------------------------------------
  subroutine create_super_array(output, SA,na,nb,nc)
 
-   !> output for write processes
+   !> Output unit for human readable messages
    integer, intent(in) :: output
 
    type(super_array) :: SA
@@ -70,7 +70,7 @@ contains
  !%--------------------------------------------------------------------------
  subroutine destroy_super_array(output, SA)
 
-   !> output for write processes
+   !> Output unit for human readable messages
    integer, intent(in) :: output
 
    type(super_array) :: SA
@@ -83,7 +83,7 @@ contains
 
  subroutine write_super_array(output, SA)
 
-   !> output for write processes
+   !> Output unit for human readable messages
    integer, intent(in) :: output
 
    type(super_array) :: SA
@@ -106,7 +106,7 @@ contains
  !%--------------------------------------------------------------------------
  subroutine create_phi_bulk(output, phi_bulk,iparm,dlx,dly,dlz,cont_mem)
 
- !> output for write processes
+ !> Output unit for human readable messages
  integer, intent(in) :: output
 
  type(super_array) :: phi_bulk(:)
@@ -311,7 +311,7 @@ end subroutine create_phi_bulk
 
 subroutine destroy_phi_bulk(output, phi_bulk)
 
- !> output for write processes
+ !> Output unit for human readable messages
  integer, intent(in) :: output
 
   type(super_array) :: phi_bulk(:)

--- a/src/dftbp/poisson/gallocation.F90
+++ b/src/dftbp/poisson/gallocation.F90
@@ -62,7 +62,7 @@ contains
   !---------------------------------------------------------------
   subroutine allocate_${LABEL}$(output, array, ${ARGS}$, err)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     ${TYPE}$, allocatable, target, intent(inout) :: array(${ARRAY}$)
@@ -112,7 +112,7 @@ contains
   !---------------------------------------------------------------
   subroutine deallocate_${LABEL}$(output, array, err)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     ${TYPE}$, allocatable, target, intent(inout) :: array(${ARRAY}$)

--- a/src/dftbp/poisson/gallocation.F90
+++ b/src/dftbp/poisson/gallocation.F90
@@ -34,7 +34,6 @@ module dftbp_poisson_gallocation
   use, intrinsic :: iso_c_binding, only : c_sizeof
   use, intrinsic :: iso_fortran_env, only : int64
   use dftbp_common_accuracy, only : dp
-  use dftbp_common_globalenv, only : stdOut
   implicit none
 
   public log_gallocate, log_gdeallocate, writePoissMemInfo, writePoissPeakInfo
@@ -61,7 +60,10 @@ contains
 #:for LABEL, TYPE, ARRAY, ARGS in ALLOC_CASES
 
   !---------------------------------------------------------------
-  subroutine allocate_${LABEL}$(array, ${ARGS}$, err)
+  subroutine allocate_${LABEL}$(output, array, ${ARGS}$, err)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     ${TYPE}$, allocatable, target, intent(inout) :: array(${ARRAY}$)
 
@@ -79,13 +81,13 @@ contains
 
     !Allocation control: if array is already allocated STOP and write error statement
     if (allocated(array)) then
-      @:ERROR_HANDLING(err,-1,"ALLOCATION ERROR: ${TYPE}$ (${LABEL}$) array is already allocated")
+      @:ERROR_HANDLING(output, err,-1,"ALLOCATION ERROR: ${TYPE}$ (${LABEL}$) array is already allocated")
     endif
 
     if(.not. allocated(array)) then
       allocate(array(${ARGS}$), stat=iErr)
       if (ierr /= 0) then
-        @:FORMATTED_ERROR_HANDLING(err, iErr, "(A,I0)", "Poisson allocation error: ", iErr)
+        @:FORMATTED_ERROR_HANDLING(output, err, iErr, "(A,I0)", "Poisson allocation error: ", iErr)
       else
         if (size(array) > 0) then
           pArrayFlat(1 : size(array)) => array
@@ -95,7 +97,7 @@ contains
           endif
         end if
       #:if defined('MEMLOG')
-        call writePoissMemInfo()
+        call writePoissMemInfo(output)
       #:endif
       endif
     endif
@@ -108,7 +110,10 @@ contains
 #:for LABEL, TYPE, ARRAY, _ in ALLOC_CASES
 
   !---------------------------------------------------------------
-  subroutine deallocate_${LABEL}$(array, err)
+  subroutine deallocate_${LABEL}$(output, array, err)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     ${TYPE}$, allocatable, target, intent(inout) :: array(${ARRAY}$)
 
@@ -128,10 +133,10 @@ contains
       end if
       deallocate(array)
      #:if defined('MEMLOG')
-      call writePoissMemInfo()
+      call writePoissMemInfo(output)
      #:endif
     else
-      @:ERROR_HANDLING(err, -1, 'ALLOCATION ERROR: ${TYPE}$ (${LABEL}$) array is not allocated')
+      @:ERROR_HANDLING(output, err, -1, 'ALLOCATION ERROR: ${TYPE}$ (${LABEL}$) array is not allocated')
     endif
 
   end subroutine deallocate_${LABEL}$
@@ -142,38 +147,29 @@ contains
   ! ------------------------------------------------------------
   subroutine writePoissMemInfo(fileId)
 
-    integer, intent(in), optional :: fileId
+    integer, intent(in) :: fileId
 
     character(3) :: str
     real(dp) :: dec
 
     call memstr(alloc_mem,dec,str)
-    if (present(fileId)) then
-      write(fileId,'(A35,F8.2,A3)') 'current Poisson memory allocated: ', real(alloc_mem,dp)*dec,&
+    write(fileId,'(A35,F8.2,A3)') 'current Poisson memory allocated: ', real(alloc_mem,dp)*dec,&
           & str
-    else
-      write(stdOut,'(A35,F8.2,A3)') 'current Poisson memory allocated: ', real(alloc_mem,dp)*dec,&
-          & str
-    end if
 
   end subroutine writePoissMemInfo
 
   ! ------------------------------------------------------------
   subroutine writePoissPeakInfo(fileId)
 
-    integer, intent(in), optional :: fileId
+    integer, intent(in) :: fileId
 
     character(3) :: str
     real(dp) :: dec
 
     call memstr(peak_mem,dec,str)
-    if (present(fileId)) then
-      write(fileId,'(A32,T36,F8.2,A3)') 'peak Poisson memory allocated: ', real(peak_mem,dp)*dec,&
+    write(fileId,'(A32,T36,F8.2,A3)') 'peak Poisson memory allocated: ', real(peak_mem,dp)*dec,&
           & str
-    else
-      write(stdOut,'(A32,T36,F8.2,A3)') 'peak Poisson memory allocated: ', real(peak_mem,dp)*dec,&
-          & str
-    end if
+
 
   end subroutine writePoissPeakInfo
 

--- a/src/dftbp/poisson/gewald.F90
+++ b/src/dftbp/poisson/gewald.F90
@@ -30,7 +30,10 @@ module dftbp_poisson_gewald
 contains
 
   !======================================================================
-  subroutine short_pot(distR,basis,uhatm,deltaQ,tol,sh_pot, iError)
+  subroutine short_pot(output, distR,basis,uhatm,deltaQ,tol,sh_pot, iError)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     real(kind=dp) :: distR(3), uhatm, deltaQ, basis(3,3), tol, sh_pot
     integer, intent(out), optional :: iError
@@ -90,14 +93,17 @@ contains
     END DO
 
     IF(abs(lastshell) .gt. tol) THEN
-      @:ERROR_HANDLING(iError, -1, 'tolerance in subroutine short_pot not reached')
+      @:ERROR_HANDLING(output, iError, -1, 'tolerance in subroutine short_pot not reached')
     END IF
 
   END subroutine short_pot
   !----------------------------------------------------------------
 
 
-  subroutine long_pot(r,basis,recbasis,alpha,vol,tol,potential, iError)
+  subroutine long_pot(output, r,basis,recbasis,alpha,vol,tol,potential, iError)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     real(kind=dp) ::  r(3), basis(3,3), recbasis(3,3), alpha, vol, tol
     real(kind=dp) ::  potential
@@ -147,7 +153,7 @@ contains
 
     ! stop if tolerance not reached
     IF ( abs(lastshell)  .gt. tol ) THEN
-      @:ERROR_HANDLING(iError, -1, 'tolerance in long_pot not reached in reciprocal space')
+      @:ERROR_HANDLING(output, iError, -1, 'tolerance in long_pot not reached in reciprocal space')
     END IF
 
     reciprocal=(4._dp*Pi*reciprocal)/vol
@@ -188,7 +194,7 @@ contains
 
     ! stop if tolerance not reached
     IF ( abs(lastshell)  .gt. tol ) THEN
-      @:ERROR_HANDLING(iError, -2, 'tolerance in long_pot not reached in real space')
+      @:ERROR_HANDLING(output, iError, -2, 'tolerance in long_pot not reached in real space')
     END IF
 
 
@@ -229,7 +235,10 @@ contains
 !
 !  ======================================================================
 
-  subroutine phi(r,basis,recbasis,alpha,vol,tol,potential, iError)
+  subroutine phi(output, r,basis,recbasis,alpha,vol,tol,potential, iError)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     real(kind=dp) ::  r(3), basis(3,3), recbasis(3,3), alpha, vol, tol
     real(kind=dp) ::  potential
@@ -280,7 +289,7 @@ contains
 
     ! stop if tolerance not reached
     IF ( abs(lastshell)  .gt. tol ) THEN
-      @:ERROR_HANDLING(iError, -1, "tolerance in phi not reached in reciprocal space")
+      @:ERROR_HANDLING(output, iError, -1, "tolerance in phi not reached in reciprocal space")
     END IF
 
     reciprocal=(4._dp*Pi*reciprocal)/vol
@@ -321,7 +330,7 @@ contains
 
     ! stop if tolerance not reached
     IF ( abs(lastshell)  .gt. tol ) THEN
-      @:ERROR_HANDLING(iError, -2, "tolerance in phi not reached in real space")
+      @:ERROR_HANDLING(output, iError, -2, "tolerance in phi not reached in real space")
     END IF
 
 
@@ -358,7 +367,10 @@ contains
   !  ======================================================================
 
 
-  subroutine phi1(r,basis,recbasis, alpha,vol,tol,deriv, iError)
+  subroutine phi1(output, r,basis,recbasis, alpha,vol,tol,deriv, iError)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     real(kind=dp) ::  r(3), basis(3,3), recbasis(3,3), alpha, vol, deriv(3)
     integer, intent(out), optional :: iError
@@ -416,7 +428,7 @@ contains
 
     ! stop if tolerance not reached
     IF ( abs(lastshell)  .gt. tol ) THEN
-      @:ERROR_HANDLING(iError, -1, "tolerance in phi1 not reached in reciprocal space")
+      @:ERROR_HANDLING(output, iError, -1, "tolerance in phi1 not reached in reciprocal space")
     END IF
 
     reciprocal(1)=(4._dp*Pi*reciprocal(1))/vol
@@ -463,7 +475,7 @@ contains
 
     ! stop if tolerance not reached
     IF ( abs(lastshell)  .gt. tol ) THEN
-      @:ERROR_HANDLING(iError, -2, "tolerance in phi1 not reached in real space")
+      @:ERROR_HANDLING(output, iError, -2, "tolerance in phi1 not reached in real space")
     END IF
 
 

--- a/src/dftbp/poisson/gewald.F90
+++ b/src/dftbp/poisson/gewald.F90
@@ -32,7 +32,7 @@ contains
   !======================================================================
   subroutine short_pot(output, distR,basis,uhatm,deltaQ,tol,sh_pot, iError)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     real(kind=dp) :: distR(3), uhatm, deltaQ, basis(3,3), tol, sh_pot
@@ -102,7 +102,7 @@ contains
 
   subroutine long_pot(output, r,basis,recbasis,alpha,vol,tol,potential, iError)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     real(kind=dp) ::  r(3), basis(3,3), recbasis(3,3), alpha, vol, tol
@@ -237,7 +237,7 @@ contains
 
   subroutine phi(output, r,basis,recbasis,alpha,vol,tol,potential, iError)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     real(kind=dp) ::  r(3), basis(3,3), recbasis(3,3), alpha, vol, tol
@@ -369,7 +369,7 @@ contains
 
   subroutine phi1(output, r,basis,recbasis, alpha,vol,tol,deriv, iError)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     real(kind=dp) ::  r(3), basis(3,3), recbasis(3,3), alpha, vol, deriv(3)

--- a/src/dftbp/poisson/parcheck.F90
+++ b/src/dftbp/poisson/parcheck.F90
@@ -42,7 +42,7 @@ contains
  ! ---------------------------------------------------------------------------
  subroutine check_poisson_box(output, iErr)
 
-   !> output for write processes
+   !> Output unit for human readable messages
    integer, intent(in) :: output
 
    integer, intent(out), optional :: iErr
@@ -97,7 +97,7 @@ contains
 
  subroutine check_biasdir(output, iErr)
 
-   !> output for write processes
+   !> Output unit for human readable messages
    integer, intent(in) :: output
 
    integer, intent(out), optional :: iErr
@@ -158,7 +158,10 @@ contains
 
  end subroutine check_biasdir
 
- subroutine check_parameters()
+ subroutine check_parameters(output)
+
+   !> Output unit for human readable messages
+   integer, intent(in) :: output
 
    if (OxLength < GateLength_l) OxLength = GateLength_l
    print *,'Oxlength=', OxLength, 'GateLength_l=', GateLength_l
@@ -167,7 +170,8 @@ contains
        call error('Insulator radius must be positive')
      end if
      if (Rmin_ins > Rmin_gate) then
-       call warning('Insulator radius is larger than gate radius: setting Rmin_ins=Rmin_gate')
+       call warning(output,&
+           & 'Insulator radius is larger than gate radius: setting Rmin_ins=Rmin_gate')
        Rmin_ins = Rmin_gate
      end if
      if (dr_eps < 0.5_dp) dr_eps = 0.5d0 !TODO: should be changed to one grid spacing
@@ -183,7 +187,7 @@ contains
    !-------WRITE DOWN FEEDBACK ABOUT INPUT FILE -------------------!
  subroutine write_parameters(output)
 
-   !> output for write processes
+   !> Output unit for human readable messages
    integer, intent(in) :: output
 
    integer i
@@ -261,7 +265,7 @@ contains
 
  subroutine check_localbc(output)
 
-   !> output for write processes
+   !> Output unit for human readable messages
    integer, intent(in) :: output
 
    integer :: m, err
@@ -339,7 +343,7 @@ contains
  !--- WRITE INFOS ABOUT THE CONTACT STRUCTURES ---------------
  subroutine check_contacts(output, iErr)
 
-   !> output for write processes
+   !> Output unit for human readable messages
    integer, intent(in) :: output
 
    integer, intent(out), optional :: iErr

--- a/src/dftbp/poisson/parcheck.F90
+++ b/src/dftbp/poisson/parcheck.F90
@@ -18,7 +18,6 @@
 module dftbp_poisson_parcheck
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : Bohr__AA, hartree__eV
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_io_message, only : warning, error
   use dftbp_poisson_mpi_poisson, only : id0, numprocs
   use dftbp_poisson_parameters, only : cluster, cntr_gate, contdir, contnames, deltaR_max,&
@@ -41,7 +40,10 @@ contains
  ! ---------------------------------------------------------------------------
  ! Perform parameters checks
  ! ---------------------------------------------------------------------------
- subroutine check_poisson_box(iErr)
+ subroutine check_poisson_box(output, iErr)
+
+   !> output for write processes
+   integer, intent(in) :: output
 
    integer, intent(out), optional :: iErr
 
@@ -60,9 +62,9 @@ contains
       if (.not.FoundBox) then
          PoissBox(:,:)=boxsiz(:,:)
          if (verbose > VBT) then
-            call warning('Box for Poisson not Found: Setting equal to supercell box')
+            call warning(output, 'Box for Poisson not Found: Setting equal to supercell box')
             do i=1,3
-               write(stdOut,'(a,i1,a,f20.10)') " L(",i,")",boxsiz(i,i)
+               write(output,'(a,i1,a,f20.10)') " L(",i,")",boxsiz(i,i)
             end do
          end if
       else
@@ -75,9 +77,9 @@ contains
    else
       if (.not.FoundBox) then
         if (verbose > VBT) then
-          call warning('Box for Poisson not Found')
+          call warning(output, 'Box for Poisson not Found')
         end if
-        @:ERROR_HANDLING(iErr, -1, 'No way to build box for Poisson')
+        @:ERROR_HANDLING(output, iErr, -1, 'No way to build box for Poisson')
       end if
    end if
 
@@ -93,7 +95,10 @@ contains
  end subroutine check_poisson_box
 
 
- subroutine check_biasdir(iErr)
+ subroutine check_biasdir(output, iErr)
+
+   !> output for write processes
+   integer, intent(in) :: output
 
    integer, intent(out), optional :: iErr
 
@@ -110,11 +115,11 @@ contains
        !if(mu(nf(1)).eq.0.d0) mu(nf(1))=bias
        if (contdir(1).ne.contdir(2)) then
          if (localBC(1).eq.0) then
-           @:ERROR_HANDLING(iErr, -1,&
+           @:ERROR_HANDLING(output, iErr, -1,&
                & 'Local BC should be used when contacts are in different directions')
          endif
          if(DoCilGate) then
-           @:ERROR_HANDLING(iErr, -2,&
+           @:ERROR_HANDLING(output, iErr, -2,&
                & 'Contacts must be in the same direction when using cylindrical gate')
          endif
        end if
@@ -147,7 +152,7 @@ contains
    end if
 
    if (period_dir(3) .and. numprocs>1) then
-     @:ERROR_HANDLING(iErr, -3,&
+     @:ERROR_HANDLING(output, iErr, -3,&
          & 'Periodicity along z is incompatible with grid parallelization strategy')
    end if
 
@@ -176,7 +181,10 @@ contains
  end subroutine check_parameters
 
    !-------WRITE DOWN FEEDBACK ABOUT INPUT FILE -------------------!
- subroutine write_parameters()
+ subroutine write_parameters(output)
+
+   !> output for write processes
+   integer, intent(in) :: output
 
    integer i
 
@@ -201,49 +209,49 @@ contains
       !endif
 
       if (DoPoisson) then
-        write(stdOut,'(a,3(f10.4),a)') ' Input PoissonBox=',PoissBox(1,1)*Bohr__AA,&
+        write(output,'(a,3(f10.4),a)') ' Input PoissonBox=',PoissBox(1,1)*Bohr__AA,&
             & PoissBox(2,2)*Bohr__AA, PoissBox(3,3)*Bohr__AA, '  A'
-         write(stdOut,*) 'PoissAcc=',PoissAcc
+         write(output,*) 'PoissAcc=',PoissAcc
          if(initPot) then
-            write(stdOut,*) 'Bulk Boundary Potential:    Yes'
+            write(output,*) 'Bulk Boundary Potential:    Yes'
          else
-            write(stdOut,*) 'Bulk Boundary Potential:    No'
+            write(output,*) 'Bulk Boundary Potential:    No'
          endif
 
-         write(stdOut,*) 'Atomic cutoff radius=', deltaR_max*Bohr__AA,'A'
+         write(output,*) 'Atomic cutoff radius=', deltaR_max*Bohr__AA,'A'
 
          if (DoGate) then
-            write(stdOut,*) 'Gate: Planar'
-            write(stdOut,*) 'Gate bias=',gate*hartree__eV,'V'
-            write(stdOut,*) 'Gate length l=',GateLength_l*Bohr__AA,'A'
-            write(stdOut,*) 'Gate length t=',GateLength_t*Bohr__AA,'A'
-            write(stdOut,*) 'Gate distance=',Rmin_Gate*Bohr__AA,'A'
-            write(stdOut,*) 'Oxide length l=',OxLength_l*Bohr__AA,'A'
-            write(stdOut,*) 'Oxide length t=',OxLength_t*Bohr__AA,'A'
-            write(stdOut,*) 'Oxide distance=',Rmin_Ins*Bohr__AA,'A'
-            write(stdOut,*) 'Dielectric constant of gate insulator=',eps_r
-            if (dr_eps/=0.0_dp) write(stdOut,*) 'Smoothing of eps_r=',(eps_r-1.d0)/(dr_eps*Bohr__AA)
+            write(output,*) 'Gate: Planar'
+            write(output,*) 'Gate bias=',gate*hartree__eV,'V'
+            write(output,*) 'Gate length l=',GateLength_l*Bohr__AA,'A'
+            write(output,*) 'Gate length t=',GateLength_t*Bohr__AA,'A'
+            write(output,*) 'Gate distance=',Rmin_Gate*Bohr__AA,'A'
+            write(output,*) 'Oxide length l=',OxLength_l*Bohr__AA,'A'
+            write(output,*) 'Oxide length t=',OxLength_t*Bohr__AA,'A'
+            write(output,*) 'Oxide distance=',Rmin_Ins*Bohr__AA,'A'
+            write(output,*) 'Dielectric constant of gate insulator=',eps_r
+            if (dr_eps/=0.0_dp) write(output,*) 'Smoothing of eps_r=',(eps_r-1.d0)/(dr_eps*Bohr__AA)
          endif
          if (DoCilGate) then
-            write(stdOut,*) 'Gate: Cylindrical'
-            write(stdOut,*) 'Gate bias=',gate*hartree__eV,'V'
-            write(stdOut,*) 'Gate length=',GateLength_l*Bohr__AA,'A'
-            write(stdOut,*) 'Oxide length=',OxLength*Bohr__AA,'A'
-            write(stdOut,*) 'Inner gate radius=',Rmin_Gate*Bohr__AA,'A'
-            write(stdOut,*) 'Inner oxide radius=',Rmin_Ins*Bohr__AA,'A'
-            write(stdOut,*) 'Dielectric constant of gate insulator=',eps_r
-            if (dr_eps/=0.0_dp) write(stdOut,*) 'Smoothing of eps_r=',(eps_r-1.d0)/(dr_eps*Bohr__AA)
-            write(stdOut,'(a,3(f10.4),a)') ' Cylindrical gate center=',cntr_gate(1)*Bohr__AA,&
+            write(output,*) 'Gate: Cylindrical'
+            write(output,*) 'Gate bias=',gate*hartree__eV,'V'
+            write(output,*) 'Gate length=',GateLength_l*Bohr__AA,'A'
+            write(output,*) 'Oxide length=',OxLength*Bohr__AA,'A'
+            write(output,*) 'Inner gate radius=',Rmin_Gate*Bohr__AA,'A'
+            write(output,*) 'Inner oxide radius=',Rmin_Ins*Bohr__AA,'A'
+            write(output,*) 'Dielectric constant of gate insulator=',eps_r
+            if (dr_eps/=0.0_dp) write(output,*) 'Smoothing of eps_r=',(eps_r-1.d0)/(dr_eps*Bohr__AA)
+            write(output,'(a,3(f10.4),a)') ' Cylindrical gate center=',cntr_gate(1)*Bohr__AA,&
                 & cntr_gate(2)*Bohr__AA, cntr_gate(3)*Bohr__AA, '  A'
          end if
          if (any(localBC.gt.0)) then
             do i=1,ncont
-               if (localBC(i).eq.1) write(stdOut,*) 'Local Boundary Conditions= Circular'
-               if (localBC(i).eq.2) write(stdOut,*) 'Local Boundary Conditions= Squared'
-               write(stdOut,'(a9,i2,a2,f8.3,a1)') ' dR_cont(',i,')=',dR_cont(i)*Bohr__AA,'A'
+               if (localBC(i).eq.1) write(output,*) 'Local Boundary Conditions= Circular'
+               if (localBC(i).eq.2) write(output,*) 'Local Boundary Conditions= Squared'
+               write(output,'(a9,i2,a2,f8.3,a1)') ' dR_cont(',i,')=',dR_cont(i)*Bohr__AA,'A'
             enddo
          endif
-         write(stdOut,*)
+         write(output,*)
       endif
 
 
@@ -251,7 +259,10 @@ contains
 
  end subroutine write_parameters
 
- subroutine check_localbc()
+ subroutine check_localbc(output)
+
+   !> output for write processes
+   integer, intent(in) :: output
 
    integer :: m, err
 
@@ -309,24 +320,27 @@ contains
       enddo
    endif
    if (err.eq.1 .and. id0) then
-      write(stdOut,*)
-      write(stdOut,*) 'ERROR: BoundaryRegion{} sets a Dirichlet BC'
-      write(stdOut,*) '       not compatible with overrideDefaultBC=Neumann'
+      write(output,*)
+      write(output,*) 'ERROR: BoundaryRegion{} sets a Dirichlet BC'
+      write(output,*) '       not compatible with overrideDefaultBC=Neumann'
    endif
    if (err.eq.2 .and. id0) then
-      write(stdOut,*)
-      write(stdOut,*) 'WARNING: '
-      write(stdOut,*) 'BoundaryRegion{} sets a mixed Neumann/Dirichlet BC'
-      write(stdOut,*) 'User setting OverrideDefaultBC = Dirichlet'
-      write(stdOut,*) 'has been disregarded !'
-      write(stdOut,*)
+      write(output,*)
+      write(output,*) 'WARNING: '
+      write(output,*) 'BoundaryRegion{} sets a mixed Neumann/Dirichlet BC'
+      write(output,*) 'User setting OverrideDefaultBC = Dirichlet'
+      write(output,*) 'has been disregarded !'
+      write(output,*)
    endif
 
  end subroutine check_localbc
 
 
  !--- WRITE INFOS ABOUT THE CONTACT STRUCTURES ---------------
- subroutine check_contacts(iErr)
+ subroutine check_contacts(output, iErr)
+
+   !> output for write processes
+   integer, intent(in) :: output
 
    integer, intent(out), optional :: iErr
 
@@ -338,22 +352,22 @@ contains
 
    if(cluster) then
       if (id0) then
-          write(stdOut,'(1x,a)',advance='NO') 'System Type: UNCONTACTED '
+          write(output,'(1x,a)',advance='NO') 'System Type: UNCONTACTED '
           if(period) then
-             write(stdOut,'(a)',advance='NO') 'PERIODIC '
+             write(output,'(a)',advance='NO') 'PERIODIC '
           else
-             write(stdOut,'(a)',advance='NO') 'CLUSTER '
+             write(output,'(a)',advance='NO') 'CLUSTER '
           endif
-          write(stdOut,*) 'STRUCTURE'
-          write(stdOut,'(1x,a,I3)') 'periodicity direction:',contdir(1)
+          write(output,*) 'STRUCTURE'
+          write(output,'(1x,a,I3)') 'periodicity direction:',contdir(1)
       endif
    endif
 
 
    if(id0.and.verbose.gt.50) then
-      write(stdOut,'(a)') 'CENTRAL REGION'
-      write(stdOut,'(1x,a,2I6)') 'Atom start - end = ',iatm(1), iatm(2)
-      write(stdOut,*)
+      write(output,'(a)') 'CENTRAL REGION'
+      write(output,'(1x,a,2I6)') 'Atom start - end = ',iatm(1), iatm(2)
+      write(output,*)
    endif
 
 
@@ -377,12 +391,12 @@ contains
          !endif
          ! ---------------------------------------------------
 
-         write(stdOut,'(a,I3,a,a)') 'CONTACT #', i, ' : ', trim(contnames(i))
-         write(stdOut,'(1x,a,2I6)') 'Atom start - end = ',iatc(3,i), iatc(2,i)
-         write(stdOut,'(1x,a,I3)') 'direction:',contdir(i)
-         write(stdOut,*) 'Fermi Level=',Efermi(i)*hartree__eV,'eV'
-         write(stdOut,*) 'mu=',mu(i)*hartree__eV,'V'
-         write(stdOut,*)
+         write(output,'(a,I3,a,a)') 'CONTACT #', i, ' : ', trim(contnames(i))
+         write(output,'(1x,a,2I6)') 'Atom start - end = ',iatc(3,i), iatc(2,i)
+         write(output,'(1x,a,I3)') 'direction:',contdir(i)
+         write(output,*) 'Fermi Level=',Efermi(i)*hartree__eV,'eV'
+         write(output,*) 'mu=',mu(i)*hartree__eV,'V'
+         write(output,*)
 
       end do !ncont
    endif !cluster
@@ -394,13 +408,13 @@ contains
    if (.not.cluster) then
      do i=1,ncont
        if (iatc(1,i).lt.iatm(2)) then
-         @:ERROR_HANDLING(iErr, -1,&
+         @:ERROR_HANDLING(output, iErr, -1,&
              & 'The contacts MUST be defined after the scattering region')
        end if
      enddo
    endif
    if ((iatm(2)-iatm(1)+1).gt.natoms) then
-     @:ERROR_HANDLING(iErr, -2, 'The number of atoms in the scattering region is higher than&
+     @:ERROR_HANDLING(output, iErr, -2, 'The number of atoms in the scattering region is higher than&
          & the total number of atoms')
    endif
    if (DoGate) then
@@ -408,7 +422,7 @@ contains
 !      @:ERROR_HANDLING(iErr, -3, 'Gate direction must be along y')
 !     end if
      if(any(abs(contdir(:)).eq.gatedir)) then
-       @:ERROR_HANDLING(iErr, -4, 'Gate direction along contacts!?')
+       @:ERROR_HANDLING(output, iErr, -4, 'Gate direction along contacts!?')
      end if
    endif
 

--- a/src/dftbp/poisson/poisson.F90
+++ b/src/dftbp/poisson/poisson.F90
@@ -20,8 +20,7 @@ module dftbp_poisson_poisson
   use dftbp_common_constants, only : Bohr__AA, hartree__eV, pi
   use dftbp_common_environment, only : globalTimers, TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut
-    use dftbp_io_message, only : warning
+  use dftbp_io_message, only : warning
   use dftbp_poisson_bulkpot, only : compbulk_pot, create_phi_bulk, destroy_phi_bulk, readbulk_pot,&
       & super_array
   use dftbp_poisson_fancybc, only : bndyc, cilgate_bound, coef, coef_cilgate,&
@@ -101,23 +100,26 @@ module dftbp_poisson_poisson
  contains
 
  !------------------------------------------------------------------------------
- subroutine poiss_freepoisson()
+ subroutine poiss_freepoisson(output)
+
+   !> output for write processes
+   integer, intent(in) :: output
 
    if (active_id) then
-     call finalize_mudpack()
+     call finalize_mudpack(output)
    endif
 
-   if(allocated(x)) call log_gdeallocate(x)
-   if(allocated(izp)) call log_gdeallocate(izp)
-   if(allocated(dQmat)) call log_gdeallocate(dQmat)
-   if(allocated(uhubb)) call log_gdeallocate(uhubb)
-   if(allocated(lmax)) call log_gdeallocate(lmax)
-   if(allocated(nshells)) call log_gdeallocate(nshells)
-   if(allocated(angshells)) call log_gdeallocate(angshells)
-   if(allocated(renorm)) call log_gdeallocate(renorm)
+   if(allocated(x)) call log_gdeallocate(output, x)
+   if(allocated(izp)) call log_gdeallocate(output, izp)
+   if(allocated(dQmat)) call log_gdeallocate(output, dQmat)
+   if(allocated(uhubb)) call log_gdeallocate(output, uhubb)
+   if(allocated(lmax)) call log_gdeallocate(output, lmax)
+   if(allocated(nshells)) call log_gdeallocate(output, nshells)
+   if(allocated(angshells)) call log_gdeallocate(output, angshells)
+   if(allocated(renorm)) call log_gdeallocate(output, renorm)
    if (id0) then
-     call writePoissPeakInfo(stdOut)
-     call writePoissMemInfo(stdOut)
+     call writePoissPeakInfo(output)
+     call writePoissMemInfo(output)
    endif
 
  end subroutine poiss_freepoisson
@@ -138,7 +140,7 @@ module dftbp_poisson_poisson
 
      if(.not.SavePot) return
 
-     write(stdOut,"('>> Saving Poisson output in potential.dat')")
+     write(env%stdOut,"('>> Saving Poisson output in potential.dat')")
 
      PoissFlag=2
 
@@ -177,7 +179,10 @@ module dftbp_poisson_poisson
  end subroutine poiss_updcoords
 
  ! -----------------------------------------------------------------------------
- subroutine init_poissbox(iErr)
+ subroutine init_poissbox(env, iErr)
+
+  !> Environment
+  type(TEnvironment), intent(in) :: env
 
   !> Error code, 0 if no problems
   integer, intent(out), optional :: iErr
@@ -229,7 +234,7 @@ module dftbp_poisson_poisson
        if (xmin > xmax) then
          bound(m) = 0.5_dp * (xmax + xmin) + bufferBox
        else
-         @:FORMATTED_ERROR_HANDLING(iErr, -1, "(A,I0)",&
+         @:FORMATTED_ERROR_HANDLING(env%stdOut, iErr, -1, "(A,I0)",&
              & "Device and contact atoms overlap at contact", m)
        end if
      else
@@ -238,7 +243,7 @@ module dftbp_poisson_poisson
        if (xmin > xmax) then
          bound(m) = 0.5_dp * (xmax + xmin) - bufferBox
        else
-         @:FORMATTED_ERROR_HANDLING(iErr, -2, "(A,I0)",&
+         @:FORMATTED_ERROR_HANDLING(env%stdOut, iErr, -2, "(A,I0)",&
              & "Device and contact atoms overlap at contact", m)
        end if
      end if
@@ -258,7 +263,7 @@ module dftbp_poisson_poisson
            tmpdir(f)=1
         endif
         if (contdir(m).eq.contdir(s).and.bound(s).ne.bound(m)) then
-          @:ERROR_HANDLING(iErr, -3, 'Contacts in the same direction must be aligned')
+          @:ERROR_HANDLING(env%stdOut, iErr, -3, 'Contacts in the same direction must be aligned')
         endif
      enddo
      ! Adjust PoissonBox if there are no facing contacts
@@ -319,7 +324,7 @@ module dftbp_poisson_poisson
   !---- ---------------------------
   do i=1,3
     if(PoissBox(i,i) .le. 0.0_dp) then
-      @:FORMATTED_ERROR_HANDLING(iErr, -4, '(A,A)', 'PoissBox negative along ', dir(i))
+      @:FORMATTED_ERROR_HANDLING(env%stdOut, iErr, -4, '(A,A)', 'PoissBox negative along ', dir(i))
     end if
   enddo
 
@@ -330,7 +335,7 @@ module dftbp_poisson_poisson
   if (DoGate) then
      biasdir = abs(contdir(1))
      if (((PoissBox(gatedir,gatedir))/2.d0).le.Rmin_Gate) then
-       @:ERROR_HANDLING(iErr, -5, 'Gate Distance too large')
+       @:ERROR_HANDLING(env%stdOut, iErr, -5, 'Gate Distance too large')
      end if
   endif
 
@@ -339,7 +344,7 @@ module dftbp_poisson_poisson
      biasdir = abs(contdir(1))
 
      if (abs(bound(2)-bound(1)).le.(OxLength+dr_eps)) then
-       call warning('Gate insulator is longer than Poisson box (use with caution)')
+       call warning(env%stdOut, 'Gate insulator is longer than Poisson box (use with caution)')
      end if
 
      do i = 1,3
@@ -347,7 +352,7 @@ module dftbp_poisson_poisson
           cycle
         end if
         if (((PoissBox(i,i))/2.d0).le.Rmin_Gate) then
-          @:ERROR_HANDLING(iErr, -7, 'Gate transversal section is bigger than Poisson box!')
+          @:ERROR_HANDLING(env%stdOut, iErr, -7, 'Gate transversal section is bigger than Poisson box!')
         end if
       end do
   end if
@@ -466,23 +471,23 @@ subroutine mudpack_drv(env, SCC_in, V_L_atm, grad_V, iErr)
     end do
 
     if (niter_.eq.1.and.verbose.gt.30) then
-       write(stdOut,'(73("-"))')
-       write(stdOut,*) "Poisson Box internally adjusted:"
-       write(stdOut,'(a,f12.5,f12.5,a11,l3)') ' x range=',PoissBounds(1,1)*Bohr__AA,&
+       write(env%stdOut,'(73("-"))')
+       write(env%stdOut,*) "Poisson Box internally adjusted:"
+       write(env%stdOut,'(a,f12.5,f12.5,a11,l3)') ' x range=',PoissBounds(1,1)*Bohr__AA,&
             PoissBounds(1,2)*Bohr__AA,'; Periodic:',period_dir(1)
-       write(stdOut,'(a,f12.5,f12.5,a11,l3)') ' y range=',PoissBounds(2,1)*Bohr__AA,&
+       write(env%stdOut,'(a,f12.5,f12.5,a11,l3)') ' y range=',PoissBounds(2,1)*Bohr__AA,&
             PoissBounds(2,2)*Bohr__AA,'; Periodic:',period_dir(2)
-       write(stdOut,'(a,f12.5,f12.5,a11,l3)') ' z range=',PoissBounds(3,1)*Bohr__AA,&
+       write(env%stdOut,'(a,f12.5,f12.5,a11,l3)') ' z range=',PoissBounds(3,1)*Bohr__AA,&
             PoissBounds(3,2)*Bohr__AA,'; Periodic:',period_dir(3)
 
-       write(stdOut,*) 'Mesh details:'
-       write(stdOut,'(a,f10.3,a,i4,a,f9.5)') ' Lx=',PoissBox(1,1)*Bohr__AA,&
+       write(env%stdOut,*) 'Mesh details:'
+       write(env%stdOut,'(a,f10.3,a,i4,a,f9.5)') ' Lx=',PoissBox(1,1)*Bohr__AA,&
             '  nx=',iparm(14),'   dlx=',dlx*Bohr__AA
-       write(stdOut,'(a,f10.3,a,i4,a,f9.5)') ' Ly=',PoissBox(2,2)*Bohr__AA,&
+       write(env%stdOut,'(a,f10.3,a,i4,a,f9.5)') ' Ly=',PoissBox(2,2)*Bohr__AA,&
             '  ny=',iparm(15),'   dly=',dly*Bohr__AA
-       write(stdOut,'(a,f10.3,a,i4,a,f9.5)') ' Lz=',PoissBox(3,3)*Bohr__AA,&
+       write(env%stdOut,'(a,f10.3,a,i4,a,f9.5)') ' Lz=',PoissBox(3,3)*Bohr__AA,&
             '  nz=',iparm(16),'   dlz=',dlz*Bohr__AA
-       write(stdOut,'(73("-"))')
+       write(env%stdOut,'(73("-"))')
     endif
 
     !--------------------------
@@ -516,11 +521,11 @@ subroutine mudpack_drv(env, SCC_in, V_L_atm, grad_V, iErr)
  ! 3. Allocate space for phi_,rhs_ and work
  !**********************************************************************************
  if (id0 .and. .not.allocated(phi_)) then
-    call log_gallocate(phi_,iparm(14),iparm(15),iparm(16))
+    call log_gallocate(env%stdOut, phi_,iparm(14),iparm(15),iparm(16))
     phi_(:,:,:) = 0.d0
  end if
  if (id0 .and. .not.allocated(rhs_)) then
-    call log_gallocate(rhs_,iparm(14),iparm(15),iparm(16))
+    call log_gallocate(env%stdOut, rhs_,iparm(14),iparm(15),iparm(16))
     rhs_(:,:,:) = 0.d0
  end if
 
@@ -610,24 +615,24 @@ case(GetPOT)     !Poisson called in order to calculate potential in SCC
 
 
     if(id0.and.niter_.eq.1.and.verbose.gt.VBT) then
-      write(stdOut,*) 'Boundary Conditions:'
+      write(env%stdOut,*) 'Boundary Conditions:'
       BCinfo = 'x: '//boundary2string(iparm(2),mixed(1))
       if (overrideBC(1).ne.0) BCinfo = trim(BCinfo)//' (overridden)'
       BCinfo = trim(BCinfo)//'  '//boundary2string(iparm(3),mixed(2))
       if (overrideBC(2).ne.0) BCinfo = trim(BCinfo)//' (overridden)'
-      write(stdOut,*) trim(BCinfo)
+      write(env%stdOut,*) trim(BCinfo)
 
       BCinfo = 'y: '//boundary2string(iparm(4),mixed(3))
       if (overrideBC(3).ne.0) BCinfo = trim(BCinfo)//' (overridden)'
       BCinfo = trim(BCinfo)//'  '//boundary2string(iparm(5),mixed(4))
       if (overrideBC(4).ne.0) BCinfo = trim(BCinfo)//' (overridden)'
-      write(stdOut,*) trim(BCinfo)
+      write(env%stdOut,*) trim(BCinfo)
 
       BCinfo = 'z: '//boundary2string(iparm(6),mixed(5))
       if (overrideBC(5).ne.0) BCinfo = trim(BCinfo)//' (overridden)'
       BCinfo = trim(BCinfo)//'  '//boundary2string(iparm(7),mixed(6))
       if (overrideBC(6).ne.0) BCinfo = trim(BCinfo)//' (overridden)'
-      write(stdOut,*) trim(BCinfo)
+      write(env%stdOut,*) trim(BCinfo)
     endif
 
     !------------------------------------------
@@ -662,7 +667,7 @@ case(GetPOT)     !Poisson called in order to calculate potential in SCC
     if (cluster.and.period .and. niter_.eq.1) then
       call env%globalTimer%startTimer(globalTimers%poissonEwald)
       if (id0) then
-        call set_phi_periodic(phi_,iparm,fparm)
+        call set_phi_periodic(env, phi_,iparm,fparm)
       end if
       call env%globalTimer%stopTimer(globalTimers%poissonEwald)
     end if
@@ -670,29 +675,29 @@ case(GetPOT)     !Poisson called in order to calculate potential in SCC
     if (ncont.gt.0) then
 
       allocate(bulk(ncont))
-       call create_phi_bulk(bulk,iparm,dlx,dly,dlz,cont_mem)
+       call create_phi_bulk(env%stdOut, bulk,iparm,dlx,dly,dlz,cont_mem)
 
        if(InitPot.and.id0.and.niter_.eq.1.and.verbose.gt.VBT) then
-         write(stdOut,*) 'Bulk Potential Info:'
+         write(env%stdOut,*) 'Bulk Potential Info:'
          do m = 1,ncont
-            write(stdOut,*) 'contact',m
+            write(env%stdOut,*) 'contact',m
             if (bulk(m)%doEwald) then
-               write(stdOut,*) 'BC = all periodic solved with Ewalds on two planes'
+               write(env%stdOut,*) 'BC = all periodic solved with Ewalds on two planes'
             endif
-            write(stdOut,*) 'x: '//boundary2string(bulk(m)%iparm(2))//'  '&
+            write(env%stdOut,*) 'x: '//boundary2string(bulk(m)%iparm(2))//'  '&
                             //boundary2string(bulk(m)%iparm(3))
-            write(stdOut,*) 'y: '//boundary2string(bulk(m)%iparm(4))//'  '&
+            write(env%stdOut,*) 'y: '//boundary2string(bulk(m)%iparm(4))//'  '&
                             //boundary2string(bulk(m)%iparm(5))
-            write(stdOut,*) 'z: '//boundary2string(bulk(m)%iparm(6))//'  '&
+            write(env%stdOut,*) 'z: '//boundary2string(bulk(m)%iparm(6))//'  '&
                             //boundary2string(bulk(m)%iparm(7))
          enddo
        endif
 
        if(id0.and.niter_.eq.1.and.verbose.gt.VBT) then
-         write(stdOut,*) 'Memory required for Poisson:', &
+         write(env%stdOut,*) 'Memory required for Poisson:', &
                           (2*size(phi_)+iparm(21)+cont_mem)*8.d0/1d6,'Mb'
 
-         write(stdOut,'(73("-"))')
+         write(env%stdOut,'(73("-"))')
        endif
 
        ! -----------------------------------------------------------------------
@@ -703,18 +708,18 @@ case(GetPOT)     !Poisson called in order to calculate potential in SCC
          if (ReadBulk) then
            !Read old bulk potential
            call env%globalTimer%startTimer(globalTimers%poissonBulkRead)
-           call readbulk_pot(bulk)
+           call readbulk_pot(env, bulk)
            call env%globalTimer%stopTimer(globalTimers%poissonBulkRead)
          else
            !Compute bulk potential
            call env%globalTimer%startTimer(globalTimers%poissonBulkCalc)
-           call compbulk_pot(bulk,iparm,fparm)
+           call compbulk_pot(env, bulk,iparm,fparm)
            ReadBulk=.true.
            call env%globalTimer%stopTimer(globalTimers%poissonBulkCalc)
          end if
 
        else
-         if(id0.and.verbose.gt.VBT) write(stdOut,*) 'No bulk potential'
+         if(id0.and.verbose.gt.VBT) write(env%stdOut,*) 'No bulk potential'
        endif
 
     else
@@ -724,7 +729,7 @@ case(GetPOT)     !Poisson called in order to calculate potential in SCC
 
     !write(stdOut,*) 'debug bulk potential'
     !do m=1,ncont
-    !  call write_super_array(bulk(m))
+    !  call write_super_array(env%stdOut, bulk(m))
     !  call save_bulkpot(bulk,m)
     !enddo
 
@@ -781,7 +786,7 @@ case(GetPOT)     !Poisson called in order to calculate potential in SCC
     !**********************************************************************************
     if (id0) then
 
-      call log_gallocate(work,worksize)
+      call log_gallocate(env%stdOut, work,worksize)
 
       call env%globalTimer%startTimer(globalTimers%poissonSoln)
       do i = 0,1
@@ -807,36 +812,36 @@ case(GetPOT)     !Poisson called in order to calculate potential in SCC
 
         if (err.ne.0.and.err.ne.9) then
           if(err.gt.0) then
-            @:FORMATTED_ERROR_HANDLING(iErr, err, "(A,I0)", 'Fatal Error in poisson solver:', err)
+            @:FORMATTED_ERROR_HANDLING(env%stdOut, iErr, err, "(A,I0)", 'Fatal Error in poisson solver:', err)
           end if
         end if
         if (err.eq.9) then
-          call log_gdeallocate(work)
-          call log_gallocate(work,worksize)
+          call log_gdeallocate(env%stdOut, work)
+          call log_gallocate(env%stdOut, work,worksize)
         end if
       end do
 
       call env%globalTimer%stopTimer(globalTimers%poissonSoln)
 
       if (err.lt.-1) then
-        write(stdOut,*) 'Non-fatal Error in poisson solver:',err
+        write(env%stdOut,*) 'Non-fatal Error in poisson solver:',err
       endif
 
       ncycles = iparm(23)
-      call log_gdeallocate(work)
+      call log_gdeallocate(env%stdOut, work)
     end if
 
     if (id0) then
       if (verbose.gt.30) then
-        write(stdOut,'(1x,73("-"))')
-        write(stdOut,*) 'Relative Poisson Error =',fparm(8)
-        write(stdOut,'(a,i3,a,i3)') ' Number of cycles executed =',ncycles,'/',iparm(18)
-        write(stdOut,'(1x,73("-"))')
+        write(env%stdOut,'(1x,73("-"))')
+        write(env%stdOut,*) 'Relative Poisson Error =',fparm(8)
+        write(env%stdOut,'(a,i3,a,i3)') ' Number of cycles executed =',ncycles,'/',iparm(18)
+        write(env%stdOut,'(1x,73("-"))')
         flush(6)
       end if
 
       if (err.eq.-1 .or. ncycles.eq.iparm(18)) then
-        @:ERROR_HANDLING(iErr, -1, 'Convergence in Poisson solver not obtained')
+        @:ERROR_HANDLING(env%stdOut, iErr, -1, 'Convergence in Poisson solver not obtained')
       end if
 
     end if
@@ -850,7 +855,7 @@ case(GetPOT)     !Poisson called in order to calculate potential in SCC
       call env%globalTimer%stopTimer(globalTimers%poissonShifts)
     end if
 
-    call destroy_phi_bulk(bulk)
+    call destroy_phi_bulk(env%stdOut, bulk)
 
     deallocate(bulk,stat=err)
 
@@ -865,13 +870,13 @@ case(GetGRAD)    ! Poisson called in order to calculate atomic shift gradient
 case(SavePOT)    ! Poisson called in order to save potential and charge density
  !////////////////////////////////////////////////////////////////////////
 
-    if (id0) call save_pot(iparm,fparm,dlx,dly,dlz,phi_,rhs_)
+    if (id0) call save_pot(env, iparm,fparm,dlx,dly,dlz,phi_,rhs_)
 
  !///////////////////////////////////////////
 case(CLEAN)       ! Deallocate Poisson variables
  !///////////////////////////////////////////
 
-   call finalize_mudpack()
+   call finalize_mudpack(env%stdOut)
    return
 
  end select
@@ -886,10 +891,13 @@ end subroutine Mudpack_drv
 !> It does the same as calling mudpack_drv() with the CLEAN(=3) choice, but does not require
 !> the unnecessary arguments of that routine.
 !>
-subroutine finalize_mudpack()
+subroutine finalize_mudpack(output)
 
-  if (allocated(phi_)) call log_gdeallocate(phi_)
-  if (allocated(rhs_)) call log_gdeallocate(rhs_)
+  !> output for write processes
+  integer, intent(in) :: output
+
+  if (allocated(phi_)) call log_gdeallocate(output, phi_)
+  if (allocated(rhs_)) call log_gdeallocate(output, rhs_)
   niter_ = 1
 
 end subroutine finalize_mudpack
@@ -924,9 +932,9 @@ subroutine set_rhs(env, iparm, fparm, dlx, dly, dlz, rhs, bulk)
 
   if (numprocs > 1) then
 
-    call log_gallocate(dim_rhs,numprocs)
-    call log_gallocate(istart,numprocs)
-    call log_gallocate(iend,numprocs)
+    call log_gallocate(env%stdOut, dim_rhs,numprocs)
+    call log_gallocate(env%stdOut, istart,numprocs)
+    call log_gallocate(env%stdOut, iend,numprocs)
 
     ! z points per processor
     npid = int(iparm(16)/numprocs)
@@ -950,7 +958,7 @@ subroutine set_rhs(env, iparm, fparm, dlx, dly, dlz, rhs, bulk)
     fparm_tmp(6) = fparm(5) + (iend(id+1)-1)*dlz
 
     ! Allocate space for local rhs.
-    call log_gallocate(rhs_par,iparm_tmp(14),iparm_tmp(15),iparm_tmp(16))
+    call log_gallocate(env%stdOut, rhs_par,iparm_tmp(14),iparm_tmp(15),iparm_tmp(16))
     !---------------------------------------------------------------------
 
     call env%globalTimer%startTimer(globalTimers%poissonDensity)
@@ -958,7 +966,7 @@ subroutine set_rhs(env, iparm, fparm, dlx, dly, dlz, rhs, bulk)
     !! Set a renormalization volume for grid projection
 
     if (do_renorm) then
-      call renormalization_volume(iparm_tmp,fparm_tmp,dlx,dly,dlz,fixed_renorm)
+      call renormalization_volume(env, iparm_tmp,fparm_tmp,dlx,dly,dlz,fixed_renorm)
       do_renorm = .false.
     endif
 
@@ -981,17 +989,17 @@ subroutine set_rhs(env, iparm, fparm, dlx, dly, dlz, rhs, bulk)
     ! gather all partial results on lead node 0
     call mpifx_gatherv(poiss_comm, rhs_par, rhs, dim_rhs)
 
-    call log_gdeallocate(rhs_par)
-    call log_gdeallocate(dim_rhs)
-    call log_gdeallocate(istart)
-    call log_gdeallocate(iend)
+    call log_gdeallocate(env%stdOut, rhs_par)
+    call log_gdeallocate(env%stdOut, dim_rhs)
+    call log_gdeallocate(env%stdOut, istart)
+    call log_gdeallocate(env%stdOut, iend)
 
   else
 
  #:endif
 
     if (do_renorm) then
-      call renormalization_volume(iparm,fparm,dlx,dly,dlz,fixed_renorm)
+      call renormalization_volume(env, iparm,fparm,dlx,dly,dlz,fixed_renorm)
       do_renorm = .false.
     endif
 
@@ -1020,9 +1028,12 @@ subroutine set_rhs(env, iparm, fparm, dlx, dly, dlz, rhs, bulk)
 end subroutine set_rhs
 
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-subroutine renormalization_volume(iparm, fparm, dlx, dly, dlz, fixed)
+subroutine renormalization_volume(env, iparm, fparm, dlx, dly, dlz, fixed)
 
   implicit none
+
+  !> Environment
+  type(TEnvironment), intent(in) :: env
 
   integer :: iparm(23)
   real(kind=dp) :: fparm(8)
@@ -1064,7 +1075,7 @@ subroutine renormalization_volume(iparm, fparm, dlx, dly, dlz, fixed)
 
   tau = 3.2d0 * uhubb
 
-  if (.not.(allocated(renorm))) call log_gallocate(renorm,maxval(nshells),natoms)
+  if (.not.(allocated(renorm))) call log_gallocate(env%stdOut, renorm,maxval(nshells),natoms)
   renorm(:,:) = 0.0
 
   if (fixed) then
@@ -1546,7 +1557,10 @@ subroutine gradient_V(phi,iparm,fparm,dlx,dly,dlz,grad_V)
 end subroutine gradient_V
 
 
-subroutine save_pot(iparm,fparm,dlx,dly,dlz,phi,rhs)
+subroutine save_pot(env, iparm,fparm,dlx,dly,dlz,phi,rhs)
+
+  !> Environment
+  type(TEnvironment), intent(in) :: env
 
   integer, intent(in) :: iparm(23)
   real(kind=dp), intent(in) :: fparm(8)
@@ -1562,7 +1576,7 @@ subroutine save_pot(iparm,fparm,dlx,dly,dlz,phi,rhs)
   FixDir=int(PoissPlane(1))
 
   if (verbose.gt.70) then
-    if(id0) write(stdOut,'(1x,a)') 'Saving charge density and potential ...'
+    if(id0) write(env%stdOut,'(1x,a)') 'Saving charge density and potential ...'
   endif
 
   ! Saving 3D potential and density
@@ -1764,7 +1778,11 @@ subroutine save_pot(iparm,fparm,dlx,dly,dlz,phi,rhs)
  !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
  ! Perform a standard gamma-functional calculation for periodic systems
  !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- subroutine set_phi_periodic(phi, iparm, fparm)
+ subroutine set_phi_periodic(env, phi, iparm, fparm)
+
+   !> Environment
+   type(TEnvironment), intent(in) :: env
+
    real(dp), dimension(:,:,:) :: phi
    integer, dimension(:) :: iparm
    real(dp), dimension(:) :: fparm
@@ -1830,7 +1848,7 @@ subroutine save_pot(iparm,fparm,dlx,dly,dlz,phi,rhs)
             nsh = nshells(izp(atom))
 
             ! Compute L-independent part:
-            call long_pot(distR,basis,recbasis,alpha,vol,tol,lng_pot)
+            call long_pot(env%stdOut, distR,basis,recbasis,alpha,vol,tol,lng_pot)
             ! total atomic charge
             deltaQ = sum(dQmat(1:nsh,atom) )
             phi(i,j,k) = phi(i,j,k) + deltaQ*lng_pot
@@ -1840,7 +1858,7 @@ subroutine save_pot(iparm,fparm,dlx,dly,dlz,phi,rhs)
                deltaQ = dQmat(l,atom)
                uhatm = uhubb(l,izp(atom))
 
-               call short_pot(distR,basis,uhatm,deltaQ,tol,sh_pot)
+               call short_pot(env%stdOut, distR,basis,uhatm,deltaQ,tol,sh_pot)
 
                !OMP CRITICAL
                phi(i,j,k) = phi(i,j,k) - sh_pot
@@ -1861,7 +1879,10 @@ subroutine save_pot(iparm,fparm,dlx,dly,dlz,phi,rhs)
  ! CALL - BACK functions used by libmesh poisson
  !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
- real(dp) function rho(xx1,yy1,zz1)
+ real(dp) function rho(env, xx1,yy1,zz1)
+
+   !> Environment
+   type(TEnvironment), intent(in) :: env
 
    real(dp) :: xx1, yy1, zz1
    real(dp) :: xx, yy, zz
@@ -1896,7 +1917,7 @@ subroutine save_pot(iparm,fparm,dlx,dly,dlz,phi,rhs)
 
    else !Periodic structure
 
-      write(stdOut,*) 'periodic poisson not yet implemented'
+      write(env%stdOut,*) 'periodic poisson not yet implemented'
 
    end if
 

--- a/src/dftbp/poisson/poisson.F90
+++ b/src/dftbp/poisson/poisson.F90
@@ -102,7 +102,7 @@ module dftbp_poisson_poisson
  !------------------------------------------------------------------------------
  subroutine poiss_freepoisson(output)
 
-   !> output for write processes
+   !> Output unit for human readable messages
    integer, intent(in) :: output
 
    if (active_id) then
@@ -893,7 +893,7 @@ end subroutine Mudpack_drv
 !>
 subroutine finalize_mudpack(output)
 
-  !> output for write processes
+  !> Output unit for human readable messages
   integer, intent(in) :: output
 
   if (allocated(phi_)) call log_gdeallocate(output, phi_)

--- a/src/dftbp/poisson/structure.F90
+++ b/src/dftbp/poisson/structure.F90
@@ -60,8 +60,11 @@ module dftbp_poisson_structure
   ! -----------------------------------------------------------------------------
   !  FILL UP Structure
   ! -----------------------------------------------------------------------------
-  subroutine init_structure(st_nAtom, st_nSpecies, st_specie0, st_x0, &
+  subroutine init_structure(output, st_nAtom, st_nSpecies, st_specie0, st_x0, &
               st_latVecs, st_isperiodic)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     integer, intent(in)   :: st_nAtom          ! number of Atoms in central cell
     integer, intent(in)   :: st_nSpecies       ! number of Species
@@ -108,10 +111,10 @@ module dftbp_poisson_structure
 
       period=st_isperiodic
 
-      call log_gallocate(x,3,natoms)
+      call log_gallocate(output, x,3,natoms)
       x(1:3,1:natoms)=st_x0(1:3,1:natoms)
 
-      call log_gallocate(izp,natoms)
+      call log_gallocate(output, izp,natoms)
       izp(1:natoms)=st_specie0(1:natoms)
 
     endif
@@ -119,17 +122,25 @@ module dftbp_poisson_structure
   end subroutine init_structure
 
   !------------------------------------------------------------------------------
-  subroutine init_charges()
+  subroutine init_charges(output)
+
+    !> output for write processes
+    integer, intent(in) :: output
+
     integer :: nsh
 
     if (active_id) then
       nsh = maxval(nshells)
-      call log_gallocate(dQmat, nsh, natoms)
+      call log_gallocate(output, dQmat, nsh, natoms)
     endif
   end subroutine init_charges
 
   !------------------------------------------------------------------------------
-  subroutine init_skdata(nShell, angShell, hubbU)
+  subroutine init_skdata(output, nShell, angShell, hubbU)
+
+    !> output for write processes
+    integer, intent(in) :: output
+
     integer, intent(in) :: nShell(:)
     integer, intent(in) :: angShell(:,:)
     real(dp), intent(in) :: hubbU(:,:)
@@ -139,15 +150,15 @@ module dftbp_poisson_structure
     if (active_id) then
 
       ! number of shells
-      call log_gallocate(nshells, ntypes)
+      call log_gallocate(output, nshells, ntypes)
       nshells(:) = nShell
 
       ! angular momentum of each shell
-      call log_gallocate(angshells,maxval(nshell),ntypes)
+      call log_gallocate(output, angshells,maxval(nshell),ntypes)
       angshells(:,:) = angShell
 
       ! set maximum angular momentum per species
-      call log_gallocate(lmax, ntypes)
+      call log_gallocate(output, lmax, ntypes)
 
       do i = 1, ntypes
          lmax(i) = maxval(angShell(:,i))
@@ -155,7 +166,7 @@ module dftbp_poisson_structure
 
       ! set Hubbard parameters
 
-      call log_gallocate(uhubb,maxval(nshell),ntypes)
+      call log_gallocate(output, uhubb,maxval(nshell),ntypes)
 
       do i = 1, ntypes
         uhubb(:nshells(i),i) = hubbU(:nshells(i),i)
@@ -269,9 +280,12 @@ module dftbp_poisson_structure
    !-------------------------------------------------------------------
    ! This section builds the Super Structure for periodic systems
    !
-   subroutine buildsupercell()
+   subroutine buildsupercell(output)
 
      implicit none
+
+     !> output for write processes
+     integer, intent(in) :: output
 
      integer :: ijk(9),algn,nu,nv,nw,i,j,k,n
 
@@ -300,8 +314,8 @@ module dftbp_poisson_structure
 
      endif
 
-     if (.not.allocated(ss_x)) call log_gallocate(ss_x,3,ss_natoms)
-     if (.not.allocated(ss_izp)) call log_gallocate(ss_izp,ss_natoms)
+     if (.not.allocated(ss_x)) call log_gallocate(output, ss_x,3,ss_natoms)
+     if (.not.allocated(ss_izp)) call log_gallocate(output, ss_izp,ss_natoms)
 
      ijk(1)=0;  ijk(2)=-1; ijk(3)=1;  ijk(4)=-2;  ijk(5)=2;
      ijk(6)=-3; ijk(7)=3;  ijk(8)=-4; ijk(9)=4;

--- a/src/dftbp/poisson/structure.F90
+++ b/src/dftbp/poisson/structure.F90
@@ -63,7 +63,7 @@ module dftbp_poisson_structure
   subroutine init_structure(output, st_nAtom, st_nSpecies, st_specie0, st_x0, &
               st_latVecs, st_isperiodic)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     integer, intent(in)   :: st_nAtom          ! number of Atoms in central cell
@@ -124,7 +124,7 @@ module dftbp_poisson_structure
   !------------------------------------------------------------------------------
   subroutine init_charges(output)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     integer :: nsh
@@ -138,7 +138,7 @@ module dftbp_poisson_structure
   !------------------------------------------------------------------------------
   subroutine init_skdata(output, nShell, angShell, hubbU)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     integer, intent(in) :: nShell(:)
@@ -284,7 +284,7 @@ module dftbp_poisson_structure
 
      implicit none
 
-     !> output for write processes
+     !> Output unit for human readable messages
      integer, intent(in) :: output
 
      integer :: ijk(9),algn,nu,nv,nw,i,j,k,n

--- a/src/dftbp/reks/rekscpeqn.F90
+++ b/src/dftbp/reks/rekscpeqn.F90
@@ -16,7 +16,6 @@
 module dftbp_reks_rekscpeqn
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : TEnvironment
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_dftb_periodic, only : TNeighbourList
   use dftbp_io_message, only : error
   use dftbp_math_blasroutines, only : gemm, gemv
@@ -200,7 +199,7 @@ module dftbp_reks_rekscpeqn
     allocate(z0(superN),z1(superN))
     allocate(p0(superN),p1(superN))
 
-    write(stdOut,"(A)") repeat("-", 82)
+    write(env%stdOut,"(A)") repeat("-", 82)
 
     ! initial guess for Z vector
     ! initial Z_initial = A_pre^{-1} * X
@@ -208,7 +207,7 @@ module dftbp_reks_rekscpeqn
       ZT(:) = 0.0_dp
       call gemv(ZT, A1ePre, XT)
     else
-      call shiftAY1ePre_(XT, Fc, Fa, omega, SAweight, FONs, G1, &
+      call shiftAY1ePre_(env, XT, Fc, Fa, omega, SAweight, FONs, G1, &
           & Nc, Na, Glevel, reksAlg, ZT)
     end if
 
@@ -238,13 +237,13 @@ module dftbp_reks_rekscpeqn
       z0(:) = 0.0_dp
       call gemv(z0, A1ePre, r0)
     else
-      call shiftAY1ePre_(r0, Fc, Fa, omega, SAweight, FONs, G1, &
+      call shiftAY1ePre_(env, r0, Fc, Fa, omega, SAweight, FONs, G1, &
           & Nc, Na, Glevel, reksAlg, z0)
     end if
     p0(:) = z0
 
     iter = 0; eps = 0.0_dp
-    write(stdOut,'(2x,a)') 'CG solver: Constructing Y initial guess'
+    write(env%stdOut,'(2x,a)') 'CG solver: Constructing Y initial guess'
 
     CGsolver: do iter = 1, maxIter
 
@@ -283,7 +282,7 @@ module dftbp_reks_rekscpeqn
         z1(:) = 0.0_dp
         call gemv(z1, A1ePre, r1)
       else
-        call shiftAY1ePre_(r1, Fc, Fa, omega, SAweight, FONs, G1, &
+        call shiftAY1ePre_(env, r1, Fc, Fa, omega, SAweight, FONs, G1, &
             & Nc, Na, Glevel, reksAlg, z1)
       end if
       ! compute a gradient correction factor
@@ -299,7 +298,7 @@ module dftbp_reks_rekscpeqn
       eps = sum( r1(:)*r1(:) )
 
       ! show current iteration
-      write(stdOut,'(2x,a,1x,i4,4x,a,F18.12)') &
+      write(env%stdOut,'(2x,a,1x,i4,4x,a,F18.12)') &
           & 'CG solver: Iteration', iter, 'eps =', eps
 
       ! convergence check
@@ -309,13 +308,13 @@ module dftbp_reks_rekscpeqn
         z0(:) = z1
         p0(:) = p1
         if (iter == maxIter) then
-          write(stdOut,'(2x,a,i4,a)') &
+          write(env%stdOut,'(2x,a,i4,a)') &
               & 'Warning! Maximum number of iterations (', maxIter, &
               & ') is exceeded in CG solver'
           call error("Increase the maximum number of iterations")
         end if
       else
-        write(stdOut,'(2x,a,1x,i4,1x,a)') &
+        write(env%stdOut,'(2x,a,1x,i4,1x,a)') &
             & 'Convergence reached in CG solver after', iter, 'iterations'
         exit CGsolver
       end if
@@ -330,8 +329,8 @@ module dftbp_reks_rekscpeqn
         & GammaAO, SpinAO, LrGammaAO, orderRmatL, getDenseAO, &
         & Lpaired, Glevel, tSaveMem, isHybridXc, ZmatL)
     call getQ2mat(eigenvecs, fillingL, weight, ZmatL, Q2mat)
-    write(stdOut,'(2x,a)') 'CG solver: Calculating converged R, Z, Q2 matrix'
-    write(stdOut,"(A)") repeat("-", 82)
+    write(env%stdOut,'(2x,a)') 'CG solver: Calculating converged R, Z, Q2 matrix'
+    write(env%stdOut,"(A)") repeat("-", 82)
 
   end subroutine CGgrad
 
@@ -481,8 +480,11 @@ module dftbp_reks_rekscpeqn
 
 
   !> Calculate A1ePre * Y shift vectors without saving super A1ePre matrix
-  subroutine shiftAY1ePre_(Y, Fc, Fa, omega, SAweight, FONs, G1, &
+  subroutine shiftAY1ePre_(env, Y, Fc, Fa, omega, SAweight, FONs, G1, &
       & Nc, Na, Glevel, reksAlg, shift1ePre)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> trial vector for soulution
     real(dp), intent(in) :: Y(:)
@@ -561,7 +563,7 @@ module dftbp_reks_rekscpeqn
 
       ! check singularity for preconditioner
       if (abs(tmpApre(ij)) <= epsilon(1.0_dp)) then
-        write(stdOut,'(A,f15.8)') " Current preconditioner value = ", tmpApre(ij)
+        write(env%stdOut,'(A,f15.8)') " Current preconditioner value = ", tmpApre(ij)
         call error("A singularity exists in preconditioner for PCG, set Preconditioner = No")
       end if
 

--- a/src/dftbp/reks/reksen.F90
+++ b/src/dftbp/reks/reksen.F90
@@ -77,7 +77,7 @@ module dftbp_reks_reksen
   !> Swap the active orbitals for feasible occupation in REKS
   subroutine activeOrbSwap(output, this, eigenvecs)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> data type for REKS
@@ -563,7 +563,7 @@ module dftbp_reks_reksen
   !> Swap active orbitals when fa < fb in REKS(2,2) case
   subroutine MOswap22_(output, eigenvecs, SAweight, FONs, Efunction, Nc)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> eigenvectors

--- a/src/dftbp/reks/reksen.F90
+++ b/src/dftbp/reks/reksen.F90
@@ -371,7 +371,7 @@ module dftbp_reks_reksen
     end if
 
     ! print state energies and couplings
-    call printReksSSRInfo(this, Wab, tmpEn, StateCoup, env%stdOut)
+    call printReksSSRInfo(this, env%stdOut, Wab, tmpEn, StateCoup)
 
   end subroutine solveSecularEqn
 

--- a/src/dftbp/reks/reksfon.F90
+++ b/src/dftbp/reks/reksfon.F90
@@ -39,7 +39,7 @@ module dftbp_reks_reksfon
     !> data type for REKS
     type(TReksCalc), intent(inout) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     real(dp) :: x
@@ -69,7 +69,7 @@ module dftbp_reks_reksfon
   !> Optimize FONs in REKS(2,2) case with Newton-Raphson method
   subroutine getFONs22_(output, x, hess0, enLtot, delta, maxIter, opt)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> converged x (= n_a/2)

--- a/src/dftbp/reks/reksfon.F90
+++ b/src/dftbp/reks/reksfon.F90
@@ -15,7 +15,6 @@
 !> * Onsite corrections are not included in this version
 module dftbp_reks_reksfon
   use dftbp_common_accuracy, only : dp
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_io_message, only : error
   use dftbp_reks_reksvar, only : reksTypes, TReksCalc
 
@@ -35,10 +34,13 @@ module dftbp_reks_reksfon
   contains
 
   !> Optimize the fractional occupation numbers (FONs) in REKS
-  subroutine optimizeFons(this)
+  subroutine optimizeFons(this, output)
 
     !> data type for REKS
     type(TReksCalc), intent(inout) :: this
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     real(dp) :: x
 
@@ -46,7 +48,7 @@ module dftbp_reks_reksfon
     case (reksTypes%noReks)
     case (reksTypes%ssr22)
 
-      call getFONs22_(x, this%hess, this%enLtot, this%delta, this%FonMaxIter, this%Plevel)
+      call getFONs22_(output, x, this%hess, this%enLtot, this%delta, this%FonMaxIter, this%Plevel)
       ! FONs(1,1) = n_a, FONs(2,1) = n_b
       this%FONs(1,1) = 2.0_dp * x
       this%FONs(2,1) = 2.0_dp - this%FONs(1,1)
@@ -65,7 +67,10 @@ module dftbp_reks_reksfon
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Optimize FONs in REKS(2,2) case with Newton-Raphson method
-  subroutine getFONs22_(x, hess0, enLtot, delta, maxIter, opt)
+  subroutine getFONs22_(output, x, hess0, enLtot, delta, maxIter, opt)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> converged x (= n_a/2)
     real(dp), intent(out) :: x
@@ -155,7 +160,7 @@ module dftbp_reks_reksfon
       ! Update eps value
       eps = (Const - grad) / hess
       if (opt >= 2) then
-        write(stdOut,'(2x,a,1x,i4,4x,a,F18.14,1x,a,F18.14)') &
+        write(output,'(2x,a,1x,i4,4x,a,F18.14,1x,a,F18.14)') &
        & 'NR solver: Iteration', iter, 'X =', x1, 'Eps =', eps
       end if
 
@@ -163,13 +168,13 @@ module dftbp_reks_reksfon
       if (abs(eps) > ConvergeLimit) then
         x0 = x1
         if (iter == maxIter) then
-          write(stdOut,'(2x,a,i4,a)') &
+          write(output,'(2x,a,i4,a)') &
          & 'Warning! Maximum number of iterations (', maxIter, &
          & ') is exceeded in NR solver'
         end if
       else
         if (opt >= 2) then
-          write(stdOut,'(2x,a,1x,i4,1x,a)') &
+          write(output,'(2x,a,1x,i4,1x,a)') &
          & 'Convergence reached in NR solver after', iter, 'iterations'
         end if
         exit NRsolver

--- a/src/dftbp/reks/reksgrad.F90
+++ b/src/dftbp/reks/reksgrad.F90
@@ -18,7 +18,6 @@
 module dftbp_reks_reksgrad
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : globalTimers, TEnvironment
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_common_schedule, only : assembleChunks, distributeRangeWithWorkload
   use dftbp_dftb_coulomb, only : addInvRPrime
   use dftbp_dftb_hybridxc, only : THybridXcFunc
@@ -820,9 +819,12 @@ contains
 
 
   !> Calculate super A hessian matrix with and without H-XC kernel
-  subroutine getSuperAMatrix(eigenvecs, HxcSqrS, HxcSqrD, Fc, Fa, &
+  subroutine getSuperAMatrix(env, eigenvecs, HxcSqrS, HxcSqrD, Fc, Fa, &
       & omega, fillingL, weight, SAweight, FONs, G1, Lpaired, Nc, &
       & Na, Glevel, reksAlg, tSaveMem, A1e, A1ePre, Aall)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Eigenvectors on eixt
     real(dp), intent(in) :: eigenvecs(:,:,:)
@@ -890,7 +892,7 @@ contains
       if (tSaveMem) then
 
         ! build super A matrix except H-XC kernel
-        call buildA1e_(Fc, Fa, omega, SAweight, FONs, G1, Nc, Na, &
+        call buildA1e_(env%stdOut, Fc, Fa, omega, SAweight, FONs, G1, Nc, Na, &
             & Glevel, reksAlg, A1e, A1ePre)
 
       end if
@@ -3112,8 +3114,11 @@ contains
 
 
   !> Calculate super A hessian matrix without H-XC kernel
-  subroutine buildA1e_(Fc, Fa, omega, SAweight, FONs, G1, Nc, Na, &
+  subroutine buildA1e_(output, Fc, Fa, omega, SAweight, FONs, G1, Nc, Na, &
       & Glevel, reksAlg, A1e, A1ePre)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> dense fock matrix for core orbitals
     real(dp), intent(in) :: Fc(:,:)
@@ -3243,7 +3248,7 @@ contains
 
       ! check singularity for preconditioner
       if (abs(A1ePre(ij,ij)) <= epsilon(1.0_dp)) then
-        write(stdOut,'(A,f15.8)') " Current preconditioner value = ", A1ePre(ij,ij)
+        write(output,'(A,f15.8)') " Current preconditioner value = ", A1ePre(ij,ij)
         call error("A singularity exists in preconditioner for PCG, set Preconditioner = No")
       end if
 

--- a/src/dftbp/reks/reksgrad.F90
+++ b/src/dftbp/reks/reksgrad.F90
@@ -3117,7 +3117,7 @@ contains
   subroutine buildA1e_(output, Fc, Fa, omega, SAweight, FONs, G1, Nc, Na, &
       & Glevel, reksAlg, A1e, A1ePre)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> dense fock matrix for core orbitals

--- a/src/dftbp/reks/reksinterface.F90
+++ b/src/dftbp/reks/reksinterface.F90
@@ -20,7 +20,6 @@ module dftbp_reks_reksinterface
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : globalTimers, TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_common_status, only : TStatus
   use dftbp_dftb_densitymatrix, only : TDensityMatrix
   use dftbp_dftb_dispiface, only : TDispersionIface
@@ -215,7 +214,7 @@ module dftbp_reks_reksinterface
         end if
       end if
 
-      call getUnrelaxedDensMatAndTdp(eigenvecs(:,:,1), this%overSqr, rhoL, &
+      call getUnrelaxedDensMatAndTdp(env, eigenvecs(:,:,1), this%overSqr, rhoL, &
           & this%FONs, this%eigvecsSSR, this%Lpaired, this%Nc, this%Na, &
           & this%rstate, this%Lstate, this%reksAlg, this%tSSR, this%tTDP, &
           & this%unrelRhoSqr, this%unrelTdm, densityMatrix, errStatus)
@@ -230,7 +229,7 @@ module dftbp_reks_reksinterface
           call getDipoleMomentMatrix(this%unrelTdm(:,:,ist), dipoleInt, this%tdp(:,ist))
         end do
         call writeReksTDP(this%tdp)
-        call getReksOsc(this%tdp, this%energy)
+        call getReksOsc(env%stdOut, this%tdp, this%energy)
       end if
 
     end if
@@ -371,9 +370,9 @@ module dftbp_reks_reksinterface
         do ist = 1, this%nstates
           if (ist /= this%SAstates) then
 
-            write(stdOut,"(A)")
-            write(stdOut,"(A)") repeat("-", 82)
-            write(stdOut,'(1x,a,1x,I2,1x,a)') &
+            write(env%stdOut,"(A)")
+            write(env%stdOut,"(A)") repeat("-", 82)
+            write(env%stdOut,'(1x,a,1x,I2,1x,a)') &
                 & 'Solving CP-REKS equation for', ist, 'state vector...'
 
             ! solve CP-REKS equation for SA-REKS state
@@ -396,9 +395,9 @@ module dftbp_reks_reksinterface
         do ist = 1, nstHalf
 
           call getTwoIndices(this%nstates, ist, ia, ib, 1)
-          write(stdOut,"(A)")
-          write(stdOut,"(A)") repeat("-", 82)
-          write(stdOut,'(1x,a,1x,I2,1x,a,1x,I2,1x,a)') &
+          write(env%stdOut,"(A)")
+          write(env%stdOut,"(A)") repeat("-", 82)
+          write(env%stdOut,'(1x,a,1x,I2,1x,a,1x,I2,1x,a)') &
               & 'Solving CP-REKS equation for SI between', ia, 'and', ib, 'state vectors...'
 
           ! solve CP-REKS equation for state-interaction term
@@ -424,9 +423,9 @@ module dftbp_reks_reksinterface
           call SaToSsrWeight(this%Rab, this%weightIL, this%G1, &
               & this%eigvecsSSR, this%rstate, this%weightL)
 
-          write(stdOut,"(A)")
-          write(stdOut,"(A)") repeat("-", 82)
-          write(stdOut,'(1x,a,1x,I2,1x,a)') &
+          write(env%stdOut,"(A)")
+          write(env%stdOut,"(A)") repeat("-", 82)
+          write(env%stdOut,'(1x,a,1x,I2,1x,a)') &
               & 'Solving CP-REKS equation for', this%rstate, 'state vector...'
 
           ! solve CP-REKS equation for SSR state
@@ -444,13 +443,13 @@ module dftbp_reks_reksinterface
 
         else
 
-          write(stdOut,"(A)")
-          write(stdOut,"(A)") repeat("-", 82)
+          write(env%stdOut,"(A)")
+          write(env%stdOut,"(A)") repeat("-", 82)
           if (this%Lstate == 0) then
-            write(stdOut,'(1x,a,1x,I2,1x,a)') &
+            write(env%stdOut,'(1x,a,1x,I2,1x,a)') &
                 & 'Solving CP-REKS equation for', this%rstate, 'state vector...'
           else
-            write(stdOut,'(1x,a,1x,I2,1x,a)') &
+            write(env%stdOut,'(1x,a,1x,I2,1x,a)') &
                 & 'Solving CP-REKS equation for', this%Lstate, 'microstate vector...'
           end if
 
@@ -493,7 +492,7 @@ module dftbp_reks_reksinterface
     end if
 
     if (this%Plevel >= 1) then
-      call printReksGradInfo(this, derivs)
+      call printReksGradInfo(this, derivs, env%stdOut)
     end if
 
   end subroutine getReksGradients
@@ -586,13 +585,13 @@ module dftbp_reks_reksinterface
 
         if (this%Lstate == 0) then
           ! get the relaxed density matrix for target SSR or SA-REKS state
-          call getRelaxedDensMat(eigenvecs(:,:,1), this%overSqr, this%unrelRhoSqr, &
+          call getRelaxedDensMat(env, eigenvecs(:,:,1), this%overSqr, this%unrelRhoSqr, &
               & this%ZT, this%omega, this%FONs, this%eigvecsSSR, this%SAweight, &
               & this%Rab, this%G1, this%Nc, this%Na, this%rstate, this%reksAlg, &
               & this%tSSR, this%tNAC, this%relRhoSqr)
         else
           ! get the relaxed density matrix for L-th microstate
-          call getRelaxedDensMatL(eigenvecs(:,:,1), this%rhoSqrL, this%overSqr, &
+          call getRelaxedDensMatL(env, eigenvecs(:,:,1), this%rhoSqrL, this%overSqr, &
               & this%weight, this%SAweight, this%unrelRhoSqr, this%RmatL, &
               & this%ZT, this%omega, this%weightIL, this%G1, this%orderRmatL, &
               & this%Lpaired, this%Nc, this%Na, this%Lstate, this%reksAlg, &
@@ -1057,7 +1056,7 @@ module dftbp_reks_reksinterface
         & this%isHybridXc, this%G1, this%weightIL, this%omega, this%Rab)
 
     ! get A1e or Aall values based on GradOpt
-    call getSuperAMatrix(eigenvecs, this%HxcSqrS, this%HxcSqrD, this%fockFc, &
+    call getSuperAMatrix(env, eigenvecs, this%HxcSqrS, this%HxcSqrD, this%fockFc, &
         & this%fockFa, this%omega, this%fillingL, this%weight, this%SAweight, &
         & this%FONs, this%G1, this%Lpaired, this%Nc, this%Na, this%Glevel, &
         & this%reksAlg, this%tSaveMem, this%A1e, this%A1ePre, this%Aall)
@@ -1222,9 +1221,9 @@ module dftbp_reks_reksinterface
       ! get converged R, Z, Q2 matrices & ZT vector
       ! RmatL : AO index, ZmatL : AO index, Q2mat : MO index
       if (optionQMMM) then
-        write(stdOut,'(a)') &
+        write(env%stdOut,'(a)') &
             & ' Warning! For calculating relaxed density for SSR state,'
-        write(stdOut,'(a)') &
+        write(env%stdOut,'(a)') &
             & '          run CG again to obtain ZT solution in (nac) case.'
       end if
       call CGgrad(env, denseDesc, neighbourList, nNeighbourSK, iSparseStart, &
@@ -1252,7 +1251,7 @@ module dftbp_reks_reksinterface
             & this%SpinAO, this%LrGammaAO, this%orderRmatL, this%getDenseAO, &
             & this%Lpaired, this%Glevel, this%tSaveMem, this%isHybridXc, ZmatL)
         call getQ2mat(eigenvecs, this%fillingL, this%weight, ZmatL, Q2mat)
-        write(stdOut,"(A)") repeat("-", 82)
+        write(env%stdOut,"(A)") repeat("-", 82)
       end if
 
     end if
@@ -1262,7 +1261,7 @@ module dftbp_reks_reksinterface
       call getQ1mat(ZT, this%fockFc, this%fockFa, this%SAweight, &
           & this%FONs, this%Nc, this%Na, this%reksAlg, Q1mat)
     else
-      write(stdOut,"(A)")
+      write(env%stdOut,"(A)")
     end if
 
   end subroutine solveCpReks_

--- a/src/dftbp/reks/reksinterface.F90
+++ b/src/dftbp/reks/reksinterface.F90
@@ -492,7 +492,7 @@ module dftbp_reks_reksinterface
     end if
 
     if (this%Plevel >= 1) then
-      call printReksGradInfo(this, derivs, env%stdOut)
+      call printReksGradInfo(this, env%stdOut, derivs)
     end if
 
   end subroutine getReksGradients

--- a/src/dftbp/reks/reksio.F90
+++ b/src/dftbp/reks/reksio.F90
@@ -41,7 +41,7 @@ module dftbp_reks_reksio
     !> repulsive energy
     real(dp), intent(in) :: Erep
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     integer :: iL
@@ -79,7 +79,7 @@ module dftbp_reks_reksio
     !> data type for REKS
     type(TReksCalc), intent(inout) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     integer :: ist
@@ -105,7 +105,7 @@ module dftbp_reks_reksio
     !> Total energy for averaged state in REKS
     real(dp), intent(in) :: Eavg
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     select case (this%reksAlg)
@@ -135,7 +135,7 @@ module dftbp_reks_reksio
     !> state-interaction term between SA-REKS states
     real(dp), intent(in) :: StateCoup(:,:)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     select case (this%reksAlg)
@@ -159,7 +159,7 @@ module dftbp_reks_reksio
     !> derivatives of energy wrt to atomic positions
     real(dp), intent(in) :: derivs(:,:)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     integer :: ist, ia, ib, nstHalf
@@ -278,7 +278,7 @@ module dftbp_reks_reksio
     !> Calculate SSR state with inclusion of SI, otherwise calculate SA-REKS state
     logical, intent(in) :: tSSR
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     integer :: ii
@@ -325,7 +325,7 @@ module dftbp_reks_reksio
     !> Calculate SSR state with inclusion of SI, otherwise calculate SA-REKS state
     logical, intent(in) :: tSSR
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     integer :: ii
@@ -364,7 +364,7 @@ module dftbp_reks_reksio
     !> Number of active orbitals
     integer, intent(in) :: Na
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     integer :: ii
@@ -480,7 +480,7 @@ module dftbp_reks_reksio
     !> Print level in standard output file
     integer, intent(in) :: Plevel
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     real(dp) :: n_a, n_b
@@ -544,7 +544,7 @@ module dftbp_reks_reksio
   subroutine printReksSSRInfo22_(output, Wab, tmpEn, StateCoup, energy, eigvecsSSR, &
       & Na, tAllStates, tSSR)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> converged Lagrangian values within active space

--- a/src/dftbp/reks/reksio.F90
+++ b/src/dftbp/reks/reksio.F90
@@ -17,7 +17,6 @@ module dftbp_reks_reksio
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : au__Debye
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_io_message, only : error
   use dftbp_reks_rekscommon, only : getSpaceSym, getTwoIndices
   use dftbp_reks_reksvar, only : reksTypes, TReksCalc
@@ -34,7 +33,7 @@ module dftbp_reks_reksio
   contains
 
   !> Print energy contribution for each microstate in SCC iteration
-  subroutine printReksMicrostates(this, Erep)
+  subroutine printReksMicrostates(this, Erep, output)
 
     !> data type for REKS
     type(TReksCalc), intent(inout) :: this
@@ -42,49 +41,55 @@ module dftbp_reks_reksio
     !> repulsive energy
     real(dp), intent(in) :: Erep
 
+    !> output for write processes
+    integer, intent(in) :: output
+
     integer :: iL
 
-    write(stdOut,'(1x,A,5x,A,9x,A,9x,A,9x,A,10x,A,9x,A,10x,A,8x,A)') &
+    write(output,'(1x,A,5x,A,9x,A,9x,A,9x,A,10x,A,9x,A,10x,A,8x,A)') &
         & "iL", "nonSCC", "SCC", "spin", "3rd", "fock", "Rep", "Disp", "Total"
     do iL = 1, this%Lmax
-      write(stdOut,'(I3,7(f13.8))',advance="no") iL, this%enLnonSCC(iL), &
+      write(output,'(I3,7(f13.8))',advance="no") iL, this%enLnonSCC(iL), &
           & this%enLscc(iL), this%enLspin(iL)
       if (this%t3rd) then
-        write(stdOut,'(1(f13.8))',advance="no") this%enL3rd(iL)
+        write(output,'(1(f13.8))',advance="no") this%enL3rd(iL)
       else
-        write(stdOut,'(1(f13.8))',advance="no") 0.0_dp
+        write(output,'(1(f13.8))',advance="no") 0.0_dp
       end if
       if (this%isHybridXc) then
-        write(stdOut,'(1(f13.8))',advance="no") this%enLfock(iL)
+        write(output,'(1(f13.8))',advance="no") this%enLfock(iL)
       else
-        write(stdOut,'(1(f13.8))',advance="no") 0.0_dp
+        write(output,'(1(f13.8))',advance="no") 0.0_dp
       end if
-      write(stdOut,'(1(f13.8))',advance="no") Erep
+      write(output,'(1(f13.8))',advance="no") Erep
       if (this%isDispersion) then
-        write(stdOut,'(1(f13.8))',advance="no") this%enLdisp(iL)
+        write(output,'(1(f13.8))',advance="no") this%enLdisp(iL)
       else
-        write(stdOut,'(1(f13.8))',advance="no") 0.0_dp
+        write(output,'(1(f13.8))',advance="no") 0.0_dp
       end if
-      write(stdOut,'(1(f13.8))') this%enLtot(iL)
+      write(output,'(1(f13.8))') this%enLtot(iL)
     end do
 
   end subroutine printReksMicrostates
 
 
   !> Print SA-REKS energy in SCC iteration
-  subroutine printSaReksEnergy(this)
+  subroutine printSaReksEnergy(this, output)
 
     !> data type for REKS
     type(TReksCalc), intent(inout) :: this
 
+    !> output for write processes
+    integer, intent(in) :: output
+
     integer :: ist
 
-    write(stdOut,'(1x,A)') "SA-REKS state energies"
+    write(output,'(1x,A)') "SA-REKS state energies"
     do ist = 1, this%nstates
       if (mod(ist,5) == 0 .or. ist == this%nstates) then
-        write(stdOut,"(I3,':',1x,1(f13.8),1x,'H')") ist, this%energy(ist)
+        write(output,"(I3,':',1x,1(f13.8),1x,'H')") ist, this%energy(ist)
       else
-        write(stdOut,"(I3,':',1x,1(f13.8),1x,'H')",advance="no") ist, this%energy(ist)
+        write(output,"(I3,':',1x,1(f13.8),1x,'H')",advance="no") ist, this%energy(ist)
       end if
     end do
 
@@ -92,7 +97,7 @@ module dftbp_reks_reksio
 
 
   !> print SA-REKS result in standard output
-  subroutine printReksSAInfo(this, Eavg)
+  subroutine printReksSAInfo(this, Eavg, output)
 
     !> data type for REKS
     type(TReksCalc), intent(inout) :: this
@@ -100,11 +105,14 @@ module dftbp_reks_reksio
     !> Total energy for averaged state in REKS
     real(dp), intent(in) :: Eavg
 
+    !> output for write processes
+    integer, intent(in) :: output
+
     select case (this%reksAlg)
     case (reksTypes%noReks)
     case (reksTypes%ssr22)
       call printReksSAInfo22_(Eavg, this%enLtot, this%energy, this%FONs, this%Efunction,&
-          & this%Plevel)
+          & this%Plevel, output)
     case (reksTypes%ssr44)
       call error("SSR(4,4) is not implemented yet")
     end select
@@ -113,7 +121,7 @@ module dftbp_reks_reksio
 
 
   !> print SI-SA-REKS result in standard output
-  subroutine printReksSSRInfo(this, Wab, tmpEn, StateCoup)
+  subroutine printReksSSRInfo(this, Wab, tmpEn, StateCoup, output)
 
     !> data type for REKS
     type(TReksCalc), intent(inout) :: this
@@ -127,10 +135,13 @@ module dftbp_reks_reksio
     !> state-interaction term between SA-REKS states
     real(dp), intent(in) :: StateCoup(:,:)
 
+    !> output for write processes
+    integer, intent(in) :: output
+
     select case (this%reksAlg)
     case (reksTypes%noReks)
     case (reksTypes%ssr22)
-      call printReksSSRInfo22_(Wab, tmpEn, StateCoup, this%energy, this%eigvecsSSR, &
+      call printReksSSRInfo22_(output, Wab, tmpEn, StateCoup, this%energy, this%eigvecsSSR, &
           & this%Na, this%tAllStates, this%tSSR)
     case (reksTypes%ssr44)
       call error("SSR(4,4) is not implemented yet")
@@ -140,7 +151,7 @@ module dftbp_reks_reksio
 
 
   !> print gradient results for REKS calculation
-  subroutine printReksGradInfo(this, derivs)
+  subroutine printReksGradInfo(this, derivs, output)
 
     !> data type for REKS
     type(TReksCalc), intent(inout) :: this
@@ -148,103 +159,106 @@ module dftbp_reks_reksio
     !> derivatives of energy wrt to atomic positions
     real(dp), intent(in) :: derivs(:,:)
 
+    !> output for write processes
+    integer, intent(in) :: output
+
     integer :: ist, ia, ib, nstHalf
     character(3), parameter :: ordinals(6) = ['1st', '2nd', '3rd', '4th', '5th', '6th']
 
     nstHalf = this%nstates * (this%nstates - 1) / 2
 
-    write(stdOut,*)
+    write(output,*)
     if (this%Efunction == 1) then
 
-      write(stdOut,"(A)") repeat("-", 50)
-      write(stdOut,"(A)") " Gradient Information"
-      write(stdOut,"(A)") repeat("-", 50)
-      write(stdOut,*) this%rstate, "state (single-state)"
-      write(stdOut,'(3(f15.8))') derivs(:,:)
-      write(stdOut,"(A)") repeat("-", 50)
+      write(output,"(A)") repeat("-", 50)
+      write(output,"(A)") " Gradient Information"
+      write(output,"(A)") repeat("-", 50)
+      write(output,*) this%rstate, "state (single-state)"
+      write(output,'(3(f15.8))') derivs(:,:)
+      write(output,"(A)") repeat("-", 50)
 
     else
 
       if (this%tNAC) then
 
-        write(stdOut,"(A)") repeat("-", 50)
-        write(stdOut,"(A)") " Gradient Information"
-        write(stdOut,"(A)") repeat("-", 50)
+        write(output,"(A)") repeat("-", 50)
+        write(output,"(A)") " Gradient Information"
+        write(output,"(A)") repeat("-", 50)
         do ist = 1, this%nstates
-          write(stdOut,'(12X,A)') ordinals(ist) // " state (SSR)"
-          write(stdOut,'(3(f15.8))') this%SSRgrad(:,:,ist)
+          write(output,'(12X,A)') ordinals(ist) // " state (SSR)"
+          write(output,'(3(f15.8))') this%SSRgrad(:,:,ist)
           if (ist == this%nstates) then
-            write(stdOut,"(A)") repeat("-", 50)
+            write(output,"(A)") repeat("-", 50)
           else
-            write(stdOut,'(3(f15.8))')
+            write(output,'(3(f15.8))')
           end if
         end do
 
         if (this%Plevel >= 2) then
-          write(stdOut,"(12X,A)") "Averaged state"
-          write(stdOut,'(3(f15.8))') this%avgGrad(:,:)
-          write(stdOut,'(3(f15.8))')
+          write(output,"(12X,A)") "Averaged state"
+          write(output,'(3(f15.8))') this%avgGrad(:,:)
+          write(output,'(3(f15.8))')
           do ist = 1, this%nstates
-            write(stdOut,'(10X,A)') ordinals(ist) // " state (SA-REKS)"
-            write(stdOut,'(3(f15.8))') this%SAgrad(:,:,ist)
+            write(output,'(10X,A)') ordinals(ist) // " state (SA-REKS)"
+            write(output,'(3(f15.8))') this%SAgrad(:,:,ist)
             if (ist == this%nstates) then
-              write(stdOut,"(A)") repeat("-", 50)
+              write(output,"(A)") repeat("-", 50)
             else
-              write(stdOut,'(3(f15.8))')
+              write(output,'(3(f15.8))')
             end if
           end do
         end if
 
-        write(stdOut,"(A)") " Coupling Information"
+        write(output,"(A)") " Coupling Information"
         do ist = 1, nstHalf
 
           call getTwoIndices(this%nstates, ist, ia, ib, 1)
 
-          write(stdOut,"(A)") repeat("-", 50)
-          write(stdOut,'(" between ",I2," and ",I2," states")') ia, ib
-          write(stdOut,"(A)") repeat("-", 50)
-          write(stdOut,*) "g vector - difference gradient"
-          write(stdOut,'(3(f15.8))') (this%SAgrad(:,:,ia) - this%SAgrad(:,:,ib)) * 0.5_dp
-          write(stdOut,'(3(f15.8))')
-          write(stdOut,*) "h vector - derivative coupling"
-          write(stdOut,'(3(f15.8))') this%SIgrad(:,:,ist)
-          write(stdOut,'(3(f15.8))')
-          write(stdOut,*) "G vector - GDV"
-          write(stdOut,'(3(f15.8))') this%nacG(:,:,ist)
-          write(stdOut,'(3(f15.8))')
-          write(stdOut,*) "H vector - DCV - non-adiabatic coupling"
-          write(stdOut,'(3(f15.8))') this%nacH(:,:,ist)
+          write(output,"(A)") repeat("-", 50)
+          write(output,'(" between ",I2," and ",I2," states")') ia, ib
+          write(output,"(A)") repeat("-", 50)
+          write(output,*) "g vector - difference gradient"
+          write(output,'(3(f15.8))') (this%SAgrad(:,:,ia) - this%SAgrad(:,:,ib)) * 0.5_dp
+          write(output,'(3(f15.8))')
+          write(output,*) "h vector - derivative coupling"
+          write(output,'(3(f15.8))') this%SIgrad(:,:,ist)
+          write(output,'(3(f15.8))')
+          write(output,*) "G vector - GDV"
+          write(output,'(3(f15.8))') this%nacG(:,:,ist)
+          write(output,'(3(f15.8))')
+          write(output,*) "H vector - DCV - non-adiabatic coupling"
+          write(output,'(3(f15.8))') this%nacH(:,:,ist)
 
         end do
-        write(stdOut,"(A)") repeat("-", 50)
+        write(output,"(A)") repeat("-", 50)
 
       else
 
-        write(stdOut,"(A)") repeat("-", 50)
-        write(stdOut,"(A)") " Gradient Information"
-        write(stdOut,"(A)") repeat("-", 50)
+        write(output,"(A)") repeat("-", 50)
+        write(output,"(A)") " Gradient Information"
+        write(output,"(A)") repeat("-", 50)
         if (this%Lstate == 0) then
           if (this%tSSR) then
-            write(stdOut,*) this%rstate, "state (SSR)"
+            write(output,*) this%rstate, "state (SSR)"
           else
-            write(stdOut,*) this%rstate, "state (SA-REKS)"
+            write(output,*) this%rstate, "state (SA-REKS)"
           end if
         else
-          write(stdOut,*) this%Lstate, "microstate"
+          write(output,*) this%Lstate, "microstate"
         end if
-        write(stdOut,'(3(f15.8))') derivs(:,:)
-        write(stdOut,"(A)") repeat("-", 50)
+        write(output,'(3(f15.8))') derivs(:,:)
+        write(output,"(A)") repeat("-", 50)
 
       end if
 
     end if
-    write(stdOut,*)
+    write(output,*)
 
   end subroutine printReksGradInfo
 
 
   !> print unrelaxed FONs for target state
-  subroutine printUnrelaxedFONs(tmpRho, rstate, Lstate, Nc, Na, tSSR)
+  subroutine printUnrelaxedFONs(tmpRho, rstate, Lstate, Nc, Na, tSSR, output)
 
     !> Occupation number matrix
     real(dp), intent(in) :: tmpRho(:,:)
@@ -264,26 +278,29 @@ module dftbp_reks_reksio
     !> Calculate SSR state with inclusion of SI, otherwise calculate SA-REKS state
     logical, intent(in) :: tSSR
 
+    !> output for write processes
+    integer, intent(in) :: output
+
     integer :: ii
 
-    write(stdOut,*)
+    write(output,*)
     if (tSSR) then
-      write(stdOut,'(A25,I1,A1)',advance="no") " unrelaxed SSR FONs for S", &
+      write(output,'(A25,I1,A1)',advance="no") " unrelaxed SSR FONs for S", &
           & rstate - 1, ":"
     else
       if (Lstate == 0) then
-        write(stdOut,'(A29,I1,A1)',advance="no") " unrelaxed SA-REKS FONs for S", &
+        write(output,'(A29,I1,A1)',advance="no") " unrelaxed SA-REKS FONs for S", &
             & rstate - 1, ":"
       else
-        write(stdOut,'(A20,I1,A12)',advance="no") " unrelaxed FONs for ", &
+        write(output,'(A20,I1,A12)',advance="no") " unrelaxed FONs for ", &
             & Lstate, " microstate:"
       end if
     end if
     do ii = 1, Na
       if (ii == Na) then
-        write(stdOut,'(1(f10.6))') tmpRho(Nc+ii,Nc+ii)
+        write(output,'(1(f10.6))') tmpRho(Nc+ii,Nc+ii)
       else
-        write(stdOut,'(1(f10.6))',advance="no") tmpRho(Nc+ii,Nc+ii)
+        write(output,'(1(f10.6))',advance="no") tmpRho(Nc+ii,Nc+ii)
       end if
     end do
 
@@ -291,7 +308,7 @@ module dftbp_reks_reksio
 
 
   !> print Relaxed FONs for target state
-  subroutine printRelaxedFONs(tmpRho, rstate, Nc, Na, tSSR)
+  subroutine printRelaxedFONs(tmpRho, rstate, Nc, Na, tSSR, output)
 
     !> Occupation number matrix
     real(dp), intent(in) :: tmpRho(:,:)
@@ -308,29 +325,32 @@ module dftbp_reks_reksio
     !> Calculate SSR state with inclusion of SI, otherwise calculate SA-REKS state
     logical, intent(in) :: tSSR
 
+    !> output for write processes
+    integer, intent(in) :: output
+
     integer :: ii
 
     if (tSSR) then
-      write(stdOut,'(A23,I1,A1)',advance="no") " relaxed SSR FONs for S", &
+      write(output,'(A23,I1,A1)',advance="no") " relaxed SSR FONs for S", &
           & rstate - 1, ":"
     else
-      write(stdOut,'(A27,I1,A1)',advance="no") " relaxed SA-REKS FONs for S", &
+      write(output,'(A27,I1,A1)',advance="no") " relaxed SA-REKS FONs for S", &
           & rstate - 1, ":"
     end if
     do ii = 1, Na
       if (ii == Na) then
-        write(stdOut,'(1(f10.6))') tmpRho(Nc+ii,Nc+ii)
+        write(output,'(1(f10.6))') tmpRho(Nc+ii,Nc+ii)
       else
-        write(stdOut,'(1(f10.6))',advance="no") tmpRho(Nc+ii,Nc+ii)
+        write(output,'(1(f10.6))',advance="no") tmpRho(Nc+ii,Nc+ii)
       end if
     end do
-    write(stdOut,*)
+    write(output,*)
 
   end subroutine printRelaxedFONs
 
 
   !> print Relaxed FONs for target L-th microstate
-  subroutine printRelaxedFONsL(tmpRho, Lstate, Nc, Na)
+  subroutine printRelaxedFONsL(tmpRho, Lstate, Nc, Na, output)
 
     !> Occupation number matrix
     real(dp), intent(in) :: tmpRho(:,:)
@@ -344,18 +364,21 @@ module dftbp_reks_reksio
     !> Number of active orbitals
     integer, intent(in) :: Na
 
+    !> output for write processes
+    integer, intent(in) :: output
+
     integer :: ii
 
-    write(stdOut,'(A18,I1,A12)',advance="no") " relaxed FONs for ", &
+    write(output,'(A18,I1,A12)',advance="no") " relaxed FONs for ", &
         & Lstate, " microstate:"
     do ii = 1, Na
       if (ii == Na) then
-        write(stdOut,'(1(f10.6))') tmpRho(Nc+ii,Nc+ii)
+        write(output,'(1(f10.6))') tmpRho(Nc+ii,Nc+ii)
       else
-        write(stdOut,'(1(f10.6))',advance="no") tmpRho(Nc+ii,Nc+ii)
+        write(output,'(1(f10.6))',advance="no") tmpRho(Nc+ii,Nc+ii)
       end if
     end do
-    write(stdOut,*)
+    write(output,*)
 
   end subroutine printRelaxedFONsL
 
@@ -437,7 +460,7 @@ module dftbp_reks_reksio
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> print SA-REKS(2,2) result in standard output
-  subroutine printReksSAInfo22_(Eavg, enLtot, energy, FONs, Efunction, Plevel)
+  subroutine printReksSAInfo22_(Eavg, enLtot, energy, FONs, Efunction, Plevel, output)
 
     !> Total energy for averaged state in REKS
     real(dp), intent(in) :: Eavg
@@ -457,6 +480,9 @@ module dftbp_reks_reksio
     !> Print level in standard output file
     integer, intent(in) :: Plevel
 
+    !> output for write processes
+    integer, intent(in) :: output
+
     real(dp) :: n_a, n_b
     integer :: iL, Lmax, ist, nstates
     character(len=8) :: strTmp
@@ -467,56 +493,59 @@ module dftbp_reks_reksio
     n_a = FONs(1,1)
     n_b = FONs(2,1)
 
-    write(stdOut,*) " "
-    write(stdOut, "(A)") repeat("-", 50)
+    write(output,*) " "
+    write(output, "(A)") repeat("-", 50)
     if (Efunction == 1) then
-      write(stdOut,'(A25,2x,F15.8)') " Final REKS(2,2) energy:", Eavg
-      write(stdOut,*) " "
-      write(stdOut,'(A46)') " State     Energy      FON(1)    FON(2)   Spin"
+      write(output,'(A25,2x,F15.8)') " Final REKS(2,2) energy:", Eavg
+      write(output,*) " "
+      write(output,'(A46)') " State     Energy      FON(1)    FON(2)   Spin"
       write(strTmp,'(A)') "PPS"
-      write(stdOut,'(1x,a4,1x,f13.8,1x,2(f10.6),2x,f4.2)') &
+      write(output,'(1x,a4,1x,f13.8,1x,2(f10.6),2x,f4.2)') &
           & trim(strTmp), energy(1), n_a, n_b, 0.0_dp
     else if (Efunction == 2) then
-      write(stdOut,'(A27,2x,F15.8)') " Final SA-REKS(2,2) energy:", Eavg
-      write(stdOut,*) " "
-      write(stdOut,'(A46)') " State     Energy      FON(1)    FON(2)   Spin"
+      write(output,'(A27,2x,F15.8)') " Final SA-REKS(2,2) energy:", Eavg
+      write(output,*) " "
+      write(output,'(A46)') " State     Energy      FON(1)    FON(2)   Spin"
       do ist = 1, nstates
         if (ist == 1) then
           write(strTmp,'(A)') "PPS"
-          write(stdOut,'(1x,a4,1x,f13.8,1x,2(f10.6),2x,f4.2)') &
+          write(output,'(1x,a4,1x,f13.8,1x,2(f10.6),2x,f4.2)') &
               & trim(strTmp), energy(1), n_a, n_b, 0.0_dp
         else if (ist == 2) then
           write(strTmp,'(A)') "OSS"
-          write(stdOut,'(1x,a4,1x,f13.8,1x,2(f10.6),2x,f4.2)') &
+          write(output,'(1x,a4,1x,f13.8,1x,2(f10.6),2x,f4.2)') &
               & trim(strTmp), energy(2), 1.0_dp, 1.0_dp, 0.0_dp
         else if (ist == 3) then
           write(strTmp,'(A)') "DES"
-          write(stdOut,'(1x,a4,1x,f13.8,1x,2(f10.6),2x,f4.2)') &
+          write(output,'(1x,a4,1x,f13.8,1x,2(f10.6),2x,f4.2)') &
               & trim(strTmp), energy(3), n_b, n_a, 0.0_dp
         end if
       end do
       write(strTmp,'(A)') "Trip"
-      write(stdOut,'(1x,a4,1x,f13.8,1x,2(f10.6),2x,f4.2)') &
+      write(output,'(1x,a4,1x,f13.8,1x,2(f10.6),2x,f4.2)') &
           & trim(strTmp), enLtot(5), 1.0_dp, 1.0_dp, 1.0_dp
     end if
-    write(stdOut, "(A)") repeat("-", 50)
+    write(output, "(A)") repeat("-", 50)
 
     if (Plevel >= 2) then
-      write(stdOut,*) " "
-      write(stdOut, "(A)") repeat("-", 25)
-      write(stdOut,'(1x,A20,2x,F15.8)') " Microstate Energies"
+      write(output,*) " "
+      write(output, "(A)") repeat("-", 25)
+      write(output,'(1x,A20,2x,F15.8)') " Microstate Energies"
       do iL = 1, Lmax
-        write(stdOut,"(1x,'L =',1x,I2,':',1x,F13.8)") iL, enLtot(iL)
+        write(output,"(1x,'L =',1x,I2,':',1x,F13.8)") iL, enLtot(iL)
       end do
-      write(stdOut, "(A)") repeat("-", 25)
+      write(output, "(A)") repeat("-", 25)
     end if
 
   end subroutine printReksSAInfo22_
 
 
   !> print SI-SA-REKS(2,2) result in standard output
-  subroutine printReksSSRInfo22_(Wab, tmpEn, StateCoup, energy, eigvecsSSR, &
+  subroutine printReksSSRInfo22_(output, Wab, tmpEn, StateCoup, energy, eigvecsSSR, &
       & Na, tAllStates, tSSR)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> converged Lagrangian values within active space
     real(dp), intent(in) :: Wab(:,:)
@@ -549,7 +578,7 @@ module dftbp_reks_reksio
     nActPair = size(Wab,dim=1)
     nstates = size(energy,dim=1)
 
-    write(stdOut,*)
+    write(output,*)
     do ist = 1, nActPair
 
       call getTwoIndices(Na, ist, ia, ib, 1)
@@ -557,19 +586,19 @@ module dftbp_reks_reksio
       call getSpaceSym(ia, stA)
       call getSpaceSym(ib, stB)
 
-      write(stdOut,"(1x,'Lagrangian W',A1,A1,': ',2(f12.8))") &
+      write(output,"(1x,'Lagrangian W',A1,A1,': ',2(f12.8))") &
           & trim(stA), trim(stB), Wab(ist,1), Wab(ist,2)
 
     end do
 
-    write(stdOut,*)
-    write(stdOut, "(A)") repeat("-", 50)
+    write(output,*)
+    write(output, "(A)") repeat("-", 50)
     if (.not. tAllStates) then
-      write(stdOut,'(A)') " SSR: 2SI-2SA-REKS(2,2) Hamiltonian matrix"
-      write(stdOut,'(15x,A3,11x,A3)') "PPS", "OSS"
+      write(output,'(A)') " SSR: 2SI-2SA-REKS(2,2) Hamiltonian matrix"
+      write(output,'(15x,A3,11x,A3)') "PPS", "OSS"
     else
-      write(stdOut,'(A)') " SSR: 3SI-2SA-REKS(2,2) Hamiltonian matrix"
-      write(stdOut,'(15x,A3,11x,A3,11x,A3)') "PPS", "OSS", "DES"
+      write(output,'(A)') " SSR: 3SI-2SA-REKS(2,2) Hamiltonian matrix"
+      write(output,'(15x,A3,11x,A3,11x,A3)') "PPS", "OSS", "DES"
     end if
 
     do ist = 1, nstates
@@ -580,45 +609,45 @@ module dftbp_reks_reksio
       else if (ist == 3) then
         write(strTmp,'(A)') "DES"
       end if
-      write(stdOut,'(1x,a5,1x)',advance="no") trim(strTmp)
+      write(output,'(1x,a5,1x)',advance="no") trim(strTmp)
       do jst = 1, nstates
         if (ist == jst) then
           if (jst == nstates) then
-            write(stdOut,'(1x,f13.8)') tmpEn(ist)
+            write(output,'(1x,f13.8)') tmpEn(ist)
           else
-            write(stdOut,'(1x,f13.8)',advance="no") tmpEn(ist)
+            write(output,'(1x,f13.8)',advance="no") tmpEn(ist)
           end if
         else
           if (jst == nstates) then
-            write(stdOut,'(1x,f13.8)') StateCoup(ist,jst)
+            write(output,'(1x,f13.8)') StateCoup(ist,jst)
           else
-            write(stdOut,'(1x,f13.8)',advance="no") StateCoup(ist,jst)
+            write(output,'(1x,f13.8)',advance="no") StateCoup(ist,jst)
           end if
         end if
       end do
     end do
-    write(stdOut, "(A)") repeat("-", 50)
+    write(output, "(A)") repeat("-", 50)
 
     if (tSSR) then
-      write(stdOut,*)
-      write(stdOut, "(A)") repeat("-", 64)
+      write(output,*)
+      write(output, "(A)") repeat("-", 64)
       if (.not. tAllStates) then
-        write(stdOut,'(A)') " SSR: 2SI-2SA-REKS(2,2) states"
-        write(stdOut,'(19x,A4,7x,A7,4x,A7)') "E_n", "C_{PPS}", "C_{OSS}"
+        write(output,'(A)') " SSR: 2SI-2SA-REKS(2,2) states"
+        write(output,'(19x,A4,7x,A7,4x,A7)') "E_n", "C_{PPS}", "C_{OSS}"
       else
-        write(stdOut,'(A)') " SSR: 3SI-2SA-REKS(2,2) states"
-        write(stdOut,'(19x,A4,7x,A7,4x,A7,4x,A7)') "E_n", "C_{PPS}", "C_{OSS}", "C_{DES}"
+        write(output,'(A)') " SSR: 3SI-2SA-REKS(2,2) states"
+        write(output,'(19x,A4,7x,A7,4x,A7,4x,A7)') "E_n", "C_{PPS}", "C_{OSS}", "C_{DES}"
       end if
       do ist = 1, nstates
         if (.not. tAllStates) then
-          write(stdOut,'(1x,A,I2,1x,f13.8,1x,f10.6,1x,f10.6)') &
+          write(output,'(1x,A,I2,1x,f13.8,1x,f10.6,1x,f10.6)') &
               & "SSR state ", ist, energy(ist), eigvecsSSR(:,ist)
         else
-          write(stdOut,'(1x,A,I2,1x,f13.8,1x,f10.6,1x,f10.6,1x,f10.6)') &
+          write(output,'(1x,A,I2,1x,f13.8,1x,f10.6,1x,f10.6,1x,f10.6)') &
               & "SSR state ", ist, energy(ist), eigvecsSSR(:,ist)
         end if
       end do
-      write(stdOut, "(A)") repeat("-", 64)
+      write(output, "(A)") repeat("-", 64)
     end if
 
   end subroutine printReksSSRInfo22_

--- a/src/dftbp/reks/reksio.F90
+++ b/src/dftbp/reks/reksio.F90
@@ -33,16 +33,16 @@ module dftbp_reks_reksio
   contains
 
   !> Print energy contribution for each microstate in SCC iteration
-  subroutine printReksMicrostates(this, Erep, output)
+  subroutine printReksMicrostates(this, output, Erep)
 
     !> data type for REKS
     type(TReksCalc), intent(inout) :: this
 
-    !> repulsive energy
-    real(dp), intent(in) :: Erep
-
     !> Output unit for human readable messages
     integer, intent(in) :: output
+
+    !> repulsive energy
+    real(dp), intent(in) :: Erep
 
     integer :: iL
 
@@ -97,22 +97,22 @@ module dftbp_reks_reksio
 
 
   !> print SA-REKS result in standard output
-  subroutine printReksSAInfo(this, Eavg, output)
+  subroutine printReksSAInfo(this, output, Eavg)
 
     !> data type for REKS
     type(TReksCalc), intent(inout) :: this
 
-    !> Total energy for averaged state in REKS
-    real(dp), intent(in) :: Eavg
-
     !> Output unit for human readable messages
     integer, intent(in) :: output
+
+    !> Total energy for averaged state in REKS
+    real(dp), intent(in) :: Eavg
 
     select case (this%reksAlg)
     case (reksTypes%noReks)
     case (reksTypes%ssr22)
-      call printReksSAInfo22_(Eavg, this%enLtot, this%energy, this%FONs, this%Efunction,&
-          & this%Plevel, output)
+      call printReksSAInfo22_(output, Eavg, this%enLtot, this%energy, this%FONs, this%Efunction,&
+          & this%Plevel)
     case (reksTypes%ssr44)
       call error("SSR(4,4) is not implemented yet")
     end select
@@ -121,10 +121,13 @@ module dftbp_reks_reksio
 
 
   !> print SI-SA-REKS result in standard output
-  subroutine printReksSSRInfo(this, Wab, tmpEn, StateCoup, output)
+  subroutine printReksSSRInfo(this, output, Wab, tmpEn, StateCoup)
 
     !> data type for REKS
     type(TReksCalc), intent(inout) :: this
+
+    !> Output unit for human readable messages
+    integer, intent(in) :: output
 
     !> converged Lagrangian values within active space
     real(dp), intent(in) :: Wab(:,:)
@@ -134,9 +137,6 @@ module dftbp_reks_reksio
 
     !> state-interaction term between SA-REKS states
     real(dp), intent(in) :: StateCoup(:,:)
-
-    !> Output unit for human readable messages
-    integer, intent(in) :: output
 
     select case (this%reksAlg)
     case (reksTypes%noReks)
@@ -151,16 +151,16 @@ module dftbp_reks_reksio
 
 
   !> print gradient results for REKS calculation
-  subroutine printReksGradInfo(this, derivs, output)
+  subroutine printReksGradInfo(this, output, derivs)
 
     !> data type for REKS
     type(TReksCalc), intent(inout) :: this
 
-    !> derivatives of energy wrt to atomic positions
-    real(dp), intent(in) :: derivs(:,:)
-
     !> Output unit for human readable messages
     integer, intent(in) :: output
+
+    !> derivatives of energy wrt to atomic positions
+    real(dp), intent(in) :: derivs(:,:)
 
     integer :: ist, ia, ib, nstHalf
     character(3), parameter :: ordinals(6) = ['1st', '2nd', '3rd', '4th', '5th', '6th']
@@ -258,7 +258,10 @@ module dftbp_reks_reksio
 
 
   !> print unrelaxed FONs for target state
-  subroutine printUnrelaxedFONs(tmpRho, rstate, Lstate, Nc, Na, tSSR, output)
+  subroutine printUnrelaxedFONs(output, tmpRho, rstate, Lstate, Nc, Na, tSSR)
+
+    !> Output unit for human readable messages
+    integer, intent(in) :: output
 
     !> Occupation number matrix
     real(dp), intent(in) :: tmpRho(:,:)
@@ -277,9 +280,6 @@ module dftbp_reks_reksio
 
     !> Calculate SSR state with inclusion of SI, otherwise calculate SA-REKS state
     logical, intent(in) :: tSSR
-
-    !> Output unit for human readable messages
-    integer, intent(in) :: output
 
     integer :: ii
 
@@ -308,7 +308,10 @@ module dftbp_reks_reksio
 
 
   !> print Relaxed FONs for target state
-  subroutine printRelaxedFONs(tmpRho, rstate, Nc, Na, tSSR, output)
+  subroutine printRelaxedFONs(output, tmpRho, rstate, Nc, Na, tSSR)
+
+    !> Output unit for human readable messages
+    integer, intent(in) :: output
 
     !> Occupation number matrix
     real(dp), intent(in) :: tmpRho(:,:)
@@ -324,9 +327,6 @@ module dftbp_reks_reksio
 
     !> Calculate SSR state with inclusion of SI, otherwise calculate SA-REKS state
     logical, intent(in) :: tSSR
-
-    !> Output unit for human readable messages
-    integer, intent(in) :: output
 
     integer :: ii
 
@@ -350,7 +350,10 @@ module dftbp_reks_reksio
 
 
   !> print Relaxed FONs for target L-th microstate
-  subroutine printRelaxedFONsL(tmpRho, Lstate, Nc, Na, output)
+  subroutine printRelaxedFONsL(output, tmpRho, Lstate, Nc, Na)
+
+    !> Output unit for human readable messages
+    integer, intent(in) :: output
 
     !> Occupation number matrix
     real(dp), intent(in) :: tmpRho(:,:)
@@ -363,9 +366,6 @@ module dftbp_reks_reksio
 
     !> Number of active orbitals
     integer, intent(in) :: Na
-
-    !> Output unit for human readable messages
-    integer, intent(in) :: output
 
     integer :: ii
 
@@ -460,7 +460,10 @@ module dftbp_reks_reksio
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> print SA-REKS(2,2) result in standard output
-  subroutine printReksSAInfo22_(Eavg, enLtot, energy, FONs, Efunction, Plevel, output)
+  subroutine printReksSAInfo22_(output, Eavg, enLtot, energy, FONs, Efunction, Plevel)
+
+    !> Output unit for human readable messages
+    integer, intent(in) :: output
 
     !> Total energy for averaged state in REKS
     real(dp), intent(in) :: Eavg
@@ -479,9 +482,6 @@ module dftbp_reks_reksio
 
     !> Print level in standard output file
     integer, intent(in) :: Plevel
-
-    !> Output unit for human readable messages
-    integer, intent(in) :: output
 
     real(dp) :: n_a, n_b
     integer :: iL, Lmax, ist, nstates

--- a/src/dftbp/reks/reksproperty.F90
+++ b/src/dftbp/reks/reksproperty.F90
@@ -584,7 +584,7 @@ module dftbp_reks_reksproperty
   !> get the oscillator strength between the states
   subroutine getReksOsc(output, tdp, energy)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> transition dipole moment between states

--- a/src/dftbp/reks/reksproperty.F90
+++ b/src/dftbp/reks/reksproperty.F90
@@ -231,7 +231,7 @@ module dftbp_reks_reksproperty
     tmpRho(:,:) = 0.0_dp
     call gemm(tmpRho, eigenvecs, tmpMat, transA='T')
 
-    call printUnrelaxedFONs(tmpRho, rstate, Lstate, Nc, Na, tSSR, env%stdOut)
+    call printUnrelaxedFONs(env%stdOut, tmpRho, rstate, Lstate, Nc, Na, tSSR)
 
   end subroutine getUnrelaxedDensMatAndTdp
 
@@ -396,7 +396,7 @@ module dftbp_reks_reksproperty
     tmpRho(:,:) = 0.0_dp
     call gemm(tmpRho, eigenvecs, tmpMat, transA='T')
 
-    call printRelaxedFONs(tmpRho, rstate, Nc, Na, tSSR, env%stdOut)
+    call printRelaxedFONs(env%stdOut, tmpRho, rstate, Nc, Na, tSSR)
 
   end subroutine getRelaxedDensMat
 
@@ -513,7 +513,7 @@ module dftbp_reks_reksproperty
     tmpRho(:,:) = 0.0_dp
     call gemm(tmpRho, eigenvecs, tmpMat, transA='T')
 
-    call printRelaxedFONsL(tmpRho, Lstate, Nc, Na, env%stdOut)
+    call printRelaxedFONsL(env%stdOut, tmpRho, Lstate, Nc, Na)
 
   end subroutine getRelaxedDensMatL
 

--- a/src/dftbp/reks/reksproperty.F90
+++ b/src/dftbp/reks/reksproperty.F90
@@ -16,8 +16,8 @@
 !> * Only for closed shell system.
 !> * Onsite corrections are not included in this version
 module dftbp_reks_reksproperty
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_common_status, only : TStatus
   use dftbp_dftb_densitymatrix, only : TDensityMatrix
   use dftbp_io_message, only : error
@@ -37,9 +37,12 @@ module dftbp_reks_reksproperty
 
   !> Calculate unrelaxed density and transition density for target
   !> SA-REKS or SSR state (or L-th state)
-  subroutine getUnrelaxedDensMatAndTdp(eigenvecs, overSqr, rhoL, FONs, &
+  subroutine getUnrelaxedDensMatAndTdp(env, eigenvecs, overSqr, rhoL, FONs, &
       & eigvecsSSR, Lpaired, Nc, Na, rstate, Lstate, reksAlg, tSSR, tTDP, &
       & unrelRhoSqr, unrelTdm, densityMatrix, errStatus)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Eigenvectors on eixt
     real(dp), intent(inout) :: eigenvecs(:,:)
@@ -228,15 +231,18 @@ module dftbp_reks_reksproperty
     tmpRho(:,:) = 0.0_dp
     call gemm(tmpRho, eigenvecs, tmpMat, transA='T')
 
-    call printUnrelaxedFONs(tmpRho, rstate, Lstate, Nc, Na, tSSR)
+    call printUnrelaxedFONs(tmpRho, rstate, Lstate, Nc, Na, tSSR, env%stdOut)
 
   end subroutine getUnrelaxedDensMatAndTdp
 
 
   !> Calculate relaxed density for target SA-REKS or SSR state
-  subroutine getRelaxedDensMat(eigenvecs, overSqr, unrelRhoSqr, ZT, omega, &
+  subroutine getRelaxedDensMat(env, eigenvecs, overSqr, unrelRhoSqr, ZT, omega, &
       & FONs, eigvecsSSR, SAweight, Rab, G1, Nc, Na, rstate, reksAlg, &
       & tSSR, tNAC, relRhoSqr)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Eigenvectors on eixt
     real(dp), intent(inout) :: eigenvecs(:,:)
@@ -390,15 +396,18 @@ module dftbp_reks_reksproperty
     tmpRho(:,:) = 0.0_dp
     call gemm(tmpRho, eigenvecs, tmpMat, transA='T')
 
-    call printRelaxedFONs(tmpRho, rstate, Nc, Na, tSSR)
+    call printRelaxedFONs(tmpRho, rstate, Nc, Na, tSSR, env%stdOut)
 
   end subroutine getRelaxedDensMat
 
 
   !> Calculate relaxed density for target L-th microstate
-  subroutine getRelaxedDensMatL(eigenvecs, rhoSqrL, overSqr, weight, &
+  subroutine getRelaxedDensMatL(env, eigenvecs, rhoSqrL, overSqr, weight, &
       & SAweight, unrelRhoSqr, RmatL, ZT, omega, weightIL, G1, orderRmatL, &
       & Lpaired, Nc, Na, Lstate, reksAlg, relRhoSqr)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Eigenvectors on eixt
     real(dp), intent(inout) :: eigenvecs(:,:)
@@ -504,7 +513,7 @@ module dftbp_reks_reksproperty
     tmpRho(:,:) = 0.0_dp
     call gemm(tmpRho, eigenvecs, tmpMat, transA='T')
 
-    call printRelaxedFONsL(tmpRho, Lstate, Nc, Na)
+    call printRelaxedFONsL(tmpRho, Lstate, Nc, Na, env%stdOut)
 
   end subroutine getRelaxedDensMatL
 
@@ -573,7 +582,10 @@ module dftbp_reks_reksproperty
 
 
   !> get the oscillator strength between the states
-  subroutine getReksOsc(tdp, energy)
+  subroutine getReksOsc(output, tdp, energy)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> transition dipole moment between states
     real(dp), intent(in) :: tdp(:,:)
@@ -587,16 +599,16 @@ module dftbp_reks_reksproperty
     nstates = size(energy,dim=1)
     nstHalf = size(tdp,dim=2)
 
-    write(stdOut,*)
-    write(stdOut,'(A)') " Oscillator Strength (au)"
+    write(output,*)
+    write(output,'(A)') " Oscillator Strength (au)"
     do ist = 1, nstHalf
 
       call getTwoIndices(nstates, ist, ia, ib, 1)
 
       osc = 2.0_dp / 3.0_dp * (energy(ib) - energy(ia)) * sum(tdp(:,ist)**2)
 
-      write(stdOut,'(A4,I1,A6,I1,A5)',advance="no") " ( S", ia - 1, " <-> S", ib - 1, " ) : "
-      write(stdOut,'(1(f12.6))') osc
+      write(output,'(A4,I1,A6,I1,A5)',advance="no") " ( S", ia - 1, " <-> S", ib - 1, " ) : "
+      write(output,'(1(f12.6))') osc
 
     end do
 

--- a/src/dftbp/solvation/born.F90
+++ b/src/dftbp/solvation/born.F90
@@ -394,7 +394,7 @@ contains
     end if
 
     allocate(nNeigh(this%nAtom))
-    call getNrOfNeighboursForAll(nNeigh, neighList, this%rCutoff)
+    call getNrOfNeighboursForAll(env%stdOut, nNeigh, neighList, this%rCutoff)
     call getBornRadii(env, nNeigh, neighList%iNeighbour, img2CentCell, &
         & neighList%neighDist2, species0, coords, this%param%vdwRad, &
         & this%rho, this%param%bornOffset, this%param%bornScale, this%param%obc, &
@@ -409,7 +409,7 @@ contains
     end if
 
     if (allocated(this%cm5)) then
-      call this%cm5%updateCoords(neighList, img2CentCell, coords, species0)
+      call this%cm5%updateCoords(env, neighList, img2CentCell, coords, species0)
     end if
 
     this%tCoordsUpdated = .true.
@@ -524,7 +524,7 @@ contains
     sigma(:, :) = 0.0_dp
     this%energies(:) = 0.0_dp
 
-    call getNrOfNeighboursForAll(nNeigh, neighList, this%rCutoff)
+    call getNrOfNeighboursForAll(env%stdOut, nNeigh, neighList, this%rCutoff)
     call getBornEGCluster(env, this%nAtom, coords, this%chargesPerAtom, &
       & this%bornRad, this%dbrdr, this%dbrdL, this%param%kernel, this%param%keps, &
       & this%energies, gradients, sigma)

--- a/src/dftbp/solvation/cm5.F90
+++ b/src/dftbp/solvation/cm5.F90
@@ -9,6 +9,7 @@
 
 !> Implementation of the charge model 5 (CM5)
 module dftbp_solvation_cm5
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : symbolToNumber
   use dftbp_dftb_periodic, only : getNrOfNeighboursForAll, TNeighbourList
@@ -187,10 +188,13 @@ contains
 
 
   !> Update internal stored coordinates
-  subroutine updateCoords(this, neighList, img2CentCell, coords, species0)
+  subroutine updateCoords(this, env, neighList, img2CentCell, coords, species0)
 
     !> data structure
     class(TChargeModel5), intent(inout) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> list of neighbours to atoms
     type(TNeighbourList), intent(in) :: neighList
@@ -208,7 +212,7 @@ contains
     integer, allocatable :: nNeigh(:)
 
     allocate(nNeigh(this%nAtom))
-    call getNrOfNeighboursForAll(nNeigh, neighList, this%rCutoff)
+    call getNrOfNeighboursForAll(env%stdOut, nNeigh, neighList, this%rCutoff)
     if (allocated(this%dcm5dr) .and. allocated(this%dcm5dL)) then
       call getCorrectionDerivs(this, nNeigh, neighList%iNeighbour, img2CentCell, &
           & neighList%neighDist2, species0, coords)

--- a/src/dftbp/solvation/fieldscaling.F90
+++ b/src/dftbp/solvation/fieldscaling.F90
@@ -47,10 +47,13 @@ contains
 
 
   !> Initialise type
-  subroutine init_TScaleExtEField(this, solvent, isRescaled)
+  subroutine init_TScaleExtEField(this, output, solvent, isRescaled)
 
     !> Instance
     type(TScaleExtEField), intent(out) :: this
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Solvent model
     class(TSolvation), allocatable, intent(in) :: solvent
@@ -63,7 +66,7 @@ contains
     if (allocated(solvent)) then
       this%isRescaled = this%isRescaled
       if (this%isRescaled .and. .not.solvent%isEFieldModified()) then
-        call warning("Field rescaling requested for solvent model with no electrostatic effects,&
+        call warning(output, "Field rescaling requested for solvent model with no electrostatic effects,&
             & turning scaling off")
         this%isRescaled= .false.
       end if

--- a/src/dftbp/solvation/fieldscaling.F90
+++ b/src/dftbp/solvation/fieldscaling.F90
@@ -52,7 +52,7 @@ contains
     !> Instance
     type(TScaleExtEField), intent(out) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Solvent model

--- a/src/dftbp/solvation/gbsafile.F90
+++ b/src/dftbp/solvation/gbsafile.F90
@@ -30,7 +30,10 @@ contains
 
 
   !> Read GBSA parameters from file
-  subroutine readParamGBSA(file, input, solvent, speciesNames, node)
+  subroutine readParamGBSA(output, file, input, solvent, speciesNames, node)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Name of the parametrisation file
     character(len=*), intent(in) :: file
@@ -70,7 +73,7 @@ contains
     lineno = 0
 
     do ii = 1, 8
-      call nextLine(lineReader, line, lineno, file, node=node)
+      call nextLine(output, lineReader, line, lineno, file, node=node)
       iStart = 1
       call getNextToken(trim(line), param(ii), iStart, iErr)
       if (iErr /= TOKEN_OK) then
@@ -89,15 +92,15 @@ contains
           & trim(file), lineno, "Trailing content", newline, trim(line), newline, &
           & repeat('-', max(iStart-1, 0)), '^'
         if (present(node)) then
-          call detailedWarning(node, trim(errorStr))
+          call detailedWarning(output, node, trim(errorStr))
         else
-          call warning(trim(errorStr))
+          call warning(output, trim(errorStr))
         end if
       end if
     end do
 
     do ii = 1, nElem
-      call nextLine(lineReader, line, lineno, file, node=node)
+      call nextLine(output, lineReader, line, lineno, file, node=node)
       iStart = 1
       call getNextToken(trim(line), surfaceTension(ii), iStart, iErr)
       if (iErr /= TOKEN_OK) then
@@ -140,9 +143,9 @@ contains
           & trim(file), lineno, "Trailing content", newline, trim(line), newline, &
           & repeat('-', max(iStart-1, 0)), '^'
         if (present(node)) then
-          call detailedWarning(node, trim(errorStr))
+          call detailedWarning(output, node, trim(errorStr))
         else
-          call warning(trim(errorStr))
+          call warning(output, trim(errorStr))
         end if
       end if
     end do
@@ -172,9 +175,9 @@ contains
         write(errorStr, '(3a)') trim(file), " contains no parameters for species ", &
             & trim(speciesNames(iSp))
         if (present(node)) then
-          call detailedWarning(node, trim(errorStr))
+          call detailedWarning(output, node, trim(errorStr))
         else
-          call warning(trim(errorStr))
+          call warning(output, trim(errorStr))
         end if
         input%descreening(iSp) = 1.0_dp
         input%sasaInput%surfaceTension(iSp) = 0.0_dp
@@ -192,7 +195,10 @@ contains
 
 
   !> Read a whole line from a formatted IO unit
-  subroutine nextLine(lineReader, line, lineno, file, node)
+  subroutine nextLine(output, lineReader, line, lineno, file, node)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Line reader able to provide the next line from an open file
     type(TLineReader), intent(inout) :: lineReader

--- a/src/dftbp/solvation/gbsafile.F90
+++ b/src/dftbp/solvation/gbsafile.F90
@@ -32,7 +32,7 @@ contains
   !> Read GBSA parameters from file
   subroutine readParamGBSA(output, file, input, solvent, speciesNames, node)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Name of the parametrisation file
@@ -197,7 +197,7 @@ contains
   !> Read a whole line from a formatted IO unit
   subroutine nextLine(output, lineReader, line, lineno, file, node)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Line reader able to provide the next line from an open file

--- a/src/dftbp/solvation/sasa.F90
+++ b/src/dftbp/solvation/sasa.F90
@@ -305,7 +305,7 @@ contains
     integer, allocatable :: nNeigh(:)
 
     allocate(nNeigh(this%nAtom))
-    call getNrOfNeighboursForAll(nNeigh, neighList, this%sCutoff)
+    call getNrOfNeighboursForAll(env%stdOut, nNeigh, neighList, this%sCutoff)
 
     call getSASA(env, nNeigh, neighList%iNeighbour, img2CentCell, species0, &
         & coords, this%tolerance, this%smoothingPar, this%probeRad, &

--- a/src/dftbp/solvation/solvparser.F90
+++ b/src/dftbp/solvation/solvparser.F90
@@ -10,11 +10,11 @@
 !> Fills the derived type with the input parameters from an HSD or an XML file.
 module dftbp_solvation_solvparser
   use, intrinsic :: ieee_arithmetic, only : ieee_positive_inf, ieee_support_inf, ieee_value
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp, lc
   use dftbp_common_atomicrad, only : getAtomicRad
   use dftbp_common_constants, only : AA__Bohr, amu__au, Boltzmann, kg__au
   use dftbp_common_filesystem, only : findFile, getParamSearchPaths
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_common_unitconversion, only : energyUnits, inverseLengthUnits, lengthUnits,&
       & massDensityUnits, massUnits
   use dftbp_dftbplus_specieslist, only : readSpeciesList
@@ -48,7 +48,10 @@ contains
 
 
   !> Reads in solvation related settings
-  subroutine readSolvation(node, geo, input)
+  subroutine readSolvation(env, node, geo, input)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to parse
     type(fnode), pointer :: node
@@ -71,19 +74,22 @@ contains
       call detailedError(node, "Invalid solvation model name.")
     case ("generalisedborn")
       allocate(input%GBInp)
-      call readSolvGB(solvModel, geo, input%GBInp)
+      call readSolvGB(env, solvModel, geo, input%GBInp)
     case ("cosmo")
       allocate(input%cosmoInp)
-      call readSolvCosmo(solvModel, geo, input%cosmoInp)
+      call readSolvCosmo(env, solvModel, geo, input%cosmoInp)
     case ("sasa")
       allocate(input%SASAInp)
-      call readSolvSASA(solvModel, geo, input%SASAInp)
+      call readSolvSASA(env, solvModel, geo, input%SASAInp)
     end select
   end subroutine readSolvation
 
 
   !> Reads in generalized Born related settings
-  subroutine readSolvGB(node, geo, input)
+  subroutine readSolvGB(env, node, geo, input)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to process
     type(fnode), pointer :: node
@@ -117,8 +123,8 @@ contains
       call getParamSearchPaths(searchPath)
       call findFile(searchPath, paramFile, paramTmp)
       if (allocated(paramTmp)) call move_alloc(paramTmp, paramFile)
-      write(stdOut, '(a)') "Reading GBSA parameter file '" // paramFile // "'"
-      call readParamGBSA(paramFile, defaults, solvent, geo%speciesNames, node=child)
+      write(env%stdOut, '(a)') "Reading GBSA parameter file '" // paramFile // "'"
+      call readParamGBSA(env%stdOut, paramFile, defaults, solvent, geo%speciesNames, node=child)
     else
       call readSolvent(node, solvent)
     end if
@@ -213,10 +219,10 @@ contains
         call setChild(node, "SASA", value1)
       end if
       if (allocated(defaults)) then
-        call readSolvSASA(value1, geo, input%sasaInput, defaults%sasaInput%probeRad,&
+        call readSolvSASA(env, value1, geo, input%sasaInput, defaults%sasaInput%probeRad,&
             & defaults%sasaInput%surfaceTension)
       else
-        call readSolvSASA(value1, geo, input%sasaInput)
+        call readSolvSASA(env, value1, geo, input%sasaInput)
       end if
 
       if (allocated(defaults)) then
@@ -256,7 +262,10 @@ contains
 
 
   !> Reads in conductor like screening model settings
-  subroutine readSolvCosmo(node, geo, input)
+  subroutine readSolvCosmo(env, node, geo, input)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to process
     type(fnode), pointer :: node
@@ -305,7 +314,7 @@ contains
       deallocate(radScaleSpecies)
     end if
 
-    call readAngularGrid(node, input%gridSize)
+    call readAngularGrid(env, node, input%gridSize)
 
     call getChildValue(node, "Solver", value1, "DomainDecomposition", child=child)
     call getNodeName(value1, buffer)
@@ -319,7 +328,7 @@ contains
     call getChild(node, "SASA", value1, requested=.false.)
     if (associated(value1)) then
       allocate(input%sasaInput)
-      call readSolvSASA(value1, geo, input%sasaInput)
+      call readSolvSASA(env, value1, geo, input%sasaInput)
     end if
 
   end subroutine readSolvCosmo
@@ -345,7 +354,10 @@ contains
 
 
   !> Read input data for non-polar surface area solvation model.
-  subroutine readSolvSASA(node, geo, input, probeRadDefault, surfaceTensionDefault)
+  subroutine readSolvSASA(env, node, geo, input, probeRadDefault, surfaceTensionDefault)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to process
     type(fnode), pointer :: node
@@ -380,7 +392,7 @@ contains
 
     call getChildValue(node, "Tolerance", input%tolerance, 1.0e-6_dp, child=child)
 
-    call readAngularGrid(node, input%gridSize, 230)
+    call readAngularGrid(env, node, input%gridSize, 230)
 
     call readVanDerWaalsRad(node, geo, input%vdwRad)
 
@@ -592,7 +604,10 @@ contains
 
 
   !> Reads settings for angular integration grid
-  subroutine readAngularGrid(node, angGrid, default)
+  subroutine readAngularGrid(env, node, angGrid, default)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to process
     type(fnode), pointer :: node
@@ -617,7 +632,7 @@ contains
       write(errorStr, '(a, *(1x, i0, 1x, a))')&
           & "No angular integration grid with", gridPoints, "points available, using",&
           &  gridSize(angGrid), "points instead"
-      call detailedWarning(child, trim(errorStr))
+      call detailedWarning(env%stdOut, child, trim(errorStr))
     end if
 
   end subroutine readAngularGrid

--- a/src/dftbp/timedep/linresp.F90
+++ b/src/dftbp/timedep/linresp.F90
@@ -17,6 +17,7 @@
 !!   case).
 !! * Onsite corrections are not included in this version
 module dftbp_timedep_linresp
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp
   use dftbp_common_environment, only : TEnvironment
   use dftbp_common_file, only : TFileDescr
@@ -140,10 +141,13 @@ module dftbp_timedep_linresp
 contains
 
   !> Initialize an internal data type for linear response excitations.
-  subroutine LinResp_init(this, ini, nAtom, nEl, nSpin, onSiteMatrixElements, isIoProc)
+  subroutine LinResp_init(this, env, ini, nAtom, nEl, nSpin, onSiteMatrixElements, isIoProc)
 
     !> Data structure for linear response
     type(TLinResp), intent(out) :: this
+
+    !> Environment settings
+    type(TEnvironment), intent(inout) :: env
 
     !> Initial values for setting parameters
     type(TLinrespini), intent(inout) :: ini
@@ -248,7 +252,7 @@ contains
         call error("CI optimization: States must be neighbouring.")
       end if
       if (ini%isCIopt .and. ini%nstat /= 0) then
-        call warning("CI optimization: Setting of StateOfInterest will be ignored.")
+        call warning(env%stdOut, "CI optimization: Setting of StateOfInterest will be ignored.")
       end if
       this%tNaCoupling = .true.
       this%indNACouplings = ini%indNACouplings

--- a/src/dftbp/timedep/linrespgrad.F90
+++ b/src/dftbp/timedep/linrespgrad.F90
@@ -5671,7 +5671,7 @@ contains
     !> Sn-S0 excitation energy
     real(dp), intent(in) :: excEnergies(:)
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     integer :: nAtoms, nexcGrad, nCoupl

--- a/src/dftbp/timedep/linrespgrad.F90
+++ b/src/dftbp/timedep/linrespgrad.F90
@@ -16,7 +16,6 @@ module dftbp_timedep_linrespgrad
   use dftbp_common_constants, only : au__Debye, cExchange, Hartree__eV
   use dftbp_common_environment, only : globalTimers, TEnvironment
   use dftbp_common_file, only : clearFile, closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_common_schedule, only : assembleChunks, distributeRangeInChunks
   use dftbp_dftb_hybridxc, only : getDirectionalCamGammaPrimeValue, THybridXcFunc
   use dftbp_dftb_nonscc, only : TNonSccDiff
@@ -677,8 +676,8 @@ contains
 
     ! Calculate Furche vectors and transition density matrix for various properties
     if (tZVector) then
-      write(stdOut,'(A)')
-      write(stdOut,'(A)') '>> Excited State gradient calculation'
+      write(env%stdOut,'(A)')
+      write(env%stdOut,'(A)') '>> Excited State gradient calculation'
 
       call env%globalTimer%startTimer(globalTimers%lrZVector)
 
@@ -801,8 +800,8 @@ contains
       end if
 
       if (this%tNaCoupling) then
-        write(stdOut,'(A)') ' '
-        write(stdOut,'(A)') '>> Non Adiabatic Coupling Vectors calculation'
+        write(env%stdOut,'(A)') ' '
+        write(env%stdOut,'(A)') '>> Non Adiabatic Coupling Vectors calculation'
 
         call env%globalTimer%startTimer(globalTimers%lrNAC)
 
@@ -1327,9 +1326,9 @@ contains
     subSpaceDim = min(lr%subSpaceFactorStratmann * nExc, rpa%nxov_rd)
     iterStrat = 1
 
-    write(stdOut,'(A)')
-    write(stdOut,'(A)') '>> Stratmann diagonalisation of response matrix'
-    write(stdOut,'(3x,A,i6,A,i6)') 'Total dimension of A+B: ', rpa%nxov_rd, ' inital subspace: ',&
+    write(env%stdOut,'(A)')
+    write(env%stdOut,'(A)') '>> Stratmann diagonalisation of response matrix'
+    write(env%stdOut,'(3x,A,i6,A,i6)') 'Total dimension of A+B: ', rpa%nxov_rd, ' inital subspace: ',&
       & subSpaceDim
 
     allocate(mP(subSpaceDim, subSpaceDim))
@@ -1489,7 +1488,7 @@ contains
           call assembleChunks(env, xmy)
         end if
 
-        write(stdOut,'(A)') '>> Stratmann converged'
+        write(env%stdOut,'(A)') '>> Stratmann converged'
         exit solveLinResp ! terminate diag. routine
 
       end if
@@ -1538,9 +1537,9 @@ contains
       subSpaceDim = subSpaceDim + newVec
 
       if(iterStrat == 1) then
-        write(stdOut,'(3x,A)') 'Iteration  Subspace dimension'
+        write(env%stdOut,'(3x,A)') 'Iteration  Subspace dimension'
       end if
-      write(stdOut,'(3x,i6,10x,i6)') iterStrat, subSpaceDim
+      write(env%stdOut,'(3x,i6,10x,i6)') iterStrat, subSpaceDim
 
       iterStrat = iterStrat + 1
 
@@ -5652,7 +5651,7 @@ contains
   !! with a differing version that assumed orthogonal X1 and X2 vectors, which leads to poor
   !! convergence.
   subroutine conicalIntersectionOptimizer(derivs, excDerivs, indNACouplings, energyShift,&
-      & naCouplings, excEnergies)
+      & naCouplings, excEnergies, output)
 
     !> Ground state gradient (overwritten)
     real(dp), intent(inout) :: derivs(:,:)
@@ -5671,6 +5670,9 @@ contains
 
     !> Sn-S0 excitation energy
     real(dp), intent(in) :: excEnergies(:)
+
+    !> Output for write processes
+    integer, intent(in) :: output
 
     integer :: nAtoms, nexcGrad, nCoupl
     real(dp), allocatable :: X1(:), X2(:), dE2(:), gpf(:)
@@ -5728,7 +5730,7 @@ contains
 
     derivs(:,:) = reshape(gpf, [3, nAtoms])
 
-    write(stdOut, format2U) "Energy gap CI", deltaE, 'H', Hartree__eV * deltaE, 'eV'
+    write(output, format2U) "Energy gap CI", deltaE, 'H', Hartree__eV * deltaE, 'eV'
 
   end subroutine conicalIntersectionOptimizer
 

--- a/src/dftbp/timedep/pprpa.F90
+++ b/src/dftbp/timedep/pprpa.F90
@@ -259,7 +259,7 @@ contains
   subroutine buildAndDiagppRPAmatrix(output, tTDA, sym, eigVal, nocc, nvir, nxvv, nxoo, env, &
       & denseDesc, gamma_eri, stimc, cc, pp_eval, vr, err)
 
-    !> Output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Tamm-Dancoff approximation?

--- a/src/dftbp/timedep/pprpa.F90
+++ b/src/dftbp/timedep/pprpa.F90
@@ -11,6 +11,7 @@
 !> Excitations energies according to the particle-particle Random Phase Approximation
 !! (doi:10.1063/1.4977928).
 module dftbp_timedep_pprpa
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : Hartree__eV
   use dftbp_common_environment, only : TEnvironment
@@ -168,7 +169,7 @@ contains
         symmetries(:) = [ "S", "T" ]
       end select
     else
-      @:ERROR_HANDLING(err, -1, "Spin-unrestricted calculations currently not possible with pp-RPA")
+      @:ERROR_HANDLING(env%stdOut, err, -1, "spin-unrestricted calculations currently not possible with pp-RPA")
     end if
 
     ! Allocation for general arrays
@@ -188,10 +189,10 @@ contains
 
     nocc = nint(rnel)
     if (abs(rnel - real(nocc,dp)) > epsilon(0.0_dp)) then
-      @:ERROR_HANDLING(err, -1, "Fractionally charged systems not possible with pp-RPA")
+      @:ERROR_HANDLING(env%stdOut, err, -1, "Fractionally charged systems not possible with pp-RPA")
     end if
     if (mod(abs(nocc),2) == 1) then
-      @:ERROR_HANDLING(err, -1, "Odd numbers of electrons not possible with pp-RPA")
+      @:ERROR_HANDLING(env%stdOut, err, -1, "Odd numbers of electrons not possible with pp-RPA")
     end if
     nocc = nocc / 2
 
@@ -238,7 +239,7 @@ contains
       allocate(pp_eval(dim_rpa))
       allocate(vr(dim_rpa, dim_rpa))
 
-      call buildAndDiagppRPAmatrix(RPA%tTDa, sym, grndEigVal(:,1), nocc, nvir, nxvv, nxoo, env,&
+      call buildAndDiagppRPAmatrix(env%stdOut, RPA%tTDa, sym, grndEigVal(:,1), nocc, nvir, nxvv, nxoo, env,&
           & denseDesc, gamma_eri, stimc, grndEigVecs, pp_eval, vr, err)
 
       call writeppRPAExcitations(RPA%tTDa, sym, grndEigVal(:,1), RPA%nExc, pp_eval, vr, nocc, nvir,&
@@ -255,8 +256,11 @@ contains
 
 
   !> Builds and diagonalizes the pp-RPA matrix
-  subroutine buildAndDiagppRPAmatrix(tTDA, sym, eigVal, nocc, nvir, nxvv, nxoo, env, &
+  subroutine buildAndDiagppRPAmatrix(output, tTDA, sym, eigVal, nocc, nvir, nxvv, nxoo, env, &
       & denseDesc, gamma_eri, stimc, cc, pp_eval, vr, err)
+
+    !> Output for write processes
+    integer, intent(in) :: output
 
     !> Tamm-Dancoff approximation?
     logical, intent(in) :: tTDA
@@ -584,7 +588,7 @@ contains
     call geev(PP, pp_eval, wi, vl, vr, info)
 
     if (info /= 0) then
-      @:FORMATTED_ERROR_HANDLING(err, info, "(A,I0)", " Error with dgeev, info = ", info)
+      @:FORMATTED_ERROR_HANDLING(output, err, info, "(A,I0)", " Error with dgeev, info = ", info)
     end if
 
   end subroutine buildAndDiagppRPAmatrix

--- a/src/dftbp/timedep/timeprop.F90
+++ b/src/dftbp/timedep/timeprop.F90
@@ -18,7 +18,6 @@ module dftbp_timedep_timeprop
   use dftbp_common_constants, only : au__fs, c, Bohr__AA, Hartree__eV, imag, pi
   use dftbp_common_environment, only : globalTimers, TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr, TOpenOptions
-  use dftbp_common_globalenv, only : stdOut
   use dftbp_common_hamiltoniantypes, only : hamiltonianTypes
   use dftbp_common_status, only : TStatus
   use dftbp_common_timer, only : TTimer
@@ -736,13 +735,16 @@ contains
 
 
   !> Initialisation of input variables
-  subroutine TElecDynamics_init(this, inp, species, speciesName, tWriteAutotest, autotestTag,&
+  subroutine TElecDynamics_init(this, env, inp, species, speciesName, tWriteAutotest, autotestTag,&
       & randomThermostat, cutoff, mass, nAtom, atomEigVal, dispersion, nonSccDeriv, tPeriodic,&
       & parallelKS, tRealHS, kPoint, kWeight, isHybridXc, sccCalc, tblite, eFieldScaling,&
       & hamiltonianType, denseDesc, tSCC_bool, errStatus)
 
     !> ElecDynamics instance
     type(TElecDynamics), intent(out) :: this
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> ElecDynamicsInp instance
     type(TElecDynamicsInp), intent(in) :: inp
@@ -888,11 +890,11 @@ contains
 
     if (this%tLaser) then
       if (tPeriodic) then
-        call warning('If the external field has components in a periodic direction,&
+        call warning(env%stdOut, 'If the external field has components in a periodic direction,&
             & please make sure to use the velocity gauge coupling (check the UseVectorPotential&
             & variable).')
         if (any(inp%imFieldPolVec > epsilon(1.0_dp))) then
-          call warning('Using circular or elliptical polarization with periodic structures might&
+          call warning(env%stdOut, 'Using circular or elliptical polarization with periodic structures might&
               & not work.')
         end if
       end if
@@ -1403,9 +1405,9 @@ contains
     call env%globalTimer%startTimer(globalTimers%elecDynLoop)
     call loopTime%start()
 
-    write(stdOut, "(A)")
-    write(stdOut, "(A)") 'Starting electronic dynamics...'
-    write(stdOut, "(A80)") repeat("-", 80)
+    write(env%stdOut, "(A)")
+    write(env%stdOut, "(A)") 'Starting electronic dynamics...'
+    write(env%stdOut, "(A80)") repeat("-", 80)
 
     ! Main loop
     do iStep = 1, this%nSteps
@@ -1420,13 +1422,13 @@ contains
       if (mod(iStep, max(this%nSteps / 10, 1)) == 0) then
         call loopTime%stop()
         timeElec  = loopTime%getWallClockTime()
-        write(stdOut, "(A,2x,I6,2(2x,A,F10.6))") 'Step ', iStep, 'elapsed loop time: ',&
+        write(env%stdOut, "(A,2x,I6,2(2x,A,F10.6))") 'Step ', iStep, 'elapsed loop time: ',&
             & timeElec, 'average time per loop ', timeElec / (iStep + 1)
       end if
 
     end do
 
-    write(stdOut, "(A)") 'Dynamics finished OK!'
+    write(env%stdOut, "(A)") 'Dynamics finished OK!'
     call env%globalTimer%stopTimer(globalTimers%elecDynLoop)
 
     if (tWriteAutotest) then
@@ -1823,7 +1825,7 @@ contains
     end do
 
   #:endif
-    write(stdout,"(A)")'Density kicked along ' // localDir(this%currPolDir) //'!'
+    write(env%stdOut,"(A)")'Density kicked along ' // localDir(this%currPolDir) //'!'
 
   end subroutine kickDM
 
@@ -2522,7 +2524,7 @@ contains
       end do
     #:endif
 
-      write(stdOut,"(A)")'S inverted'
+      write(env%stdOut,"(A)")'S inverted'
 
 
     #:if WITH_SCALAPACK
@@ -3016,7 +3018,7 @@ contains
     if (this%tPump) then
       call execute_command_line("mkdir "//trim(pumpFilesDir), exitstat=iErr)
       if (iErr /= 0) then
-        write (stdOut,*) 'cannot create '//trim(pumpFilesDir)//', error status of mkdir: ', iErr
+        write (env%stdOut,*) 'cannot create '//trim(pumpFilesDir)//', error status of mkdir: ', iErr
       end if
     end if
 
@@ -4282,6 +4284,7 @@ contains
     type(TEnvironment), intent(inout) :: env
 
     !> Data type for energy components and total
+
     type(TEnergies), intent(inout) :: energy
 
     !> All atomic coordinates
@@ -4300,7 +4303,7 @@ contains
     integer, intent(in) :: iAtInCentralRegion(:)
 
     if (allocated(repulsive)) then
-      call repulsive%updateCoords(coordAll, this%speciesAll, img2CentCell, neighbourList)
+      call repulsive%updateCoords(env, coordAll, this%speciesAll, img2CentCell, neighbourList)
       call repulsive%getEnergy(coordAll, this%speciesAll, img2CentCell, neighbourList,&
           & energy%atomRep, energy%Erep, iAtInCentralRegion=iAtInCentralRegion)
     else
@@ -4308,7 +4311,7 @@ contains
       energy%Erep = 0.0_dp
     end if
     if (allocated(this%dispersion)) then
-      call calcDispersionEnergy(this%dispersion, energy%atomDisp, energy%eDisp, iAtInCentralRegion)
+      call calcDispersionEnergy(env, this%dispersion, energy%atomDisp, energy%eDisp, iAtInCentralRegion)
     else
       energy%atomDisp(:) = 0.0_dp
       energy%eDisp = 0.0_dp
@@ -5298,7 +5301,7 @@ contains
         & neighbourList, nAllAtom, coord0Fold, this%species0, this%cutoff%mCutoff, this%rCellVec,&
         & errStatus)
     @:PROPAGATE_ERROR(errStatus)
-    call getNrOfNeighboursForAll(nNeighbourSK, neighbourList, this%cutoff%skCutoff)
+    call getNrOfNeighboursForAll(env%stdOut, nNeighbourSK, neighbourList, this%cutoff%skCutoff)
     call getSparseDescriptor(neighbourList%iNeighbour, nNeighbourSK, img2CentCell, orb,&
         & iSparseStart, this%sparseSize)
 
@@ -5309,7 +5312,7 @@ contains
           & this%cutoff%camCutoff, this%rCellVec, errStatus, symmetric=.true.)
       @:PROPAGATE_ERROR(errStatus)
       if (allocated(nNeighbourCamSym)) then
-        call getNrOfNeighboursForAll(nNeighbourCamSym, symNeighbourList%neighbourList,&
+        call getNrOfNeighboursForAll(env%stdOut, nNeighbourCamSym, symNeighbourList%neighbourList,&
             & this%cutoff%camCutoff)
         call getSparseDescriptor(symNeighbourList%neighbourList%iNeighbour, nNeighbourCamSym,&
             & symNeighbourList%img2CentCell, orb, symNeighbourList%iPair,&

--- a/src/dftbp/transport/negfint.F90
+++ b/src/dftbp/transport/negfint.F90
@@ -469,7 +469,7 @@ contains
     !> Instance.
     class(TNegfInt), intent(inout) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> density of states in tunnel region
@@ -489,7 +489,7 @@ contains
   !> Initialise electron-phonon coupling model
   subroutine negf_setup_elph(output, negf, elph)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> NEGF container
@@ -519,7 +519,7 @@ contains
   !> Initialise Buttiker Probe dephasing
   subroutine negf_setup_bp(output, negf, elph)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> NEGF container
@@ -583,7 +583,7 @@ contains
   !> Destroy CSR matrices
   subroutine TNegfInt_final(output, this)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     type(TNegfInt), intent(inout) :: this
@@ -606,7 +606,7 @@ contains
     !> Instance.
     class(TNegfInt), intent(inout) :: this
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> Dense matrix information
@@ -657,7 +657,7 @@ contains
 
     nAtom = size(denseDescr%iAtomStart) - 1
 
-    call check_pls(outut, transpar, greendens, nAtom, iNeigh, nNeigh, img2CentCell, info)
+    call check_pls(output, transpar, greendens, nAtom, iNeigh, nNeigh, img2CentCell, info)
 
     allocate(PL_end(nDevicePLs))
     allocate(atomStart(nDevicePLs+1))
@@ -767,7 +767,7 @@ contains
   !> Subroutine to check the principal layer (PL) definitions
   subroutine check_pls(output, transPar, greenDens, nAtoms, iNeigh, nNeigh, img2CentCell, info)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> transport calculation parameters
@@ -966,7 +966,7 @@ contains
   !>
   subroutine negf_dumpHS(output, HH,SS)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> hamiltonian in CSR format
@@ -1003,7 +1003,7 @@ contains
   !> Routines to setup orthogonalised H and S have been moved here
   subroutine prepare_HS(output, negf, H_dev,S_dev,HH,SS)
 
-    !> output for write processes
+    !> Output unit for human readable messages
     integer, intent(in) :: output
 
     !> NEGF container
@@ -1516,11 +1516,11 @@ contains
     ncont = size(mu,1)
 
     if (params%verbose > 30) then
-      write(output, *)
-      write(output, '(80("="))')
-      write(output, *) '                            COMPUTATION OF CURRENT         '
-      write(output, '(80("="))')
-      write(output, *)
+      write(env%stdOut, *)
+      write(env%stdOut, '(80("="))')
+      write(env%stdOut, *) '                            COMPUTATION OF CURRENT         '
+      write(env%stdOut, '(80("="))')
+      write(env%stdOut, *)
     end if
 
     do iKS = 1, nKS

--- a/src/dftbp/transport/negfint.F90
+++ b/src/dftbp/transport/negfint.F90
@@ -14,7 +14,7 @@ module dftbp_transport_negfint
   use dftbp_common_constants, only : Hartree__eV, pi
   use dftbp_common_environment, only : TEnvironment
   use dftbp_common_file, only : closeFile, openFile, TFileDescr
-  use dftbp_common_globalenv, only : stdOut, tIOproc
+  use dftbp_common_globalenv, only : tIOproc
   use dftbp_common_status, only : TStatus
   use dftbp_geometry_boundarycond, only : TBoundaryConds
   use dftbp_dftb_periodic, only : TNeighbourList, TNeighbourlist_init, updateNeighbourListAndSpecies
@@ -269,28 +269,28 @@ contains
         params%FictCont(i) = transpar%contacts(i)%wideBand
         params%contact_DOS(i) = transpar%contacts(i)%wideBandDOS
 
-        write(stdOut,"(1X,A,I0,A)") '(negf_init) CONTACT INFO #', i,&
+        write(env%stdOut,"(1X,A,I0,A)") '(negf_init) CONTACT INFO #', i,&
             & ' "'//trim(transpar%contacts(i)%name)//'"'
 
         if (params%FictCont(i)) then
-          write(stdOut,*) 'FICTITIOUS CONTACT '
-          write(stdOut,*) 'DOS: ', params%contact_DOS(i)
+          write(env%stdOut,*) 'FICTITIOUS CONTACT '
+          write(env%stdOut,*) 'DOS: ', params%contact_DOS(i)
         end if
-        write(stdOut,*) 'Temperature (DM): ', params%kbT_dm(i)
-        write(stdOut,*) 'Temperature (Current): ', params%kbT_t(i)
+        write(env%stdOut,*) 'Temperature (DM): ', params%kbT_dm(i)
+        write(env%stdOut,*) 'Temperature (Current): ', params%kbT_t(i)
         if (transpar%contacts(i)%tFermiSet) then
-          write(stdOut,format2U)'Potential (with built-in)', pot(i), 'H', Hartree__eV*pot(i), 'eV'
-          write(stdOut,format2U)'eFermi', eFermi(i), 'H', Hartree__eV*eFermi(i), 'eV'
+          write(env%stdOut,format2U)'Potential (with built-in)', pot(i), 'H', Hartree__eV*pot(i), 'eV'
+          write(env%stdOut,format2U)'eFermi', eFermi(i), 'H', Hartree__eV*eFermi(i), 'eV'
         end if
-        write(stdOut,*)
+        write(env%stdOut,*)
 
         ! Define electrochemical potentials
         params%mu(i) = eFermi(i) - pot(i)
 
         if (transpar%contacts(i)%tFermiSet) then
-          write(stdOut,format2U)'Electro-chemical potentials', params%mu(i), 'H',&
+          write(env%stdOut,format2U)'Electro-chemical potentials', params%mu(i), 'H',&
               & Hartree__eV*params%mu(i), 'eV'
-          write(stdOut,*)
+          write(env%stdOut,*)
         end if
 
       enddo
@@ -344,20 +344,20 @@ contains
         params%n_poles = 0
       end if
 
-      write(stdOut,*) 'Density Matrix Parameters'
+      write(env%stdOut,*) 'Density Matrix Parameters'
       if (.not.transpar%defined) then
-        write(stdOut,*) 'Temperature (DM): ', params%kbT_dm(1)
-        write(stdOut,*) 'eFermi: ', params%mu(1)
+        write(env%stdOut,*) 'Temperature (DM): ', params%kbT_dm(1)
+        write(env%stdOut,*) 'eFermi: ', params%mu(1)
       end if
-      write(stdOut,*) 'Contour Points: ', params%Np_n(:2)
-      write(stdOut,*) 'Number of poles: ', params%N_poles
-      write(stdOut,*) 'Real-axis points: ', params%Np_real
+      write(env%stdOut,*) 'Contour Points: ', params%Np_n(:2)
+      write(env%stdOut,*) 'Number of poles: ', params%N_poles
+      write(env%stdOut,*) 'Real-axis points: ', params%Np_real
       if (params%readOldDM_SGFs==0) then
-        write(stdOut,*) 'Read Existing SGFs: Yes '
+        write(env%stdOut,*) 'Read Existing SGFs: Yes '
       else
-        write(stdOut,*) 'Read Existing SGFs: No, option ', params%readOldDM_SGFs
+        write(env%stdOut,*) 'Read Existing SGFs: No, option ', params%readOldDM_SGFs
       end if
-      write(stdOut,*)
+      write(env%stdOut,*)
 
     end if
 
@@ -464,27 +464,33 @@ contains
 
 
   !> Initialise dephasing effects
-  subroutine setup_dephasing(this, tundos)
+  subroutine setup_dephasing(this, output, tundos)
 
     !> Instance.
     class(TNegfInt), intent(inout) :: this
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> density of states in tunnel region
     type(TNEGFTunDos), intent(in) :: tundos
 
     if(this%negf%tDephasingVE) then
-      call negf_setup_elph(this%negf, tundos%elph)
+      call negf_setup_elph(output, this%negf, tundos%elph)
     end if
 
     if(this%negf%tDephasingBP) then
-      call negf_setup_bp(this%negf, tundos%bp)
+      call negf_setup_bp(output, this%negf, tundos%bp)
     end if
 
   end subroutine setup_dephasing
 
 
   !> Initialise electron-phonon coupling model
-  subroutine negf_setup_elph(negf, elph)
+  subroutine negf_setup_elph(output, negf, elph)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> NEGF container
     type(TNegf), intent(inout) :: negf
@@ -492,16 +498,16 @@ contains
     !> el-ph coupling structure
     type(TElPh), intent(in) :: elph
 
-    write(stdOut,*)
+    write(output,*)
     select case(elph%model)
     case(1)
-      write(stdOut,*) 'Setting local fully diagonal (FD) elastic dephasing model'
+      write(output,*) 'Setting local fully diagonal (FD) elastic dephasing model'
       call set_elph_dephasing(negf, elph%coupling, elph%scba_niter)
     case(2)
-      write(stdOut,*) 'Setting local block diagonal (BD) elastic dephasing model'
+      write(output,*) 'Setting local block diagonal (BD) elastic dephasing model'
       call set_elph_block_dephasing(negf, elph%coupling, elph%orbsperatm, elph%scba_niter)
     case(3)
-      write(stdOut,*) 'Setting overlap mask (OM) block diagonal elastic dephasing model'
+      write(output,*) 'Setting overlap mask (OM) block diagonal elastic dephasing model'
       call set_elph_s_dephasing(negf, elph%coupling, elph%orbsperatm, elph%scba_niter)
     case default
       call error("This electron-phonon model is not supported")
@@ -511,7 +517,10 @@ contains
 
 
   !> Initialise Buttiker Probe dephasing
-  subroutine negf_setup_bp(negf, elph)
+  subroutine negf_setup_bp(output, negf, elph)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> NEGF container
     type(TNegf), intent(inout) :: negf
@@ -519,17 +528,17 @@ contains
     !> el-ph coupling structure
     type(TElPh), intent(in) :: elph
 
-    write(stdOut,*)
+    write(output,*)
     select case(elph%model)
     case(1)
-      write(stdOut,*) 'Setting local fully diagonal (FD) BP dephasing model'
+      write(output,*) 'Setting local fully diagonal (FD) BP dephasing model'
       !write(stdOut,*) 'coupling=',elph%coupling
       call set_bp_dephasing(negf, elph%coupling)
     case(2)
-      write(stdOut,*) 'Setting local block diagonal (BD) BP dephasing model'
+      write(output,*) 'Setting local block diagonal (BD) BP dephasing model'
       call error('NOT IMPLEMENTED! INTERRUPTED!')
     case(3)
-      write(stdOut,*) 'Setting overlap mask (OM) block diagonal BP dephasing model'
+      write(output,*) 'Setting overlap mask (OM) block diagonal BP dephasing model'
       call error('NOT IMPLEMENTED! INTERRUPTED!')
     case default
       call error("BP model is not supported")
@@ -572,26 +581,33 @@ contains
 
 
   !> Destroy CSR matrices
-  subroutine TNegfInt_final(this)
+  subroutine TNegfInt_final(output, this)
+
+    !> output for write processes
+    integer, intent(in) :: output
+
     type(TNegfInt), intent(inout) :: this
 
-    write(stdOut, *)
-    write(stdOut, *) 'Release NEGF memory:'
+    write(output, *)
+    write(output, *) 'Release NEGF memory:'
     !BA: the following two/three calls are probably absolutely unnecessary
     call destruct(this%csrHam)
     call destruct(this%csrOver)
     call destroy_negf(this%negf)
-    call writePeakInfo(stdOut)
-    call writeMemInfo(stdOut)
+    call writePeakInfo(output)
+    call writeMemInfo(output)
 
   end subroutine TNegfInt_final
 
 
   !> Initialise the structures for the libNEGF library
-  subroutine setup_str(this, denseDescr, transpar, greendens, iNeigh, nNeigh, img2CentCell)
+  subroutine setup_str(this, output, denseDescr, transpar, greendens, iNeigh, nNeigh, img2CentCell)
 
     !> Instance.
     class(TNegfInt), intent(inout) :: this
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> Dense matrix information
     Type(TDenseDescr), intent(in) :: denseDescr
@@ -641,7 +657,7 @@ contains
 
     nAtom = size(denseDescr%iAtomStart) - 1
 
-    call check_pls(transpar, greendens, nAtom, iNeigh, nNeigh, img2CentCell, info)
+    call check_pls(outut, transpar, greendens, nAtom, iNeigh, nNeigh, img2CentCell, info)
 
     allocate(PL_end(nDevicePLs))
     allocate(atomStart(nDevicePLs+1))
@@ -708,17 +724,17 @@ contains
         do j1 = 1, ncont
 
           if (all(minv(:,j1) == 0)) then
-            write(stdOut,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
-            write(stdOut,"(A,I0,A)") 'WARNING: contact ',j1,' does not interact with any PL'
-            write(stdOut,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+            write(output,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+            write(output,"(A,I0,A)") 'WARNING: contact ',j1,' does not interact with any PL'
+            write(output,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
             minv(1,j1) = j1
           end if
 
           if (count(minv(:,j1).eq.j1) > 1) then
-            write(stdOut,"(A)")     '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
-            write(stdOut,"(A,I0,A)")'ERROR: contact ',j1,' interacts with more than one PL'
-            write(stdOut,"(A)")     '       check structure and increase PL size         '
-            write(stdOut,"(A)")     '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+            write(output,"(A)")     '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+            write(output,"(A,I0,A)")'ERROR: contact ',j1,' interacts with more than one PL'
+            write(output,"(A)")     '       check structure and increase PL size         '
+            write(output,"(A)")     '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
             call error("")
           end if
 
@@ -736,10 +752,10 @@ contains
 
       end if
 
-      write(stdOut,*) ' Structure info:'
-      write(stdOut,"(1X,A,1X,I0)") ' Number of PLs:',nDevicePLs
-      write(stdOut,*) ' PLs coupled to contacts:',cblk(:ncont)
-      write(stdOut,*)
+      write(output,*) ' Structure info:'
+      write(output,"(1X,A,1X,I0)") ' Number of PLs:',nDevicePLs
+      write(output,*) ' PLs coupled to contacts:',cblk(:ncont)
+      write(output,*)
 
     end if
 
@@ -749,7 +765,10 @@ contains
 
 
   !> Subroutine to check the principal layer (PL) definitions
-  subroutine check_pls(transPar, greenDens, nAtoms, iNeigh, nNeigh, img2CentCell, info)
+  subroutine check_pls(output, transPar, greenDens, nAtoms, iNeigh, nNeigh, img2CentCell, info)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> transport calculation parameters
     type(TTranspar), intent(in) :: transPar
@@ -815,9 +834,9 @@ contains
                img2CentCell(iNeigh(:nNeigh(ii),ii)) <= iate) )
          end do
          if (nn > mm+1 .and. kk >= iats .and. kk <= iate) then
-           write(stdOut,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
-           write(stdOut,*) 'WARNING: PL ',mm,' interacts with PL',nn
-           write(stdOut,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+           write(output,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+           write(output,*) 'WARNING: PL ',mm,' interacts with PL',nn
+           write(output,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
            info = mm
          end if
        end do
@@ -945,7 +964,10 @@ contains
   !>
   !> NOTE: This routine is not MPI-aware, call it only on MPI-lead!
   !>
-  subroutine negf_dumpHS(HH,SS)
+  subroutine negf_dumpHS(output, HH,SS)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> hamiltonian in CSR format
     type(z_CSR), intent(in) :: HH
@@ -955,7 +977,7 @@ contains
 
     type(TFileDescr) :: fd
 
-    write(stdOut, *) 'Dumping H and S in files...'
+    write(output, *) 'Dumping H and S in files...'
 
     call openFile(fd, 'HH.dat', mode="w")
     write(fd%unit, *) '% Size =',HH%nrow, HH%ncol
@@ -979,7 +1001,10 @@ contains
 
 
   !> Routines to setup orthogonalised H and S have been moved here
-  subroutine prepare_HS(negf, H_dev,S_dev,HH,SS)
+  subroutine prepare_HS(output, negf, H_dev,S_dev,HH,SS)
+
+    !> output for write processes
+    integer, intent(in) :: output
 
     !> NEGF container
     type(TNegf), intent(inout) :: negf
@@ -997,12 +1022,12 @@ contains
     type(z_CSR), intent(inout) :: SS
 
     if (negf%tOrthonormal) then
-      write(stdOut, "(' Lowdin orthogonalization for the whole system ')")
+      write(output, "(' Lowdin orthogonalization for the whole system ')")
       call Orthogonalization(negf, H_dev, S_dev)
     end if
 
     if (negf%tOrthonormalDevice) then
-      write(stdOut, "(' Lowdin orthogonalization for device-only')")
+      write(output, "(' Lowdin orthogonalization for device-only')")
       call Orthogonalization_dev(negf, H_dev, S_dev)
     end if
 
@@ -1179,10 +1204,10 @@ contains
     nSpin = size(ham, dim=2)
     rho = 0.0_dp
 
-    write(stdOut, *)
-    write(stdOut, '(80("="))')
-    write(stdOut, *) '                         COMPUTING DENSITY MATRIX      '
-    write(stdOut, '(80("="))')
+    write(env%stdOut, *)
+    write(env%stdOut, '(80("="))')
+    write(env%stdOut, *) '                         COMPUTING DENSITY MATRIX      '
+    write(env%stdOut, '(80("="))')
 
     do iKS = 1, nKS
       iK = groupKS(1, iKS)
@@ -1190,10 +1215,10 @@ contains
 
     #:if WITH_MPI
       if (env%mpi%nGroup == 1) then
-        write(stdOut,*) 'k-point',iK,'Spin',iS
+        write(env%stdOut,*) 'k-point',iK,'Spin',iS
       end if
     #:else
-      write(stdOut,*) 'k-point',iK,'Spin',iS
+      write(env%stdOut,*) 'k-point',iK,'Spin',iS
     #:endif
 
       call foldToCSR(this%csrHam, ham(:,iS), kPoints(:,iK), iAtomStart, iPair, iNeighbor,&
@@ -1232,8 +1257,8 @@ contains
       call set_readOldDMsgf(this%negf, READ_SGF)  ! read from files
     end if
 
-    write(stdOut,'(80("="))')
-    write(stdOut,*)
+    write(env%stdOut,'(80("="))')
+    write(env%stdOut,*)
 
   end subroutine calcdensity_green
 
@@ -1330,16 +1355,16 @@ contains
     nSpin = size(ham, dim=2)
     rhoE = 0.0_dp
 
-    write(stdOut, *)
-    write(stdOut, '(80("="))')
-    write(stdOut, *) '                     COMPUTING E-WEIGHTED DENSITY MATRIX '
-    write(stdOut, '(80("="))')
+    write(env%stdOut, *)
+    write(env%stdOut, '(80("="))')
+    write(env%stdOut, *) '                     COMPUTING E-WEIGHTED DENSITY MATRIX '
+    write(env%stdOut, '(80("="))')
 
     do iKS = 1, nKS
       iK = groupKS(1, iKS)
       iS = groupKS(2, iKS)
 
-      write(stdOut,*) 'k-point',iK,'Spin',iS
+      write(env%stdOut,*) 'k-point',iK,'Spin',iS
 
       call foldToCSR(this%csrHam, ham(:,iS), kPoints(:,iK), iAtomStart, iPair, iNeighbor,&
           & nNeighbor, img2CentCell, iCellVec, cellVec, orb)
@@ -1369,8 +1394,8 @@ contains
       call set_readOldDMsgf(this%negf, READ_SGF)  ! read from files
     end if
 
-    write(stdOut,'(80("="))')
-    write(stdOut,*)
+    write(env%stdOut,'(80("="))')
+    write(env%stdOut,*)
 
   end subroutine calcEdensity_green
 
@@ -1491,18 +1516,18 @@ contains
     ncont = size(mu,1)
 
     if (params%verbose > 30) then
-      write(stdOut, *)
-      write(stdOut, '(80("="))')
-      write(stdOut, *) '                            COMPUTATION OF CURRENT         '
-      write(stdOut, '(80("="))')
-      write(stdOut, *)
+      write(output, *)
+      write(output, '(80("="))')
+      write(output, *) '                            COMPUTATION OF CURRENT         '
+      write(output, '(80("="))')
+      write(output, *)
     end if
 
     do iKS = 1, nKS
       iK = groupKS(1, iKS)
       iS = groupKS(2, iKS)
 
-      write(stdOut,*) 'Spin',iS,'k-point',iK,'k-weight',kWeights(iK)
+      write(env%stdOut,*) 'Spin',iS,'k-point',iK,'k-weight',kWeights(iK)
 
       params%mu(:ncont) = mu(:ncont,iS)
 
@@ -1532,7 +1557,7 @@ contains
         call unpackHS(S_all, over, iNeighbor, nNeighbor, iAtomStart, iPair, img2CentCell)
         call adjointLowerTriangle(S_all)
 
-        call prepare_HS(this%negf, H_all, S_all, this%csrHam, this%csrOver)
+        call prepare_HS(env%stdOut, this%negf, H_all, S_all, this%csrHam, this%csrOver)
 
       else
 
@@ -1587,8 +1612,8 @@ contains
     currLead(:) = currLead * convertCurrent(unitsOfEnergy, unitsOfCurrent)
 
     do ii = 1, size(currLead)
-      write(stdOut, *)
-      write(stdOut, '(1x,a,i3,i3,a,ES14.5,a,a)') ' contacts: ',params%ni(ii),params%nf(ii),&
+      write(env%stdOut, *)
+      write(env%stdOut, '(1x,a,i3,i3,a,ES14.5,a,a)') ' contacts: ',params%ni(ii),params%nf(ii),&
           & ' current: ', currLead(ii),' ',unitsOfCurrent%name
     enddo
 
@@ -2013,11 +2038,11 @@ contains
       endif
     endif
 
-    write(stdOut, *)
-    write(stdOut, '(80("="))')
-    write(stdOut, *) '                        COMPUTING LOCAL CURRENTS          '
-    write(stdOut, '(80("="))')
-    write(stdOut, *)
+    write(env%stdOut, *)
+    write(env%stdOut, '(80("="))')
+    write(env%stdOut, *) '                        COMPUTING LOCAL CURRENTS          '
+    write(env%stdOut, '(80("="))')
+    write(env%stdOut, *)
 
     nKS = size(groupKS, dim=2)
     nK = size(kPoints, dim=2)
@@ -2048,7 +2073,7 @@ contains
       iK = groupKS(1, iKS)
       iS = groupKS(2, iKS)
 
-      write(stdOut,*) 'k-point',iK,'Spin',iS
+      write(env%stdOut,*) 'k-point',iK,'Spin',iS
 
       ! We need to recompute Rho and RhoE .....
       call foldToCSR(this%csrHam, ham(:,iS), kPoints(:,iK), iAtomStart, iPair,&
@@ -2152,10 +2177,10 @@ contains
     deallocate(lcurr)
 
     if (tIoProc) then
-      write(stdOut,*)
+      write(env%stdOut,*)
       call writeXYZFormat("supercell.xyz", lc_coord, lc_species,&
           & speciesName)
-      write(stdOut,*) " <<< supercell.xyz written on file"
+      write(env%stdOut,*) " <<< supercell.xyz written on file"
     end if
 
   contains

--- a/src/dftbp/type/typegeometryhsd.F90
+++ b/src/dftbp/type/typegeometryhsd.F90
@@ -7,10 +7,10 @@
 
 !> Routines to read/write a TGeometry type in HSD and XML format.
 module dftbp_type_typegeometryhsd
+  use dftbp_common_environment, only : TEnvironment
   use dftbp_common_accuracy, only : dp, lc, mc
   use dftbp_common_atomicmass, only : getAtomicSymbol
   use dftbp_common_constants, only : AA__Bohr, avogadConst, Bohr__AA, pi
-  use dftbp_common_globalenv, only : stdout
   use dftbp_common_unitconversion, only : angularUnits, lengthUnits
   use dftbp_extlibs_xmlf90, only : char, fnode, getNodeType, getNodeValue,&
       & flib_normalize => normalize, string, TEXT_NODE, xmlf_t
@@ -215,7 +215,10 @@ contains
 
 
   !> Reads the geometry from a node in a HSD tree in GEN format
-  subroutine readTGeometryGen(node, geo)
+  subroutine readTGeometryGen(env, node, geo)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node containing the geometry in Gen format
     type(fnode), pointer :: node
@@ -226,13 +229,16 @@ contains
     type(string) :: text
 
     call getFirstTextChild(node, text)
-    call readTGeometryGen_help(node, geo, char(text))
+    call readTGeometryGen_help(env, node, geo, char(text))
 
   end subroutine readTGeometryGen
 
 
   !> Helping routine for reading geometry from a HSD tree in GEN format
-  subroutine readTGeometryGen_help(node, geo, text)
+  subroutine readTGeometryGen_help(env, node, geo, text)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to parse (only needed to produce proper error messages)
     type(fnode), pointer :: node
@@ -374,7 +380,7 @@ contains
 
     ! tests that are relevant to periodic geometries only
     if (geo%tPeriodic) then
-      call setupPeriodicGeometry(node, geo)
+      call setupPeriodicGeometry(env, node, geo)
     end if
 
     ! convert coords to correct internal units
@@ -510,7 +516,10 @@ contains
 
 
   !> Reads the geometry from a node in a HSD tree in VASP POSCAR/CONTCAR formats
-  subroutine readTGeometryVasp(node, geo)
+  subroutine readTGeometryVasp(env, node, geo)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node containing the geometry in Gen format
     type(fnode), pointer :: node
@@ -521,13 +530,16 @@ contains
     type(string) :: text
 
     call getFirstTextChild(node, text)
-    call readTGeometryVasp_help(node, geo, char(text))
+    call readTGeometryVasp_help(env, node, geo, char(text))
 
   end subroutine readTGeometryVasp
 
 
   !> Helping routine for reading geometry from a HSD tree in VASP format
-  subroutine readTGeometryVasp_help(node, geo, text)
+  subroutine readTGeometryVasp_help(env, node, geo, text)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to parse (only needed to produce proper error messages)
     type(fnode), pointer :: node
@@ -687,7 +699,7 @@ contains
       iStart = iEnd + 1
     end do
 
-    call setupPeriodicGeometry(node, geo)
+    call setupPeriodicGeometry(env, node, geo)
 
     ! convert coords to correct internal units
     if (geo%tFracCoord) then
@@ -705,7 +717,10 @@ contains
 
 
   !> Reads the geometry in a HSD tree in LAMMPS data file format
-  subroutine readTGeometryLammps(node, geo)
+  subroutine readTGeometryLammps(env, node, geo)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node containing the geometry in Gen format
     type(fnode), pointer :: node
@@ -728,13 +743,16 @@ contains
     end if
     call getNodeValue(child, text2)
 
-    call readTGeometryLammps_help(node, geo, char(text1), char(text2))
+    call readTGeometryLammps_help(env, node, geo, char(text1), char(text2))
 
   end subroutine readTGeometryLammps
 
 
   !> Helping routine for reading geometry from a HSD tree in LAMMPS format
-  subroutine readTGeometryLammps_help(node, geo, commandInput, dataInput)
+  subroutine readTGeometryLammps_help(env, node, geo, commandInput, dataInput)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to parse (only needed to produce proper error messages)
     type(fnode), pointer :: node
@@ -1014,10 +1032,10 @@ contains
     geo%tFracCoord = .false.
     geo%tHelical = .false.
 
-    call setupPeriodicGeometry(node, geo)
+    call setupPeriodicGeometry(env, node, geo)
     geo%coords = geo%coords * AA__Bohr
 
-    write(stdout, "(A,I8,A,I3,A)") "Read values from LAMMPS input file: ",&
+    write(env%stdout, "(A,I8,A,I3,A)") "Read values from LAMMPS input file: ",&
         & geo%nAtom, " atoms, ", geo%nSpecies, " species"
 
     call normalize(geo)
@@ -1026,7 +1044,10 @@ contains
 
 
   !> Common checks for periodic input and generation of associated information
-  subroutine setupPeriodicGeometry(node, geo)
+  subroutine setupPeriodicGeometry(env, node, geo)
+
+    !> Environment
+    type(TEnvironment), intent(in) :: env
 
     !> Node to parse (only needed to produce proper error messages)
     type(fnode), pointer :: node
@@ -1040,7 +1061,7 @@ contains
     geo%latVecs = geo%latVecs * AA__Bohr
     if (geo%tFracCoord) then
       if (any(abs(geo%coords) > 1.0_dp)) then
-        call detailedWarning(node, "Fractional coordinates with absolute value greater than one.")
+        call detailedWarning(env%stdOut, node, "Fractional coordinates with absolute value greater than one.")
       end if
     end if
     allocate(geo%recVecs2p(3, 3))

--- a/test/src/dftbp/unit/dftb/periodic.F90
+++ b/test/src/dftbp/unit/dftb/periodic.F90
@@ -10,6 +10,8 @@
 module test_dftb_periodic
   use fortuno_serial, only : suite => serial_suite_item, test_list
   use dftbp_common_accuracy, only : dp, minNeighDist
+  use dftbp_common_environment, only : TEnvironment, TEnvironment_init
+  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv
   use dftbp_common_status, only : TStatus
   use dftbp_dftb_periodic, only : allocateNeighbourArrays, distributeAtoms, fillNeighbourArrays,&
       & reallocateArrays2, TNeighbourList, TNeighbourlist_init, updateNeighbourList
@@ -32,10 +34,11 @@ contains
   subroutine init_test_env(this)
     type(test_env), intent(out) :: this
 
-    call initGlobalEnv()
-    call TEnvironment_init(this%env)
-    ! temporary fix
-    this%env%stdOut = stdOut
+    integer :: stdOut
+
+    call initGlobalEnv(stdOut=stdOut)
+    print *, "STDOUT: ", stdOut
+    call TEnvironment_init(this%env, stdOut=stdOut)
 
   end subroutine init_test_env
 
@@ -87,6 +90,8 @@ contains
     integer :: startAtom, endAtom, ii
     logical :: error
     integer, parameter :: nRanks = 4
+
+    call init_test_env(tenv)
 
     write(*,*)
     write(*,"(1X,A,I0,A)")'Expect errors for the next ', nRanks, ' ranks.'

--- a/test/src/dftbp/unit/dftb/periodic.F90
+++ b/test/src/dftbp/unit/dftb/periodic.F90
@@ -19,14 +19,45 @@ module test_dftb_periodic
   private
   public :: tests
 
+  type :: test_env
+    type(TEnvironment) :: env
+  contains
+    final :: final_test_env
+  end type test_env
+
 contains
 
 
+  !> Intializes the test environment
+  subroutine init_test_env(this)
+    type(test_env), intent(out) :: this
+
+    call initGlobalEnv()
+    call TEnvironment_init(this%env)
+    ! temporary fix
+    this%env%stdOut = stdOut
+
+  end subroutine init_test_env
+
+
+  !> Finalizes the test environment
+  subroutine final_test_env(this)
+    type(test_env), intent(inout) :: this
+
+    call this%env%destruct()
+    call destructGlobalEnv()
+
+  end subroutine final_test_env
+
+
   $:TEST("singleRank")
+    type(test_env) :: tenv
     integer :: startAtom, endAtom
     logical :: error
 
-    call distributeAtoms(0, 1, 42, startAtom, endAtom, error)
+    call init_test_env(tenv)
+
+    call distributeAtoms(tenv%env%stdOut, 0, 1, 42, startAtom, endAtom, error)
     @:ASSERT(startAtom == 1)
     @:ASSERT(endAtom == 42)
     @:ASSERT(.not. error)
@@ -34,14 +65,17 @@ contains
 
 
   $:TEST("multipleRanks")
+    type(test_env) :: tenv
     integer :: startAtom, endAtom
     logical :: error
 
-    call distributeAtoms(0, 2, 13, startAtom, endAtom, error)
+    call init_test_env(tenv)
+
+    call distributeAtoms(tenv%env%stdOut, 0, 2, 13, startAtom, endAtom, error)
     @:ASSERT(startAtom == 1)
     @:ASSERT(endAtom == 7)
     @:ASSERT(.not. error)
-    call distributeAtoms(1, 2, 13, startAtom, endAtom, error)
+    call distributeAtoms(tenv%env%stdOut, 1, 2, 13, startAtom, endAtom, error)
     @:ASSERT(startAtom == 8)
     @:ASSERT(endAtom == 13)
     @:ASSERT(.not. error)
@@ -49,6 +83,7 @@ contains
 
 
   $:TEST("tooManyRanks")
+    type(test_env) :: tenv
     integer :: startAtom, endAtom, ii
     logical :: error
     integer, parameter :: nRanks = 4
@@ -56,7 +91,7 @@ contains
     write(*,*)
     write(*,"(1X,A,I0,A)")'Expect errors for the next ', nRanks, ' ranks.'
     do ii = 1, nRanks
-      call distributeAtoms(ii, nRanks, 2, startAtom, endAtom, error)
+      call distributeAtoms(tenv%env%stdOut, ii, nRanks, 2, startAtom, endAtom, error)
       @:ASSERT(error)
     end do
   $:END_TEST()

--- a/test/src/dftbp/unit/type/typegeometryhsd.F90
+++ b/test/src/dftbp/unit/type/typegeometryhsd.F90
@@ -12,7 +12,7 @@ module test_type_typegeometryhsd
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : AA__Bohr
   use dftbp_common_environment, only : TEnvironment, TEnvironment_init
-  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv, stdOut
+  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv
   use dftbp_extlibs_xmlf90, only : createDocumentNode, createTextNode, destroyNode, fnode
   use dftbp_io_hsdutils, only : setChildValue
   use dftbp_type_typegeometryhsd, only : readTGeometryLammps, TGeometry
@@ -48,10 +48,10 @@ contains
   subroutine init_test_env(this)
     type(test_env), intent(out) :: this
 
-    call initGlobalEnv()
-    call TEnvironment_init(this%env)
-    ! temporary fix
-    this%env%stdOut = stdOut
+    integer :: stdOut
+
+    call initGlobalEnv(stdOut=stdOut)
+    call TEnvironment_init(this%env, stdOut=stdOut)
 
   end subroutine init_test_env
 

--- a/test/src/dftbp/unit/type/typegeometryhsd.F90
+++ b/test/src/dftbp/unit/type/typegeometryhsd.F90
@@ -11,6 +11,8 @@ module test_type_typegeometryhsd
   use fortuno_serial, only : suite => serial_suite_item, test_list
   use dftbp_common_accuracy, only : dp
   use dftbp_common_constants, only : AA__Bohr
+  use dftbp_common_environment, only : TEnvironment, TEnvironment_init
+  use dftbp_common_globalenv, only : destructGlobalEnv, initGlobalEnv, stdOut
   use dftbp_extlibs_xmlf90, only : createDocumentNode, createTextNode, destroyNode, fnode
   use dftbp_io_hsdutils, only : setChildValue
   use dftbp_type_typegeometryhsd, only : readTGeometryLammps, TGeometry
@@ -20,6 +22,11 @@ module test_type_typegeometryhsd
   private
   public :: tests
 
+  type :: test_env
+    type(TEnvironment) :: env
+  contains
+    final :: final_test_env
+  end type test_env
 
   ! Floating point parsing precision
   real(dp), parameter :: prec = 10.0_dp * epsilon(1.0_dp)
@@ -37,10 +44,35 @@ module test_type_typegeometryhsd
 contains
 
 
+  !> Intializes the test environment
+  subroutine init_test_env(this)
+    type(test_env), intent(out) :: this
+
+    call initGlobalEnv()
+    call TEnvironment_init(this%env)
+    ! temporary fix
+    this%env%stdOut = stdOut
+
+  end subroutine init_test_env
+
+
+  !> Finalizes the test environment
+  subroutine final_test_env(this)
+    type(test_env), intent(inout) :: this
+
+    call this%env%destruct()
+    call destructGlobalEnv()
+
+  end subroutine final_test_env
+
+
   $:TEST("minimalCaseWithDefaultValues")
     type(TLammpsGeoNode) :: nw
     type(TGeometry) :: geo
+    type(test_env) :: tenv
     integer :: ii
+
+    call init_test_env(tenv)
 
     call TLammpsGeoNode_init(nw, "units real",&
         & "3 atoms" // nl //&
@@ -51,7 +83,7 @@ contains
         & "1 1" // nl //&
         & "2 1" // nl //&
         & "3 1")
-    call readTGeometryLammps(nw%node, geo)
+    call readTGeometryLammps(tenv%env, nw%node, geo)
     @:ASSERT(geo%natom == 3)
     @:ASSERT(geo%nSpecies == 1)
     @:ASSERT(geo%speciesNames(1) == 'H')
@@ -67,7 +99,10 @@ contains
   $:TEST("explicitValuesForAll")
     type(TLammpsGeoNode) :: nw
     type(TGeometry) :: geo
+    type(test_env) :: tenv
     integer :: ii
+
+    call init_test_env(tenv)
 
     call TLammpsGeoNode_init(nw, "boundary p p p" // nl //&
         & "atom_style atomic" // nl //&
@@ -84,7 +119,7 @@ contains
         & "1 1" // nl //&
         & "2 1" // nl //&
         & "3 1")
-    call readTGeometryLammps(nw%node, geo)
+    call readTGeometryLammps(tenv%env, nw%node, geo)
     @:ASSERT(geo%natom == 3)
     @:ASSERT(geo%nSpecies == 1)
     @:ASSERT(geo%speciesNames(1) == 'H')
@@ -99,7 +134,10 @@ contains
   $:TEST("differentOrder")
     type(TLammpsGeoNode) :: nw
     type(TGeometry) :: geo
+    type(test_env) :: tenv
     integer :: ii
+
+    call init_test_env(tenv)
 
     call TLammpsGeoNode_init(nw, "atom_style atomic" // nl //&
         & "units real" // nl //&
@@ -116,7 +154,7 @@ contains
         & "3 1" // nl //&
         & "Masses" // nl //&
         & "1 1.0")
-    call readTGeometryLammps(nw%node, geo)
+    call readTGeometryLammps(tenv%env, nw%node, geo)
     @:ASSERT(geo%natom == 3)
     @:ASSERT(geo%nSpecies == 1)
     @:ASSERT(geo%speciesNames(1) == 'H')
@@ -132,7 +170,10 @@ contains
   $:TEST("atomsWithCoordinates")
     type(TLammpsGeoNode) :: nw
     type(TGeometry) :: geo
+    type(test_env) :: tenv
     integer :: ii, jj
+
+    call init_test_env(tenv)
 
     call TLammpsGeoNode_init(nw, "atom_style full" // nl //&
         & "units real",&
@@ -144,7 +185,7 @@ contains
         & "1 0 1 99 11.0 12.0 13.0" // nl //&
         & "2 0 1 99 21.0 22.0 23.0" // nl //&
         & "3 0 1 99 31.0 32.0 33.0")
-    call readTGeometryLammps(nw%node, geo)
+    call readTGeometryLammps(tenv%env, nw%node, geo)
     @:ASSERT(geo%natom == 3)
     @:ASSERT(geo%nSpecies == 1)
     @:ASSERT(geo%speciesNames(1) == 'H')
@@ -161,7 +202,10 @@ contains
   $:TEST("speciesNames")
     type(TLammpsGeoNode) :: nw
     type(TGeometry) :: geo
+    type(test_env) :: tenv
     integer :: ii
+
+    call init_test_env(tenv)
 
     call TLammpsGeoNode_init(nw, "units real",&
         & "6 atoms" // nl //&
@@ -180,7 +224,7 @@ contains
         & "4 4" // nl //&
         & "5 5" // nl //&
         & "6 6")
-    call readTGeometryLammps(nw%node, geo)
+    call readTGeometryLammps(tenv%env, nw%node, geo)
     @:ASSERT(geo%nSpecies == 6)
     @:ASSERT(geo%speciesNames(1) == 'H')
     @:ASSERT(geo%speciesNames(2) == 'O')
@@ -197,7 +241,10 @@ contains
   $:TEST("strangeFormatting")
     type(TLammpsGeoNode) :: nw
     type(TGeometry) :: geo
+    type(test_env) :: tenv
     integer :: ii
+
+    call init_test_env(tenv)
 
     call TLammpsGeoNode_init(nw, "# comment" // nl // nl //&
         & "  boundary     p p p #some comment" // nl // nl // nl //&
@@ -215,7 +262,7 @@ contains
         & " 1 1 4 4 4 #ignore everything here" // nl //&
         & "  2 1 #ignore me" // nl // nl //&
         & "3 1")
-    call readTGeometryLammps(nw%node, geo)
+    call readTGeometryLammps(tenv%env, nw%node, geo)
     @:ASSERT(geo%natom == 3)
     @:ASSERT(geo%nSpecies == 1)
     @:ASSERT(geo%tPeriodic)
@@ -237,6 +284,9 @@ contains
   $:TEST("triclinicCell")
     type(TLammpsGeoNode) :: nw
     type(TGeometry) :: geo
+    type(test_env) :: tenv
+
+    call init_test_env(tenv)
 
     call TLammpsGeoNode_init(nw, "units real",&
         & "1 atoms" // nl //&
@@ -249,7 +299,7 @@ contains
         & "1 1.0" // nl //&
         & "Atoms" // nl //&
         & "1 1")
-    call readTGeometryLammps(nw%node, geo)
+    call readTGeometryLammps(tenv%env, nw%node, geo)
     geo%latVecs = geo%latVecs / AA__Bohr
     @:ASSERT(abs(geo%latVecs(1,1) - 1.0_dp) < prec)
     @:ASSERT(abs(geo%latVecs(2,1)) < prec)
@@ -266,7 +316,10 @@ contains
   $:TEST("unitConversion")
     type(TLammpsGeoNode) :: nw
     type(TGeometry) :: geo
+    type(test_env) :: tenv
     integer :: ii
+
+    call init_test_env(tenv)
 
     call TLammpsGeoNode_init(nw, "units si",&
         & "1 atoms" // nl //&
@@ -278,7 +331,7 @@ contains
         & "1 1.99e-26" // nl //&
         & "Atoms" // nl //&
         & "1 1 1.0e-10 2.0e-10 3.0e-10")
-    call readTGeometryLammps(nw%node, geo)
+    call readTGeometryLammps(tenv%env, nw%node, geo)
     @:ASSERT(geo%speciesNames(1) == 'C')
     do ii = 1, 3
       @:ASSERT(abs(geo%latVecs(ii,ii) - 1.0e10_dp * AA__Bohr) < prec)


### PR DESCRIPTION
Passes (user or caller configurable) standard out to all places writing to console and elminates the corresponding global variable. Standard output can be suppressed of configured completely this way.

Only exceptions, where a hard coded standard output (stdout0), are:
- Debug messages (only active in debug mode)
- Asserts (only active in debug mode)
- Errors, calling abortProgram() after I/O  (which should be refactored in a next step anyway)