### PR TITLE
Download test data only if necessary

### DIFF
--- a/cmake/DftbPlusUtils.cmake
+++ b/cmake/DftbPlusUtils.cmake
@@ -722,3 +722,49 @@ function (dftbp_check_minimal_compiler_version lang compiler_versions)
     endif()
   endwhile()
 endfunction()
+
+
+# Download the external data (SK-files, GBSA-data) needed for testing, if not present yet.
+function (dftbp_download_test_data)
+  _dftbp_download_test_data_from_github(
+    dftbplus
+    testparams
+    1f5aefe45b7951f3fd1c0b63e40b80f80fdab612
+    external/slakos
+    "SK-files"
+  )
+  _dftbp_download_test_data_from_github(
+    grimme-lab
+    gbsa-parameters
+    6836c4d997e4135e418cfbe273c96b1a3adb13e2
+    external/gbsa
+    "GBSA-data"
+  )
+endfunction ()
+
+
+# Helper function to download external test data
+function (_dftbp_download_test_data_from_github owner repository commit_id targetdir content)
+  set(targetdirpath "${PROJECT_SOURCE_DIR}/${targetdir}")
+  if (EXISTS "${targetdirpath}/origin")
+    message(STATUS "Directory '${targetdir}/origin' exists, skipping download of ${content}")
+  else()
+    message(STATUS "Fetching ${content} into directory '${targetdir}'")
+    file(DOWNLOAD
+      "https://github.com/${owner}/${repository}/archive/${commit_id}.tar.gz"
+      "${targetdirpath}/origin.tar.gz"
+      STATUS download_status
+      )
+    list(GET download_status 0 status_code)
+    if (NOT status_code EQUAL 0)
+      list(GET download_status 1 status_message)
+      if (EXISTS "${targetdirpath}/origin.tar.gz")
+        file(REMOVE "${targetdirpath}/origin.tar.gz")
+      endif ()
+      message(FATAL_ERROR "Download of ${content} failed: ${status_message} (code: ${status_code})")
+    endif ()
+    file(ARCHIVE_EXTRACT INPUT "${targetdirpath}/origin.tar.gz" DESTINATION "${targetdirpath}")
+    file(RENAME "${targetdirpath}/${repository}-${commit_id}" "${targetdirpath}/origin")
+    file(REMOVE "${targetdirpath}/origin.tar.gz")
+  endif ()
+endfunction ()

--- a/config.cmake
+++ b/config.cmake
@@ -115,7 +115,8 @@ else()
     "How to run the modes code for tests")
 endif()
 
-option(TEST_AUTO_DOWNLOAD "Automatically download test data (slakos, gbsa) at configure time" TRUE)
+# Whether data necessary for the tests should be downloaded if not present yet
+option(TEST_DOWNLOAD_DATA "Download test data (slakos, gbsa) at configure time if not present yet" TRUE)
 
 # Turn it on to include the unit tests (needs the Fortuno unit testing framework)
 option(WITH_UNIT_TESTS "Whether the unit tests should be built" FALSE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,21 +1,6 @@
-include(FetchContent)
-
-if (TEST_AUTO_DOWNLOAD)
-  FetchContent_Declare(
-    slakos
-    URL https://github.com/dftbplus/testparams/archive/1f5aefe45b7951f3fd1c0b63e40b80f80fdab612.tar.gz
-    SOURCE_DIR "${PROJECT_SOURCE_DIR}/external/slakos/origin"
-  )
-  FetchContent_MakeAvailable(slakos)
-
-  FetchContent_Declare(
-    gbsa
-    URL https://github.com/grimme-lab/gbsa-parameters/archive/6836c4d997e4135e418cfbe273c96b1a3adb13e2.tar.gz
-    SOURCE_DIR "${PROJECT_SOURCE_DIR}/external/gbsa/origin"
-  )
-  FetchContent_MakeAvailable(gbsa)
-endif()
-
+if (TEST_DOWNLOAD_DATA)
+  dftbp_download_test_data()
+endif ()
 add_subdirectory(src/dftbp)
 add_subdirectory(app)
 add_subdirectory(tools/dptools)


### PR DESCRIPTION
Fixes current automatic test-data, which is triggered at each new configuration, even if the data is present.
The current approach only downloads the data when not present yet.
